### PR TITLE
#85 Phase 4a: journal accomplishment patterns + emit-message design

### DIFF
--- a/Mods/QudJP/Localization/Dictionaries/journal-patterns.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/journal-patterns.ja.json
@@ -120,6 +120,136 @@
       "pattern": "^A \"SATED\" baetyl$",
       "template": "「満足した」ベテル",
       "route": "journal"
+    },
+    {
+      "pattern": "^You crossed into the Thin World, rarefied, and stood before the gate to (.+?)\\.$",
+      "template": "希薄な薄界へ足を踏み入れ、{t0}への門前に立った。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You have received a new quest, (.+?)(!+)$",
+      "template": "新しいクエストを受けた: {0}{1}",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You slew (.+?) and encoded their psyche's psionic bits on the holographic boundary of your own psyche\\.$",
+      "template": "{0}を倒し、その精神のサイオニック・ビットを自らの精神のホログラフィック境界面に刻み付けた。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You slew (.+?) and watched their psyche radiate into nothingness\\.$",
+      "template": "{0}を倒し、その精神が虚無へ放射されるのを見届けた。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You slew your bonded kith (.+?), violating the covenant of the water ritual and earning the emnity of all\\.$",
+      "template": "水の儀式で結ばれた同胞{0}を殺し、その誓約を破って全ての者の敵意を買った。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You slew (.+?)\\.$",
+      "template": "{0}を倒した。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You read (.+?)\\.$",
+      "template": "{0}を読んだ。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You invented a mouthwatering dish called \\{\\{\\|(.+?)\\}\\}\\.$",
+      "template": "垂涎の料理「{{{{|{0}}}}}」を発明した。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You imbued (.+?) with life\\. Why\\?$",
+      "template": "{0}に命を吹き込んだ。なぜ？",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You convinced (.+?) to join your cause\\.$",
+      "template": "{0}を説得し仲間に加えた。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You rebuked (.+?) into submission\\.$",
+      "template": "{0}を叱責して従わせた。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^Your heart sang at the sight of (.+?)\\.$",
+      "template": "{0}を見て心が歌った。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^Your mind was stranded inside (.+?)\\.$",
+      "template": "あなたの精神は{0}の中に閉じ込められた。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You contracted (.+?) on your (.+?), endearing (.+?) to (.+?)\\.$",
+      "template": "{1}に{0}を罹患し、{2}に対する{3}の好感を得た。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You woke from a long, convincing dream and returned to your life as the (.+?) (.+?)\\.$",
+      "template": "長く信じ込むような夢から目覚め、{0}の{1}としての日常に戻った。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You named (.+?) '(.+?)'\\.$",
+      "template": "{0}に「{1}」と名付けた。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^Your larva gestated and you gained the (.+?) mutation\\.$",
+      "template": "あなたの幼虫が成長し、{0}の変異を獲得した。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^Your genome destabilized and you gained the (.+?) (.+?)\\.$",
+      "template": "あなたのゲノムが不安定になり、{0}の{1}を得た。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You discovered (.+?)\\.$",
+      "template": "{0}を発見した。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You traveled to (.+?)\\.$",
+      "template": "{t0}に旅した。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You located (.+?)\\.$",
+      "template": "{0}を発見した。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You recovered (.+?)\\.$",
+      "template": "{0}を回収した。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You ate (.+?)\\.$",
+      "template": "{0}を食べた。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You witnessed the rare formation of (.+?)\\.$",
+      "template": "珍しい{0}の形成を目撃した。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You installed (?:a |some )cybernetic (.+?) and committed (.+?) to (.+?)\\.$",
+      "template": "サイバネティック{0}を装着し、{1}を{2}に捧げた。",
+      "route": "journal"
+    },
+    {
+      "pattern": "^You started calling (.+?) '(.+?)'\\.$",
+      "template": "{0}を「{1}」と呼ぶことにした。",
+      "route": "journal"
     }
   ]
 }

--- a/Mods/QudJP/Localization/Dictionaries/messages.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/messages.ja.json
@@ -777,16 +777,6 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^You crossed into the Thin World, rarefied, and stood before the gate to (.+?)\\.$",
-      "template": "希薄な薄界へ足を踏み入れ、{t0}への門前に立った。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You have received a new quest, (.+?)(!+)$",
-      "template": "新しいクエストを受けた: {0}{1}",
-      "route": "emit-message"
-    },
-    {
       "pattern": "^You harvest ((?:two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|\\d+)) (.+?) from (?:the |a |an )?(.+?)[.!]?$",
       "template": "{2}から{0}個の{1}を収穫した",
       "route": "emit-message"
@@ -992,64 +982,9 @@
       "route": "unclassified"
     },
     {
-      "pattern": "^You slew (.+?) and encoded their psyche's psionic bits on the holographic boundary of your own psyche\\.$",
-      "template": "{0}を倒し、その精神のサイオニック・ビットを自らの精神のホログラフィック境界面に刻み付けた。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You slew (.+?) and watched their psyche radiate into nothingness\\.$",
-      "template": "{0}を倒し、その精神が虚無へ放射されるのを見届けた。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You slew your bonded kith (.+?), violating the covenant of the water ritual and earning the emnity of all\\.$",
-      "template": "水の儀式で結ばれた同胞{0}を殺し、その誓約を破って全ての者の敵意を買った。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You slew (.+?)\\.$",
-      "template": "{0}を倒した。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You read (.+?)\\.$",
-      "template": "{0}を読んだ。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You invented a mouthwatering dish called \\{\\{\\|(.+?)\\}\\}\\.$",
-      "template": "垂涎の料理「{{{{|{0}}}}}」を発明した。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You imbued (.+?) with life\\. Why\\?$",
-      "template": "{0}に命を吹き込んだ。なぜ？",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You convinced (.+?) to join your cause\\.$",
-      "template": "{0}を説得し仲間に加えた。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You rebuked (.+?) into submission\\.$",
-      "template": "{0}を叱責して従わせた。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^Your heart sang at the sight of (.+?)\\.$",
-      "template": "{0}を見て心が歌った。",
-      "route": "emit-message"
-    },
-    {
       "pattern": "^Though your affection for (.+?) endowed you with a certain wisdom, you no longer feel the tug on your heartstrings\\.$",
       "template": "{0}への愛情がある種の知恵を授けてくれたが、もう心の琴線が揺れることはない。",
       "route": "unclassified"
-    },
-    {
-      "pattern": "^Your mind was stranded inside (.+?)\\.$",
-      "template": "あなたの精神は{0}の中に閉じ込められた。",
-      "route": "emit-message"
     },
     {
       "pattern": "^Your (.+?) (?:was|were) dismembered\\.$",
@@ -1072,79 +1007,14 @@
       "route": "unclassified"
     },
     {
-      "pattern": "^You contracted (.+?) on your (.+?), endearing (.+?) to (.+?)\\.$",
-      "template": "{1}に{0}を罹患し、{2}に対する{3}の好感を得た。",
-      "route": "emit-message"
-    },
-    {
       "pattern": "^(.+?) ogled you lovingly after you employed your charm\\.$",
       "template": "あなたの魅了術を受けて{0}がうっとりとこちらを見つめた。",
       "route": "unclassified"
     },
     {
-      "pattern": "^You woke from a long, convincing dream and returned to your life as the (.+?) (.+?)\\.$",
-      "template": "長く信じ込むような夢から目覚め、{0}の{1}としての日常に戻った。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You named (.+?) '(.+?)'\\.$",
-      "template": "{0}に「{1}」と名付けた。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^Your larva gestated and you gained the (.+?) mutation\\.$",
-      "template": "あなたの幼虫が成長し、{0}の変異を獲得した。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^Your genome destabilized and you gained the (.+?) (.+?)\\.$",
-      "template": "あなたのゲノムが不安定になり、{0}の{1}を得た。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You discovered (.+?)\\.$",
-      "template": "{0}を発見した。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You traveled to (.+?)\\.$",
-      "template": "{t0}に旅した。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You located (.+?)\\.$",
-      "template": "{0}を発見した。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You recovered (.+?)\\.$",
-      "template": "{0}を回収した。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You ate (.+?)\\.$",
-      "template": "{0}を食べた。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You witnessed the rare formation of (.+?)\\.$",
-      "template": "珍しい{0}の形成を目撃した。",
-      "route": "emit-message"
-    },
-    {
       "pattern": "^With the help of Pax Klanq and the Barathrumites, you constructed (.+?)\\.$",
       "template": "パクス・クランクとバラスルム派の助けを借りて{0}を建造した。",
       "route": "unclassified"
-    },
-    {
-      "pattern": "^You installed (?:a |some )cybernetic (.+?) and committed (.+?) to (.+?)\\.$",
-      "template": "サイバネティック{0}を装着し、{1}を{2}に捧げた。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You started calling (.+?) '(.+?)'\\.$",
-      "template": "{0}を「{1}」と呼ぶことにした。",
-      "route": "emit-message"
     },
     {
       "pattern": "^(.+?) provided you with insightful commentary on (.+?)\\.$",

--- a/docs/superpowers/plans/2026-03-24-phase4-emit-message-design.md
+++ b/docs/superpowers/plans/2026-03-24-phase4-emit-message-design.md
@@ -1,0 +1,72 @@
+# Phase 4: emit-message Producer Migration Design
+
+Date: 2026-03-24
+
+## Scope
+
+116 patterns in `messages.ja.json` with `route=emit-message`. These match text emitted through `AddPlayerMessage` (intercepted by `MessageLogPatch`).
+
+## Key Insight
+
+Unlike Phase 3 (does-verb → verbs.ja.json), these patterns **cannot simply move to a different data file**. They need producer-side Harmony patches that translate text BEFORE it reaches `AddPlayerMessage`.
+
+However, creating 30+ new Harmony patches is impractical in one PR. The practical approach is:
+
+1. **Patterns that already have producer coverage** → remove from messages.ja.json (already translated by producer)
+2. **Leaf-like patterns (no captures)** → move to leaf dictionary
+3. **Patterns whose producers are already patched** → extend existing patches
+4. **Remaining patterns** → keep in messages.ja.json with route='emit-message' until dedicated producers are built in later phases
+
+## Pattern Breakdown
+
+| Category | Count | Strategy |
+|----------|-------|----------|
+| Combat hit/crit/miss/damage | 37 | Keep — needs MissileWeapon/Combat producer patches (Phase 6) |
+| Journal accomplishments (slew, discovered, traveled...) | 20 | Move to journal-patterns.ja.json — JournalTextTranslator already owns these |
+| Inventory actions (pick up, drop, equip, fire, reload) | 7 | Keep — common UI actions, low risk in sink |
+| Perception (see, hear, feel) | 6 | Keep — diverse producers |
+| Door/lock interactions | 8 | Keep — needs Door.cs producer patch |
+| Harvest | 5 | Keep — partially covered by verbs.ja.json |
+| Movement/navigation | 7 | Keep — diverse producers |
+| Bleeding/nosebleed | 4 | Keep — needs Nosebleed.cs producer patch |
+| Game stats (XP, HP) | 3 | Keep — core UI feedback |
+| No-capture leaf patterns | 6 | Move to leaf dictionary |
+| Misc (ammo, tinkering, rind, genome, infiltrate) | 13 | Keep — scattered producers |
+
+## Actionable Now (Phase 4a)
+
+### 1. Move 6 leaf-like patterns → ui-messagelog-leaf.ja.json
+Patterns with no regex captures that are effectively exact strings.
+
+### 2. Move ~20 journal accomplishment patterns → journal-patterns.ja.json
+Patterns like "You slew X.", "You discovered X.", "You traveled to X." are journal entries. JournalTextTranslator already uses JournalPatternTranslator, so these belong there.
+
+### 3. Reclassify remaining 90 patterns as 'emit-message-deferred'
+These stay in messages.ja.json but with an updated route tag indicating they need future producer work.
+
+## Phase 4a Implementation
+
+- Move leaf patterns (6) → exact dictionary entries
+- Move journal patterns (~20) → journal-patterns.ja.json
+- Update route tags for remaining patterns
+- No new C# code needed
+- All existing tests should continue passing
+
+## Future Phases (not in Phase 4)
+
+### Phase 4b: Combat producer patches
+- MissileWeapon hit/crit/damage family (22 patterns)
+- Combat.cs melee hit/miss/block/dodge/parry (15 patterns)
+
+### Phase 4c: Interaction producer patches
+- Door.cs lock/unlock/open/close (8 patterns)
+- Nosebleed.cs bleeding (4 patterns)
+
+### Phase 4d: Remaining scattered producers
+- Inventory actions, perception, movement, misc (45 patterns)
+
+## Risk Assessment
+
+Moving patterns to journal or leaf is low-risk (same translation mechanism, different file).
+Reclassifying routes is zero-risk (route tag is metadata only, not used at runtime).
+No C# changes in Phase 4a means no Harmony patch risks.


### PR DESCRIPTION
## Summary
Move 26 journal accomplishment patterns from emit-message to journal scope. Add Phase 4 design document.

## Changes
- 26 patterns moved: messages.ja.json → journal-patterns.ja.json
  - Accomplishment patterns: slew, discovered, traveled, read, named, invented, ate, etc.
- Pattern reduction: messages.ja.json 297 → 271
- Design doc: `phase4-emit-message-design.md`

## Remaining emit-message (90 patterns)
- Combat: 37 (needs MissileWeapon/Combat producer patches)
- Interaction: 15 (door, harvest, bleeding)
- Inventory/perception/movement: 20 (diverse producers)
- Misc: 18

## Test plan
- [x] 638 L1 tests pass
- [ ] CI green
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * Phase 4 emit-messageプロデューサー移行設計に関するドキュメントを追加

* **ローカライゼーション**
  * 日本語ローカライゼーションの辞書エントリを最適化し、ゲームイベントおよびメッセージパターンのマッピングを改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->