### PR TITLE
feat(translation): Phase 4b — dynamic verb property coverage (#85)

### DIFF
--- a/Mods/QudJP/Localization/MessageFrames/verbs.ja.json
+++ b/Mods/QudJP/Localization/MessageFrames/verbs.ja.json
@@ -23,6 +23,10 @@
       "text": "なった"
     },
     {
+      "verb": "arrive",
+      "text": "到着した"
+    },
+    {
       "verb": "assume",
       "text": "とった"
     },
@@ -315,6 +319,14 @@
       "text": "繰り出した"
     },
     {
+      "verb": "lay",
+      "text": "設置した"
+    },
+    {
+      "verb": "leave",
+      "text": "離れた"
+    },
+    {
       "verb": "lie",
       "text": "横になった"
     },
@@ -451,6 +463,10 @@
       "text": "感知した"
     },
     {
+      "verb": "set",
+      "text": "仕掛けた"
+    },
+    {
       "verb": "shake",
       "text": "振り払った"
     },
@@ -473,6 +489,10 @@
     {
       "verb": "smash",
       "text": "打ち破った"
+    },
+    {
+      "verb": "spawn",
+      "text": "出現した"
     },
     {
       "verb": "spew",


### PR DESCRIPTION
## Summary
- Add 5 tier1 verb entries for dynamic verb properties (SpawnVerb, LeaveVerb, ArriveVerb, set/lay conditional)
- Investigation confirmed 30 IComponent generic dispatch sites are already covered by XDidYTranslationPatch
- No new C# Harmony patches needed — all 45 "dynamic verb" sites resolved via existing pipeline + dictionary entries

## Investigation Results
| Category | Sites | Resolution |
|---|---|---|
| IComponent generic dispatch | 30 | Already covered by XDidYTranslationPatch |
| Dynamic verb properties | 7 | Tier1 entries (arrive, leave, spawn, set, lay) + existing (die, detonate, vibrate) |
| Conditional verb (Timed ternary) | 2 | Tier1 entries for both branches (set, lay) |
| Literal verb strings | ~80 | Covered by PR #93 verb entries |

## Test plan
- [x] JSON validation passes
- [x] `dotnet build` succeeds
- [x] All 638 L1 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ローカライズ**
  * 日本語ローカライズに新たに5つの動詞表現が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->