### PR TITLE
fix: scope bracketed display-name states to display dictionaries (#294)

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs
@@ -43,17 +43,34 @@ public sealed class GetDisplayNameRouteTranslatorTests
     }
 
     [Test]
-    public void TranslatePreservingColors_PreservesTmpColorMarkup()
+    public void TranslatePreservingColors_UsesDisplayNameScopedBracketedStateLookups()
     {
-        WriteDictionary(
-            ("water flask", "水袋"),
-            ("[empty]", "[空]"));
+        WriteDictionary(("water flask", "水袋"));
+        WriteDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("[empty]", "[空]"),
+            ("[empty, sealed]", "[空／密封]"),
+            ("[sealed]", "[密封]"),
+            ("[auto-collecting]", "[自動採取中]"));
 
-        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
-            "<color=#44ff88>water flask [empty]</color>",
-            nameof(GetDisplayNamePatch));
-
-        Assert.That(translated, Is.EqualTo("<color=#44ff88>水袋 [空]</color>"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                GetDisplayNameRouteTranslator.TranslatePreservingColors(
+                    "<color=#44ff88>water flask [empty]</color>",
+                    nameof(GetDisplayNamePatch)),
+                Is.EqualTo("<color=#44ff88>水袋 [空]</color>"));
+            Assert.That(
+                GetDisplayNameRouteTranslator.TranslatePreservingColors(
+                    "<color=#44ff88>water flask [empty, sealed]</color>",
+                    nameof(GetDisplayNamePatch)),
+                Is.EqualTo("<color=#44ff88>水袋 [空／密封]</color>"));
+            Assert.That(
+                GetDisplayNameRouteTranslator.TranslatePreservingColors(
+                    "<color=#44ff88>water flask [auto-collecting]</color>",
+                    nameof(GetDisplayNamePatch)),
+                Is.EqualTo("<color=#44ff88>水袋 [自動採取中]</color>"));
+        });
     }
 
     [TestCase("花瓶 [空]")]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarAfterRenderTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarAfterRenderTranslationPatchTests.cs
@@ -76,7 +76,9 @@ public sealed class AbilityBarAfterRenderTranslationPatchTests
     {
         WriteDictionary(
             ("TARGET:", "ターゲット:"),
-            ("snapjaw", "スナップジョー"),
+            ("snapjaw", "スナップジョー"));
+        WriteDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
             ("[empty]", "[空]"));
 
         var trace = TestTraceHelper.CaptureTrace(() =>

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/GetDisplayNameProcessPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/GetDisplayNameProcessPatchTests.cs
@@ -281,7 +281,9 @@ public sealed class GetDisplayNameProcessPatchTests
     [Test]
     public void Postfix_TranslatesBracketedInventoryState_WhenPatched()
     {
-        WriteDictionary(("[empty]", "[空]"));
+        WriteDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("[empty]", "[空]"));
 
         RunWithDisplayNameProcessPatch(() =>
         {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/UIExpansionPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/UIExpansionPatchTests.cs
@@ -290,8 +290,9 @@ public sealed class UIExpansionPatchTests
     [Test]
     public void Inventory_TranslatesStructuredDisplayName_WhenPatched()
     {
-        WriteDictionary(
-            ("water flask", "水袋"),
+        WriteDictionary(("water flask", "水袋"));
+        WriteDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
             ("[empty]", "[空]"));
 
         RunWithPostfixPatch(
@@ -386,6 +387,17 @@ public sealed class UIExpansionPatchTests
     {
         var path = Path.Combine(tempDirectory, "ui-expansion-l2.ja.json");
         File.WriteAllText(path, content, Utf8WithoutBom);
+    }
+
+    private void WriteDictionaryFile(string fileName, params (string key, string text)[] entries)
+    {
+        var builder = new StringBuilder();
+        builder.Append("{\"entries\":[");
+        AppendEntries(builder, entries);
+        builder.AppendLine("]}");
+
+        var path = Path.Combine(tempDirectory, fileName);
+        File.WriteAllText(path, builder.ToString(), Utf8WithoutBom);
     }
 
     private sealed class DummyCharGenScreen

--- a/Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs
@@ -532,8 +532,8 @@ internal static class GetDisplayNameRouteTranslator
     private static bool TryTranslateBracketedStateExact(string source, out string translated)
     {
         var bracketed = "[" + source + "]";
-        var direct = Translator.Translate(bracketed);
-        if (string.Equals(direct, bracketed, StringComparison.Ordinal))
+        var direct = ScopedDictionaryLookup.TranslateExactOrLowerAscii(bracketed, DisplayNameDictionaryFiles);
+        if (direct is null)
         {
             translated = source;
             return false;

--- a/Mods/QudJP/Localization/Dictionaries/ui-displayname-adjectives.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-displayname-adjectives.ja.json
@@ -135,6 +135,26 @@
       "text": "空の"
     },
     {
+      "key": "[empty]",
+      "context": "GetDisplayName.State",
+      "text": "[空]"
+    },
+    {
+      "key": "[empty, sealed]",
+      "context": "GetDisplayName.State",
+      "text": "[空／密封]"
+    },
+    {
+      "key": "[sealed]",
+      "context": "GetDisplayName.State",
+      "text": "[密封]"
+    },
+    {
+      "key": "[auto-collecting]",
+      "context": "GetDisplayName.State",
+      "text": "[自動採取中]"
+    },
+    {
       "key": "lit",
       "context": "GetDisplayName.Adjective",
       "text": "点灯した"

--- a/Mods/QudJP/Localization/Dictionaries/world-parts.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/world-parts.ja.json
@@ -305,59 +305,9 @@
             "text": "容れ物"
         },
         {
-            "key": "[empty, sealed]",
-            "context": "XRL.World.Parts.XRL.World.Parts.LiquidVolume",
-            "text": "[空／密封]"
-        },
-        {
-            "key": "{{y|[{{K|empty, {{c|sealed}}}}]}}",
-            "context": "XRL.World.Parts.XRL.World.Parts.LiquidVolume",
-            "text": "{{y|[{{K|空、{{c|密封}}}}]}}"
-        },
-        {
-            "key": "[empty]",
-            "context": "XRL.World.Parts.XRL.World.Parts.LiquidVolume",
-            "text": "[空]"
-        },
-        {
-            "key": "{{y|[{{K|empty}}]}}",
-            "context": "XRL.World.Parts.XRL.World.Parts.LiquidVolume",
-            "text": "{{y|[{{K|空}}]}}"
-        },
-        {
-            "key": "[sealed]",
-            "context": "XRL.World.Parts.XRL.World.Parts.LiquidVolume",
-            "text": "[密封]"
-        },
-        {
-            "key": "{{y|[{{c|sealed}}]}}",
-            "context": "XRL.World.Parts.XRL.World.Parts.LiquidVolume",
-            "text": "{{y|[{{c|密封}}]}}"
-        },
-        {
-            "key": "[auto-collecting ",
-            "context": "XRL.World.Parts.XRL.World.Parts.LiquidVolume",
-            "text": "[自動採取 "
-        },
-        {
-            "key": "{{y|[{{c|auto-collecting ",
-            "context": "XRL.World.Parts.XRL.World.Parts.LiquidVolume",
-            "text": "{{y|[{{c|自動採取 "
-        },
-        {
             "key": "unknown AutoCollectLiquidType ",
             "context": "XRL.World.Parts.XRL.World.Parts.LiquidVolume",
             "text": "未知の自動採取液種 "
-        },
-        {
-            "key": "[auto-collecting]",
-            "context": "XRL.World.Parts.XRL.World.Parts.LiquidVolume",
-            "text": "[自動採取中]"
-        },
-        {
-            "key": "{{y|[{{c|auto-collecting}}]}}",
-            "context": "XRL.World.Parts.XRL.World.Parts.LiquidVolume",
-            "text": "{{y|[{{c|自動採取中}}]}}"
         },
         {
             "key": "Light scatters off the surface of the wide and yawning pool and gets lost in its depths.",


### PR DESCRIPTION
Closes #294

## Summary
- move bracketed display-name state ownership into `GetDisplayName` scoped dictionary lookup
- migrate bracketed state entries to display-name dictionaries and remove conflicting `world-parts` exact entries
- update L1/L2 coverage to assert display-name ownership for bracketed states

## Validation
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~GetDisplayNameRouteTranslatorTests|FullyQualifiedName~GetDisplayNameProcessPatchTests|FullyQualifiedName~AbilityBarAfterRenderTranslationPatchTests|FullyQualifiedName~UIExpansionPatchTests'`
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- `git diff --check`

## Convergence
- subagent convergence: focused `61 pass`, build clean, final review in progress

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 括弧付きアイテム状態の翻訳システムを改善しました。

* **翻訳更新**
  * 「[空]」「[密閉]」「[自動採取中]」など、複数のアイテム状態表示に関する日本語翻訳を追加しました。
  * 複合状態（例：「[空／密閉]」）の翻訳に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
