### PR TITLE
perf(test): L1 test time 2m33s → 1s via OneTimeSetUp (#210)

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs
@@ -13,8 +13,8 @@ public sealed class DoesVerbFamilyTests
     private string dictionaryDirectory = null!;
     private string leafFilePath = null!;
 
-    [SetUp]
-    public void SetUp()
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
     {
         tempDirectory = Path.Combine(Path.GetTempPath(), "qudjp-does-l1", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDirectory);
@@ -60,8 +60,8 @@ public sealed class DoesVerbFamilyTests
         MessagePatternTranslator.SetLeafFileForTests(leafFilePath);
     }
 
-    [TearDown]
-    public void TearDown()
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
     {
         MessagePatternTranslator.ResetForTests();
         MessageFrameTranslator.ResetForTests();


### PR DESCRIPTION
## Summary
- `DoesVerbFamilyTests` の `[SetUp]` → `[OneTimeSetUp]`、`[TearDown]` → `[OneTimeTearDown]` に変更
- 409テストケースが毎回辞書ファイル読み込み・正規表現コンパイルを繰り返していた問題を解消
- 全テストケースは同じ本番辞書を読むだけで変更しないため安全

## Performance
| テスト | Before | After |
|--------|--------|-------|
| L1 (750) | **2m 33s** | **1s** |
| L2 (420) | 2s | 2s |

## Test plan
- [x] L1: 750 pass (1s)
- [x] L2: 420 pass (2s)
- [x] Codex 安全性評価済み
- [x] Claude code review: findings 0件

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * テスト実行パフォーマンスの最適化。フィクスチャの初期化と終了処理を最適化し、テスト実行効率を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->