### PR TITLE
fix(patch): Grammar patch parameter names — match game signatures

### DIFF
--- a/Mods/QudJP/Assemblies/src/Patches/GrammarPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GrammarPatch.cs
@@ -341,12 +341,12 @@ public static class GrammarInitCapsPatch
         }
     }
 
-    public static bool Prefix(string Text, ref string __result)
+    public static bool Prefix(string word, ref string __result)
     {
         try
         {
-            __result = Text;
-            GrammarPatchHelpers.LogTransform("InitCap", Text, __result, logWhenUnchanged: true);
+            __result = word;
+            GrammarPatchHelpers.LogTransform("InitCap", word, __result, logWhenUnchanged: true);
             return false;
         }
         catch (Exception ex)
@@ -377,12 +377,12 @@ public static class GrammarCardinalNumberPatch
         }
     }
 
-    public static bool Prefix(int Number, ref string __result)
+    public static bool Prefix(int num, ref string __result)
     {
         try
         {
-            __result = Number.ToString(CultureInfo.InvariantCulture);
-            GrammarPatchHelpers.LogTransform("Cardinal", Number.ToString(CultureInfo.InvariantCulture), __result, logWhenUnchanged: true);
+            __result = num.ToString(CultureInfo.InvariantCulture);
+            GrammarPatchHelpers.LogTransform("Cardinal", num.ToString(CultureInfo.InvariantCulture), __result, logWhenUnchanged: true);
             return false;
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary

Follow-up to #148 — the Grammar method names were corrected but the Harmony Prefix parameter names didn't match the actual game method signatures, causing "Parameter not found" errors at runtime.

- `GrammarInitCapsPatch.Prefix`: `Text` → `word` (matching `InitCap(string word)`)
- `GrammarCardinalNumberPatch.Prefix`: `Number` → `num` (matching `Cardinal(int num)`)

## Log Evidence (before fix)

```
[QudJP] Warning: Failed to apply patch GrammarInitCapsPatch: Parameter "Text" not found in method Grammar::InitCap(System.String word)
[QudJP] Warning: Failed to apply patch GrammarCardinalNumberPatch: Parameter "Number" not found in method Grammar::Cardinal(System.Int32 num)
```

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 1117 passed, 0 failed
- [x] Deployed and verified no new warnings in Player.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストは内部的なコード改善のみで、エンドユーザーに対する変更はありません。

* **Refactor**
  * 内部コードの保守性向上のため、文法パッチのパラメータ名を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->