### PR TITLE
feat(scripts): add string provenance analyzer (closes #43)

### DIFF
--- a/Mods/QudJP/Assemblies/AGENTS.md
+++ b/Mods/QudJP/Assemblies/AGENTS.md
@@ -53,6 +53,21 @@
   - L1 for parser/template logic
   - L2 or L2G for the actual patch route and untranslated pass-through behavior
 
+### Provenance Check Before Dictionary Addition
+
+- Before adding any new translation-dictionary entry for runtime text, run `python3.12 -m scripts.analyze_provenance --output /tmp/provenance-report.json`.
+- Check whether the candidate key's context namespace appears in the report's `generator_catalog`.
+- If it does, the text is likely dynamically composed. Do not add a dictionary entry. Instead:
+  - identify the upstream generator family,
+  - implement the smallest route/template change for that family,
+  - add L1/L2 coverage for the generator's slot structure.
+- If it does not, the string may still be `exact_leaf`, but confirm upstream evidence before widening dictionaries.
+- Treat the analyzer classifications as follows:
+  - `exact_leaf`: compile-time constant or stable leaf string; dictionary is acceptable
+  - `structured_dynamic`: slot-bearing template such as `string.Format` or `StringBuilder`; use a route/template
+  - `generator_family`: known generator API such as `DescriptionBuilder`, `GetDisplayNameEvent`, `Grammar.*`, `GameText`, or `HistoricStringExpander`; dictionary addition is forbidden
+  - `opaque`: provenance unclear; investigate upstream before adding dictionary coverage
+
 ### Runtime Failure Model
 
 - Initialization failures are expected to fail fast.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -38,6 +38,21 @@
 - Keep error paths explicit and actionable because these scripts are used for validation and deployment tasks.
 - When a script validates localization assets, align its checks with the canonical repo docs rather than duplicating new rules ad hoc.
 
+### Provenance Check Before Dictionary Addition
+
+- Before adding a new JSON dictionary entry for dynamic-looking text, run `python3.12 -m scripts.analyze_provenance --output /tmp/provenance-report.json`.
+- Check whether the entry's context namespace overlaps with the report's `generator_catalog`.
+- If it does, treat the string as logic-required work instead of a leaf dictionary candidate:
+  - identify the upstream generator family,
+  - implement the smallest route/template change that matches its slots,
+  - add tests at the same composition boundary.
+- The analyzer classifications are:
+  - `exact_leaf`: fixed leaf string, dictionary-safe
+  - `structured_dynamic`: template with slots such as `string.Format` or `StringBuilder`, use a route/template instead of exact-key growth
+  - `generator_family`: known generator API such as `DescriptionBuilder`, `GetDisplayNameEvent`, `Grammar.*`, `GameText`, or `HistoricStringExpander`; dictionary addition is forbidden until upstream handling is in place
+  - `opaque`: provenance unclear, investigate upstream first
+- `messages.ja.json` `patterns` entries are already handled by message-pattern routing and are intentionally out of scope for the provenance analyzer.
+
 ### Area-Specific Constraints
 
 - Do not add silent fallbacks that hide invalid asset state.

--- a/scripts/analyze_provenance.py
+++ b/scripts/analyze_provenance.py
@@ -1,0 +1,95 @@
+"""Analyze string provenance across dictionaries and decompiled source."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the provenance-analysis CLI.
+
+    Args:
+        argv: Optional command-line arguments.
+
+    Returns:
+        Exit code where ``0`` means success and ``1`` means failure.
+    """
+    _configure_import_path()
+
+    from scripts.provenance.cross_reference import cross_reference  # noqa: PLC0415
+    from scripts.provenance.csharp_pattern_scanner import scan_directory  # noqa: PLC0415
+    from scripts.provenance.dictionary_auditor import audit_dictionaries, load_dictionary_entries  # noqa: PLC0415
+    from scripts.provenance.report import generate_report  # noqa: PLC0415
+
+    parser = argparse.ArgumentParser(
+        description="Analyze translation dictionary entries for string provenance risks.",
+    )
+    project_root = _find_project_root()
+    parser.add_argument(
+        "--dictionaries",
+        type=Path,
+        default=project_root / "Mods" / "QudJP" / "Localization" / "Dictionaries",
+        help="Directory containing translation dictionaries.",
+    )
+    parser.add_argument(
+        "--ilspy-raw",
+        type=Path,
+        default=project_root / "docs" / "ilspy-raw",
+        help="Directory containing decompiled C# source files.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional file path for the generated JSON report.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        audit_findings = audit_dictionaries(args.dictionaries)
+        generator_signatures = scan_directory(args.ilspy_raw) if args.ilspy_raw.exists() else []
+        xref_findings = cross_reference(load_dictionary_entries(args.dictionaries), generator_signatures)
+        report = generate_report(
+            audit_findings=audit_findings,
+            generator_signatures=generator_signatures,
+            xref_findings=xref_findings,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)  # noqa: T201
+        return 1
+
+    if args.output is None:
+        print(report)  # noqa: T201
+        return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(report, encoding="utf-8")
+    print(f"Report written to {args.output}", file=sys.stderr)  # noqa: T201
+    return 0
+
+
+def _find_project_root() -> Path:
+    """Find the repository root that contains ``pyproject.toml``."""
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / "pyproject.toml").exists():
+            return current
+        current = current.parent
+    msg = "Could not locate project root containing pyproject.toml"
+    raise FileNotFoundError(msg)
+
+
+def _configure_import_path() -> None:
+    """Ensure direct script execution can import the repo-root ``scripts`` package."""
+    if __package__ not in {None, ""}:
+        return
+    project_root = Path(__file__).resolve().parents[1]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/provenance/__init__.py
+++ b/scripts/provenance/__init__.py
@@ -1,0 +1,19 @@
+"""String provenance analysis tooling for QudJP dictionaries."""
+
+from .models import (
+    AuditFinding,
+    AuditFindingKind,
+    DictEntry,
+    GeneratorSignature,
+    ProvenanceReport,
+    StringClassification,
+)
+
+__all__ = [
+    "AuditFinding",
+    "AuditFindingKind",
+    "DictEntry",
+    "GeneratorSignature",
+    "ProvenanceReport",
+    "StringClassification",
+]

--- a/scripts/provenance/cross_reference.py
+++ b/scripts/provenance/cross_reference.py
@@ -1,0 +1,114 @@
+"""Cross-reference dictionary entries against generator signatures."""
+
+from __future__ import annotations
+
+import re
+
+from scripts.provenance.models import (
+    AuditFinding,
+    AuditFindingKind,
+    DictEntry,
+    GeneratorSignature,
+    StringClassification,
+)
+
+_FRAGMENT_TRAILING_WS = re.compile(r"\s+$")
+_FRAGMENT_LEADING_WS = re.compile(r"^\s+")
+_FRAGMENT_OPEN_BRACKET = re.compile(r"(?:\[|\()$")
+_MIN_SHARED_NAMESPACE_DEPTH = 2
+
+
+def cross_reference(entries: list[DictEntry], signatures: list[GeneratorSignature]) -> list[AuditFinding]:
+    """Flag dictionary entries that overlap generator-family namespaces.
+
+    Args:
+        entries: Dictionary entries under analysis.
+        signatures: C# scanner output.
+
+    Returns:
+        Cross-reference findings highlighting likely misclassified dictionary entries.
+    """
+    generator_namespaces = {
+        namespace
+        for signature in signatures
+        if signature.classification == StringClassification.GENERATOR_FAMILY
+        if (namespace := _extract_namespace(signature)) is not None
+    }
+
+    findings: list[AuditFinding] = []
+    for entry in entries:
+        if not _context_overlaps_generator(entry.context, generator_namespaces):
+            continue
+        if _is_fragment_key(entry.key):
+            findings.append(
+                AuditFinding(
+                    kind=AuditFindingKind.FRAGMENT_KEY,
+                    dictionary_id=entry.dictionary_id,
+                    key=entry.key,
+                    message=(
+                        "Fragment-style dictionary key overlaps a generator-family namespace; "
+                        "prefer a template or patch route instead of a dictionary entry, "
+                        "because it likely belongs to generator-family code"
+                    ),
+                )
+            )
+            continue
+        findings.append(
+            AuditFinding(
+                kind=AuditFindingKind.FRAGMENT_KEY,
+                dictionary_id=entry.dictionary_id,
+                key=entry.key,
+                message=(
+                    f"Entry context {entry.context!r} shares a namespace with generator-family code; "
+                    "verify this is not dynamically composed upstream"
+                ),
+            )
+        )
+    return findings
+
+
+def _extract_namespace(signature: GeneratorSignature) -> str | None:
+    """Extract a namespace hint from a generator signature."""
+    if "." in signature.class_name:
+        parts = signature.class_name.split(".")
+        if len(parts) >= _MIN_SHARED_NAMESPACE_DEPTH:
+            return ".".join(parts[:-1])
+    source_hint = signature.source_file.removesuffix(".cs").replace("_", ".")
+    if "." in source_hint:
+        return ".".join(source_hint.split(".")[:-1])
+    return None
+
+
+def _context_overlaps_generator(entry_context: str | None, namespaces: set[str]) -> bool:
+    """Return whether an entry context shares a namespace prefix depth of two or more."""
+    if entry_context is None:
+        return False
+    entry_parts = _namespace_parts(entry_context)
+    return any(
+        _shared_prefix_depth(entry_parts, _namespace_parts(namespace)) >= _MIN_SHARED_NAMESPACE_DEPTH
+        for namespace in namespaces
+    )
+
+
+def _namespace_parts(value: str) -> list[str]:
+    """Split a dotted namespace string into normalized parts."""
+    return [part for part in value.split(".") if part]
+
+
+def _shared_prefix_depth(left: list[str], right: list[str]) -> int:
+    """Count how many namespace segments two inputs share from the start."""
+    depth = 0
+    for left_part, right_part in zip(left, right, strict=False):
+        if left_part != right_part:
+            break
+        depth += 1
+    return depth
+
+
+def _is_fragment_key(key: str) -> bool:
+    """Return whether a key looks like a dynamic string fragment."""
+    return bool(
+        _FRAGMENT_TRAILING_WS.search(key)
+        or _FRAGMENT_LEADING_WS.search(key)
+        or _FRAGMENT_OPEN_BRACKET.search(key)
+    )

--- a/scripts/provenance/csharp_pattern_scanner.py
+++ b/scripts/provenance/csharp_pattern_scanner.py
@@ -1,0 +1,271 @@
+"""Scan decompiled C# source files for string provenance heuristics."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from scripts.provenance.models import GeneratorSignature, StringClassification
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_GENERATOR_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(r"\bDescriptionBuilder\b[\s\S]*?(?:\.\s*)?Add\w*\s*\("),
+        "DescriptionBuilder.Add* composition",
+    ),
+    (re.compile(r"\bDescriptionBuilder\b"), "DescriptionBuilder.Add* composition"),
+    (re.compile(r"\bGetDisplayNameEvent\.[A-Za-z_][A-Za-z0-9_]*\b"), "GetDisplayNameEvent composition"),
+    (re.compile(r"\bGetDisplayNameEvent\b"), "GetDisplayNameEvent composition"),
+    (re.compile(r"\bGrammar\.(?:A|Pluralize|MakePossessive)\s*\("), "Grammar API"),
+    (re.compile(r"\bHistoricStringExpander\.[A-Za-z_][A-Za-z0-9_]*\s*\("), "HistoricStringExpander"),
+    (re.compile(r"\bHistoricStringExpander\b"), "HistoricStringExpander"),
+    (re.compile(r"\bGameText\.(?:Process|VariableReplace)\s*\("), "GameText variable replacement"),
+]
+_DYNAMIC_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\bstring\.Format\s*\("), "string.Format"),
+    (re.compile(r"\bStringBuilder\b[\s\S]*?\.Append\w*\s*\("), "StringBuilder.Append chain"),
+    (re.compile(r"\.Append\w*\s*\("), "StringBuilder.Append chain"),
+    (re.compile(r"\bstring\.Concat\s*\("), "string.Concat"),
+]
+_METHOD_SIGNATURE_PATTERN = re.compile(
+    r"^\s*(?:\[[^\]]+\]\s*)*(?:public|private|protected|internal)"
+    r"(?:\s+static|\s+virtual|\s+override|\s+sealed|\s+extern|\s+unsafe|\s+partial)*"
+    r"\s+[A-Za-z_][A-Za-z0-9_<>,\[\]?\s\.]*?\s+([A-Za-z_][A-Za-z0-9_]*)\s*\([^;]*\)",
+)
+_NAMESPACE_PATTERN = re.compile(r"^\s*namespace\s+([A-Za-z_][A-Za-z0-9_\.]*)", re.MULTILINE)
+_CLASS_PATTERN = re.compile(
+    r"^\s*(?:public|private|protected|internal)?(?:\s+static|\s+partial|\s+abstract|\s+sealed)*\s*"
+    r"(?:class|struct)\s+([A-Za-z_][A-Za-z0-9_]*)",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class _BraceScanState:
+    """State carried across lines while counting structural braces."""
+
+    in_block_comment: bool = False
+
+
+def scan_source_file(path: Path) -> list[GeneratorSignature]:
+    """Scan a decompiled C# source file for string-producing methods.
+
+    Args:
+        path: Source file to scan.
+
+    Returns:
+        Generator signatures for methods matching known heuristics.
+    """
+    if not path.exists() or not path.is_file() or path.stat().st_size == 0:
+        return []
+
+    content = path.read_text(encoding="utf-8", errors="replace")
+    qualified_class_name = _resolve_qualified_class_name(path, content)
+    signatures: list[GeneratorSignature] = []
+    for method_name, method_body, start_line in _split_into_methods(content):
+        classification, pattern_kind, evidence_line = _classify_method(
+            qualified_class_name,
+            method_name,
+            method_body,
+            start_line,
+        )
+        if classification is None:
+            continue
+        signatures.append(
+            GeneratorSignature(
+                source_file=path.name,
+                class_name=qualified_class_name,
+                method_name=method_name,
+                classification=classification,
+                pattern_kind=pattern_kind,
+                evidence_line=evidence_line,
+            )
+        )
+    return signatures
+
+
+def scan_directory(ilspy_dir: Path) -> list[GeneratorSignature]:
+    """Scan every C# file beneath a decompile directory."""
+    if not ilspy_dir.exists():
+        return []
+
+    signatures: list[GeneratorSignature] = []
+    for path in sorted(ilspy_dir.rglob("*.cs")):
+        signatures.extend(scan_source_file(path))
+    return signatures
+
+
+def _resolve_qualified_class_name(path: Path, content: str) -> str:
+    """Build a qualified class name from namespace and class declarations."""
+    namespace_match = _NAMESPACE_PATTERN.search(content)
+    class_match = _CLASS_PATTERN.search(content)
+    namespace = namespace_match.group(1) if namespace_match else None
+    class_name = class_match.group(1) if class_match else path.name.removesuffix(".cs")
+    if namespace:
+        return f"{namespace}.{class_name}"
+    return class_name
+
+
+def _split_into_methods(content: str) -> list[tuple[str, str, int]]:
+    """Split source text into ``(method_name, body, start_line)`` tuples."""
+    methods: list[tuple[str, str, int]] = []
+    lines = content.splitlines()
+    line_index = 0
+    while line_index < len(lines):
+        signature_match = _METHOD_SIGNATURE_PATTERN.search(lines[line_index])
+        if signature_match is None:
+            line_index += 1
+            continue
+
+        method_name = signature_match.group(1)
+        start_line = line_index + 1
+        body_lines = [lines[line_index]]
+        state = _BraceScanState()
+        brace_delta, state = _brace_delta(lines[line_index], state)
+        brace_depth = brace_delta
+        saw_open_brace = brace_delta > 0
+        cursor = line_index + 1
+
+        while cursor < len(lines):
+            line = lines[cursor]
+            body_lines.append(line)
+            brace_delta, state = _brace_delta(line, state)
+            brace_depth += brace_delta
+            if brace_delta > 0:
+                saw_open_brace = True
+            if saw_open_brace and brace_depth <= 0:
+                break
+            cursor += 1
+
+        if saw_open_brace and brace_depth <= 0:
+            methods.append((method_name, "\n".join(body_lines), start_line))
+            line_index = cursor + 1
+            continue
+
+        line_index += 1
+    return methods
+
+
+def _classify_method(
+    qualified_class_name: str,
+    method_name: str,
+    body: str,
+    start_line: int,
+) -> tuple[StringClassification | None, str, int]:
+    """Classify one method body and return evidence metadata."""
+    class_pattern_kind = _classify_known_generator_class(qualified_class_name, method_name)
+    if class_pattern_kind is not None:
+        return StringClassification.GENERATOR_FAMILY, class_pattern_kind, start_line
+
+    for pattern, kind in _GENERATOR_PATTERNS:
+        match = pattern.search(body)
+        if match is not None:
+            return StringClassification.GENERATOR_FAMILY, kind, _match_line(body, start_line, match.start())
+
+    for pattern, kind in _DYNAMIC_PATTERNS:
+        match = pattern.search(body)
+        if match is not None:
+            return StringClassification.STRUCTURED_DYNAMIC, kind, _match_line(body, start_line, match.start())
+
+    return None, "", 0
+
+
+def _match_line(body: str, start_line: int, offset: int) -> int:
+    """Translate a regex match offset into a 1-based source line number."""
+    return start_line + body[:offset].count("\n")
+
+
+def _classify_known_generator_class(qualified_class_name: str, method_name: str) -> str | None:
+    """Return a generator pattern label for methods on known generator classes."""
+    class_name = qualified_class_name.rsplit(".", maxsplit=1)[-1]
+    if class_name == "DescriptionBuilder" and (
+        method_name.startswith("Add") or method_name in {"TryAddTag", "ToString"}
+    ):
+        return "DescriptionBuilder.Add* composition"
+    if class_name == "GetDisplayNameEvent" and method_name in {"GetFor", "ProcessFor"}:
+        return "GetDisplayNameEvent composition"
+    if class_name == "Grammar" and method_name in {"A", "Pluralize", "MakePossessive"}:
+        return "Grammar API"
+    if class_name == "HistoricStringExpander" and method_name == "ExpandString":
+        return "HistoricStringExpander"
+    if class_name == "GameText" and method_name in {"Process", "VariableReplace"}:
+        return "GameText variable replacement"
+    return None
+
+
+def _brace_delta(line: str, state: _BraceScanState) -> tuple[int, _BraceScanState]:  # noqa: C901, PLR0912, PLR0915
+    """Count structural braces in a line while ignoring strings and comments."""
+    delta = 0
+    index = 0
+    in_string = False
+    in_char = False
+    in_verbatim_string = False
+    in_block_comment = state.in_block_comment
+
+    while index < len(line):
+        char = line[index]
+        next_char = line[index + 1] if index + 1 < len(line) else ""
+
+        if in_block_comment:
+            if char == "*" and next_char == "/":
+                in_block_comment = False
+                index += 2
+                continue
+            index += 1
+            continue
+
+        if in_verbatim_string:
+            if char == '"' and next_char == '"':
+                index += 2
+                continue
+            if char == '"':
+                in_verbatim_string = False
+            index += 1
+            continue
+
+        if in_string:
+            if char == "\\":
+                index += 2
+                continue
+            if char == '"':
+                in_string = False
+            index += 1
+            continue
+
+        if in_char:
+            if char == "\\":
+                index += 2
+                continue
+            if char == "'":
+                in_char = False
+            index += 1
+            continue
+
+        if char == "/" and next_char == "/":
+            break
+        if char == "/" and next_char == "*":
+            in_block_comment = True
+            index += 2
+            continue
+        if char == "@" and next_char == '"':
+            in_verbatim_string = True
+            index += 2
+            continue
+        if char == '"':
+            in_string = True
+            index += 1
+            continue
+        if char == "'":
+            in_char = True
+            index += 1
+            continue
+        if char == "{":
+            delta += 1
+        elif char == "}":
+            delta -= 1
+        index += 1
+
+    return delta, _BraceScanState(in_block_comment=in_block_comment)

--- a/scripts/provenance/dictionary_auditor.py
+++ b/scripts/provenance/dictionary_auditor.py
@@ -1,0 +1,198 @@
+"""Audit translation dictionaries for structural anti-patterns."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING
+
+from scripts.provenance.models import AuditFinding, AuditFindingKind, DictEntry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_FRAGMENT_TRAILING_WS = re.compile(r"\s+$")
+_FRAGMENT_LEADING_WS = re.compile(r"^\s+")
+_FRAGMENT_OPEN_BRACKET = re.compile(r"(?:\[|\()$")
+_PLACEHOLDER_PATTERN = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def load_dictionary_entries(dictionaries_dir: Path) -> list[DictEntry]:
+    """Load translation entries from every ``*.json`` dictionary file.
+
+    The loader accepts all known repository schema variants:
+
+    - ``meta`` + ``rules`` + ``entries``
+    - ``entries`` only
+    - ``entries`` + ``patterns``
+
+    The ``patterns`` collection is intentionally ignored because message-pattern
+    translation is handled elsewhere and is out of scope for provenance analysis.
+
+    Args:
+        dictionaries_dir: Directory containing dictionary JSON files.
+
+    Returns:
+        Loaded dictionary entries sorted by file name order.
+
+    Raises:
+        FileNotFoundError: If the directory does not exist.
+        ValueError: If the path is not a directory.
+    """
+    if not dictionaries_dir.exists():
+        msg = f"Dictionaries directory not found: {dictionaries_dir}"
+        raise FileNotFoundError(msg)
+    if not dictionaries_dir.is_dir():
+        msg = f"Dictionaries path is not a directory: {dictionaries_dir}"
+        raise ValueError(msg)
+
+    entries: list[DictEntry] = []
+    for path in sorted(dictionaries_dir.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        dict_id = _resolve_dictionary_id(path, data)
+        entries.extend(
+            DictEntry(
+                dictionary_id=dict_id,
+                key=str(raw_entry["key"]),
+                text=str(raw_entry.get("text", "")),
+                context=_normalize_context(raw_entry.get("context")),
+            )
+            for raw_entry in data.get("entries", [])
+        )
+    return entries
+
+
+def audit_dictionaries(dictionaries_dir: Path) -> list[AuditFinding]:
+    """Run all dictionary audit checks for a directory.
+
+    Args:
+        dictionaries_dir: Directory containing translation dictionaries.
+
+    Returns:
+        Aggregated findings from fragment, duplicate, and placeholder checks.
+    """
+    entries = load_dictionary_entries(dictionaries_dir)
+    findings: list[AuditFinding] = []
+    findings.extend(_detect_fragments(entries))
+    findings.extend(_detect_duplicates(entries))
+    findings.extend(_detect_placeholder_issues(entries))
+    return findings
+
+
+def _resolve_dictionary_id(path: Path, data: dict[str, object]) -> str:
+    """Return the effective dictionary id for one JSON file."""
+    meta = data.get("meta")
+    if isinstance(meta, dict):
+        meta_id = meta.get("id")
+        if isinstance(meta_id, str) and meta_id:
+            return meta_id
+    return path.name.removesuffix(".ja.json").removesuffix(".json")
+
+
+def _normalize_context(raw_context: object) -> str | None:
+    """Normalize an optional context value from JSON input."""
+    if raw_context is None:
+        return None
+    if isinstance(raw_context, str):
+        stripped = raw_context.strip()
+        return stripped or None
+    return str(raw_context)
+
+
+def _detect_fragments(entries: list[DictEntry]) -> list[AuditFinding]:
+    """Detect keys that look like string fragments instead of complete leaves."""
+    findings: list[AuditFinding] = []
+    for entry in entries:
+        if _FRAGMENT_TRAILING_WS.search(entry.key):
+            findings.append(
+                AuditFinding(
+                    kind=AuditFindingKind.FRAGMENT_KEY,
+                    dictionary_id=entry.dictionary_id,
+                    key=entry.key,
+                    message=f"Key has trailing whitespace and likely represents a string fragment: {entry.key!r}",
+                )
+            )
+            continue
+        if _FRAGMENT_LEADING_WS.search(entry.key):
+            findings.append(
+                AuditFinding(
+                    kind=AuditFindingKind.FRAGMENT_KEY,
+                    dictionary_id=entry.dictionary_id,
+                    key=entry.key,
+                    message=f"Key has leading whitespace and likely represents a suffix fragment: {entry.key!r}",
+                )
+            )
+            continue
+        if _FRAGMENT_OPEN_BRACKET.search(entry.key):
+            findings.append(
+                AuditFinding(
+                    kind=AuditFindingKind.FRAGMENT_KEY,
+                    dictionary_id=entry.dictionary_id,
+                    key=entry.key,
+                    message=f"Key ends with an open bracket or paren and looks truncated: {entry.key!r}",
+                )
+            )
+    return findings
+
+
+def _detect_duplicates(entries: list[DictEntry]) -> list[AuditFinding]:
+    """Detect duplicate keys across dictionaries."""
+    seen: dict[str, DictEntry] = {}
+    findings: list[AuditFinding] = []
+    for entry in entries:
+        previous = seen.get(entry.key)
+        if previous is None:
+            seen[entry.key] = entry
+            continue
+        findings.append(
+            AuditFinding(
+                kind=AuditFindingKind.DUPLICATE_KEY,
+                dictionary_id=entry.dictionary_id,
+                key=entry.key,
+                message=(
+                    f"Duplicate key already exists in dictionary {previous.dictionary_id!r}; "
+                    "verify ownership before keeping both entries"
+                ),
+                related_dictionary_id=previous.dictionary_id,
+                related_key=previous.key,
+            )
+        )
+    return findings
+
+
+def _detect_placeholder_issues(entries: list[DictEntry]) -> list[AuditFinding]:
+    """Detect placeholder mismatches and dead placeholders."""
+    findings: list[AuditFinding] = []
+    for entry in entries:
+        key_placeholders = _extract_placeholders(entry.key)
+        text_placeholders = _extract_placeholders(entry.text)
+        if key_placeholders and text_placeholders and key_placeholders != text_placeholders:
+            findings.append(
+                AuditFinding(
+                    kind=AuditFindingKind.PLACEHOLDER_MISMATCH,
+                    dictionary_id=entry.dictionary_id,
+                    key=entry.key,
+                    message=(
+                        f"Key placeholders {sorted(key_placeholders)} do not match text placeholders "
+                        f"{sorted(text_placeholders)}"
+                    ),
+                )
+            )
+            continue
+        if not key_placeholders and text_placeholders:
+            findings.append(
+                AuditFinding(
+                    kind=AuditFindingKind.DEAD_PLACEHOLDER,
+                    dictionary_id=entry.dictionary_id,
+                    key=entry.key,
+                    message=(
+                        f"Text includes unresolved placeholders {sorted(text_placeholders)} but the key has none"
+                    ),
+                )
+            )
+    return findings
+
+
+def _extract_placeholders(text: str) -> set[str]:
+    """Extract ``{name}`` placeholders from a string."""
+    return set(_PLACEHOLDER_PATTERN.findall(text))

--- a/scripts/provenance/models.py
+++ b/scripts/provenance/models.py
@@ -1,0 +1,101 @@
+"""Shared data models for provenance analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class StringClassification(StrEnum):
+    """Four-category classification for translation string provenance."""
+
+    EXACT_LEAF = "exact_leaf"
+    STRUCTURED_DYNAMIC = "structured_dynamic"
+    GENERATOR_FAMILY = "generator_family"
+    OPAQUE = "opaque"
+
+
+class AuditFindingKind(StrEnum):
+    """Kinds of issues the provenance pipeline can report."""
+
+    FRAGMENT_KEY = "fragment_key"
+    DUPLICATE_KEY = "duplicate_key"
+    PLACEHOLDER_MISMATCH = "placeholder_mismatch"
+    COPY_PASTE_ERROR = "copy_paste_error"
+    DEAD_PLACEHOLDER = "dead_placeholder"
+
+
+@dataclass(frozen=True)
+class DictEntry:
+    """A single translation dictionary entry.
+
+    Attributes:
+        dictionary_id: Stable dictionary identifier.
+        key: English lookup key.
+        text: Localized output text.
+        context: Optional source or route namespace hint.
+    """
+
+    dictionary_id: str
+    key: str
+    text: str
+    context: str | None
+
+
+@dataclass(frozen=True)
+class AuditFinding:
+    """A structured issue emitted by an audit or cross-reference pass.
+
+    Attributes:
+        kind: Category of finding.
+        dictionary_id: Dictionary that owns the finding.
+        key: Entry key associated with the finding.
+        message: Human-readable explanation.
+        related_dictionary_id: Optional secondary dictionary involved in the finding.
+        related_key: Optional secondary key involved in the finding.
+    """
+
+    kind: AuditFindingKind
+    dictionary_id: str
+    key: str
+    message: str
+    related_dictionary_id: str | None = None
+    related_key: str | None = None
+
+
+@dataclass(frozen=True)
+class GeneratorSignature:
+    """A string-producing method detected in decompiled C# source.
+
+    Attributes:
+        source_file: Decompiled source file name.
+        class_name: Fully qualified class name when available.
+        method_name: Method that matched a provenance heuristic.
+        classification: Provenance classification assigned to the method.
+        pattern_kind: Short label describing the matched heuristic.
+        evidence_line: 1-based source line of the matched evidence.
+    """
+
+    source_file: str
+    class_name: str
+    method_name: str
+    classification: StringClassification
+    pattern_kind: str
+    evidence_line: int
+
+
+@dataclass(frozen=True)
+class ProvenanceReport:
+    """Combined provenance analysis output.
+
+    Attributes:
+        audit_findings: Dictionary-auditor findings.
+        xref_findings: Cross-reference findings.
+        generator_signatures: Scanner matches catalogued from C# source.
+        findings_by_kind: Count of all findings grouped by kind value.
+    """
+
+    audit_findings: list[AuditFinding] = field(default_factory=list)
+    xref_findings: list[AuditFinding] = field(default_factory=list)
+    generator_signatures: list[GeneratorSignature] = field(default_factory=list)
+    findings_by_kind: dict[str, int] = field(default_factory=dict)

--- a/scripts/provenance/report.py
+++ b/scripts/provenance/report.py
@@ -1,0 +1,60 @@
+"""Generate structured provenance analysis reports."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import asdict
+
+from scripts.provenance.models import AuditFinding, GeneratorSignature, ProvenanceReport
+
+
+def generate_report(
+    *,
+    audit_findings: list[AuditFinding],
+    generator_signatures: list[GeneratorSignature],
+    xref_findings: list[AuditFinding],
+) -> str:
+    """Serialize provenance analysis output to JSON.
+
+    Args:
+        audit_findings: Findings from dictionary-auditor checks.
+        generator_signatures: Generator signatures catalogued from C# source.
+        xref_findings: Findings from the cross-reference pass.
+
+    Returns:
+        Pretty-printed JSON report text.
+    """
+    combined_findings = audit_findings + xref_findings
+    report = ProvenanceReport(
+        audit_findings=audit_findings,
+        xref_findings=xref_findings,
+        generator_signatures=generator_signatures,
+        findings_by_kind=dict(Counter(finding.kind.value for finding in combined_findings)),
+    )
+    payload = {
+        "summary": {
+            "total_audit_findings": len(report.audit_findings),
+            "total_xref_findings": len(report.xref_findings),
+            "total_generators": len(report.generator_signatures),
+            "findings_by_kind": report.findings_by_kind,
+        },
+        "audit_findings": [_serialize_finding(finding) for finding in report.audit_findings],
+        "xref_findings": [_serialize_finding(finding) for finding in report.xref_findings],
+        "generator_catalog": [_serialize_signature(signature) for signature in report.generator_signatures],
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def _serialize_finding(finding: AuditFinding) -> dict[str, object]:
+    """Convert an audit finding to a JSON-serializable dictionary."""
+    data = asdict(finding)
+    data["kind"] = finding.kind.value
+    return data
+
+
+def _serialize_signature(signature: GeneratorSignature) -> dict[str, object]:
+    """Convert a generator signature to a JSON-serializable dictionary."""
+    data = asdict(signature)
+    data["classification"] = signature.classification.value
+    return data

--- a/scripts/tests/test_analyze_provenance.py
+++ b/scripts/tests/test_analyze_provenance.py
@@ -1,0 +1,76 @@
+"""Tests for the provenance analysis CLI."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.analyze_provenance import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_dict(path: Path, dict_id: str, entries: list[dict[str, object]]) -> None:
+    """Write a minimal test dictionary file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "meta": {"id": dict_id, "lang": "ja", "version": "0.1.0"},
+        "rules": {"protectColorTags": True, "protectHtmlEntities": True},
+        "entries": entries,
+    }
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _write_cs(path: Path, content: str) -> None:
+    """Write a minimal C# file for CLI tests."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_cli_runs_and_produces_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI writes a JSON report file and reports the output path on stderr."""
+    dict_dir = tmp_path / "Dictionaries"
+    ilspy_dir = tmp_path / "ilspy-raw"
+    _write_dict(
+        dict_dir / "test.ja.json",
+        "test",
+        [{"key": "You stagger ", "text": "よろめかせた："}],  # noqa: RUF001
+    )
+    _write_cs(
+        ilspy_dir / "XRL_World_MyPart.cs",
+        """\
+namespace XRL.World
+{
+    public class MyPart
+    {
+        public string Build(string name)
+        {
+            return string.Concat(name, "!");
+        }
+    }
+}
+""",
+    )
+    out_path = tmp_path / "report.json"
+
+    result = main(["--dictionaries", str(dict_dir), "--ilspy-raw", str(ilspy_dir), "--output", str(out_path)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert out_path.exists()
+    assert "Report written to" in captured.err
+    data = json.loads(out_path.read_text(encoding="utf-8"))
+    assert data["summary"]["total_audit_findings"] >= 1
+    assert data["summary"]["total_generators"] >= 1
+
+
+def test_cli_help_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    """Argparse help exits successfully."""
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--help"])
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 0
+    assert "Analyze translation dictionary entries" in captured.out

--- a/scripts/tests/test_cross_reference.py
+++ b/scripts/tests/test_cross_reference.py
@@ -1,0 +1,74 @@
+"""Tests for provenance cross-reference logic."""
+
+from __future__ import annotations
+
+from scripts.provenance.cross_reference import cross_reference
+from scripts.provenance.models import DictEntry, GeneratorSignature, StringClassification
+
+
+def _sidebar_sig() -> GeneratorSignature:
+    """Return a structured-dynamic signature that should not drive generator overlap."""
+    return GeneratorSignature(
+        source_file="XRL_UI_Sidebar.cs",
+        class_name="XRL.UI.Sidebar",
+        method_name="FormatHP",
+        classification=StringClassification.STRUCTURED_DYNAMIC,
+        pattern_kind="string.Format",
+        evidence_line=42,
+    )
+
+
+def _description_builder_sig() -> GeneratorSignature:
+    """Return a generator-family signature rooted in XRL.World."""
+    return GeneratorSignature(
+        source_file="XRL_World_DescriptionBuilder.cs",
+        class_name="XRL.World.DescriptionBuilder",
+        method_name="ToString",
+        classification=StringClassification.GENERATOR_FAMILY,
+        pattern_kind="DescriptionBuilder.Add* composition",
+        evidence_line=331,
+    )
+
+
+def test_flag_entry_matching_known_context() -> None:
+    """Namespace overlap at shared depth two or greater is flagged."""
+    entries = [
+        DictEntry(
+            dictionary_id="world-parts",
+            key="Electrified: When powered, this weapon deals",
+            text="通電：起動中、この武器は",  # noqa: RUF001
+            context="XRL.World.Parts.Combat",
+        )
+    ]
+    findings = cross_reference(entries, [_description_builder_sig()])
+    assert len(findings) == 1
+    assert "generator-family code" in findings[0].message
+
+
+def test_exact_leaf_not_flagged() -> None:
+    """Entries without context overlap are ignored."""
+    entries = [
+        DictEntry(
+            dictionary_id="ui-default",
+            key="Inventory",
+            text="インベントリ",
+            context=None,
+        )
+    ]
+    findings = cross_reference(entries, [_sidebar_sig()])
+    assert findings == []
+
+
+def test_fragment_entry_near_dynamic_source_flagged() -> None:
+    """Fragment keys plus generator overlap create a high-confidence finding."""
+    entries = [
+        DictEntry(
+            dictionary_id="msg",
+            key="You stagger ",
+            text="よろめかせた：",  # noqa: RUF001
+            context="XRL.World.Parts.Combat",
+        )
+    ]
+    findings = cross_reference(entries, [_sidebar_sig(), _description_builder_sig()])
+    assert len(findings) == 1
+    assert "prefer a template or patch route" in findings[0].message

--- a/scripts/tests/test_csharp_pattern_scanner.py
+++ b/scripts/tests/test_csharp_pattern_scanner.py
@@ -1,0 +1,223 @@
+"""Tests for the C# provenance pattern scanner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.provenance.csharp_pattern_scanner import scan_directory, scan_source_file
+from scripts.provenance.models import StringClassification
+
+_EXACT_LEAF_SOURCE = """\
+using System;
+
+namespace Qud.UI
+{
+    public static class Labels
+    {
+        public static string Title => \"Inventory\";
+        public static string Subtitle => \"Equipment\";
+    }
+}
+"""
+
+_STRUCTURED_DYNAMIC_SOURCE = """\
+using System;
+using System.Text;
+
+namespace Qud.UI
+{
+    public class Sidebar
+    {
+        public string FormatHP(int current, int max)
+        {
+            return string.Format(\"HP: {0}/{1}\", current, max);
+        }
+
+        public string BuildLine(string label, int value)
+        {
+            var sb = new StringBuilder();
+            sb.Append(label);
+            sb.Append(": ");
+            sb.Append(value);
+            return sb.ToString();
+        }
+
+        public string JoinPieces(string left, string right)
+        {
+            return string.Concat(left, right);
+        }
+    }
+}
+"""
+
+_GENERATOR_FAMILY_SOURCE = """\
+using System;
+
+namespace XRL.World
+{
+    public class MyPart
+    {
+        public void Describe(DescriptionBuilder DB)
+        {
+            DB.AddAdjective(\"rusty\");
+            DB.AddBase(\"sword\");
+            DB.AddClause(\"of power\");
+        }
+
+        public string GetName(GetDisplayNameEvent E)
+        {
+            E.DB.AddTag(\"[equipped]\");
+            return E.DB.ToString();
+        }
+
+        public string BuildArticle(string noun)
+        {
+            return Grammar.A(noun);
+        }
+
+        public string ExpandHistoric(string template)
+        {
+            return HistoricStringExpander.ExpandString(template);
+        }
+
+        public string ReplaceText(string text)
+        {
+            return GameText.VariableReplace(GameText.Process(text));
+        }
+    }
+}
+"""
+
+_ILSPY_RAW_DIR = Path(__file__).resolve().parents[2] / "docs" / "ilspy-raw"
+
+
+def _write_cs(path: Path, content: str) -> None:
+    """Write a synthetic C# source file for scanner tests."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_scan_exact_leaf(tmp_path: Path) -> None:
+    """Literal-only source produces no dynamic signatures."""
+    path = tmp_path / "Qud_UI_Labels.cs"
+    _write_cs(path, _EXACT_LEAF_SOURCE)
+    assert scan_source_file(path) == []
+
+
+def test_scan_structured_dynamic(tmp_path: Path) -> None:
+    """StringBuilder, string.Format, and string.Concat are detected."""
+    path = tmp_path / "Qud_UI_Sidebar.cs"
+    _write_cs(path, _STRUCTURED_DYNAMIC_SOURCE)
+    signatures = scan_source_file(path)
+    dynamic_signatures = [
+        signature for signature in signatures if signature.classification == StringClassification.STRUCTURED_DYNAMIC
+    ]
+    assert len(dynamic_signatures) == 3
+    assert {signature.method_name for signature in dynamic_signatures} == {"FormatHP", "BuildLine", "JoinPieces"}
+
+
+def test_scan_generator_family(tmp_path: Path) -> None:
+    """Known generator-family APIs are classified at highest priority."""
+    path = tmp_path / "XRL_World_MyPart.cs"
+    _write_cs(path, _GENERATOR_FAMILY_SOURCE)
+    signatures = scan_source_file(path)
+    generator_signatures = [
+        signature for signature in signatures if signature.classification == StringClassification.GENERATOR_FAMILY
+    ]
+    assert len(generator_signatures) == 5
+    assert any("DescriptionBuilder" in signature.pattern_kind for signature in generator_signatures)
+    assert {signature.method_name for signature in generator_signatures} == {
+        "Describe",
+        "GetName",
+        "BuildArticle",
+        "ExpandHistoric",
+        "ReplaceText",
+    }
+
+
+def test_scan_unrelated_add_method_not_generator(tmp_path: Path) -> None:
+    """Arbitrary Add calls do not get mislabeled as DescriptionBuilder generators."""
+    path = tmp_path / "Qud_UI_CustomList.cs"
+    _write_cs(
+        path,
+        """\
+using System.Collections.Generic;
+
+namespace Qud.UI
+{
+    public class CustomList
+    {
+        public void AddName(List<string> items, string name)
+        {
+            items.Add(name);
+        }
+    }
+}
+""",
+    )
+    signatures = scan_source_file(path)
+    assert not any(signature.classification == StringClassification.GENERATOR_FAMILY for signature in signatures)
+
+
+def test_scan_ignores_braces_inside_strings_when_splitting_methods(tmp_path: Path) -> None:
+    """Method splitting ignores literal braces so later methods still scan correctly."""
+    path = tmp_path / "Qud_UI_MarkupBuilder.cs"
+    _write_cs(
+        path,
+        """\
+namespace Qud.UI
+{
+    public class MarkupBuilder
+    {
+        public string PrefixOnly()
+        {
+            return "{{";
+        }
+
+        public string FormatHP(int current, int max)
+        {
+            return string.Format("HP: {0}/{1}", current, max);
+        }
+    }
+}
+""",
+    )
+    signatures = scan_source_file(path)
+    dynamic_methods = [
+        signature.method_name
+        for signature in signatures
+        if signature.classification == StringClassification.STRUCTURED_DYNAMIC
+    ]
+    assert "FormatHP" in dynamic_methods
+
+
+@pytest.mark.skipif(not _ILSPY_RAW_DIR.exists(), reason="ilspy-raw not available")
+def test_scan_description_builder_real() -> None:
+    """DescriptionBuilder decompile yields at least one generator-family signature."""
+    path = _ILSPY_RAW_DIR / "XRL_World_DescriptionBuilder.cs"
+    if not path.exists():
+        pytest.skip("DescriptionBuilder decompile not available")
+    signatures = scan_source_file(path)
+    assert any(signature.classification == StringClassification.GENERATOR_FAMILY for signature in signatures)
+
+
+@pytest.mark.skipif(not _ILSPY_RAW_DIR.exists(), reason="ilspy-raw not available")
+def test_scan_sidebar_real() -> None:
+    """Sidebar decompile yields at least one structured-dynamic signature."""
+    path = _ILSPY_RAW_DIR / "XRL_UI_Sidebar.cs"
+    if not path.exists():
+        pytest.skip("Sidebar decompile not available")
+    signatures = scan_source_file(path)
+    assert any(signature.classification == StringClassification.STRUCTURED_DYNAMIC for signature in signatures)
+
+
+@pytest.mark.skipif(not _ILSPY_RAW_DIR.exists(), reason="ilspy-raw not available")
+def test_scan_full_directory() -> None:
+    """Full-directory scan returns a non-trivial signature catalog."""
+    signatures = scan_directory(_ILSPY_RAW_DIR)
+    assert len(signatures) >= 10
+    classifications = {signature.classification for signature in signatures}
+    assert StringClassification.GENERATOR_FAMILY in classifications
+    assert StringClassification.STRUCTURED_DYNAMIC in classifications

--- a/scripts/tests/test_dictionary_auditor.py
+++ b/scripts/tests/test_dictionary_auditor.py
@@ -1,0 +1,161 @@
+"""Tests for dictionary provenance auditing."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from scripts.provenance.dictionary_auditor import audit_dictionaries, load_dictionary_entries
+from scripts.provenance.models import AuditFindingKind
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_dict(
+    path: Path,
+    entries: list[dict[str, object]],
+    *,
+    dict_id: str | None = None,
+    include_meta: bool = True,
+    include_rules: bool = True,
+    patterns: list[dict[str, object]] | None = None,
+) -> None:
+    """Write a test dictionary JSON file with configurable schema variants."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data: dict[str, object] = {"entries": entries}
+    if include_meta:
+        data["meta"] = {"id": dict_id or path.name.removesuffix(".ja.json"), "lang": "ja", "version": "0.1.0"}
+    if include_rules:
+        data["rules"] = {"protectColorTags": True, "protectHtmlEntities": True}
+    if patterns is not None:
+        data["patterns"] = patterns
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def test_load_dictionary_entries(tmp_path: Path) -> None:
+    """Loader reads standard dictionaries with metadata."""
+    _write_dict(tmp_path / "test.ja.json", [{"key": "Inventory", "text": "インベントリ"}], dict_id="test")
+    entries = load_dictionary_entries(tmp_path)
+    assert len(entries) == 1
+    assert entries[0].dictionary_id == "test"
+    assert entries[0].key == "Inventory"
+
+
+def test_load_dictionary_entries_without_meta_uses_filename(tmp_path: Path) -> None:
+    """Entries-only dictionaries derive their id from the file name."""
+    _write_dict(
+        tmp_path / "ui-death.ja.json",
+        [{"key": "Dead", "text": "死亡"}],
+        include_meta=False,
+        include_rules=False,
+    )
+    entries = load_dictionary_entries(tmp_path)
+    assert entries[0].dictionary_id == "ui-death"
+
+
+def test_load_dictionary_entries_ignores_patterns_variant(tmp_path: Path) -> None:
+    """Patterns are ignored because provenance analysis only audits explicit entries."""
+    _write_dict(
+        tmp_path / "messages.ja.json",
+        [],
+        include_meta=False,
+        include_rules=False,
+        patterns=[{"pattern": "^You hit (.+)$", "template": "{0}に命中した"}],
+    )
+    assert load_dictionary_entries(tmp_path) == []
+
+
+def test_detect_trailing_whitespace_fragment(tmp_path: Path) -> None:
+    """Keys with trailing whitespace are flagged as fragments."""
+    _write_dict(
+        tmp_path / "msg.ja.json",
+        [{"key": "You stagger ", "text": "よろめかせた："}],  # noqa: RUF001
+        dict_id="msg",
+    )
+    findings = audit_dictionaries(tmp_path)
+    fragment_findings = [finding for finding in findings if finding.kind == AuditFindingKind.FRAGMENT_KEY]
+    assert len(fragment_findings) == 1
+    assert "trailing whitespace" in fragment_findings[0].message.lower()
+
+
+def test_detect_leading_whitespace_fragment(tmp_path: Path) -> None:
+    """Keys with leading whitespace are flagged as suffix fragments."""
+    _write_dict(
+        tmp_path / "msg.ja.json",
+        [{"key": " with your shield block!", "text": "（盾ブロック）"}],  # noqa: RUF001
+        dict_id="msg",
+    )
+    findings = audit_dictionaries(tmp_path)
+    fragment_findings = [finding for finding in findings if finding.kind == AuditFindingKind.FRAGMENT_KEY]
+    assert len(fragment_findings) == 1
+    assert "leading whitespace" in fragment_findings[0].message.lower()
+
+
+def test_detect_incomplete_bracket_fragment(tmp_path: Path) -> None:
+    """Keys ending with an unmatched bracket are treated as fragments."""
+    _write_dict(
+        tmp_path / "msg.ja.json",
+        [{"key": "You fail to deal damage with your attack! [", "text": "攻撃はダメージを与えられなかった！["}],  # noqa: RUF001
+        dict_id="msg",
+    )
+    findings = audit_dictionaries(tmp_path)
+    fragment_findings = [finding for finding in findings if finding.kind == AuditFindingKind.FRAGMENT_KEY]
+    assert len(fragment_findings) == 1
+
+
+def test_normal_entry_no_fragment_finding(tmp_path: Path) -> None:
+    """Complete labels are not flagged as fragments."""
+    _write_dict(tmp_path / "ui.ja.json", [{"key": "Inventory", "text": "インベントリ"}], dict_id="ui")
+    findings = audit_dictionaries(tmp_path)
+    fragment_findings = [finding for finding in findings if finding.kind == AuditFindingKind.FRAGMENT_KEY]
+    assert fragment_findings == []
+
+
+def test_detect_duplicate_key_across_dictionaries(tmp_path: Path) -> None:
+    """Duplicate keys across files produce a finding with related dictionary metadata."""
+    shared_entry = {"key": "You stagger {target} with your shield block!", "text": "翻訳A"}
+    _write_dict(tmp_path / "a.ja.json", [shared_entry], dict_id="a")
+    _write_dict(tmp_path / "b.ja.json", [{**shared_entry, "text": "翻訳B"}], dict_id="b")
+    findings = audit_dictionaries(tmp_path)
+    duplicate_findings = [finding for finding in findings if finding.kind == AuditFindingKind.DUPLICATE_KEY]
+    assert len(duplicate_findings) == 1
+    assert duplicate_findings[0].related_dictionary_id == "a"
+
+
+def test_detect_placeholder_mismatch(tmp_path: Path) -> None:
+    """Different placeholder sets between key and text are flagged."""
+    _write_dict(
+        tmp_path / "msg.ja.json",
+        [{"key": "You pass by {target}.", "text": "{targets}のそばを通り過ぎた。"}],
+        dict_id="msg",
+    )
+    findings = audit_dictionaries(tmp_path)
+    placeholder_findings = [finding for finding in findings if finding.kind == AuditFindingKind.PLACEHOLDER_MISMATCH]
+    assert len(placeholder_findings) == 1
+
+
+def test_matching_placeholders_no_finding(tmp_path: Path) -> None:
+    """Matching placeholder sets are accepted."""
+    _write_dict(
+        tmp_path / "msg.ja.json",
+        [{"key": "You pass by {targets}.", "text": "{targets}のそばを通り過ぎた。"}],
+        dict_id="msg",
+    )
+    findings = audit_dictionaries(tmp_path)
+    placeholder_findings = [finding for finding in findings if finding.kind == AuditFindingKind.PLACEHOLDER_MISMATCH]
+    assert placeholder_findings == []
+
+
+def test_dead_placeholder_in_text(tmp_path: Path) -> None:
+    """Text-only placeholders are reported without fragment false positives."""
+    _write_dict(
+        tmp_path / "msg.ja.json",
+        [{"key": "You hit", "text": "{target}に命中した。"}],
+        dict_id="msg",
+    )
+    findings = audit_dictionaries(tmp_path)
+    dead_findings = [finding for finding in findings if finding.kind == AuditFindingKind.DEAD_PLACEHOLDER]
+    fragment_findings = [finding for finding in findings if finding.kind == AuditFindingKind.FRAGMENT_KEY]
+    assert len(dead_findings) == 1
+    assert fragment_findings == []

--- a/scripts/tests/test_provenance_integration.py
+++ b/scripts/tests/test_provenance_integration.py
@@ -1,0 +1,84 @@
+"""Integration tests for the provenance analysis pipeline."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.analyze_provenance import main
+from scripts.provenance.dictionary_auditor import audit_dictionaries
+from scripts.provenance.models import AuditFindingKind
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_DICT_DIR = _PROJECT_ROOT / "Mods" / "QudJP" / "Localization" / "Dictionaries"
+_ILSPY_DIR = _PROJECT_ROOT / "docs" / "ilspy-raw"
+
+
+def test_full_pipeline_with_synthetic_inputs(tmp_path: Path) -> None:
+    """End-to-end pipeline works on isolated synthetic inputs."""
+    dict_dir = tmp_path / "Dictionaries"
+    ilspy_dir = tmp_path / "ilspy-raw"
+    dict_dir.mkdir()
+    ilspy_dir.mkdir()
+    (dict_dir / "msg.ja.json").write_text(
+        json.dumps(
+            {
+                "meta": {"id": "msg", "lang": "ja", "version": "0.1.0"},
+                "rules": {"protectColorTags": True, "protectHtmlEntities": True},
+                "entries": [
+                    {"key": "You stagger ", "text": "よろめかせた：", "context": "XRL.World.Parts.Combat"},  # noqa: RUF001
+                    {"key": "You hit", "text": "{target}に命中した。"},
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (ilspy_dir / "XRL_World_MyPart.cs").write_text(
+        """
+namespace XRL.World
+{
+    public class MyPart
+    {
+        public void Describe(DescriptionBuilder DB)
+        {
+            DB.AddBase("sword");
+        }
+    }
+}
+""",
+        encoding="utf-8",
+    )
+
+    out_path = tmp_path / "report.json"
+    result = main(["--dictionaries", str(dict_dir), "--ilspy-raw", str(ilspy_dir), "--output", str(out_path)])
+    data = json.loads(out_path.read_text(encoding="utf-8"))
+
+    assert result == 0
+    assert data["summary"]["total_audit_findings"] >= 2
+    assert data["summary"]["total_xref_findings"] >= 1
+    assert data["summary"]["total_generators"] >= 1
+
+
+@pytest.mark.skipif(not _DICT_DIR.exists(), reason="Dictionaries not available")
+def test_real_dictionary_audit_runs() -> None:
+    """Real repository dictionaries can be audited successfully."""
+    findings = audit_dictionaries(_DICT_DIR)
+    assert isinstance(findings, list)
+    assert all(finding.kind in AuditFindingKind for finding in findings)
+
+
+@pytest.mark.skipif(
+    not (_DICT_DIR.exists() and _ILSPY_DIR.exists()),
+    reason="Real provenance inputs not fully available",
+)
+def test_full_pipeline_real_inputs(tmp_path: Path) -> None:
+    """Real repository data can run through the CLI when ilspy-raw is present."""
+    out_path = tmp_path / "real-report.json"
+    result = main(["--dictionaries", str(_DICT_DIR), "--ilspy-raw", str(_ILSPY_DIR), "--output", str(out_path)])
+    assert result == 0
+    data = json.loads(out_path.read_text(encoding="utf-8"))
+    assert data["summary"]["total_generators"] >= 1

--- a/scripts/tests/test_provenance_models.py
+++ b/scripts/tests/test_provenance_models.py
@@ -1,0 +1,74 @@
+"""Tests for provenance data models."""
+
+from __future__ import annotations
+
+from scripts.provenance.models import (
+    AuditFinding,
+    AuditFindingKind,
+    DictEntry,
+    GeneratorSignature,
+    ProvenanceReport,
+    StringClassification,
+)
+
+
+def test_string_classification_values() -> None:
+    """Enum values match the public JSON contract."""
+    assert StringClassification.EXACT_LEAF.value == "exact_leaf"
+    assert StringClassification.STRUCTURED_DYNAMIC.value == "structured_dynamic"
+    assert StringClassification.GENERATOR_FAMILY.value == "generator_family"
+    assert StringClassification.OPAQUE.value == "opaque"
+
+
+def test_dict_entry_creation() -> None:
+    """DictEntry stores required fields."""
+    entry = DictEntry(
+        dictionary_id="ui-default",
+        key="Inventory",
+        text="インベントリ",
+        context=None,
+    )
+    assert entry.dictionary_id == "ui-default"
+    assert entry.context is None
+
+
+def test_dict_entry_with_context() -> None:
+    """DictEntry preserves optional context values."""
+    entry = DictEntry(
+        dictionary_id="ui-messagelog-world",
+        key="You stagger {target} with your shield block!",
+        text="{target}を盾受けでよろめかせた！",  # noqa: RUF001
+        context="XRL.Messages.MessageQueue",
+    )
+    assert entry.context == "XRL.Messages.MessageQueue"
+
+
+def test_audit_finding_creation() -> None:
+    """AuditFinding stores its kind and related metadata."""
+    finding = AuditFinding(
+        kind=AuditFindingKind.FRAGMENT_KEY,
+        dictionary_id="ui-messagelog",
+        key="You stagger ",
+        message="Key has trailing whitespace, likely a string concatenation fragment",
+    )
+    assert finding.kind == AuditFindingKind.FRAGMENT_KEY
+
+
+def test_generator_signature_creation() -> None:
+    """Generator signatures record scanner evidence."""
+    signature = GeneratorSignature(
+        source_file="XRL_World_DescriptionBuilder.cs",
+        class_name="XRL.World.DescriptionBuilder",
+        method_name="ToString",
+        classification=StringClassification.GENERATOR_FAMILY,
+        pattern_kind="DescriptionBuilder.Add* composition",
+        evidence_line=331,
+    )
+    assert signature.classification == StringClassification.GENERATOR_FAMILY
+
+
+def test_provenance_report_defaults() -> None:
+    """ProvenanceReport starts with empty collections by default."""
+    report = ProvenanceReport()
+    assert report.audit_findings == []
+    assert report.findings_by_kind == {}

--- a/scripts/tests/test_report.py
+++ b/scripts/tests/test_report.py
@@ -1,0 +1,53 @@
+"""Tests for provenance report generation."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.provenance.models import (
+    AuditFinding,
+    AuditFindingKind,
+    GeneratorSignature,
+    StringClassification,
+)
+from scripts.provenance.report import generate_report
+
+
+def test_generate_report_json_structure() -> None:
+    """Report JSON exposes the expected top-level sections and counts."""
+    findings = [
+        AuditFinding(
+            kind=AuditFindingKind.FRAGMENT_KEY,
+            dictionary_id="msg",
+            key="You stagger ",
+            message="trailing whitespace",
+        )
+    ]
+    signatures = [
+        GeneratorSignature(
+            source_file="XRL_World_DescriptionBuilder.cs",
+            class_name="XRL.World.DescriptionBuilder",
+            method_name="ToString",
+            classification=StringClassification.GENERATOR_FAMILY,
+            pattern_kind="DescriptionBuilder.Add* composition",
+            evidence_line=331,
+        )
+    ]
+    report = generate_report(audit_findings=findings, generator_signatures=signatures, xref_findings=[])
+    data = json.loads(report)
+    assert set(data) == {"summary", "audit_findings", "xref_findings", "generator_catalog"}
+    assert data["summary"]["total_audit_findings"] == 1
+    assert data["summary"]["total_generators"] == 1
+
+
+def test_generate_report_summary_by_kind() -> None:
+    """Summary counts findings by enum value."""
+    findings = [
+        AuditFinding(kind=AuditFindingKind.FRAGMENT_KEY, dictionary_id="a", key="k1", message="m1"),
+        AuditFinding(kind=AuditFindingKind.FRAGMENT_KEY, dictionary_id="b", key="k2", message="m2"),
+        AuditFinding(kind=AuditFindingKind.DUPLICATE_KEY, dictionary_id="c", key="k3", message="m3"),
+    ]
+    report = generate_report(audit_findings=findings, generator_signatures=[], xref_findings=[])
+    data = json.loads(report)
+    assert data["summary"]["findings_by_kind"]["fragment_key"] == 2
+    assert data["summary"]["findings_by_kind"]["duplicate_key"] == 1


### PR DESCRIPTION
## Summary
- add a provenance analyzer CLI and supporting scripts/provenance pipeline
- audit dictionary schema variants, scan ilspy-raw C# composition patterns, and cross-reference likely generator-family entries
- add provenance guidance to both scripts and assemblies AGENTS docs

## Validation
- `pytest scripts/tests/test_provenance_models.py scripts/tests/test_dictionary_auditor.py scripts/tests/test_csharp_pattern_scanner.py scripts/tests/test_cross_reference.py scripts/tests/test_report.py scripts/tests/test_analyze_provenance.py scripts/tests/test_provenance_integration.py -q`
- `pytest scripts/tests/ -q`
- `ruff check scripts/`
- `python3 scripts/analyze_provenance.py --output /tmp/provenance-report.json`

## Notes
- local shell did not provide a `python3.12` binary, so direct CLI smoke validation used the available `python3` (3.14.3), which still satisfies the repo's Python 3.12+ baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 翻訳辞書エントリのプロビナンス分析ツールを追加しました。
  * 新しいCLIコマンド `python3.12 -m scripts.analyze_provenance` で、辞書エントリの動的生成源を検証できます。
  * 重複キーやプレースホルダーの不一致など、辞書の品質問題を自動検出します。

* **Documentation**
  * 辞書追加前のプロビナンスチェック手順をドキュメントに追加しました。

* **Tests**
  * プロビナンス分析機能の包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->