### PR TITLE
fix(test): remove stale tests and dead regex patterns (#96)

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -258,16 +258,6 @@ public sealed class MessagePatternTranslatorTests
     }
 
     [Test]
-    public void Translate_AppliesAggressiveStancePattern()
-    {
-        WritePatternDictionary(("^(.+) switches to aggressive stance[.!]?$", "{0}は攻撃態勢に入った。"));
-
-        var translated = MessagePatternTranslator.Translate("監視官イラメ switches to aggressive stance.");
-
-        Assert.That(translated, Is.EqualTo("監視官イラメは攻撃態勢に入った。"));
-    }
-
-    [Test]
     public void Translate_AppliesFreezingEffectDamagePattern()
     {
         WritePatternDictionary(("^You take (\\d+) damage from (.+?)の freezing effect![.!]?$", "{1}の凍結効果で{0}ダメージを受けた！"));
@@ -327,16 +317,6 @@ public sealed class MessagePatternTranslatorTests
         var translated = MessagePatternTranslator.Translate("You pass by ウォーターヴァインと薄めの塩の水たまり.");
 
         Assert.That(translated, Is.EqualTo("ウォーターヴァインと薄めの塩の水たまりのそばを通り過ぎた。"));
-    }
-
-    [Test]
-    public void Translate_AppliesWadeThroughPattern()
-    {
-        WritePatternDictionary(("^You wade through (?:a |an )?(.+?)[.!]?$", "{0}をかき分けて進んだ。"));
-
-        var translated = MessagePatternTranslator.Translate("You wade through a 塩辛い水の水たまり.");
-
-        Assert.That(translated, Is.EqualTo("塩辛い水の水たまりをかき分けて進んだ。"));
     }
 
     [TestCase("north", "北")]
@@ -546,16 +526,6 @@ public sealed class MessagePatternTranslatorTests
     }
 
     [Test]
-    public void Translate_AppliesSitDownPattern()
-    {
-        WritePatternDictionary(("^You sit down on the (.+?)[.!]?$", "{0}に腰を下ろした。"));
-
-        var translated = MessagePatternTranslator.Translate("You sit down on the フロアクッション.");
-
-        Assert.That(translated, Is.EqualTo("フロアクッションに腰を下ろした。"));
-    }
-
-    [Test]
     public void Translate_AppliesDeathPattern()
     {
         WritePatternDictionary(("^You died\\.\\n\\nYou were killed by (.+?)[.!]?$", "あなたは死んだ。\n\n{0}に殺された。"));
@@ -590,20 +560,20 @@ public sealed class MessagePatternTranslatorTests
     [Test]
     public void Translate_LogsDynamicTransformProbe_WhenPatternMatches()
     {
-        WritePatternDictionary(("^You sit down on the (.+?)[.!]?$", "{0}に腰を下ろした。"));
+        WritePatternDictionary(("^You pass by (?:a |an |the )?(.+?)[.!]?$", "{0}のそばを通り過ぎた。"));
 
         var output = TestTraceHelper.CaptureTrace(() =>
             Assert.That(
-                MessagePatternTranslator.Translate("You sit down on the フロアクッション.", "MessageLogPatch"),
-                Is.EqualTo("フロアクッションに腰を下ろした。")));
+                MessagePatternTranslator.Translate("You pass by a ウォーターヴァイン.", "MessageLogPatch"),
+                Is.EqualTo("ウォーターヴァインのそばを通り過ぎた。")));
 
         Assert.Multiple(() =>
         {
             Assert.That(output, Does.Contain("DynamicTextProbe/v1"));
             Assert.That(output, Does.Contain("route='MessagePatternTranslator'"));
-            Assert.That(output, Does.Contain("family='^You sit down on the (.+?)[.!]?$'"));
-            Assert.That(output, Does.Contain("source='You sit down on the フロアクッション.'"));
-            Assert.That(output, Does.Contain("translated='フロアクッションに腰を下ろした。'"));
+            Assert.That(output, Does.Contain("family='^You pass by (?:a |an |the )?(.+?)[.!]?$'"));
+            Assert.That(output, Does.Contain("source='You pass by a ウォーターヴァイン.'"));
+            Assert.That(output, Does.Contain("translated='ウォーターヴァインのそばを通り過ぎた。'"));
         });
     }
 

--- a/Mods/QudJP/Localization/Dictionaries/messages.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/messages.ja.json
@@ -122,11 +122,6 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+) switches to aggressive stance[.!]?$",
-      "template": "{0}は攻撃態勢に入った。",
-      "route": "emit-message"
-    },
-    {
       "pattern": "^You take (\\d+) damage from (.+?)の freezing effect![.!]?$",
       "template": "{1}の凍結効果で{0}ダメージを受けた！",
       "route": "emit-message"
@@ -747,11 +742,6 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^You wade through (?:a |an )?(.+?)[.!]?$",
-      "template": "{0}をかき分けて進んだ。",
-      "route": "emit-message"
-    },
-    {
       "pattern": "^A (.+?) appears here[.!]?$",
       "template": "{0}がここに現れた。",
       "route": "emit-message"
@@ -819,11 +809,6 @@
     {
       "pattern": "^The (.+?) takes (\\d+) damage from your poison![.!]?$",
       "template": "{0}はあなたの毒で{1}ダメージを受けた。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You sit down on the (.+?)[.!]?$",
-      "template": "{0}に腰を下ろした。",
       "route": "emit-message"
     },
     {


### PR DESCRIPTION
## Summary
Remove 3 stale tests and their corresponding dead regex patterns identified by Copilot CLI test quality audit.

## Removed (no producer in decompiled 2.0.4)
| Pattern | Test | Evidence |
|---|---|---|
| `aggressive stance` | `Translate_AppliesAggressiveStancePattern` | Only status labels in `LongbladeStance_Aggressive.cs`, no message producer |
| `wade through` | `Translate_AppliesWadeThroughPattern` | No producer found in decompiled source |
| `sit down on the` | `Translate_AppliesSitDownPattern` + trace test | No producer found in decompiled source |

## Replaced
- Trace logging test now uses verified `pass by` pattern (confirmed at `Physics.cs:2232`)

## Stats
- messages.ja.json: 304 → 301 patterns
- Tests: 638 → 635

Partial fix for #96. P1 (PopupMessage signature) and P3 (stale test inputs) remain for separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テストケースを更新し、メッセージパターン翻訳の検証を一部削除しました。

* **Localization**
  * 日本語翻訳マッピングから3つのメッセージパターンを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->