### PR TITLE
feat(translation): SetText UI entries for Issue #83

### DIFF
--- a/Mods/QudJP/Localization/Dictionaries/ui-default.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-default.ja.json
@@ -1083,6 +1083,26 @@
     {
       "key": "You annulled the plagues of the Gyre.\n\nThen you launched yourself into the dusted cosmos to ply the stars.",
       "text": "あなたは回転の疫病を無効化した。\n\nそして塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。"
+    },
+    {
+      "key": "switch to modifications",
+      "context": "Qud.UI.TinkeringStatusScreen",
+      "text": "改造に切り替え"
+    },
+    {
+      "key": "switch to build",
+      "context": "Qud.UI.TinkeringStatusScreen",
+      "text": "製作に切り替え"
+    },
+    {
+      "key": "Fetching leaderboard",
+      "context": "Qud.UI.HighScoresScreen",
+      "text": "リーダーボードを取得中"
+    },
+    {
+      "key": "Empty leaderboard",
+      "context": "Qud.UI.HighScoresScreen",
+      "text": "リーダーボードは空です"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Add 4 static UI dictionary entries for SetText sites from Issue #83.

## Analysis (60 sites total)
| Category | Count | Action |
|---|---|---|
| Already covered by existing dictionaries | ~22 | No action needed |
| Filtered by ShouldSkipTranslation | ~5 | UI controls, skipped |
| Template_static (runtime variables) | ~29 | Needs pattern translators (future) |
| **New static entries** | **4** | **Added in this PR** |

## Entries added to ui-default.ja.json
- `switch to modifications` → `改造に切り替え`
- `switch to build` → `製作に切り替え`
- `Fetching leaderboard` → `リーダーボードを取得中`
- `Empty leaderboard` → `リーダーボードは空です`

## Key finding
UITextSkinTranslationPatch strips color tags before lookup (confirmed by Copilot analysis). Dictionary keys use plain visible text, not {{W|...}} wrapped text.

## Test plan
- [x] JSON validation passes
- [x] `dotnet build` succeeds
- [x] All 638 L1 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメンテーション**
  * 改造画面とハイスコア画面に関する日本語ローカライズエントリが4つ追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->