### PR TITLE
feat: combat message pipeline — add Messaging.EmitMessage target + pattern-match-first for mixed JP/EN (#219, #220)

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
@@ -318,6 +318,34 @@ internal sealed class DummyGameObjectEmitMessageTarget
     }
 }
 
+internal static class DummyMessagingEmitMessageTarget
+{
+    public static string MessageToSend { get; set; } = string.Empty;
+
+    public static string? ColorToSend { get; set; }
+
+    public static void EmitMessage(
+        DummyGameObject who,
+        string message,
+        char ifPlayer,
+        bool inScreenBuffer,
+        bool log,
+        bool single,
+        DummyGameObject? fromDialog = null,
+        DummyGameObject? fromCurrentCell = null)
+    {
+        _ = who;
+        _ = message;
+        _ = ifPlayer;
+        _ = inScreenBuffer;
+        _ = log;
+        _ = single;
+        _ = fromDialog;
+        _ = fromCurrentCell;
+        DummyMessageQueue.AddPlayerMessage(MessageToSend, ColorToSend, Capitalize: false);
+    }
+}
+
 internal sealed class DummyZoneManagerTryThawZoneTarget
 {
     public string MessageToSend { get; set; } = string.Empty;

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
@@ -122,7 +122,7 @@ internal static class ColorRouteCatalog
             ["Mods/QudJP/Assemblies/src/Patches/MainMenuRowTranslationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/PlayerStatusBarProducerTranslationHelpers.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/MessageLogProducerTranslationHelpers.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 2,
-            ["Mods/QudJP/Assemblies/src/Patches/MessageLogProducerTranslationHelpers.cs|MessagePatternTranslator.Translate("] = 3,
+            ["Mods/QudJP/Assemblies/src/Patches/MessageLogProducerTranslationHelpers.cs|MessagePatternTranslator.Translate("] = 4,
             ["Mods/QudJP/Assemblies/src/Patches/OptionsLocalizationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/PickGameObjectScreenTranslationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/PopupMessageTranslationPatch.cs|PopupTranslationPatch.TranslatePopupTextForProducerRoute("] = 1,

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
@@ -485,6 +485,80 @@ public sealed class CombatAndLogMessageQueuePatchTests
     }
 
     [Test]
+    public void MessagingEmitMessage_TranslatesVariableReplaceOutput_WhenPatched()
+    {
+        WritePatternDictionary(
+            ("^You are surrounded by (.+?)\\.$", "{0}に包囲されている。"));
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(
+                    typeof(DummyMessagingEmitMessageTarget),
+                    nameof(DummyMessagingEmitMessageTarget.EmitMessage),
+                    typeof(DummyGameObject),
+                    typeof(string),
+                    typeof(char),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(DummyGameObject),
+                    typeof(DummyGameObject)),
+                typeof(GameObjectEmitMessageTranslationPatch));
+
+            DummyMessagingEmitMessageTarget.MessageToSend = "You are surrounded by baboons.";
+            DummyMessagingEmitMessageTarget.EmitMessage(new DummyGameObject(), "unused", 'W', false, false, false);
+
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("baboonsに包囲されている。"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void MessagingEmitMessage_TranslatesMixedJapaneseAndEnglishCombatMessage_WhenPatched()
+    {
+        WritePatternDictionary(
+            ("^(?:The )?(.+) hits \\((x\\d+)\\) for (\\d+) damage with (?:his|her|its) (.+?)[.!] \\[(.+?)\\]$", "{0}の{3}で{2}ダメージを受けた。({1}) [{4}]"));
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(
+                    typeof(DummyMessagingEmitMessageTarget),
+                    nameof(DummyMessagingEmitMessageTarget.EmitMessage),
+                    typeof(DummyGameObject),
+                    typeof(string),
+                    typeof(char),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(DummyGameObject),
+                    typeof(DummyGameObject)),
+                typeof(GameObjectEmitMessageTranslationPatch));
+
+            DummyMessagingEmitMessageTarget.MessageToSend = "The ウォーターヴァイン農家 hits (x2) for 4 damage with his 鉄の蔓刈り斧. [17]";
+            DummyMessagingEmitMessageTarget.EmitMessage(new DummyGameObject(), "unused", 'W', false, false, false);
+
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("ウォーターヴァイン農家の鉄の蔓刈り斧で4ダメージを受けた。(x2) [17]"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
     public void ZoneManagerTryThawZone_TranslatesLeafMessage_WhenPatched()
     {
         WriteLeafDictionary(("ThawZone exception", "ゾーン解凍エラー"));
@@ -565,6 +639,37 @@ public sealed class CombatAndLogMessageQueuePatchTests
             var target = new DummyZoneManagerMapNotesTarget
             {
                 MessageToSend = "Notes: ancient bones",
+            };
+
+            target.SetActiveZone(new DummyZone());
+
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("注記: ancient bones"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void ZoneManagerSetActiveZoneMapNotes_PreservesMixedLocalizedNotes_WhenPatched()
+    {
+        WritePatternDictionary(
+            ("^Notes: (.+)$", "注記: {0}"));
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(typeof(DummyZoneManagerMapNotesTarget), nameof(DummyZoneManagerMapNotesTarget.SetActiveZone), typeof(DummyZone)),
+                typeof(ZoneManagerSetActiveZoneMapNotesTranslationPatch));
+
+            var target = new DummyZoneManagerMapNotesTarget
+            {
+                MessageToSend = "注記: ancient bones",
             };
 
             target.SetActiveZone(new DummyZone());

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -245,7 +245,6 @@ public sealed class TargetMethodResolutionTests
         "System.String",
     })]
     [TestCase(typeof(GameObjectRegeneraTranslationPatch), "FireEvent", "XRL.World.GameObject", "System.Boolean", new[] { "XRL.World.Event" })]
-    [TestCase(typeof(GameObjectEmitMessageTranslationPatch), "EmitMessage", "XRL.World.GameObject", "System.Void", new[] { "System.String", "XRL.World.GameObject", "System.String", "System.Boolean" })]
     [TestCase(typeof(GameObjectToggleActivatedAbilityTranslationPatch), "ToggleActivatedAbility", "XRL.World.GameObject", "System.Boolean", new[] { "System.Guid", "System.Boolean", "System.Nullable`1[[System.Boolean]]" })]
     [TestCase(typeof(ZoneManagerTryThawZoneTranslationPatch), "TryThawZone", "XRL.World.ZoneManager", "System.Boolean", new[] { "System.String", "XRL.World.Zone&" })]
     [TestCase(typeof(ZoneManagerTickTranslationPatch), "Tick", "XRL.World.ZoneManager", "System.Void", new[] { "System.Boolean" })]
@@ -334,6 +333,11 @@ public sealed class TargetMethodResolutionTests
     {
         "",
         "",
+    })]
+    [TestCase(typeof(GameObjectEmitMessageTranslationPatch), new[]
+    {
+        "System.String|XRL.World.GameObject|System.String|System.Boolean",
+        "XRL.World.GameObject|System.String|System.Char|System.Boolean|System.Boolean|System.Boolean|XRL.World.GameObject|XRL.World.GameObject",
     })]
     [TestCase(typeof(BookScreenTranslationPatch), new[]
     {

--- a/Mods/QudJP/Assemblies/src/Patches/GameObjectEmitMessageTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GameObjectEmitMessageTranslationPatch.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using HarmonyLib;
@@ -13,23 +14,55 @@ public static class GameObjectEmitMessageTranslationPatch
     [ThreadStatic]
     private static int activeDepth;
 
-    [HarmonyTargetMethod]
-    private static MethodBase? TargetMethod()
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
     {
         var gameObjectType = AccessTools.TypeByName("XRL.World.GameObject");
         if (gameObjectType is null)
         {
             Trace.TraceError("QudJP: GameObjectEmitMessageTranslationPatch target type not found.");
-            return null;
+            yield break;
         }
 
-        var method = AccessTools.Method(gameObjectType, "EmitMessage", new[] { typeof(string), gameObjectType, typeof(string), typeof(bool) });
-        if (method is null)
+        var gameObjectMethod = AccessTools.Method(gameObjectType, "EmitMessage", new[] { typeof(string), gameObjectType, typeof(string), typeof(bool) });
+        if (gameObjectMethod is not null)
+        {
+            yield return gameObjectMethod;
+        }
+        else
         {
             Trace.TraceError("QudJP: GameObjectEmitMessageTranslationPatch.EmitMessage(string, GameObject, string, bool) not found.");
         }
 
-        return method;
+        var messagingType = AccessTools.TypeByName("XRL.World.Capabilities.Messaging");
+        if (messagingType is null)
+        {
+            Trace.TraceError("QudJP: GameObjectEmitMessageTranslationPatch messaging type not found.");
+            yield break;
+        }
+
+        var messagingMethod = AccessTools.Method(
+            messagingType,
+            "EmitMessage",
+            new[]
+            {
+                gameObjectType,
+                typeof(string),
+                typeof(char),
+                typeof(bool),
+                typeof(bool),
+                typeof(bool),
+                gameObjectType,
+                gameObjectType,
+            });
+        if (messagingMethod is not null)
+        {
+            yield return messagingMethod;
+        }
+        else
+        {
+            Trace.TraceError("QudJP: GameObjectEmitMessageTranslationPatch.Messaging.EmitMessage(GameObject, string, char, bool, bool, bool, GameObject, GameObject) not found.");
+        }
     }
 
     public static void Prefix()

--- a/Mods/QudJP/Assemblies/src/Patches/MessageLogProducerTranslationHelpers.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/MessageLogProducerTranslationHelpers.cs
@@ -115,6 +115,14 @@ internal static class MessageLogProducerTranslationHelpers
 
         if (markJapaneseAsDirect && ContainsJapaneseCharacters(source))
         {
+            var patternTranslated = MessagePatternTranslator.Translate(source, route);
+            if (!string.Equals(patternTranslated, source, StringComparison.Ordinal))
+            {
+                DynamicTextObservability.RecordTransform(route, detail, source, patternTranslated);
+                source = MessageFrameTranslator.MarkDirectTranslation(patternTranslated);
+                return true;
+            }
+
             source = MessageFrameTranslator.MarkDirectTranslation(source);
             return true;
         }


### PR DESCRIPTION
## Summary
- add `Messaging.EmitMessage(GameObject, string, char, bool, bool, bool, GameObject, GameObject)` as a second Harmony target for `GameObjectEmitMessageTranslationPatch`
- try `MessagePatternTranslator.Translate()` before direct-marking JP-containing messages so mixed JP/EN combat strings can still match patterns
- add focused L2/L2G regressions for the static messaging path and map-note safety, and update the color-route catalog count

## Issues
Refs #218
Refs #219
Refs #220

## Validation
- ✅ `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- ✅ `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1`
- ✅ `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2`
- ✅ `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "Name~MessagingEmitMessage|Name~ZoneManagerSetActiveZoneMapNotes_PreservesMixedLocalizedNotes_WhenPatched|Name~GameObjectEmitMessageTranslationPatch"`
- ⚠️ `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2G` currently fails in unrelated existing `TargetMethodResolutionTests` cases for `GrammarMakeAndListPatch`, `GrammarInitCapsPatch`, `GrammarCardinalNumberPatch`, `SinkPrereqSetDataTranslationPatch`, `SinkPrereqUiMethodTranslationPatch`, `GrammarMakeOrListPatch`, and `PopupTranslationPatch`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * メッセージング機能の翻訳動作を検証するテストケースを追加しました。複数の言語パターンとメッセージキューの処理を確認する新しいテストが含まれています。

* **Refactor**
  * メッセージ翻訳システムの内部処理を改善しました。複数のメソッドオーバーロードに対応できるようにアーキテクチャを拡張し、パターン翻訳のロジックを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->