### PR TITLE
fix(binding): add TradeLine + UpdateTitleBars to SinkPrereq coverage (issue #201)

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummySinkPrereqTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummySinkPrereqTargets.cs
@@ -179,10 +179,37 @@ internal sealed class DummyTradeScreen
 {
     public DummyUITextSkinField detailsRightText = new DummyUITextSkinField();
     public DummyUITextSkinField detailsLeftText = new DummyUITextSkinField();
+    public DummyUITextSkinField[] traderNames = new DummyUITextSkinField[]
+    {
+        new DummyUITextSkinField(),
+        new DummyUITextSkinField(),
+    };
 
     public void HandleHighlightObject(DummyFrameworkDataElement element)
     {
         detailsRightText.SetText(element.Description ?? "");
         detailsLeftText.SetText(element.Title ?? "");
+    }
+
+    public void UpdateTitleBars()
+    {
+        traderNames[0].SetText("Mehmet");
+        traderNames[1].SetText("Player Name");
+    }
+}
+
+internal sealed class DummyTradeLine
+{
+    public DummyUITextSkinField categoryText = new DummyUITextSkinField();
+    public DummyUITextSkinField text = new DummyUITextSkinField();
+    public DummyUITextSkinField check = new DummyUITextSkinField();
+    public DummyUITextSkinField rightFloatText = new DummyUITextSkinField();
+
+    public void setData(DummyFrameworkDataElement data)
+    {
+        categoryText.SetText("[+] " + (data.Title ?? ""));
+        text.SetText(data.Description ?? "");
+        check.SetText("{{W|1}}");
+        rightFloatText.SetText("[$1.00]");
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/SinkPrereqTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/SinkPrereqTranslationPatchTests.cs
@@ -441,6 +441,70 @@ public sealed class SinkPrereqTranslationPatchTests
     }
 
     [Test]
+    public void SetDataPatch_ObservationOnly_LeavesTradeLineFieldsUnchanged()
+    {
+        WriteDictionary(("Weapons", "武器"), ("iron sword", "鉄の剣"));
+        Translator.SetDictionaryDirectoryForTests(tempDir);
+
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyTradeLine), "setData"),
+            postfix: new HarmonyMethod(RequireMethod(
+                typeof(SinkPrereqSetDataTranslationPatch), "Postfix")));
+
+        var instance = new DummyTradeLine();
+        instance.setData(new DummyFrameworkDataElement
+        {
+            Title = "Weapons",
+            Description = "iron sword"
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(instance.categoryText.text, Is.EqualTo("[+] Weapons"));
+            Assert.That(instance.text.text, Is.EqualTo("iron sword"));
+            Assert.That(instance.check.text, Is.EqualTo("{{W|1}}"));
+            Assert.That(instance.rightFloatText.text, Is.EqualTo("[$1.00]"));
+            Assert.That(
+                SinkObservation.GetHitCountForTests(
+                    nameof(UITextSkinTranslationPatch),
+                    nameof(SinkPrereqSetDataTranslationPatch),
+                    SinkObservation.ObservationOnlyDetail,
+                    "iron sword",
+                    "iron sword"),
+                Is.GreaterThan(0));
+        });
+    }
+
+    [Test]
+    public void UiMethodPatch_ObservationOnly_LeavesTradeScreenTitleBarsUnchanged()
+    {
+        WriteDictionary(("Mehmet", "メフメト"), ("Player Name", "プレイヤー名"));
+        Translator.SetDictionaryDirectoryForTests(tempDir);
+
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyTradeScreen), "UpdateTitleBars"),
+            postfix: new HarmonyMethod(RequireMethod(
+                typeof(SinkPrereqUiMethodTranslationPatch), "Postfix")));
+
+        var instance = new DummyTradeScreen();
+        instance.UpdateTitleBars();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(instance.traderNames[0].text, Is.EqualTo("Mehmet"));
+            Assert.That(instance.traderNames[1].text, Is.EqualTo("Player Name"));
+            Assert.That(
+                SinkObservation.GetHitCountForTests(
+                    nameof(UITextSkinTranslationPatch),
+                    nameof(SinkPrereqUiMethodTranslationPatch),
+                    SinkObservation.ObservationOnlyDetail,
+                    "Mehmet",
+                    "Mehmet"),
+                Is.GreaterThan(0));
+        });
+    }
+
+    [Test]
     public void SetDataPatch_UntranslatedTextPassesThrough()
     {
         // No dictionary entries — text should pass through unchanged

--- a/Mods/QudJP/Assemblies/src/Patches/SinkPrereqSetDataTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/SinkPrereqSetDataTranslationPatch.cs
@@ -26,6 +26,7 @@ public static class SinkPrereqSetDataTranslationPatch
         "Qud.UI.CharacterEffectLine",
         "Qud.UI.CharacterAttributeLine",
         "Qud.UI.TinkeringDetailsLine",
+        "Qud.UI.TradeLine",
     };
 
     [HarmonyTargetMethods]
@@ -73,6 +74,7 @@ public static class SinkPrereqSetDataTranslationPatch
         "text", "textSkin", "title", "attributeText",
         "descriptionText", "modDescriptionText", "modBitCostText",
         "requirementsHeaderText", "RightText", "ObjectDescription",
+        "categoryText", "check", "rightFloatText",
     };
 
     public static void Postfix(object __instance)

--- a/Mods/QudJP/Assemblies/src/Patches/SinkPrereqTextFieldTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/SinkPrereqTextFieldTranslator.cs
@@ -7,6 +7,29 @@ namespace QudJP.Patches;
 
 internal static class SinkPrereqTextFieldTranslator
 {
+    internal static void TranslateArrayField(object? instance, string fieldName, string context)
+    {
+        if (instance is null)
+        {
+            return;
+        }
+
+        if (!TryGetMemberValue(instance, fieldName, out var arrayObj))
+        {
+            return;
+        }
+
+        if (arrayObj is not Array array)
+        {
+            return;
+        }
+
+        for (var i = 0; i < array.Length; i++)
+        {
+            TranslateTextSkin(array.GetValue(i), context);
+        }
+    }
+
     private static readonly ConcurrentDictionary<(Type Type, string MemberName), MemberInfo?> MemberCache =
         new ConcurrentDictionary<(Type Type, string MemberName), MemberInfo?>();
 

--- a/Mods/QudJP/Assemblies/src/Patches/SinkPrereqUiMethodTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/SinkPrereqUiMethodTranslationPatch.cs
@@ -26,6 +26,7 @@ public static class SinkPrereqUiMethodTranslationPatch
         ("Qud.UI.TradeScreen", "HandleHighlightObject"),
         ("MapScrollerPinItem", "SetData"),
         ("Qud.UI.PlayerStatusBar", "Update"),
+        ("Qud.UI.TradeScreen", "UpdateTitleBars"),
     };
 
     [HarmonyTargetMethods]
@@ -119,6 +120,11 @@ public static class SinkPrereqUiMethodTranslationPatch
         "detailsRightText", "detailsLeftText", "detailsText", "ZoneText",
     };
 
+    private static readonly string[] ArrayTextSkinFieldNames =
+    {
+        "traderNames",
+    };
+
     public static void Postfix(object __instance)
     {
         try
@@ -127,6 +133,12 @@ public static class SinkPrereqUiMethodTranslationPatch
             {
                 SinkPrereqTextFieldTranslator.TranslateField(
                     __instance, TextSkinFieldNames[index], Context);
+            }
+
+            for (var index = 0; index < ArrayTextSkinFieldNames.Length; index++)
+            {
+                SinkPrereqTextFieldTranslator.TranslateArrayField(
+                    __instance, ArrayTextSkinFieldNames[index], Context);
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- **TradeLine.setData**: Added `Qud.UI.TradeLine` to `SinkPrereqSetDataTranslationPatch` targets + `categoryText`, `check`, `rightFloatText` fields
- **TradeScreen.UpdateTitleBars**: Added to `SinkPrereqUiMethodTranslationPatch` targets + array field handling for `traderNames` (UITextSkin[])
- **SinkPrereqTextFieldTranslator**: New `TranslateArrayField` method to handle UITextSkin array fields via reflection

2 new L2 tests, 2 new DummyTargets. All 750 L1 + 391 L2 tests pass.

Closes partial #201 (TRADE_SCREEN 4/5 remaining items — UpdateViewFromData has no translatable text, HandleHighlightObject was already covered)

## Design decisions
- **Observation-only**: SinkPrereq remains observation-only per #201 design principles — fields are observed but not translated at sink level
- **Array field handling**: `traderNames` is `UITextSkin[]`, not a single field. Added `ArrayTextSkinFieldNames` + `TranslateArrayField` to handle array-type fields generically

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] 750/750 L1 tests pass
- [x] 391/391 L2 tests pass
- [ ] L3: manual in-game verification of trade screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * トレード画面のUI要素（商人名、取引行フィールド）に対する翻訳機能を拡張しました。

* **テスト**
  * トレードUI翻訳動作に関する新しいテストケースを追加しました。

* **改善**
  * 配列フィールド翻訳のための内部ヘルパー機能を追加し、翻訳パッチの対象範囲を拡大しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->