### PR TITLE
fix: route lost-sight through owner translation (#288)

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
@@ -13,6 +13,11 @@ internal sealed class DummyZone
     public string ZoneId { get; set; } = string.Empty;
 }
 
+internal sealed class DummyScreenBuffer
+{
+    public int Width { get; set; }
+}
+
 internal sealed class DummyMissilePath
 {
     public int Length { get; set; }
@@ -201,6 +206,19 @@ internal sealed class DummyGameObjectPerformThrowTarget
         _ = energyCost;
         DummyMessageQueue.AddPlayerMessage(MessageToSend, ColorToSend, Capitalize: false);
         return true;
+    }
+}
+
+internal sealed class DummyXrlCoreRenderTarget
+{
+    public string MessageToSend { get; set; } = string.Empty;
+
+    public string? ColorToSend { get; set; }
+
+    public void RenderBaseToBuffer(DummyScreenBuffer buffer)
+    {
+        _ = buffer;
+        DummyMessageQueue.AddPlayerMessage(MessageToSend, ColorToSend, Capitalize: false);
     }
 }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/WorldPartsProducerTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/WorldPartsProducerTranslationPatchTests.cs
@@ -172,6 +172,55 @@ public sealed class WorldPartsProducerTranslationPatchTests
     }
 
     [Test]
+    public void XrlCoreLostSightPatch_RecordsOwnerRouteTransforms_WithoutMessageLogSinkObservation_WhenPatched()
+    {
+        WritePatternDictionary(("^You have lost sight of (.+?)[.!]?$", "{0}を見失った。"));
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchMessageLog(harmony);
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(typeof(DummyXrlCoreRenderTarget), nameof(DummyXrlCoreRenderTarget.RenderBaseToBuffer), typeof(DummyScreenBuffer)),
+                typeof(XrlCoreLostSightTranslationPatch));
+
+            const string source = "You have lost sight of bloody Naruur.";
+            var target = new DummyXrlCoreRenderTarget
+            {
+                MessageToSend = source,
+            };
+
+            target.RenderBaseToBuffer(new DummyScreenBuffer());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("bloody Naruurを見失った。"));
+                Assert.That(
+                    DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                        nameof(XrlCoreLostSightTranslationPatch),
+                        "LostSight"),
+                    Is.GreaterThan(0));
+                Assert.That(
+                    SinkObservation.GetHitCountForTests(
+                        nameof(MessageLogPatch),
+                        nameof(XrlCoreLostSightTranslationPatch),
+                        SinkObservation.ObservationOnlyDetail,
+                        source,
+                        source),
+                    Is.EqualTo(0));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
     public void EnclosingPatch_TranslatesExtricatePopup_WhenPatched()
     {
         var harmonyId = CreateHarmonyId();
@@ -249,12 +298,52 @@ public sealed class WorldPartsProducerTranslationPatchTests
             prefix: new HarmonyMethod(RequireMethod(typeof(CombatAndLogMessageQueuePatch), nameof(CombatAndLogMessageQueuePatch.Prefix), typeof(string).MakeByRefType(), typeof(string), typeof(bool))));
     }
 
+    private static void PatchMessageLog(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyMessageQueue), nameof(DummyMessageQueue.AddPlayerMessage), typeof(string), typeof(string), typeof(bool)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(MessageLogPatch), nameof(MessageLogPatch.Prefix), typeof(string).MakeByRefType(), typeof(string), typeof(bool))));
+    }
+
     private static void PatchOwner(Harmony harmony, MethodInfo original, Type patchType)
     {
         harmony.Patch(
             original: original,
             prefix: new HarmonyMethod(RequireMethod(patchType, nameof(LiquidVolumeTranslationPatch.Prefix))),
             finalizer: new HarmonyMethod(RequireMethod(patchType, nameof(LiquidVolumeTranslationPatch.Finalizer), typeof(Exception))));
+    }
+
+    private void WritePatternDictionary(params (string pattern, string template)[] patterns)
+    {
+        var builder = new StringBuilder();
+        builder.Append('{');
+        builder.Append("\"patterns\":[");
+
+        for (var index = 0; index < patterns.Length; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append("{\"pattern\":\"");
+            builder.Append(EscapeJson(patterns[index].pattern));
+            builder.Append("\",\"template\":\"");
+            builder.Append(EscapeJson(patterns[index].template));
+            builder.Append("\"}");
+        }
+
+        builder.Append("]}");
+        builder.AppendLine();
+
+        File.WriteAllText(patternFilePath, builder.ToString(), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private static string EscapeJson(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
     }
 
     private static string CreateHarmonyId()

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -154,6 +154,7 @@ public sealed class TargetMethodResolutionTests
     [TestCase(typeof(MessageLogPatch), "AddPlayerMessage", "XRL.Messages.MessageQueue", "System.Void", new[] { "System.String", "System.String", "System.Boolean" })]
     [TestCase(typeof(PhysicsEnterCellPassByTranslationPatch), "AddPlayerMessage", "XRL.Messages.MessageQueue", "System.Void", new[] { "System.String", "System.String", "System.Boolean" })]
     [TestCase(typeof(ZoneManagerSetActiveZoneMessageQueuePatch), "AddPlayerMessage", "XRL.Messages.MessageQueue", "System.Void", new[] { "System.String", "System.String", "System.Boolean" })]
+    [TestCase(typeof(XrlCoreLostSightTranslationPatch), "RenderBaseToBuffer", "XRL.Core.XRLCore", "System.Void", new[] { "ConsoleLib.Console.ScreenBuffer" })]
     [TestCase(typeof(ZoneManagerSetActiveZoneTranslationPatch), "SetActiveZone", "XRL.World.ZoneManager", "XRL.World.Zone", new[] { "XRL.World.Zone" })]
     [TestCase(typeof(JournalEntryDisplayTextPatch), "GetDisplayText", "Qud.API.IBaseJournalEntry", "System.String", new string[0])]
     [TestCase(typeof(JournalMapNoteDisplayTextPatch), "GetDisplayText", "Qud.API.JournalMapNote", "System.String", new string[0])]

--- a/Mods/QudJP/Assemblies/src/Patches/CombatAndLogMessageQueuePatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/CombatAndLogMessageQueuePatch.cs
@@ -42,6 +42,7 @@ public static class CombatAndLogMessageQueuePatch
                 || GameObjectRegeneraTranslationPatch.TryTranslateQueuedMessage(ref Message, Color)
                 || ClonelingVehicleTranslationPatch.TryTranslateQueuedMessage(ref Message, Color)
                 || GameObjectSpotTranslationPatch.TryTranslateQueuedMessage(ref Message, Color)
+                || XrlCoreLostSightTranslationPatch.TryTranslateQueuedMessage(ref Message, Color)
                 || GameObjectEmitMessageTranslationPatch.TryTranslateQueuedMessage(ref Message, Color)
                 || ZoneManagerTryThawZoneTranslationPatch.TryTranslateQueuedMessage(ref Message, Color)
                 || ZoneManagerTickTranslationPatch.TryTranslateQueuedMessage(ref Message, Color)

--- a/Mods/QudJP/Assemblies/src/Patches/XrlCoreLostSightTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/XrlCoreLostSightTranslationPatch.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class XrlCoreLostSightTranslationPatch
+{
+    private const string Context = nameof(XrlCoreLostSightTranslationPatch);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var coreType = GameTypeResolver.FindType("XRL.Core.XRLCore", "XRLCore");
+        if (coreType is null)
+        {
+            Trace.TraceError("QudJP: XrlCoreLostSightTranslationPatch target type not found.");
+            return null;
+        }
+
+        var screenBufferType = AccessTools.TypeByName("ConsoleLib.Console.ScreenBuffer");
+        if (screenBufferType is null)
+        {
+            Trace.TraceError("QudJP: XrlCoreLostSightTranslationPatch screen buffer type not found.");
+            return null;
+        }
+
+        var method = AccessTools.Method(coreType, "RenderBaseToBuffer", new[] { screenBufferType });
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: XrlCoreLostSightTranslationPatch.RenderBaseToBuffer(ScreenBuffer) not found.");
+        }
+
+        return method;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            activeDepth++;
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: XrlCoreLostSightTranslationPatch.Prefix failed: {0}", ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            if (activeDepth > 0)
+            {
+                activeDepth--;
+            }
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: XrlCoreLostSightTranslationPatch.Finalizer failed: {0}", ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color)
+    {
+        _ = color;
+
+        return activeDepth > 0
+            && !string.IsNullOrEmpty(message)
+            && message.StartsWith("You have lost sight of ", StringComparison.Ordinal)
+            && MessageLogProducerTranslationHelpers.TryPreparePatternMessage(ref message, Context, "LostSight");
+    }
+}


### PR DESCRIPTION
Closes #288

## Summary
- add an owner route on `XRL.Core.XRLCore.RenderBaseToBuffer(ScreenBuffer)` for `You have lost sight of ...`
- route the message through producer-side pattern translation before it reaches sink observation
- add L2 and target-resolution coverage for the new owner route

## Validation
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~WorldPartsProducerTranslationPatchTests.XrlCoreLostSightPatch_RecordsOwnerRouteTransforms_WithoutMessageLogSinkObservation_WhenPatched|Name~XrlCoreLostSightTranslationPatch" --nologo`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2 --nologo`
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`

## Convergence
- subagent convergence review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 翻訳パッチの動作検証とメソッド解決に関するテストを追加しました。

* **Bug Fixes**
  * 日本語翻訳における「視界喪失」メッセージの処理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
