### PR TITLE
feat: expand DeathWrapperFamilyTranslator for all death causes (#221)

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DeathWrapperFamilyTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DeathWrapperFamilyTranslatorTests.cs
@@ -1,0 +1,262 @@
+using System.Text;
+using QudJP.Patches;
+
+namespace QudJP.Tests.L1;
+
+[TestFixture]
+[Category("L1")]
+[NonParallelizable]
+public sealed class DeathWrapperFamilyTranslatorTests
+{
+    private string tempDirectory = null!;
+    private string dictionaryDirectory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempDirectory = Path.Combine(Path.GetTempPath(), "qudjp-death-wrapper-l1", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        dictionaryDirectory = Path.Combine(tempDirectory, "dict");
+        Directory.CreateDirectory(dictionaryDirectory);
+
+        Translator.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(dictionaryDirectory);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+
+        WriteDictionary(CommonEntries());
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+
+        if (Directory.Exists(tempDirectory))
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [TestCaseSource(nameof(SupportedDeathCases))]
+    public void TryTranslateMessage_TranslatesSupportedDeathCases(string source, string expectedBody)
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                DeathWrapperFamilyTranslator.TryTranslateMessage(source, spans: null, out var bareTranslated),
+                Is.True,
+                source);
+            Assert.That(bareTranslated, Is.EqualTo(expectedBody));
+
+            var wrappedSource = "You died.\n\n" + source;
+            Assert.That(
+                DeathWrapperFamilyTranslator.TryTranslateMessage(wrappedSource, spans: null, out var wrappedTranslated),
+                Is.True,
+                wrappedSource);
+            Assert.That(wrappedTranslated, Is.EqualTo("あなたは死んだ。\n\n" + expectedBody));
+        });
+    }
+
+    [TestCaseSource(nameof(PopupDeathCases))]
+    public void TryTranslatePopup_TranslatesRepresentativeWrappedCases(string source, string expectedBody)
+    {
+        var wrappedSource = "You died.\n\n" + source;
+
+        var translated = DeathWrapperFamilyTranslator.TryTranslatePopup(
+            wrappedSource,
+            spans: null,
+            nameof(PopupTranslationPatch),
+            out var popupTranslated);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(popupTranslated, Is.EqualTo("あなたは死んだ。\n\n" + expectedBody));
+        });
+    }
+
+    [Test]
+    public void TryTranslateMessage_KeepsAlreadyLocalizedKillerName()
+    {
+        const string source = "You were killed by 監視官イラメ.";
+
+        var translated = DeathWrapperFamilyTranslator.TryTranslateMessage(source, spans: null, out var messageTranslated);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(messageTranslated, Is.EqualTo("監視官イラメに殺された。"));
+        });
+    }
+
+    [TestCase("You were killed by a snapjaw.", "スナップジョーに殺された。")]
+    [TestCase("You were killed by an amoeba.", "アメーバに殺された。")]
+    [TestCase("You were killed by the snapjaw.", "スナップジョーに殺された。")]
+    public void TryTranslateMessage_StripsEnglishArticlesFromKiller(string source, string expected)
+    {
+        var translated = DeathWrapperFamilyTranslator.TryTranslateMessage(source, spans: null, out var messageTranslated);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(messageTranslated, Is.EqualTo(expected));
+        });
+    }
+
+    [Test]
+    public void TryTranslateMessage_ReturnsFalseForUnknownCause()
+    {
+        const string source = "You were frobulated by a snapjaw.";
+
+        var translated = DeathWrapperFamilyTranslator.TryTranslateMessage(source, spans: null, out var messageTranslated);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.False);
+            Assert.That(messageTranslated, Is.EqualTo(source));
+        });
+    }
+
+    private static IEnumerable<TestCaseData> SupportedDeathCases()
+    {
+        yield return Case("You were killed by a snapjaw.", "スナップジョーに殺された。");
+        yield return Case("You were accidentally killed by a snapjaw.", "スナップジョーにうっかり殺された。");
+        yield return Case("You were bitten to death by a snapjaw.", "スナップジョーに噛み殺された。");
+        yield return Case("You were frozen to death by a snapjaw.", "スナップジョーに凍死させられた。");
+        yield return Case("You were immolated by a snapjaw.", "スナップジョーに焼き殺された。");
+        yield return Case("You were vaporized by a snapjaw.", "スナップジョーに蒸発させられた。");
+        yield return Case("You were electrocuted by an amoeba.", "アメーバに感電死させられた。");
+        yield return Case("You were dissolved by a snapjaw.", "スナップジョーに溶解させられた。");
+        yield return Case("You were disintegrated by a snapjaw.", "スナップジョーに分解された。");
+        yield return Case("You were plasma-burned to death by a snapjaw.", "スナップジョーにプラズマで焼き殺された。");
+        yield return Case("You were lased to death by a snapjaw.", "スナップジョーにレーザーで殺された。");
+        yield return Case("You were illuminated to death by a snapjaw.", "スナップジョーに光で殺された。");
+        yield return Case("You were cooked by a snapjaw.", "スナップジョーに調理された。");
+        yield return Case("You died of poison from a snapjaw.", "スナップジョーの毒で死亡した。");
+        yield return Case("You bled to death because of a snapjaw.", "スナップジョーのせいで出血死した。");
+        yield return Case("You died of asphyxiation from a snapjaw.", "スナップジョーによる窒息で死亡した。");
+        yield return Case("Your metabolism failed from a snapjaw.", "スナップジョーによる代謝不全で死亡した。");
+        yield return Case("Your vital essence was drained to extinction by a snapjaw.", "スナップジョーに生命力を吸い尽くされた。");
+        yield return Case("You were psychically extinguished by a snapjaw.", "スナップジョーに精神的に消滅させられた。");
+        yield return Case("You were mentally obliterated by a snapjaw.", "スナップジョーに精神破壊された。");
+        yield return Case("You were pricked to death by a snapjaw.", "スナップジョーに刺し殺された。");
+        yield return Case("You were killed by colliding with a wall.", "壁に衝突して死亡した。");
+        yield return Case("You were decapitated by a snapjaw.", "スナップジョーに斬首された。");
+        yield return Case("You were consumed whole by a snapjaw.", "スナップジョーに丸呑みにされた。");
+        yield return Case("You were slammed by a snapjaw.", "スナップジョーに叩きつけられて死んだ。");
+        yield return Case("You were slammed into a wall by a snapjaw.", "スナップジョーに壁へ叩きつけられて死んだ。");
+        yield return Case("You were slammed into two walls by a snapjaw.", "スナップジョーに二つの壁へ叩きつけられて死んだ。");
+        yield return Case("You were relieved of your vital anatomy by a snapjaw.", "スナップジョーに生命維持に必要な部位を失わされて死んだ。");
+        yield return Case("You died in the explosion of a grenade.", "グレネードの爆発で死んだ。");
+        yield return Case("You died in an explosion.", "爆発で死んだ。");
+        yield return Case("You exploded.", "爆発した。");
+        yield return Case("You were crushed under the weight of a thousand suns.", "千の太陽の重みで押し潰された。");
+        yield return Case("You died of thirst.", "渇きで死んだ。");
+        yield return Case("You killed yourself.", "自殺した。");
+        yield return Case("You accidentally killed yourself.", "うっかり自殺した。");
+    }
+
+    private static IEnumerable<TestCaseData> PopupDeathCases()
+    {
+        yield return Case("You were killed by a snapjaw.", "スナップジョーに殺された。");
+        yield return Case("You died of poison from a snapjaw.", "スナップジョーの毒で死亡した。");
+        yield return Case("You bled to death because of a snapjaw.", "スナップジョーのせいで出血死した。");
+        yield return Case("You died in the explosion of a grenade.", "グレネードの爆発で死んだ。");
+        yield return Case("You died of thirst.", "渇きで死んだ。");
+    }
+
+    private static TestCaseData Case(string source, string expectedBody)
+    {
+        return new TestCaseData(source, expectedBody)
+            .SetName(source.Replace("\n", "\\n", StringComparison.Ordinal));
+    }
+
+    private static IEnumerable<(string key, string text)> CommonEntries()
+    {
+        return new (string key, string text)[]
+        {
+            ("QudJP.DeathWrapper.Generic.Wrapped", "あなたは死んだ。\n\n{body}"),
+            ("QudJP.DeathWrapper.KilledBy.Bare", "{killer}に殺された。"),
+            ("QudJP.DeathWrapper.KilledByCollidingWith.Bare", "{killer}に衝突して死亡した。"),
+            ("QudJP.DeathWrapper.AccidentallyKilledBy.Bare", "{killer}にうっかり殺された。"),
+            ("QudJP.DeathWrapper.BittenToDeathBy.Bare", "{killer}に噛み殺された。"),
+            ("QudJP.DeathWrapper.FrozenToDeathBy.Bare", "{killer}に凍死させられた。"),
+            ("QudJP.DeathWrapper.ImmolatedBy.Bare", "{killer}に焼き殺された。"),
+            ("QudJP.DeathWrapper.VaporizedBy.Bare", "{killer}に蒸発させられた。"),
+            ("QudJP.DeathWrapper.ElectrocutedBy.Bare", "{killer}に感電死させられた。"),
+            ("QudJP.DeathWrapper.DissolvedBy.Bare", "{killer}に溶解させられた。"),
+            ("QudJP.DeathWrapper.DisintegratedBy.Bare", "{killer}に分解された。"),
+            ("QudJP.DeathWrapper.PlasmaBurnedToDeathBy.Bare", "{killer}にプラズマで焼き殺された。"),
+            ("QudJP.DeathWrapper.LasedToDeathBy.Bare", "{killer}にレーザーで殺された。"),
+            ("QudJP.DeathWrapper.IlluminatedToDeathBy.Bare", "{killer}に光で殺された。"),
+            ("QudJP.DeathWrapper.CookedBy.Bare", "{killer}に調理された。"),
+            ("QudJP.DeathWrapper.DiedOfPoisonFrom.Bare", "{killer}の毒で死亡した。"),
+            ("QudJP.DeathWrapper.BledToDeathBecauseOf.Bare", "{killer}のせいで出血死した。"),
+            ("QudJP.DeathWrapper.DiedOfAsphyxiationFrom.Bare", "{killer}による窒息で死亡した。"),
+            ("QudJP.DeathWrapper.MetabolismFailedFrom.Bare", "{killer}による代謝不全で死亡した。"),
+            ("QudJP.DeathWrapper.VitalEssenceDrainedToExtinctionBy.Bare", "{killer}に生命力を吸い尽くされた。"),
+            ("QudJP.DeathWrapper.PsychicallyExtinguishedBy.Bare", "{killer}に精神的に消滅させられた。"),
+            ("QudJP.DeathWrapper.MentallyObliteratedBy.Bare", "{killer}に精神破壊された。"),
+            ("QudJP.DeathWrapper.PrickedToDeathBy.Bare", "{killer}に刺し殺された。"),
+            ("QudJP.DeathWrapper.DecapitatedBy.Bare", "{killer}に斬首された。"),
+            ("QudJP.DeathWrapper.ConsumedWholeBy.Bare", "{killer}に丸呑みにされた。"),
+            ("QudJP.DeathWrapper.SlammedBy.Bare", "{killer}に叩きつけられて死んだ。"),
+            ("QudJP.DeathWrapper.SlammedIntoWallBy.Bare", "{killer}に壁へ叩きつけられて死んだ。"),
+            ("QudJP.DeathWrapper.SlammedIntoTwoWallsBy.Bare", "{killer}に二つの壁へ叩きつけられて死んだ。"),
+            ("QudJP.DeathWrapper.RelievedOfYourVitalAnatomyBy.Bare", "{killer}に生命維持に必要な部位を失わされて死んだ。"),
+            ("QudJP.DeathWrapper.DiedInExplosionOf.Bare", "{killer}の爆発で死んだ。"),
+            ("QudJP.DeathWrapper.DiedInExplosion.Bare", "爆発で死んだ。"),
+            ("QudJP.DeathWrapper.Exploded.Bare", "爆発した。"),
+            ("QudJP.DeathWrapper.CrushedUnderSuns.Bare", "千の太陽の重みで押し潰された。"),
+            ("QudJP.DeathWrapper.DiedOfThirst.Bare", "渇きで死んだ。"),
+            ("QudJP.DeathWrapper.Suicide.Bare", "自殺した。"),
+            ("QudJP.DeathWrapper.AccidentalSuicide.Bare", "うっかり自殺した。"),
+            ("snapjaw", "スナップジョー"),
+            ("amoeba", "アメーバ"),
+            ("wall", "壁"),
+            ("grenade", "グレネード")
+        };
+    }
+
+    private void WriteDictionary(IEnumerable<(string key, string text)> entries)
+    {
+        var builder = new StringBuilder();
+        builder.Append('{');
+        builder.Append("\"entries\":[");
+
+        var first = true;
+        foreach (var (key, text) in entries)
+        {
+            if (!first)
+            {
+                builder.Append(',');
+            }
+
+            first = false;
+            builder.Append("{\"key\":\"");
+            builder.Append(EscapeJson(key));
+            builder.Append("\",\"text\":\"");
+            builder.Append(EscapeJson(text));
+            builder.Append("\"}");
+        }
+
+        builder.Append("]}");
+        File.WriteAllText(
+            Path.Combine(dictionaryDirectory, "test.ja.json"),
+            builder.ToString(),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private static string EscapeJson(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\t", "\\t", StringComparison.Ordinal);
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -662,11 +662,40 @@ public sealed class MessagePatternTranslatorTests
     public void Translate_AppliesWrappedDeathWrapperViaSharedFamily()
     {
         WritePatternDictionary(("^You hear (.+?)[.!]?$", "{0}を聞いた。"));
-        WriteExactDictionary(("QudJP.DeathWrapper.KilledBy.Wrapped", "あなたは死んだ。\n\n{killer}に殺された。"));
+        WriteExactDictionary(
+            ("QudJP.DeathWrapper.Generic.Wrapped", "あなたは死んだ。\n\n{body}"),
+            ("QudJP.DeathWrapper.KilledBy.Bare", "{killer}に殺された。"));
 
         var translated = MessagePatternTranslator.Translate("You died.\n\nYou were killed by a ウォーターヴァイン農家.");
 
         Assert.That(translated, Is.EqualTo("あなたは死んだ。\n\nウォーターヴァイン農家に殺された。"));
+    }
+
+    [Test]
+    public void Translate_AppliesWrappedDeathWrapperWithFromPrepositionViaSharedFamily()
+    {
+        WritePatternDictionary(("^You hear (.+?)[.!]?$", "{0}を聞いた。"));
+        WriteExactDictionary(
+            ("QudJP.DeathWrapper.Generic.Wrapped", "あなたは死んだ。\n\n{body}"),
+            ("QudJP.DeathWrapper.DiedOfPoisonFrom.Bare", "{killer}の毒で死亡した。"));
+
+        var translated = MessagePatternTranslator.Translate("You died.\n\nYou died of poison from a ウォーターヴァイン農家.");
+
+        Assert.That(translated, Is.EqualTo("あなたは死んだ。\n\nウォーターヴァイン農家の毒で死亡した。"));
+    }
+
+    [Test]
+    public void Translate_AppliesExplosionDeathWrapperViaSharedFamily()
+    {
+        WritePatternDictionary(("^You hear (.+?)[.!]?$", "{0}を聞いた。"));
+        WriteExactDictionary(
+            ("QudJP.DeathWrapper.Generic.Wrapped", "あなたは死んだ。\n\n{body}"),
+            ("QudJP.DeathWrapper.DiedInExplosionOf.Bare", "{killer}の爆発で死んだ。"),
+            ("grenade", "グレネード"));
+
+        var translated = MessagePatternTranslator.Translate("You died.\n\nYou died in the explosion of a grenade.");
+
+        Assert.That(translated, Is.EqualTo("あなたは死んだ。\n\nグレネードの爆発で死んだ。"));
     }
 
     [Test]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupTranslationPatchTests.cs
@@ -362,12 +362,12 @@ public sealed class PopupTranslationPatchTests
     }
 
     [Test]
-    public void Prefix_ObservationOnly_DeathPopupReturnsSourceUnchanged()
+    public void Prefix_TranslatesDeathPopup_WhenPatched()
     {
         WriteDictionary(
-            ("QudJP.DeathWrapper.KilledBy.Wrapped", "あなたは死んだ。\n\n{killer}に殺された。"),
-            ("dromad merchant", "ドロマド商人"),
-            ("sitting", "座っている"));
+            ("QudJP.DeathWrapper.Generic.Wrapped", "あなたは死んだ。\n\n{body}"),
+            ("QudJP.DeathWrapper.KilledBy.Bare", "{killer}に殺された。"),
+            ("dromad merchant", "ドロマド商人"));
 
         var harmonyId = CreateHarmonyId();
         var harmony = new Harmony(harmonyId);
@@ -378,9 +378,9 @@ public sealed class PopupTranslationPatchTests
                 original: RequireMethod(typeof(DummyPopupTarget), nameof(DummyPopupTarget.ShowBlock)),
                 prefix: new HarmonyMethod(RequireMethod(typeof(PopupTranslationPatch), nameof(PopupTranslationPatch.Prefix))));
 
-            DummyPopupTarget.ShowBlock("You died.\n\nYou were killed by タム, dromad merchant [sitting].", "Warning");
+            DummyPopupTarget.ShowBlock("You died.\n\nYou were killed by a dromad merchant.", "Warning");
 
-            Assert.That(DummyPopupTarget.LastShowBlockMessage, Is.EqualTo("You died.\n\nYou were killed by タム, dromad merchant [sitting]."));
+            Assert.That(DummyPopupTarget.LastShowBlockMessage, Is.EqualTo("あなたは死んだ。\n\nドロマド商人に殺された。"));
         }
         finally
         {
@@ -389,9 +389,12 @@ public sealed class PopupTranslationPatchTests
     }
 
     [Test]
-    public void Prefix_ObservationOnly_DeathPopupWithArticleReturnsSourceUnchanged()
+    public void Prefix_TranslatesDeathPopupWithFromPreposition_WhenPatched()
     {
-        WriteDictionary(("QudJP.DeathWrapper.KilledBy.Wrapped", "あなたは死んだ。\n\n{killer}に殺された。"));
+        WriteDictionary(
+            ("QudJP.DeathWrapper.Generic.Wrapped", "あなたは死んだ。\n\n{body}"),
+            ("QudJP.DeathWrapper.DiedOfPoisonFrom.Bare", "{killer}の毒で死亡した。"),
+            ("viper", "毒蛇"));
 
         var harmonyId = CreateHarmonyId();
         var harmony = new Harmony(harmonyId);
@@ -402,9 +405,9 @@ public sealed class PopupTranslationPatchTests
                 original: RequireMethod(typeof(DummyPopupTarget), nameof(DummyPopupTarget.ShowBlock)),
                 prefix: new HarmonyMethod(RequireMethod(typeof(PopupTranslationPatch), nameof(PopupTranslationPatch.Prefix))));
 
-            DummyPopupTarget.ShowBlock("You died.\n\nYou were killed by a ウォーターヴァイン農家.", "Warning");
+            DummyPopupTarget.ShowBlock("You died.\n\nYou died of poison from a viper.", "Warning");
 
-            Assert.That(DummyPopupTarget.LastShowBlockMessage, Is.EqualTo("You died.\n\nYou were killed by a ウォーターヴァイン農家."));
+            Assert.That(DummyPopupTarget.LastShowBlockMessage, Is.EqualTo("あなたは死んだ。\n\n毒蛇の毒で死亡した。"));
         }
         finally
         {
@@ -413,9 +416,12 @@ public sealed class PopupTranslationPatchTests
     }
 
     [Test]
-    public void Prefix_ObservationOnly_BittenToDeathReturnsSourceUnchanged()
+    public void Prefix_TranslatesBittenToDeathPopup_WhenPatched()
     {
-        WriteDictionary(("QudJP.DeathWrapper.BittenToDeathBy.Wrapped", "あなたは死んだ。\n\n{killer}に噛み殺された。"));
+        WriteDictionary(
+            ("QudJP.DeathWrapper.Generic.Wrapped", "あなたは死んだ。\n\n{body}"),
+            ("QudJP.DeathWrapper.BittenToDeathBy.Bare", "{killer}に噛み殺された。"),
+            ("snapjaw", "スナップジョー"));
 
         var harmonyId = CreateHarmonyId();
         var harmony = new Harmony(harmonyId);
@@ -426,9 +432,36 @@ public sealed class PopupTranslationPatchTests
                 original: RequireMethod(typeof(DummyPopupTarget), nameof(DummyPopupTarget.ShowBlock)),
                 prefix: new HarmonyMethod(RequireMethod(typeof(PopupTranslationPatch), nameof(PopupTranslationPatch.Prefix))));
 
-            DummyPopupTarget.ShowBlock("You died.\n\nYou were bitten to death by the ウォーターヴァイン農家.", "Warning");
+            DummyPopupTarget.ShowBlock("You died.\n\nYou were bitten to death by a snapjaw.", "Warning");
 
-            Assert.That(DummyPopupTarget.LastShowBlockMessage, Is.EqualTo("You died.\n\nYou were bitten to death by the ウォーターヴァイン農家."));
+            Assert.That(DummyPopupTarget.LastShowBlockMessage, Is.EqualTo("あなたは死んだ。\n\nスナップジョーに噛み殺された。"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void Prefix_TranslatesExplosionDeathPopup_WhenPatched()
+    {
+        WriteDictionary(
+            ("QudJP.DeathWrapper.Generic.Wrapped", "あなたは死んだ。\n\n{body}"),
+            ("QudJP.DeathWrapper.DiedInExplosionOf.Bare", "{killer}の爆発で死んだ。"),
+            ("grenade", "グレネード"));
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyPopupTarget), nameof(DummyPopupTarget.ShowBlock)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(PopupTranslationPatch), nameof(PopupTranslationPatch.Prefix))));
+
+            DummyPopupTarget.ShowBlock("You died.\n\nYou died in the explosion of a grenade.", "Warning");
+
+            Assert.That(DummyPopupTarget.LastShowBlockMessage, Is.EqualTo("あなたは死んだ。\n\nグレネードの爆発で死んだ。"));
         }
         finally
         {

--- a/Mods/QudJP/Assemblies/src/Patches/DeathWrapperFamilyTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/DeathWrapperFamilyTranslator.cs
@@ -6,53 +6,117 @@ namespace QudJP.Patches;
 
 internal static class DeathWrapperFamilyTranslator
 {
-    private static readonly DeathWrapperDefinition[] PopupDefinitions =
+    private const string WrappedTemplateKey = "QudJP.DeathWrapper.Generic.Wrapped";
+
+    private static readonly Regex WrappedCausePattern =
+        new Regex(
+            "^You died\\.\\n\\n(?:You were|You|Your) (?<cause>.+?) (?<prep>by colliding with|because of|from|by) (?:a |an |the )?(?<killer>.+?)[.!]?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex BareCausePattern =
+        new Regex(
+            "^(?:You were|You|Your) (?<cause>.+?) (?<prep>by colliding with|because of|from|by) (?:a |an |the )?(?<killer>.+?)[.!]?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex WrappedExplosionPattern =
+        new Regex(
+            "^You died\\.\\n\\nYou died in the explosion of (?:a |an |the )?(?<killer>.+?)[.!]?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex BareExplosionPattern =
+        new Regex(
+            "^You died in the explosion of (?:a |an |the )?(?<killer>.+?)[.!]?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex WrappedGenericExplosionPattern =
+        new Regex(
+            "^You died\\.\\n\\nYou died in an explosion[.!]?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex BareGenericExplosionPattern =
+        new Regex(
+            "^You died in an explosion[.!]?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex WrappedSelfExplosionPattern =
+        new Regex(
+            "^You died\\.\\n\\nYou exploded[.!]?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex BareSelfExplosionPattern =
+        new Regex(
+            "^You exploded[.!]?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex WrappedNeutronPattern =
+        new Regex(
+            "^You died\\.\\n\\nYou were crushed under the weight of a thousand suns[.!]?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex BareNeutronPattern =
+        new Regex(
+            "^You were crushed under the weight of a thousand suns[.!]?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex WrappedThirstPattern =
+        new Regex(
+            "^You died\\.\\n\\nYou died of thirst[.!]?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex BareThirstPattern =
+        new Regex(
+            "^You died of thirst[.!]?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex WrappedSuicidePattern =
+        new Regex(
+            "^You died\\.\\n\\nYou (?<accidental>accidentally )?killed yourself[.!]?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex BareSuicidePattern =
+        new Regex(
+            "^You (?<accidental>accidentally )?killed yourself[.!]?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Dictionary<string, string> CauseBodyKeys = new(StringComparer.Ordinal)
     {
-        new(
-            "DeathWrapper.KilledBy",
-            "^You died\\.\\n\\nYou were killed by (?:a |an |the )?(?<killer>.+?)[.!]?$",
-            "QudJP.DeathWrapper.KilledBy.Wrapped",
-            "{killer}"),
-        new(
-            "DeathWrapper.BittenToDeathBy",
-            "^You died\\.\\n\\nYou were bitten to death by (?:a |an |the )?(?<killer>.+?)[.!]?$",
-            "QudJP.DeathWrapper.BittenToDeathBy.Wrapped",
-            "{killer}"),
+        ["killed|by"] = "QudJP.DeathWrapper.KilledBy.Bare",
+        ["killed|by colliding with"] = "QudJP.DeathWrapper.KilledByCollidingWith.Bare",
+        ["accidentally killed|by"] = "QudJP.DeathWrapper.AccidentallyKilledBy.Bare",
+        ["bitten to death|by"] = "QudJP.DeathWrapper.BittenToDeathBy.Bare",
+        ["frozen to death|by"] = "QudJP.DeathWrapper.FrozenToDeathBy.Bare",
+        ["immolated|by"] = "QudJP.DeathWrapper.ImmolatedBy.Bare",
+        ["vaporized|by"] = "QudJP.DeathWrapper.VaporizedBy.Bare",
+        ["electrocuted|by"] = "QudJP.DeathWrapper.ElectrocutedBy.Bare",
+        ["dissolved|by"] = "QudJP.DeathWrapper.DissolvedBy.Bare",
+        ["disintegrated|by"] = "QudJP.DeathWrapper.DisintegratedBy.Bare",
+        ["plasma-burned to death|by"] = "QudJP.DeathWrapper.PlasmaBurnedToDeathBy.Bare",
+        ["lased to death|by"] = "QudJP.DeathWrapper.LasedToDeathBy.Bare",
+        ["illuminated to death|by"] = "QudJP.DeathWrapper.IlluminatedToDeathBy.Bare",
+        ["cooked|by"] = "QudJP.DeathWrapper.CookedBy.Bare",
+        ["died of poison|from"] = "QudJP.DeathWrapper.DiedOfPoisonFrom.Bare",
+        ["bled to death|because of"] = "QudJP.DeathWrapper.BledToDeathBecauseOf.Bare",
+        ["died of asphyxiation|from"] = "QudJP.DeathWrapper.DiedOfAsphyxiationFrom.Bare",
+        ["metabolism failed|from"] = "QudJP.DeathWrapper.MetabolismFailedFrom.Bare",
+        ["vital essence was drained to extinction|by"] = "QudJP.DeathWrapper.VitalEssenceDrainedToExtinctionBy.Bare",
+        ["psychically extinguished|by"] = "QudJP.DeathWrapper.PsychicallyExtinguishedBy.Bare",
+        ["mentally obliterated|by"] = "QudJP.DeathWrapper.MentallyObliteratedBy.Bare",
+        ["pricked to death|by"] = "QudJP.DeathWrapper.PrickedToDeathBy.Bare",
+        ["decapitated|by"] = "QudJP.DeathWrapper.DecapitatedBy.Bare",
+        ["consumed whole|by"] = "QudJP.DeathWrapper.ConsumedWholeBy.Bare",
+        ["slammed|by"] = "QudJP.DeathWrapper.SlammedBy.Bare",
+        ["slammed into a wall|by"] = "QudJP.DeathWrapper.SlammedIntoWallBy.Bare",
+        ["slammed into two walls|by"] = "QudJP.DeathWrapper.SlammedIntoTwoWallsBy.Bare",
+        ["relieved of your vital anatomy|by"] = "QudJP.DeathWrapper.RelievedOfYourVitalAnatomyBy.Bare",
     };
 
-    private static readonly DeathWrapperDefinition[] MessageDefinitions =
+    internal static bool TryTranslatePopup(
+        string source,
+        IReadOnlyList<ColorSpan>? spans,
+        string route,
+        out string translated)
     {
-        new(
-            "DeathWrapper.KilledBy",
-            "^You died\\.\\n\\nYou were killed by (?:a |an |the )?(?<killer>.+?)[.!]?$",
-            "QudJP.DeathWrapper.KilledBy.Wrapped",
-            "{killer}"),
-        new(
-            "DeathWrapper.BittenToDeathBy",
-            "^You died\\.\\n\\nYou were bitten to death by (?:a |an |the )?(?<killer>.+?)[.!]?$",
-            "QudJP.DeathWrapper.BittenToDeathBy.Wrapped",
-            "{killer}"),
-        new(
-            "DeathWrapper.KilledByBare",
-            "^You were killed by (?:a |an |the )?(?<killer>.+?)[.!]?$",
-            "QudJP.DeathWrapper.KilledBy.Bare",
-            "{killer}"),
-        new(
-            "DeathWrapper.AccidentallyKilledByBare",
-            "^You were accidentally killed by (?:a |an |the )?(?<killer>.+?)[.!]?$",
-            "QudJP.DeathWrapper.AccidentallyKilledBy.Bare",
-            "{killer}"),
-    };
-
-    internal static bool TryTranslatePopup(string source, out string translated)
-    {
-        return TryTranslate(
-            source,
-            spans: null,
-            PopupDefinitions,
-            translationContext: nameof(PopupTranslationPatch),
-            observabilityRoute: nameof(PopupTranslationPatch),
-            out translated);
+        return TryTranslate(source, spans, route, route, out translated);
     }
 
     internal static bool TryTranslateMessage(string source, IReadOnlyList<ColorSpan>? spans, out string translated)
@@ -60,7 +124,6 @@ internal static class DeathWrapperFamilyTranslator
         return TryTranslate(
             source,
             spans,
-            MessageDefinitions,
             translationContext: nameof(MessageLogPatch),
             observabilityRoute: nameof(MessagePatternTranslator),
             out translated);
@@ -89,67 +152,280 @@ internal static class DeathWrapperFamilyTranslator
     private static bool TryTranslate(
         string source,
         IReadOnlyList<ColorSpan>? spans,
-        DeathWrapperDefinition[] definitions,
         string translationContext,
         string observabilityRoute,
         out string translated)
     {
-        for (var index = 0; index < definitions.Length; index++)
+        if (TryTranslateKillerBody(
+                source,
+                spans,
+                WrappedCausePattern,
+                wrapped: true,
+                family: "DeathWrapper.Generic.Wrapped",
+                translationContext,
+                observabilityRoute,
+                ResolveCauseBodyKey,
+                out translated)
+            || TryTranslateKillerBody(
+                source,
+                spans,
+                BareCausePattern,
+                wrapped: false,
+                family: "DeathWrapper.Generic.Bare",
+                translationContext,
+                observabilityRoute,
+                ResolveCauseBodyKey,
+                out translated)
+            || TryTranslateKillerBody(
+                source,
+                spans,
+                WrappedExplosionPattern,
+                wrapped: true,
+                family: "DeathWrapper.ExplosionOf.Wrapped",
+                translationContext,
+                observabilityRoute,
+                _ => "QudJP.DeathWrapper.DiedInExplosionOf.Bare",
+                out translated)
+            || TryTranslateKillerBody(
+                source,
+                spans,
+                BareExplosionPattern,
+                wrapped: false,
+                family: "DeathWrapper.ExplosionOf.Bare",
+                translationContext,
+                observabilityRoute,
+                _ => "QudJP.DeathWrapper.DiedInExplosionOf.Bare",
+                out translated)
+            || TryTranslateBody(
+                source,
+                spans,
+                WrappedGenericExplosionPattern,
+                wrapped: true,
+                family: "DeathWrapper.Explosion.Wrapped",
+                observabilityRoute,
+                _ => "QudJP.DeathWrapper.DiedInExplosion.Bare",
+                out translated)
+            || TryTranslateBody(
+                source,
+                spans,
+                BareGenericExplosionPattern,
+                wrapped: false,
+                family: "DeathWrapper.Explosion.Bare",
+                observabilityRoute,
+                _ => "QudJP.DeathWrapper.DiedInExplosion.Bare",
+                out translated)
+            || TryTranslateBody(
+                source,
+                spans,
+                WrappedSelfExplosionPattern,
+                wrapped: true,
+                family: "DeathWrapper.Exploded.Wrapped",
+                observabilityRoute,
+                _ => "QudJP.DeathWrapper.Exploded.Bare",
+                out translated)
+            || TryTranslateBody(
+                source,
+                spans,
+                BareSelfExplosionPattern,
+                wrapped: false,
+                family: "DeathWrapper.Exploded.Bare",
+                observabilityRoute,
+                _ => "QudJP.DeathWrapper.Exploded.Bare",
+                out translated)
+            || TryTranslateBody(
+                source,
+                spans,
+                WrappedNeutronPattern,
+                wrapped: true,
+                family: "DeathWrapper.CrushedUnderSuns.Wrapped",
+                observabilityRoute,
+                _ => "QudJP.DeathWrapper.CrushedUnderSuns.Bare",
+                out translated)
+            || TryTranslateBody(
+                source,
+                spans,
+                BareNeutronPattern,
+                wrapped: false,
+                family: "DeathWrapper.CrushedUnderSuns.Bare",
+                observabilityRoute,
+                _ => "QudJP.DeathWrapper.CrushedUnderSuns.Bare",
+                out translated)
+            || TryTranslateBody(
+                source,
+                spans,
+                WrappedThirstPattern,
+                wrapped: true,
+                family: "DeathWrapper.Thirst.Wrapped",
+                observabilityRoute,
+                _ => "QudJP.DeathWrapper.DiedOfThirst.Bare",
+                out translated)
+            || TryTranslateBody(
+                source,
+                spans,
+                BareThirstPattern,
+                wrapped: false,
+                family: "DeathWrapper.Thirst.Bare",
+                observabilityRoute,
+                _ => "QudJP.DeathWrapper.DiedOfThirst.Bare",
+                out translated)
+            || TryTranslateBody(
+                source,
+                spans,
+                WrappedSuicidePattern,
+                wrapped: true,
+                family: "DeathWrapper.Suicide.Wrapped",
+                observabilityRoute,
+                ResolveSuicideBodyKey,
+                out translated)
+            || TryTranslateBody(
+                source,
+                spans,
+                BareSuicidePattern,
+                wrapped: false,
+                family: "DeathWrapper.Suicide.Bare",
+                observabilityRoute,
+                ResolveSuicideBodyKey,
+                out translated))
         {
-            var definition = definitions[index];
-            var match = definition.Pattern.Match(source);
-            if (!match.Success)
-            {
-                continue;
-            }
-
-            var translatedTemplate = Translator.Translate(definition.TemplateKey);
-            if (string.Equals(translatedTemplate, definition.TemplateKey, StringComparison.Ordinal))
-            {
-                translated = source;
-                return false;
-            }
-
-            var killer = TranslateEntityReference(match.Groups["killer"].Value, translationContext);
-            if (spans is not null && spans.Count > 0)
-            {
-                killer = ColorAwareTranslationComposer.RestoreCapture(killer, spans, match.Groups["killer"]);
-            }
-
-            translated = translatedTemplate.Replace(definition.Placeholder, killer);
-            if (spans is not null && spans.Count > 0)
-            {
-                var boundarySpans = ColorAwareTranslationComposer.SliceBoundarySpans(
-                    spans,
-                    match,
-                    source.Length,
-                    translated.Length);
-                translated = ColorAwareTranslationComposer.Restore(translated, boundarySpans);
-            }
-
-            DynamicTextObservability.RecordTransform(observabilityRoute, definition.Family, source, translated);
             return true;
         }
 
         translated = source;
         return false;
     }
-    private sealed class DeathWrapperDefinition
+
+    private static bool TryTranslateKillerBody(
+        string source,
+        IReadOnlyList<ColorSpan>? spans,
+        Regex pattern,
+        bool wrapped,
+        string family,
+        string translationContext,
+        string observabilityRoute,
+        Func<Match, string?> resolveBodyKey,
+        out string translated)
     {
-        internal DeathWrapperDefinition(string family, string pattern, string templateKey, string placeholder)
+        var match = pattern.Match(source);
+        if (!match.Success)
         {
-            Family = family;
-            Pattern = new Regex(pattern, RegexOptions.Compiled | RegexOptions.CultureInvariant);
-            TemplateKey = templateKey;
-            Placeholder = placeholder;
+            translated = source;
+            return false;
         }
 
-        internal string Family { get; }
+        if (resolveBodyKey(match) is not string bodyKey
+            || !TryTranslateBodyTemplate(bodyKey, out var bodyTemplate))
+        {
+            translated = source;
+            return false;
+        }
 
-        internal Regex Pattern { get; }
+        var killer = TranslateEntityReference(match.Groups["killer"].Value, translationContext);
+        if (spans is not null && spans.Count > 0)
+        {
+            killer = ColorAwareTranslationComposer.RestoreCapture(killer, spans, match.Groups["killer"]);
+        }
 
-        internal string TemplateKey { get; }
+        return TryComposeTranslation(
+            source,
+            spans,
+            match,
+            wrapped,
+            family,
+            observabilityRoute,
+            bodyTemplate.Replace("{killer}", killer),
+            out translated);
+    }
 
-        internal string Placeholder { get; }
+    private static bool TryTranslateBody(
+        string source,
+        IReadOnlyList<ColorSpan>? spans,
+        Regex pattern,
+        bool wrapped,
+        string family,
+        string observabilityRoute,
+        Func<Match, string?> resolveBodyKey,
+        out string translated)
+    {
+        var match = pattern.Match(source);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        if (resolveBodyKey(match) is not string bodyKey
+            || !TryTranslateBodyTemplate(bodyKey, out var bodyTemplate))
+        {
+            translated = source;
+            return false;
+        }
+
+        return TryComposeTranslation(
+            source,
+            spans,
+            match,
+            wrapped,
+            family,
+            observabilityRoute,
+            bodyTemplate,
+            out translated);
+    }
+
+    private static bool TryComposeTranslation(
+        string source,
+        IReadOnlyList<ColorSpan>? spans,
+        Match match,
+        bool wrapped,
+        string family,
+        string observabilityRoute,
+        string body,
+        out string translated)
+    {
+        if (wrapped)
+        {
+            if (!TryTranslateBodyTemplate(WrappedTemplateKey, out var wrappedTemplate))
+            {
+                translated = source;
+                return false;
+            }
+
+            translated = wrappedTemplate.Replace("{body}", body);
+        }
+        else
+        {
+            translated = body;
+        }
+
+        if (spans is not null && spans.Count > 0)
+        {
+            var boundarySpans = ColorAwareTranslationComposer.SliceBoundarySpans(
+                spans,
+                match,
+                source.Length,
+                translated.Length);
+            translated = ColorAwareTranslationComposer.Restore(translated, boundarySpans);
+        }
+
+        DynamicTextObservability.RecordTransform(observabilityRoute, family, source, translated);
+        return true;
+    }
+
+    private static bool TryTranslateBodyTemplate(string templateKey, out string translatedTemplate)
+    {
+        translatedTemplate = Translator.Translate(templateKey);
+        return !string.Equals(translatedTemplate, templateKey, StringComparison.Ordinal);
+    }
+
+    private static string? ResolveCauseBodyKey(Match match)
+    {
+        var causeKey = match.Groups["cause"].Value + "|" + match.Groups["prep"].Value;
+        return CauseBodyKeys.TryGetValue(causeKey, out var bodyKey) ? bodyKey : null;
+    }
+
+    private static string ResolveSuicideBodyKey(Match match)
+    {
+        return match.Groups["accidental"].Success
+            ? "QudJP.DeathWrapper.AccidentalSuicide.Bare"
+            : "QudJP.DeathWrapper.Suicide.Bare";
     }
 }

--- a/Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs
@@ -267,6 +267,12 @@ public static class PopupTranslationPatch
     {
         var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
 
+        if (DeathWrapperFamilyTranslator.TryTranslatePopup(stripped, spans, route, out var deathTranslated))
+        {
+            translated = deathTranslated;
+            return true;
+        }
+
         if (StringHelpers.TryGetTranslationExactOrLowerAscii(stripped, out var exact)
             && !string.Equals(exact, stripped, StringComparison.Ordinal))
         {

--- a/Mods/QudJP/Localization/Dictionaries/ui-death.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-death.ja.json
@@ -1,6 +1,10 @@
 {
     "entries": [
         {
+            "key": "QudJP.DeathWrapper.Generic.Wrapped",
+            "text": "あなたは死んだ。\n\n{body}"
+        },
+        {
             "key": "QudJP.DeathWrapper.KilledBy.Wrapped",
             "text": "あなたは死んだ。\n\n{killer}に殺された。"
         },
@@ -13,8 +17,140 @@
             "text": "{killer}に殺された。"
         },
         {
+            "key": "QudJP.DeathWrapper.KilledByCollidingWith.Bare",
+            "text": "{killer}に衝突して死亡した。"
+        },
+        {
             "key": "QudJP.DeathWrapper.AccidentallyKilledBy.Bare",
             "text": "{killer}にうっかり殺された。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.BittenToDeathBy.Bare",
+            "text": "{killer}に噛み殺された。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.FrozenToDeathBy.Bare",
+            "text": "{killer}に凍死させられた。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.ImmolatedBy.Bare",
+            "text": "{killer}に焼き殺された。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.VaporizedBy.Bare",
+            "text": "{killer}に蒸発させられた。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.ElectrocutedBy.Bare",
+            "text": "{killer}に感電死させられた。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.DissolvedBy.Bare",
+            "text": "{killer}に溶解させられた。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.DisintegratedBy.Bare",
+            "text": "{killer}に分解された。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.PlasmaBurnedToDeathBy.Bare",
+            "text": "{killer}にプラズマで焼き殺された。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.LasedToDeathBy.Bare",
+            "text": "{killer}にレーザーで殺された。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.IlluminatedToDeathBy.Bare",
+            "text": "{killer}に光で殺された。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.CookedBy.Bare",
+            "text": "{killer}に調理された。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.DiedOfPoisonFrom.Bare",
+            "text": "{killer}の毒で死亡した。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.BledToDeathBecauseOf.Bare",
+            "text": "{killer}のせいで出血死した。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.DiedOfAsphyxiationFrom.Bare",
+            "text": "{killer}による窒息で死亡した。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.MetabolismFailedFrom.Bare",
+            "text": "{killer}による代謝不全で死亡した。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.VitalEssenceDrainedToExtinctionBy.Bare",
+            "text": "{killer}に生命力を吸い尽くされた。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.PsychicallyExtinguishedBy.Bare",
+            "text": "{killer}に精神的に消滅させられた。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.MentallyObliteratedBy.Bare",
+            "text": "{killer}に精神破壊された。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.PrickedToDeathBy.Bare",
+            "text": "{killer}に刺し殺された。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.DecapitatedBy.Bare",
+            "text": "{killer}に斬首された。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.ConsumedWholeBy.Bare",
+            "text": "{killer}に丸呑みにされた。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.SlammedBy.Bare",
+            "text": "{killer}に叩きつけられて死んだ。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.SlammedIntoWallBy.Bare",
+            "text": "{killer}に壁へ叩きつけられて死んだ。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.SlammedIntoTwoWallsBy.Bare",
+            "text": "{killer}に二つの壁へ叩きつけられて死んだ。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.RelievedOfYourVitalAnatomyBy.Bare",
+            "text": "{killer}に生命維持に必要な部位を失わされて死んだ。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.DiedInExplosionOf.Bare",
+            "text": "{killer}の爆発で死んだ。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.DiedInExplosion.Bare",
+            "text": "爆発で死んだ。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.Exploded.Bare",
+            "text": "爆発した。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.CrushedUnderSuns.Bare",
+            "text": "千の太陽の重みで押し潰された。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.DiedOfThirst.Bare",
+            "text": "渇きで死んだ。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.Suicide.Bare",
+            "text": "自殺した。"
+        },
+        {
+            "key": "QudJP.DeathWrapper.AccidentalSuicide.Bare",
+            "text": "うっかり自殺した。"
         },
         {
             "key": "You were vaporized.",


### PR DESCRIPTION
## Summary
- expand `DeathWrapperFamilyTranslator` to translate all known wrapped death causes via cause/body lookup
- wire popup producer text through `TryTranslatePopup`, including non-`by` prepositions and special forms
- add focused L1/L2 coverage for cause variants, popup integration, and special death messages

Refs #218
Refs #221

## Test results
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2`

## Supported death causes
| Cause text | Preposition | Translation |
| --- | --- | --- |
| killed | by | `に殺された` |
| accidentally killed | by | `にうっかり殺された` |
| bitten to death | by | `に噛み殺された` |
| frozen to death | by | `に凍死させられた` |
| immolated | by | `に焼き殺された` |
| vaporized | by | `に蒸発させられた` |
| electrocuted | by | `に感電死させられた` |
| dissolved | by | `に溶解させられた` |
| disintegrated | by | `に分解された` |
| plasma-burned to death | by | `にプラズマで焼き殺された` |
| lased to death | by | `にレーザーで殺された` |
| illuminated to death | by | `に光で殺された` |
| cooked | by | `に調理された` |
| died of poison | from | `の毒で死亡した` |
| bled to death | because of | `のせいで出血死した` |
| died of asphyxiation | from | `による窒息で死亡した` |
| metabolism failed | from | `による代謝不全で死亡した` |
| vital essence was drained to extinction | by | `に生命力を吸い尽くされた` |
| psychically extinguished | by | `に精神的に消滅させられた` |
| mentally obliterated | by | `に精神破壊された` |
| pricked to death | by | `に刺し殺された` |
| killed | by colliding with | `に衝突して死亡した` |
| decapitated | by | `に斬首された` |
| consumed whole | by | `に丸呑みにされた` |
| slammed | by | `に叩きつけられて死んだ` |
| slammed into a wall | by | `に壁へ叩きつけられて死んだ` |
| slammed into two walls | by | `に二つの壁へ叩きつけられて死んだ` |
| relieved of your vital anatomy | by | `に生命維持に必要な部位を失わされて死んだ` |
| You died in the explosion of {thing}. | special | `{thing}の爆発で死んだ` |
| You died in an explosion. | special | `爆発で死んだ` |
| You exploded. | special | `爆発した` |
| You were crushed under the weight of a thousand suns. | special | `千の太陽の重みで押し潰された` |
| You died of thirst. | special | `渇きで死んだ` |
| You killed yourself. | special | `自殺した` |
| You accidentally killed yourself. | special | `うっかり自殺した` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 死亡メッセージ翻訳の包括的なテストスイートを追加し、多様な死亡シナリオとポップアップ翻訳を検証します。

* **Refactor**
  * 死亡メッセージの翻訳ロジックを再構成し、複数の死因パターン（ラッパー／素体、爆発等）を優先的に判定して正確に組み立てるよう改善しました。ポップアップ翻訳経路と連携します。

* **Chores**
  * 日本語辞書に30以上の死因関連テンプレート／エントリを追加して翻訳カバレッジを大幅に拡張しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->