### PR TITLE
Issue #151: implement producer patch for category 5

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
@@ -104,6 +104,7 @@ internal static class ColorRouteCatalog
             ["Mods/QudJP/Assemblies/src/Patches/JournalTextTranslator.cs|JournalPatternTranslator.Translate("] = 2,
             ["Mods/QudJP/Assemblies/src/Patches/LoadingStatusTranslationPatch.cs|UITextSkinTranslationPatch.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/LookTooltipContentPatch.cs|UITextSkinTranslationPatch.TranslatePreservingColors("] = 1,
+            ["Mods/QudJP/Assemblies/src/Patches/MainMenuLocalizationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/PopupMessageTranslationPatch.cs|PopupTranslationPatch.TranslatePopupTextForRoute("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/QudMenuBottomContextTranslationPatch.cs|PopupTranslationPatch.TranslatePopupMenuItemTextForRoute("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/SkillsAndPowersStatusScreenTranslationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 3,

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/MainMenuLocalizationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/MainMenuLocalizationPatchTests.cs
@@ -38,7 +38,7 @@ public sealed class MainMenuLocalizationPatchTests
     }
 
     [Test]
-    public void Postfix_ObservationOnly_LeavesMenuOptionsUnchanged_WhenPatched()
+    public void Postfix_TranslatesMenuOptions_WhenPatched()
     {
         WriteDictionary(
             ("Options", "設定"),
@@ -57,16 +57,8 @@ public sealed class MainMenuLocalizationPatchTests
 
             Assert.Multiple(() =>
             {
-                Assert.That(DummyMainMenuTarget.LeftOptions[0].Text, Is.EqualTo("Options"));
-                Assert.That(DummyMainMenuTarget.RightOptions[0].Text, Is.EqualTo("Help"));
-                Assert.That(
-                    SinkObservation.GetHitCountForTests(
-                        nameof(UITextSkinTranslationPatch),
-                        nameof(MainMenuLocalizationPatch),
-                        SinkObservation.ObservationOnlyDetail,
-                        "Options",
-                        "Options"),
-                    Is.GreaterThan(0));
+                Assert.That(DummyMainMenuTarget.LeftOptions[0].Text, Is.EqualTo("設定"));
+                Assert.That(DummyMainMenuTarget.RightOptions[0].Text, Is.EqualTo("ヘルプ"));
             });
         }
         finally
@@ -76,7 +68,7 @@ public sealed class MainMenuLocalizationPatchTests
     }
 
     [Test]
-    public void Postfix_ObservationOnly_LeavesMarkupWrappedTextUnchanged_WhenPatched()
+    public void Postfix_TranslatesMarkupWrappedText_WhenPatched()
     {
         WriteDictionary(("Mods", "モッド"));
 
@@ -95,15 +87,7 @@ public sealed class MainMenuLocalizationPatchTests
 
             Assert.Multiple(() =>
             {
-                Assert.That(DummyMainMenuTarget.LeftOptions[1].Text, Is.EqualTo("{{G|Mods}}"));
-                Assert.That(
-                    SinkObservation.GetHitCountForTests(
-                        nameof(UITextSkinTranslationPatch),
-                        nameof(MainMenuLocalizationPatch),
-                        SinkObservation.ObservationOnlyDetail,
-                        "{{G|Mods}}",
-                        "Mods"),
-                    Is.GreaterThan(0));
+                Assert.That(DummyMainMenuTarget.LeftOptions[1].Text, Is.EqualTo("{{G|モッド}}"));
             });
         }
         finally
@@ -113,7 +97,7 @@ public sealed class MainMenuLocalizationPatchTests
     }
 
     [Test]
-    public void Postfix_ObservationOnly_LeavesHotkeyBarDescriptionsUnchanged_WhenUpdateMenuBarsRuns()
+    public void Postfix_TranslatesHotkeyBarDescriptions_WhenUpdateMenuBarsRuns()
     {
         WriteDictionary(
             ("navigate", "移動"),
@@ -134,17 +118,9 @@ public sealed class MainMenuLocalizationPatchTests
 
             Assert.Multiple(() =>
             {
-                Assert.That(DummyMainMenuTarget.LastHotkeyChoices[0].Description, Is.EqualTo("navigate"));
-                Assert.That(DummyMainMenuTarget.LastHotkeyChoices[1].Description, Is.EqualTo("select"));
-                Assert.That(DummyMainMenuTarget.LastHotkeyChoices[2].Description, Is.EqualTo("quit"));
-                Assert.That(
-                    SinkObservation.GetHitCountForTests(
-                        nameof(UITextSkinTranslationPatch),
-                        nameof(MainMenuLocalizationPatch),
-                        SinkObservation.ObservationOnlyDetail,
-                        "navigate",
-                        "navigate"),
-                    Is.GreaterThan(0));
+                Assert.That(DummyMainMenuTarget.LastHotkeyChoices[0].Description, Is.EqualTo("移動"));
+                Assert.That(DummyMainMenuTarget.LastHotkeyChoices[1].Description, Is.EqualTo("選択"));
+                Assert.That(DummyMainMenuTarget.LastHotkeyChoices[2].Description, Is.EqualTo("終了"));
             });
         }
         finally

--- a/Mods/QudJP/Assemblies/src/Patches/MainMenuLocalizationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/MainMenuLocalizationPatch.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Collections;
 using System.Reflection;
 using HarmonyLib;
 
@@ -61,16 +62,10 @@ public static class MainMenuLocalizationPatch
             }
 
             var leftOptions = AccessCollectionField(targetType, __instance, "LeftOptions");
-            UITextSkinTranslationPatch.TranslateStringFieldsInCollection(
-                leftOptions,
-                ObservabilityHelpers.ComposeContext(nameof(MainMenuLocalizationPatch), "collection=LeftOptions"),
-                "Text");
+            TranslateCollectionField(leftOptions, "Text", "MainMenu.LeftOptions");
 
             var rightOptions = AccessCollectionField(targetType, __instance, "RightOptions");
-            UITextSkinTranslationPatch.TranslateStringFieldsInCollection(
-                rightOptions,
-                ObservabilityHelpers.ComposeContext(Context, "collection=RightOptions"),
-                "Text");
+            TranslateCollectionField(rightOptions, "Text", "MainMenu.RightOptions");
 
             TranslateHotkeyBarChoices(targetType, __instance);
         }
@@ -116,9 +111,75 @@ public static class MainMenuLocalizationPatch
             return;
         }
 
-        UITextSkinTranslationPatch.TranslateStringFieldsInCollection(
+        TranslateCollectionField(
             AccessTools.Field(hotkeyBar.GetType(), "choices")?.GetValue(hotkeyBar),
-            ObservabilityHelpers.ComposeContext(Context, "collection=HotkeyBarChoices"),
-            "Description");
+            "Description",
+            "MainMenu.HotkeyBar");
+    }
+
+    private static void TranslateCollectionField(object? maybeCollection, string fieldName, string family)
+    {
+        if (maybeCollection is null || string.IsNullOrEmpty(fieldName) || maybeCollection is string)
+        {
+            return;
+        }
+
+        if (maybeCollection is not IEnumerable collection)
+        {
+            return;
+        }
+
+        foreach (var item in collection)
+        {
+            TranslateField(item, fieldName, family);
+        }
+    }
+
+    private static void TranslateField(object? item, string fieldName, string family)
+    {
+        if (item is null)
+        {
+            return;
+        }
+
+        var field = AccessTools.Field(item.GetType(), fieldName);
+        if (field is null || field.FieldType != typeof(string))
+        {
+            return;
+        }
+
+        var current = field.GetValue(item) as string;
+        if (string.IsNullOrEmpty(current))
+        {
+            return;
+        }
+
+        var translated = TranslateProducerText(current!);
+        if (string.Equals(translated, current, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        DynamicTextObservability.RecordTransform(Context, family, current, translated);
+        field.SetValue(item, translated);
+    }
+
+    private static string TranslateProducerText(string source)
+    {
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            return markedText;
+        }
+
+        var (stripped, _) = ColorAwareTranslationComposer.Strip(source);
+        if (stripped.Length == 0
+            || UITextSkinTranslationPatch.IsAlreadyLocalizedDirectRouteTextForContext(stripped, Context))
+        {
+            return source;
+        }
+
+        return ColorAwareTranslationComposer.TranslatePreservingColors(
+            source,
+            static visible => StringHelpers.TranslateExactOrLowerAsciiFallback(visible));
     }
 }


### PR DESCRIPTION
## Summary
- switch MainMenu producer routes from observation-only pass-through to exact/lower-ascii translation
- translate left/right main menu option text and hotkey bar descriptions after MainMenu.Show/UpdateMenuBars
- update L2 main menu expectations and the color route catalog for the new producer call site

## Testing
- DOTNET_CLI_UI_LANGUAGE=en dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~MainMenuLocalizationPatchTests --logger "console;verbosity=minimal"
- DOTNET_CLI_UI_LANGUAGE=en dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1 --blame-hang --blame-hang-timeout 30s --logger "console;verbosity=minimal"
- DOTNET_CLI_UI_LANGUAGE=en dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2 --logger "console;verbosity=minimal"

Refs #151 (category 5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * メインメニューのオプション、マークアップ付きテキスト、ホットキーバーの説明が日本語に正しく翻訳されるようになりました
  * 翻訳時にカラーコードが適切に保持されるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->