### PR TITLE
feat(translation): DidX Tier 3 — exclude 2件 + Immobilized translated 2件 (#127)

### DIFF
--- a/docs/candidate-inventory.json
+++ b/docs/candidate-inventory.json
@@ -9389,7 +9389,7 @@
     "needs_runtime": false,
     "pattern": "DidX(\"are\", Text, \"!\", null, null, null, Object)",
     "sink": "DidX",
-    "status": "needs_patch",
+    "status": "translated",
     "type": "MessageFrame",
     "verb": "are"
   },
@@ -9406,7 +9406,7 @@
     "needs_runtime": false,
     "pattern": "DidX(\"are\", \"no longer \" + Text, null, null, null, base.Object)",
     "sink": "DidX",
-    "status": "needs_patch",
+    "status": "translated",
     "type": "MessageFrame",
     "verb": "are"
   },
@@ -9930,7 +9930,8 @@
     "sink": "DidX",
     "status": "needs_patch",
     "type": "MessageFrame",
-    "verb": "are"
+    "verb": "are",
+    "note": "extra is runtime DisplayName from GetStateDescription(); requires a Stuck-specific patch"
   },
   {
     "column": 6,
@@ -11170,7 +11171,8 @@
     "sink": "DidX",
     "status": "needs_patch",
     "type": "MessageFrame",
-    "verb": "draw"
+    "verb": "draw",
+    "note": "extra concatenates direction text, nested Target.Does(\"are\"), and trailing \" marked\"; requires a Rifle_DrawABead-specific patch"
   },
   {
     "column": 4,
@@ -12662,10 +12664,10 @@
     "needs_runtime": false,
     "pattern": "DidXToY(Verb, Object, Preposition, Grammar.MakeAndList(list), null, null, null, null, UseFullNames: false, IndefiniteSubject: false, IndefiniteObject: true)",
     "sink": "DidX",
-    "status": "needs_patch",
+    "status": "excluded",
     "type": "MessageFrame",
     "verb": "Verb",
-    "note": "VARIABLE_VERB: verb parameter is 'Verb'"
+    "note": "data-driven, no concrete verb in C#"
   },
   {
     "column": 5,
@@ -12697,10 +12699,10 @@
     "needs_runtime": false,
     "pattern": "DidXToY(Verb, Object, Preposition, Grammar.MakeAndList(list), null, null, null, null, UseFullNames: false, IndefiniteSubject: false, IndefiniteObject: true)",
     "sink": "DidX",
-    "status": "needs_patch",
+    "status": "excluded",
     "type": "MessageFrame",
     "verb": "Verb",
-    "note": "VARIABLE_VERB: verb parameter is 'Verb'"
+    "note": "data-driven, no concrete verb in C#"
   },
   {
     "column": 5,
@@ -13774,7 +13776,8 @@
     "sink": "DidX",
     "status": "needs_patch",
     "type": "MessageFrame",
-    "verb": "gain"
+    "verb": "gain",
+    "note": "extra comes from RandomAltarBaetyl.GiveReward(...); reward text is dynamic and requires a GameObjectBaetylUnit-specific patch"
   },
   {
     "column": 5,


### PR DESCRIPTION
## 概要
DidX Tier 3 の7件を調査結果に基づいて分類・更新。

## 変更
- Immobilized 2件 → translated（既存Tier2辞書でカバー確認済み）
- InventoryItemConvertor/ItemConvertor 2件 → excluded（data-driven, concrete verb なし）
- Stuck/DrawABead/Baetyl 3件 → note追記（専用パッチ要の調査サマリー）

Closes #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション
* ドキュメンテーションインベントリの複数エントリのステータスを更新しました。
* いくつかのエントリを翻訳済みまたは除外に再分類しました。
* 対象エントリの説明情報を追加および更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->