### PR TITLE
fix: preserve missing-key counters under suppression (#296)

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/TranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/TranslatorTests.cs
@@ -84,6 +84,31 @@ public sealed class TranslatorTests
     }
 
     [Test]
+    public void Translate_PushMissingKeyLoggingSuppression_PreservesCounters()
+    {
+        WriteDictionary("ui-test.ja.json", "Hello", "こんにちは");
+        _ = Translator.Translate("Hello");
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+        {
+            using var route = Translator.PushLogContext("MessageLogPatch");
+            using var suppression = Translator.PushMissingKeyLoggingSuppression(true);
+
+            _ = Translator.Translate("MISSING_KEY_FOR_Suppressed_A");
+            _ = Translator.Translate("MISSING_KEY_FOR_Suppressed_B");
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(output, Does.Not.Contain("Translator: missing key 'MISSING_KEY_FOR_Suppressed_A'"));
+            Assert.That(output, Does.Not.Contain("Translator: missing key 'MISSING_KEY_FOR_Suppressed_B'"));
+            Assert.That(Translator.GetMissingKeyHitCountForTests("MISSING_KEY_FOR_Suppressed_A"), Is.EqualTo(1));
+            Assert.That(Translator.GetMissingKeyHitCountForTests("MISSING_KEY_FOR_Suppressed_B"), Is.EqualTo(1));
+            Assert.That(Translator.GetMissingRouteHitCountForTests("MessageLogPatch"), Is.EqualTo(2));
+        });
+    }
+
+    [Test]
     public void Translate_LogsNestedContextDetails_WhileKeepingPrimaryRouteCounts()
     {
         WriteDictionary("ui-test.ja.json", "Hello", "こんにちは");

--- a/Mods/QudJP/Assemblies/src/Translator.cs
+++ b/Mods/QudJP/Assemblies/src/Translator.cs
@@ -153,6 +153,11 @@ public static class Translator
         return new MissingKeySuppressionScope();
     }
 
+    private static bool IsMissingKeyLoggingSuppressed()
+    {
+        return suppressMissingKeyLoggingDepth > 0;
+    }
+
     private static string TranslateCore(string key)
     {
         var translations = GetLoadedTranslations();
@@ -163,7 +168,7 @@ public static class Translator
         }
 
         var hitCount = RecordMissingKey(key);
-        if (ObservabilityHelpers.ShouldLogMissingHit(hitCount))
+        if (!IsMissingKeyLoggingSuppressed() && ObservabilityHelpers.ShouldLogMissingHit(hitCount))
         {
             LogObservability(
                 $"[QudJP] Translator: missing key '{key}' (hit {hitCount}).{GetCurrentLogContextSuffix()}");
@@ -303,11 +308,6 @@ public static class Translator
 
     private static int RecordMissingKey(string key)
     {
-        if (suppressMissingKeyLoggingDepth > 0)
-        {
-            return 0;
-        }
-
         var hitCount = MissingKeyCounts.AddOrUpdate(key, 1, ObservabilityHelpers.IncrementCounter);
         _ = MissingRouteCounts.AddOrUpdate(
             ObservabilityHelpers.ExtractPrimaryContext(GetCurrentLogContext()),


### PR DESCRIPTION
Closes #296

## Summary
- limit `PushMissingKeyLoggingSuppression` to log suppression only
- keep missing-key and missing-route counters incrementing under suppression
- add focused regression coverage for suppression semantics

## Validation
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~QudJP.Tests.L1.TranslatorTests.Translate_PushMissingKeyLoggingSuppression_PreservesCounters" --nologo`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1 --nologo`
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`

## Convergence
- subagent convergence review: passable, no blocking findings observed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * ロギング抑制時のカウンター保持を検証する新しいテストを追加

* **Bug Fixes**
  * ロギング抑制中もカウンターが継続して正しく更新されるよう改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
