### PR TITLE
Fix popup translation handoffs for #306

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupAskStringTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupAskStringTranslationPatchTests.cs
@@ -32,6 +32,7 @@ public sealed class PopupAskStringTranslationPatchTests
         SinkObservation.ResetForTests();
         File.WriteAllText(patternFilePath, "{\"patterns\":[]}\n", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         DummyPopupGenericTarget.Reset();
+        DummyPopupMessageTarget.Reset();
     }
 
     [TearDown]
@@ -41,6 +42,7 @@ public sealed class PopupAskStringTranslationPatchTests
         MessagePatternTranslator.ResetForTests();
         DynamicTextObservability.ResetForTests();
         SinkObservation.ResetForTests();
+        DummyPopupMessageTarget.Reset();
 
         if (Directory.Exists(tempDirectory))
         {
@@ -137,6 +139,67 @@ public sealed class PopupAskStringTranslationPatchTests
         DummyPopupGenericTarget.AskString("\u0001既に翻訳済み");
 
         Assert.That(DummyPopupGenericTarget.LastAskStringMessage, Is.EqualTo("既に翻訳済み"));
+    }
+
+    [Test]
+    public void Prefix_PreservesQuitPromptThroughPopupMessageHandoff()
+    {
+        WriteDictionary(
+            ("Are you sure you want to quit?", "本当に終了しますか？"),
+            ("Quit Without Saving", "セーブせずに終了"),
+            ("[Enter] Submit", "[Enter] 送信"),
+            ("[Esc] Cancel", "[Esc] キャンセル"));
+
+        var buttons = new List<DummyPopupMessageItem>
+        {
+            new("{{W|[Enter]}} {{y|Submit}}", "Accept", "Accept"),
+            new("{{W|[Esc]}} {{y|Cancel}}", "Cancel", "Cancel"),
+        };
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyPopupGenericTarget), nameof(DummyPopupGenericTarget.AskStringAsync)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(PopupAskStringTranslationPatch), nameof(PopupAskStringTranslationPatch.Prefix))));
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyPopupMessageTarget), nameof(DummyPopupMessageTarget.ShowPopup)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(PopupMessageTranslationPatch), nameof(PopupMessageTranslationPatch.Prefix))));
+
+            _ = DummyPopupGenericTarget.AskStringAsync(
+                "Are you sure you want to quit?",
+                WantsSpecificPrompt: "QUIT").GetAwaiter().GetResult();
+
+            var clippedMessage = DummyPopupGenericTarget.LastAskStringMessage;
+            new DummyPopupMessageTarget().ShowPopup(
+                clippedMessage,
+                buttons,
+                title: "Quit Without Saving",
+                WantsSpecificPrompt: "QUIT");
+
+            var renderedMessage = DummyPopupMessageTarget.LastMessage;
+            var renderedButton = DummyPopupMessageTarget.LastButtons![0].text;
+            UITextSkinTranslationPatch.Prefix(ref renderedMessage);
+            UITextSkinTranslationPatch.Prefix(ref renderedButton);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupGenericTarget.LastAskStringMessage, Is.EqualTo("本当に終了しますか？"));
+                Assert.That(DummyPopupMessageTarget.LastMessage, Is.EqualTo("本当に終了しますか？"));
+                Assert.That(DummyPopupMessageTarget.LastTitle, Is.EqualTo("セーブせずに終了"));
+                Assert.That(DummyPopupMessageTarget.LastButtons![0].text, Is.EqualTo("{{W|[Enter]}} {{y|送信}}"));
+                Assert.That(DummyPopupMessageTarget.LastButtons[1].text, Is.EqualTo("{{W|[Esc]}} {{y|キャンセル}}"));
+                Assert.That(DummyPopupMessageTarget.LastWantsSpecificPrompt, Is.EqualTo("QUIT"));
+                Assert.That(renderedMessage, Is.EqualTo("本当に終了しますか？"));
+                Assert.That(renderedButton, Is.EqualTo("{{W|[Enter]}} {{y|送信}}"));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
     }
 
     private static IDisposable PatchMethod(string methodName)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupMessageTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupMessageTranslationPatchTests.cs
@@ -293,6 +293,68 @@ public sealed class PopupMessageTranslationPatchTests
         }
     }
 
+    [Test]
+    public void Prefix_TranslatesQuitPayloadAcrossOwnedFields_WhenPatched()
+    {
+        WriteDictionary(
+            ("Are you sure you want to quit?", "本当に終了しますか？"),
+            ("Quit Without Saving", "セーブせずに終了"),
+            ("Game Menu", "ゲームメニュー"),
+            ("[Enter] Submit", "[Enter] 送信"),
+            ("[Esc] Cancel", "[Esc] キャンセル"),
+            ("Continue playing", "続行する"));
+
+        var buttons = new List<DummyPopupMessageItem>
+        {
+            new("{{W|[Enter]}} {{y|Submit}}", "Accept", "Accept"),
+            new("{{W|[Esc]}} {{y|Cancel}}", "Cancel", "Cancel"),
+        };
+        var items = new List<DummyPopupMessageItem>
+        {
+            new("Continue playing", "Space", "Continue"),
+        };
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyPopupMessageTarget), nameof(DummyPopupMessageTarget.ShowPopup)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(PopupMessageTranslationPatch), nameof(PopupMessageTranslationPatch.Prefix))));
+
+            new DummyPopupMessageTarget().ShowPopup(
+                "Are you sure you want to quit?",
+                buttons,
+                items: items,
+                title: "Quit Without Saving",
+                contextTitle: "Game Menu",
+                WantsSpecificPrompt: "QUIT");
+
+            var renderedMessage = DummyPopupMessageTarget.LastMessage;
+            var renderedButton = DummyPopupMessageTarget.LastButtons![0].text;
+            UITextSkinTranslationPatch.Prefix(ref renderedMessage);
+            UITextSkinTranslationPatch.Prefix(ref renderedButton);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupMessageTarget.LastMessage, Is.EqualTo("本当に終了しますか？"));
+                Assert.That(DummyPopupMessageTarget.LastTitle, Is.EqualTo("セーブせずに終了"));
+                Assert.That(DummyPopupMessageTarget.LastContextTitle, Is.EqualTo("ゲームメニュー"));
+                Assert.That(DummyPopupMessageTarget.LastButtons![0].text, Is.EqualTo("{{W|[Enter]}} {{y|送信}}"));
+                Assert.That(DummyPopupMessageTarget.LastButtons[1].text, Is.EqualTo("{{W|[Esc]}} {{y|キャンセル}}"));
+                Assert.That(DummyPopupMessageTarget.LastItems![0].text, Is.EqualTo("続行する"));
+                Assert.That(DummyPopupMessageTarget.LastWantsSpecificPrompt, Is.EqualTo("QUIT"));
+                Assert.That(renderedMessage, Is.EqualTo("本当に終了しますか？"));
+                Assert.That(renderedButton, Is.EqualTo("{{W|[Enter]}} {{y|送信}}"));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
     private static string CreateHarmonyId()
     {
         return $"qudjp.tests.{Guid.NewGuid():N}";

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupPickOptionTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupPickOptionTranslationPatchTests.cs
@@ -174,6 +174,44 @@ public sealed class PopupPickOptionTranslationPatchTests
         });
     }
 
+    [Test]
+    public void Prefix_TranslatesSiblingHotkeyOptionsConsistently()
+    {
+        WriteDictionary(
+            ("[l] look", "[l] 調べる"),
+            ("[w] show effects", "[w] 効果を表示"),
+            ("[n] detonate", "[n] 起爆"),
+            ("Quit Without Saving", "セーブせずに終了"),
+            ("[Esc] Cancel", "[Esc] キャンセル"));
+
+        using var patch = PatchPickOption();
+
+        DummyPopupGenericTarget.PickOption(
+            Options: new[]
+            {
+                "[l] look",
+                "[w] show effects",
+                "[n] detonate",
+                "Quit Without Saving",
+            },
+            Buttons: new[] { new DummyPopupMenuItem("{{W|[Esc]}} {{y|Cancel}}") });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                DummyPopupGenericTarget.LastPickOptionOptions,
+                Is.EqualTo(new[]
+                {
+                    "[l] 調べる",
+                    "[w] 効果を表示",
+                    "[n] 起爆",
+                    "セーブせずに終了",
+                }));
+            Assert.That(DummyPopupGenericTarget.LastPickOptionButtons, Is.Not.Null);
+            Assert.That(DummyPopupGenericTarget.LastPickOptionButtons![0].text, Is.EqualTo("{{W|[Esc]}} {{y|キャンセル}}"));
+        });
+    }
+
     private static IDisposable PatchPickOption()
     {
         var harmonyId = CreateHarmonyId();

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupRouteHandoffTranslationTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupRouteHandoffTranslationTests.cs
@@ -1,0 +1,348 @@
+using System.Reflection;
+using System.Text;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class PopupRouteHandoffTranslationTests
+{
+    private string tempDirectory = null!;
+    private string dictionaryDirectory = null!;
+    private string patternFilePath = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempDirectory = Path.Combine(Path.GetTempPath(), "qudjp-popup-route-handoff-l2", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        dictionaryDirectory = Path.Combine(tempDirectory, "dict");
+        Directory.CreateDirectory(dictionaryDirectory);
+        patternFilePath = Path.Combine(tempDirectory, "messages.ja.json");
+
+        Translator.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(dictionaryDirectory);
+        MessagePatternTranslator.ResetForTests();
+        MessagePatternTranslator.SetPatternFileForTests(patternFilePath);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+        File.WriteAllText(patternFilePath, "{\"patterns\":[]}\n", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        DummyPopupShow.Reset();
+        DummyPopupGenericTarget.Reset();
+        DummyPopupMessageTarget.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        MessagePatternTranslator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+
+        if (Directory.Exists(tempDirectory))
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void ShowRoute_HandsOffTranslatedMessage_ToPopupMessageAndUITextSkin()
+    {
+        WriteDictionary(("You do not have a missile weapon equipped!", "飛び道具を装備していない！"));
+
+        using var showPatch = PatchMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.Show), typeof(PopupShowTranslationPatch));
+        using var popupMessagePatch = PatchMethod(typeof(DummyPopupMessageTarget), nameof(DummyPopupMessageTarget.ShowPopup), typeof(PopupMessageTranslationPatch));
+
+        DummyPopupShow.Show("You do not have a missile weapon equipped!");
+        new DummyPopupMessageTarget().ShowPopup(DummyPopupShow.LastShowMessage!);
+
+        var rendered = WrapPopupBody(DummyPopupMessageTarget.LastMessage);
+        var sinkText = UITextSkinTranslationPatch.TranslatePreservingColors(rendered, nameof(PopupMessageTranslationPatch));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("飛び道具を装備していない！"));
+            Assert.That(DummyPopupMessageTarget.LastMessage, Is.EqualTo("飛び道具を装備していない！"));
+            Assert.That(sinkText, Is.EqualTo("{{y|飛び道具を装備していない！}}"));
+            Assert.That(
+                DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                    nameof(PopupShowTranslationPatch),
+                    "Popup.ProducerText.Exact"),
+                Is.GreaterThan(0));
+            Assert.That(
+                SinkObservation.GetHitCountForTests(
+                    nameof(UITextSkinTranslationPatch),
+                    nameof(PopupMessageTranslationPatch),
+                    SinkObservation.ObservationOnlyDetail,
+                    "{{y|You do not have a missile weapon equipped!}}",
+                    "You do not have a missile weapon equipped!"),
+                Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void AskStringQuitRoute_HandsOffTranslatedPrompt_AndConfirmButtons()
+    {
+        WriteDictionary(
+            ("Are you sure you want to quit?", "本当に終了しますか？"),
+            ("Hold to Accept", "長押しで決定"),
+            ("Quit Without Saving", "保存せず終了"),
+            ("[Tab] Hold to Accept", "[Tab] 長押しで決定"),
+            ("[Esc] Quit Without Saving", "[Esc] 保存せず終了"));
+
+        using var askStringPatch = PatchMethod(typeof(DummyPopupGenericTarget), nameof(DummyPopupGenericTarget.AskStringAsync), typeof(PopupAskStringTranslationPatch));
+        using var popupMessagePatch = PatchMethod(typeof(DummyPopupMessageTarget), nameof(DummyPopupMessageTarget.ShowPopup), typeof(PopupMessageTranslationPatch));
+
+        _ = DummyPopupGenericTarget.AskStringAsync("Are you sure you want to quit?", WantsSpecificPrompt: "QUIT")
+            .GetAwaiter()
+            .GetResult();
+
+        var clippedMessage = SimulateClipText(DummyPopupGenericTarget.LastAskStringMessage, 5);
+        var buttons = new List<DummyPopupMessageItem>
+        {
+            new("{{W|[Tab]}} {{y|Hold to Accept}}", "Submit", "Submit"),
+            new("{{W|[Esc]}} {{y|Quit Without Saving}}", "Cancel", "Cancel"),
+        };
+
+        new DummyPopupMessageTarget().ShowPopup(
+            clippedMessage,
+            buttons,
+            WantsSpecificPrompt: "QUIT");
+
+        var rendered = WrapPopupBody(DummyPopupMessageTarget.LastMessage);
+        var sinkText = UITextSkinTranslationPatch.TranslatePreservingColors(rendered, nameof(PopupMessageTranslationPatch));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupGenericTarget.LastAskStringMessage, Is.EqualTo("本当に終了しますか？"));
+            Assert.That(clippedMessage, Does.Contain('\n'));
+            Assert.That(DummyPopupMessageTarget.LastMessage, Is.EqualTo(clippedMessage));
+            Assert.That(DummyPopupMessageTarget.LastButtons, Is.Not.Null);
+            Assert.That(DummyPopupMessageTarget.LastButtons![0].text, Is.EqualTo("{{W|[Tab]}} {{y|長押しで決定}}"));
+            Assert.That(DummyPopupMessageTarget.LastButtons[1].text, Is.EqualTo("{{W|[Esc]}} {{y|保存せず終了}}"));
+            Assert.That(DummyPopupMessageTarget.LastWantsSpecificPrompt, Is.EqualTo("QUIT"));
+            Assert.That(sinkText, Is.EqualTo(rendered));
+            Assert.That(
+                DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                    nameof(PopupAskStringTranslationPatch),
+                    "Popup.ProducerText.Exact"),
+                Is.GreaterThan(0));
+        });
+    }
+
+    [Test]
+    public void PickOptionRoute_HandsOffTranslatedSiblingOptions_ToSelectableText()
+    {
+        WriteDictionary(
+            ("Look", "調べる"),
+            ("Show Effects", "効果を見る"),
+            ("Detonate", "起爆する"),
+            ("Quit Without Saving", "保存せず終了"));
+
+        using var pickOptionPatch = PatchMethod(typeof(DummyPopupGenericTarget), nameof(DummyPopupGenericTarget.PickOption), typeof(PopupPickOptionTranslationPatch));
+
+        DummyPopupGenericTarget.PickOption(Options: new[] { "Look", "Show Effects", "Detonate", "Quit Without Saving" });
+
+        Assert.That(DummyPopupGenericTarget.LastPickOptionOptions, Is.Not.Null);
+
+        var renderedOptions = new[]
+        {
+            "{{W|[L]}} {{y|" + DummyPopupGenericTarget.LastPickOptionOptions![0] + "}}",
+            "{{W|[E]}} {{y|" + DummyPopupGenericTarget.LastPickOptionOptions[1] + "}}",
+            "{{W|[N]}} {{y|" + DummyPopupGenericTarget.LastPickOptionOptions[2] + "}}",
+            "{{W|[Q]}} {{y|" + DummyPopupGenericTarget.LastPickOptionOptions[3] + "}}",
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                DummyPopupGenericTarget.LastPickOptionOptions,
+                Is.EqualTo(new[] { "調べる", "効果を見る", "起爆する", "保存せず終了" }));
+            Assert.That(
+                UITextSkinTranslationPatch.TranslatePreservingColors(renderedOptions[0], nameof(PopupMessageTranslationPatch)),
+                Is.EqualTo(renderedOptions[0]));
+            Assert.That(
+                UITextSkinTranslationPatch.TranslatePreservingColors(renderedOptions[1], nameof(PopupMessageTranslationPatch)),
+                Is.EqualTo(renderedOptions[1]));
+            Assert.That(
+                UITextSkinTranslationPatch.TranslatePreservingColors(renderedOptions[2], nameof(PopupMessageTranslationPatch)),
+                Is.EqualTo(renderedOptions[2]));
+            Assert.That(
+                UITextSkinTranslationPatch.TranslatePreservingColors(renderedOptions[3], nameof(PopupMessageTranslationPatch)),
+                Is.EqualTo(renderedOptions[3]));
+            Assert.That(
+                DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                    nameof(PopupPickOptionTranslationPatch),
+                    "Popup.ProducerText.Exact"),
+                Is.GreaterThan(0));
+        });
+    }
+
+    [Test]
+    public void PopupMessageRoute_OwnsMixedQuitFlowFields_Directly()
+    {
+        WriteDictionary(
+            ("You can't deploy there!", "そこには設置できない！"),
+            ("Quit Without Saving", "保存せず終了"),
+            ("Are you sure you want to quit?", "本当に終了しますか？"),
+            ("Hold to Accept", "長押しで決定"),
+            ("Look", "調べる"),
+            ("Show Effects", "効果を見る"),
+            ("Detonate", "起爆する"),
+            ("[Tab] Hold to Accept", "[Tab] 長押しで決定"),
+            ("[Esc] Quit Without Saving", "[Esc] 保存せず終了"),
+            ("[L] Look", "[L] 調べる"),
+            ("[E] Show Effects", "[E] 効果を見る"),
+            ("[N] Detonate", "[N] 起爆する"));
+
+        using var popupMessagePatch = PatchMethod(typeof(DummyPopupMessageTarget), nameof(DummyPopupMessageTarget.ShowPopup), typeof(PopupMessageTranslationPatch));
+
+        var buttons = new List<DummyPopupMessageItem>
+        {
+            new("{{W|[Tab]}} {{y|Hold to Accept}}", "Submit", "Submit"),
+            new("{{W|[Esc]}} {{y|Quit Without Saving}}", "Cancel", "Cancel"),
+        };
+        var items = new List<DummyPopupMessageItem>
+        {
+            new("{{W|[L]}} {{y|Look}}", "Look", "Look"),
+            new("{{W|[E]}} {{y|Show Effects}}", "ShowEffects", "ShowEffects"),
+            new("{{W|[N]}} {{y|Detonate}}", "Detonate", "Detonate"),
+        };
+
+        new DummyPopupMessageTarget().ShowPopup(
+            "You can't deploy there!",
+            buttons,
+            items: items,
+            title: "Quit Without Saving",
+            contextTitle: "Are you sure you want to quit?");
+
+        var rendered = WrapPopupBody(DummyPopupMessageTarget.LastMessage);
+        var sinkText = UITextSkinTranslationPatch.TranslatePreservingColors(rendered, nameof(PopupMessageTranslationPatch));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupMessageTarget.LastMessage, Is.EqualTo("そこには設置できない！"));
+            Assert.That(DummyPopupMessageTarget.LastTitle, Is.EqualTo("保存せず終了"));
+            Assert.That(DummyPopupMessageTarget.LastContextTitle, Is.EqualTo("本当に終了しますか？"));
+            Assert.That(DummyPopupMessageTarget.LastButtons, Is.Not.Null);
+            Assert.That(DummyPopupMessageTarget.LastButtons![0].text, Is.EqualTo("{{W|[Tab]}} {{y|長押しで決定}}"));
+            Assert.That(DummyPopupMessageTarget.LastButtons[1].text, Is.EqualTo("{{W|[Esc]}} {{y|保存せず終了}}"));
+            Assert.That(DummyPopupMessageTarget.LastItems, Is.Not.Null);
+            Assert.That(DummyPopupMessageTarget.LastItems![0].text, Is.EqualTo("{{W|[L]}} {{y|調べる}}"));
+            Assert.That(DummyPopupMessageTarget.LastItems[1].text, Is.EqualTo("{{W|[E]}} {{y|効果を見る}}"));
+            Assert.That(DummyPopupMessageTarget.LastItems[2].text, Is.EqualTo("{{W|[N]}} {{y|起爆する}}"));
+            Assert.That(sinkText, Is.EqualTo("{{y|そこには設置できない！}}"));
+            Assert.That(
+                DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                    nameof(PopupMessageTranslationPatch),
+                    "Popup.ProducerText.Exact"),
+                Is.GreaterThan(0));
+        });
+    }
+
+    private static IDisposable PatchMethod(Type targetType, string methodName, Type patchType)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        harmony.Patch(
+            original: RequireMethod(targetType, methodName),
+            prefix: new HarmonyMethod(RequireMethod(patchType, "Prefix")));
+        return new HarmonyPatchScope(harmony, harmonyId);
+    }
+
+    private static string WrapPopupBody(string text)
+    {
+        return "{{y|" + text + "}}";
+    }
+
+    private static string SimulateClipText(string text, int width)
+    {
+        if (string.IsNullOrEmpty(text) || width <= 0 || text.Length <= width)
+        {
+            return text;
+        }
+
+        var builder = new StringBuilder(text.Length + (text.Length / width));
+        for (var index = 0; index < text.Length; index += width)
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append('\n');
+            }
+
+            builder.Append(text.AsSpan(index, Math.Min(width, text.Length - index)));
+        }
+
+        return builder.ToString();
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName)
+    {
+        return AccessTools.Method(type, methodName)
+            ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private void WriteDictionary(params (string key, string text)[] entries)
+    {
+        var builder = new StringBuilder();
+        builder.Append('{');
+        builder.Append("\"entries\":[");
+
+        for (var index = 0; index < entries.Length; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append("{\"key\":\"");
+            builder.Append(EscapeJson(entries[index].key));
+            builder.Append("\",\"text\":\"");
+            builder.Append(EscapeJson(entries[index].text));
+            builder.Append("\"}");
+        }
+
+        builder.Append("]}");
+        File.WriteAllText(
+            Path.Combine(dictionaryDirectory, "popup-route-handoff.ja.json"),
+            builder.ToString(),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private static string EscapeJson(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\t", "\\t", StringComparison.Ordinal);
+    }
+
+    private sealed class HarmonyPatchScope : IDisposable
+    {
+        private readonly Harmony harmony;
+        private readonly string harmonyId;
+
+        public HarmonyPatchScope(Harmony harmony, string harmonyId)
+        {
+            this.harmony = harmony;
+            this.harmonyId = harmonyId;
+        }
+
+        public void Dispose()
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupShowTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupShowTranslationPatchTests.cs
@@ -220,6 +220,54 @@ public sealed class PopupShowTranslationPatchTests
         }
     }
 
+    [Test]
+    public void Prefix_PreservesTranslatedShowFailMessage_ThroughPopupMessageAndUITextSkin()
+    {
+        WriteDictionary(
+            ("You do not have a missile weapon equipped!", "射撃武器を装備していない！"),
+            ("[Esc] Cancel", "[Esc] キャンセル"));
+        DummyPopupMessageTarget.Reset();
+
+        var buttons = new List<DummyPopupMessageItem>
+        {
+            new("{{W|[Esc]}} {{y|Cancel}}", "Cancel", "Cancel"),
+        };
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.ShowFail)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyPopupMessageTarget), nameof(DummyPopupMessageTarget.ShowPopup)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(PopupMessageTranslationPatch), nameof(PopupMessageTranslationPatch.Prefix))));
+
+            DummyPopupShow.ShowFail("You do not have a missile weapon equipped!");
+            new DummyPopupMessageTarget().ShowPopup($"{{{{y|{DummyPopupShow.LastShowMessage}}}}}", buttons);
+
+            var renderedMessage = DummyPopupMessageTarget.LastMessage;
+            var renderedButton = DummyPopupMessageTarget.LastButtons![0].text;
+            UITextSkinTranslationPatch.Prefix(ref renderedMessage);
+            UITextSkinTranslationPatch.Prefix(ref renderedButton);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("射撃武器を装備していない！"));
+                Assert.That(DummyPopupMessageTarget.LastMessage, Is.EqualTo("{{y|射撃武器を装備していない！}}"));
+                Assert.That(DummyPopupMessageTarget.LastButtons![0].text, Is.EqualTo("{{W|[Esc]}} {{y|キャンセル}}"));
+                Assert.That(renderedMessage, Is.EqualTo("{{y|射撃武器を装備していない！}}"));
+                Assert.That(renderedButton, Is.EqualTo("{{W|[Esc]}} {{y|キャンセル}}"));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
 #if !HAS_GAME_DLL
     [Test]
     public void TargetMethods_ResolvesShowFamilyOverloads()

--- a/Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs
@@ -382,6 +382,15 @@ public static class PopupTranslationPatch
             return true;
         }
 
+        if (!string.Equals(source, stripped, StringComparison.Ordinal)
+            && StringHelpers.TryGetTranslationExactOrLowerAscii(source, out var exactSource)
+            && !string.Equals(exactSource, source, StringComparison.Ordinal))
+        {
+            translated = exactSource;
+            DynamicTextObservability.RecordTransform(route, family + ".ExactSource", source, translated);
+            return true;
+        }
+
         if (TryTranslateSinglePlaceholderTemplate(
                 stripped,
                 route,


### PR DESCRIPTION
Closes #306

## Summary
- add popup route-handoff L2 regressions for Show, AskString, PickOption, and direct PopupMessage flows
- add a popup exact-source fallback when stripped-text lookup misses, covering handoff-owned popup text
- extend existing popup L2 coverage around quit and hotkey-driven popup routes

## Validation
- dotnet build Mods/QudJP/Assemblies/QudJP.csproj
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~PopupShowTranslationPatchTests|FullyQualifiedName~PopupAskStringTranslationPatchTests|FullyQualifiedName~PopupPickOptionTranslationPatchTests|FullyQualifiedName~PopupMessageTranslationPatchTests"
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ポップアップのテキスト翻訳ロジックが強化され、より多くのテキスト変動パターンに対応する翻訳検索パスが拡張されました。

* **テスト**
  * ポップアップメッセージ、プロンプト、オプション、ボタンラベルなど複数のポップアップUI要素の翻訳一貫性を検証する包括的なテストカバレッジを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->