### PR TITLE
fix(patch): PopupShowTranslationPatch namespace + ActiveEffects label loss

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -180,6 +180,11 @@ public sealed class TargetMethodResolutionTests
         "System.String|System.Collections.Generic.IReadOnlyList`1[[System.String]]|System.Collections.Generic.IReadOnlyList`1[[System.Char]]|System.Int32|System.String|System.Int32|System.Boolean|System.Boolean|System.Int32|System.String|System.Action`1[[System.Int32]]|XRL.World.GameObject|System.Collections.Generic.IReadOnlyList`1[[ConsoleLib.Console.IRenderable]]|ConsoleLib.Console.IRenderable|System.Collections.Generic.IReadOnlyList`1[[Qud.UI.QudMenuItem]]|System.Boolean|System.Boolean|System.Int32|System.Boolean",
         "System.String|XRL.World.GameObject|System.String|System.Collections.Generic.List`1[[System.String]]|System.Boolean|System.Boolean|System.Boolean",
     })]
+    [TestCase(typeof(PopupShowTranslationPatch), new[]
+    {
+        "System.String|System.String|System.String|System.Boolean|System.Boolean|System.Boolean|System.Boolean|Genkit.Location2D",
+        "System.String|System.String|System.Boolean|XRL.UI.DialogResult",
+    })]
     public void TargetMethods_ResolveExpectedOverloads(Type patchType, string[] expectedSignatures)
     {
         var targetMethodsMethod = patchType.GetMethod("TargetMethods", BindingFlags.NonPublic | BindingFlags.Static);

--- a/Mods/QudJP/Assemblies/src/Patches/GameObjectShowActiveEffectsPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GameObjectShowActiveEffectsPatch.cs
@@ -48,13 +48,17 @@ public static class GameObjectShowActiveEffectsPatch
             {
                 if (string.Equals(literal, NoActiveEffectsText, StringComparison.Ordinal))
                 {
-                    yield return new CodeInstruction(OpCodes.Call, TranslateNoActiveEffectsTextMethod);
+                    instruction.opcode = OpCodes.Call;
+                    instruction.operand = TranslateNoActiveEffectsTextMethod;
+                    yield return instruction;
                     continue;
                 }
 
                 if (string.Equals(literal, ActiveEffectsTitlePrefix, StringComparison.Ordinal))
                 {
-                    yield return new CodeInstruction(OpCodes.Call, TranslateActiveEffectsTitlePrefixMethod);
+                    instruction.opcode = OpCodes.Call;
+                    instruction.operand = TranslateActiveEffectsTitlePrefixMethod;
+                    yield return instruction;
                     continue;
                 }
             }

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowTranslationPatch.cs
@@ -43,7 +43,7 @@ public static class PopupShowTranslationPatch
         }
 
         var showYesNoMethod = AccessTools.Method(popupType, "ShowYesNo",
-            new[] { typeof(string), typeof(string), typeof(bool), AccessTools.TypeByName("Qud.UI.DialogResult") });
+            new[] { typeof(string), typeof(string), typeof(bool), AccessTools.TypeByName("XRL.UI.DialogResult") });
         if (showYesNoMethod is null)
         {
             showYesNoMethod = AccessTools.Method(popupType, "ShowYesNo");


### PR DESCRIPTION
## Summary

Fixes two runtime Harmony patch application failures that caused untranslated UI text:

- **PopupShowTranslationPatch** (#142): `Qud.UI.DialogResult` → `XRL.UI.DialogResult` namespace typo caused `TargetMethods` to throw `ArgumentNullException`, completely skipping `Popup.Show`/`ShowYesNo` translation
- **GameObjectShowActiveEffectsPatch** (#143): Transpiler created new `CodeInstruction` objects, discarding labels/blocks from branch-target `ldstr` instructions — `Label #6` loss caused Harmony IL verification failure, leaving "Active Effects" and "No active effects." untranslated
- Adds L2G test coverage for `PopupShowTranslationPatch.TargetMethods` resolution

Closes #142, closes #143

## Investigation

Both bugs were independently verified by:
1. Claude Code sub-agents (source analysis + decompiled game source cross-reference)
2. Codex CLI (`codex exec --full-auto`) — confirmed IL structure via `ilspycmd -il`, verified namespace via decompiled `DialogResult.cs`

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 1109 passed, 0 failed
- [x] L2G tests — 81 passed (includes new `PopupShowTranslationPatch` test case)
- [ ] L3: deploy mod and verify popup/active effects translation in-game

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * 翻訳パッチの検証テストを追加しました。

* **改善**
  * コード処理エンジンの内部ロジックを最適化しました。
  * メソッド解決の精度を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->