### PR TITLE
docs(render): add L3 reproduction procedures for runtime-required families (#192)

### DIFF
--- a/docs/display-path-ownership.md
+++ b/docs/display-path-ownership.md
@@ -108,7 +108,7 @@ Use this checklist before marking a route family as complete:
 4. **Status messages**: Pick up, drop, eat, or drink an item — verify feedback messages
 5. **Environmental messages**: Walk into a zone with temperature or radiation — verify notifications
 6. **Zone transition**: Move between zones — verify zone entry messages
-7. Check `Player.log` for `[QudJP] MessagePatternTranslator: no pattern for` entries (indicates unclaimed messages)
+7. Check `Player.log` — verify `[QudJP] MessagePatternTranslator: no pattern for` entries do NOT appear (their presence indicates unclaimed messages that lack a producer-side translation)
 8. Check `Player.log` for `[QudJP] SinkObserve/v1: sink='MessageLogPatch'` entries (observation-only sink recording)
 
 ### UITextSkin (runtime-required)


### PR DESCRIPTION
## Summary

- Add L3 verification reproduction steps for message log, UITextSkin, and SinkPrereq route families
- Each procedure covers game scenarios to trigger, UI elements to verify, and Player.log markers to check

Closes #192

## Test plan

- [x] Documentation-only change, no code modified
- [x] Procedures aligned with patch code analysis (MessageLogPatch, UITextSkinTranslationPatch, SinkPrereqSetDataTranslationPatch, SinkPrereqUiMethodTranslationPatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * 検証ドキュメントに3つの新しいセクションを追加しました（Message log、UITextSkin、SinkPrereq）。各セクションにはビルド・同期・起動手順、ゲーム内での日本語表示確認手順、及び該当ルートを起動してログでの検証を行うための手順とチェックリストが詳述されています。既存のチェックリストや分類は変更されていません。変更はドキュメントのみです。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->