### PR TITLE
Fix combat message skeleton translations

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -26,6 +26,7 @@ public sealed class MessagePatternTranslatorTests
 
         Translator.ResetForTests();
         Translator.SetDictionaryDirectoryForTests(dictionaryDirectory);
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
         MessagePatternTranslator.ResetForTests();
         MessagePatternTranslator.SetPatternFileForTests(patternFilePath);
     }
@@ -34,6 +35,7 @@ public sealed class MessagePatternTranslatorTests
     public void TearDown()
     {
         Translator.ResetForTests();
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
         MessagePatternTranslator.ResetForTests();
 
         if (Directory.Exists(tempDirectory))
@@ -415,6 +417,36 @@ public sealed class MessagePatternTranslatorTests
         var translated = MessagePatternTranslator.Translate("The ウォーターヴァイン農家 misses you with his 鉄の蔓刈り斧! [3 vs 7]");
 
         Assert.That(translated, Is.EqualTo("ウォーターヴァイン農家の鉄の蔓刈り斧は外れた。[3 vs 7]"));
+    }
+
+    [Test]
+    public void Translate_RepositoryDictionary_UsesPlayerHitWithRollPatternBeforeGenericHitPattern()
+    {
+        UseRepositoryPatternDictionary();
+
+        var translated = MessagePatternTranslator.Translate("You hit (x1) for 1 damage with your レンチ! [18]");
+
+        Assert.That(translated, Is.EqualTo("レンチで1ダメージを与えた。(x1) [18]"));
+    }
+
+    [Test]
+    public void Translate_RepositoryDictionary_TranslatesPlayerAcidDamageMessage()
+    {
+        UseRepositoryPatternDictionary();
+
+        var translated = MessagePatternTranslator.Translate("You take 1 damage from the 腐食性ガスの acid!");
+
+        Assert.That(translated, Is.EqualTo("腐食性ガスの酸で1ダメージを受けた！"));
+    }
+
+    [Test]
+    public void Translate_RepositoryDictionary_TranslatesThirdPersonAcidDamageMessage()
+    {
+        UseRepositoryPatternDictionary();
+
+        var translated = MessagePatternTranslator.Translate("The ワニ takes 1 damage from the 腐食性ガスの acid!");
+
+        Assert.That(translated, Is.EqualTo("ワニは腐食性ガスの酸で1ダメージを受けた！"));
     }
 
     [Test]
@@ -1015,5 +1047,12 @@ public sealed class MessagePatternTranslatorTests
             .Replace("\r", "\\r", StringComparison.Ordinal)
             .Replace("\n", "\\n", StringComparison.Ordinal)
             .Replace("\"", "\\\"", StringComparison.Ordinal);
+    }
+
+    private static void UseRepositoryPatternDictionary()
+    {
+        var localizationRoot = Path.Combine(TestProjectPaths.GetRepositoryRoot(), "Mods", "QudJP", "Localization");
+        LocalizationAssetResolver.SetLocalizationRootForTests(localizationRoot);
+        MessagePatternTranslator.SetPatternFileForTests(null);
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
@@ -23,6 +23,7 @@ public sealed class CombatAndLogMessageQueuePatchTests
 
         Translator.ResetForTests();
         Translator.SetDictionaryDirectoryForTests(tempDirectory);
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
         MessagePatternTranslator.ResetForTests();
         MessagePatternTranslator.SetPatternFileForTests(patternFilePath);
         File.WriteAllText(patternFilePath, "{\"patterns\":[]}\n", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
@@ -33,6 +34,7 @@ public sealed class CombatAndLogMessageQueuePatchTests
     public void TearDown()
     {
         Translator.ResetForTests();
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
         MessagePatternTranslator.ResetForTests();
 
         if (Directory.Exists(tempDirectory))
@@ -587,6 +589,114 @@ public sealed class CombatAndLogMessageQueuePatchTests
     }
 
     [Test]
+    public void MessagingEmitMessage_TranslatesPlayerWeaponHitWithRoll_WhenPatched()
+    {
+        UseRepositoryPatternDictionary();
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(
+                    typeof(DummyMessagingEmitMessageTarget),
+                    nameof(DummyMessagingEmitMessageTarget.EmitMessage),
+                    typeof(DummyGameObject),
+                    typeof(string),
+                    typeof(char),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(DummyGameObject),
+                    typeof(DummyGameObject)),
+                typeof(GameObjectEmitMessageTranslationPatch));
+
+            DummyMessagingEmitMessageTarget.MessageToSend = "You hit (x1) for 1 damage with your レンチ! [18]";
+            DummyMessagingEmitMessageTarget.EmitMessage(new DummyGameObject(), "unused", 'W', false, false, false);
+
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("レンチで1ダメージを与えた。(x1) [18]"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void MessagingEmitMessage_TranslatesPlayerAcidDamageMessage_WhenPatched()
+    {
+        UseRepositoryPatternDictionary();
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(
+                    typeof(DummyMessagingEmitMessageTarget),
+                    nameof(DummyMessagingEmitMessageTarget.EmitMessage),
+                    typeof(DummyGameObject),
+                    typeof(string),
+                    typeof(char),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(DummyGameObject),
+                    typeof(DummyGameObject)),
+                typeof(GameObjectEmitMessageTranslationPatch));
+
+            DummyMessagingEmitMessageTarget.MessageToSend = "You take 1 damage from the 腐食性ガスの acid!";
+            DummyMessagingEmitMessageTarget.EmitMessage(new DummyGameObject(), "unused", 'W', false, false, false);
+
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("腐食性ガスの酸で1ダメージを受けた！"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void MessagingEmitMessage_TranslatesThirdPersonAcidDamageMessage_WhenPatched()
+    {
+        UseRepositoryPatternDictionary();
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(
+                    typeof(DummyMessagingEmitMessageTarget),
+                    nameof(DummyMessagingEmitMessageTarget.EmitMessage),
+                    typeof(DummyGameObject),
+                    typeof(string),
+                    typeof(char),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(DummyGameObject),
+                    typeof(DummyGameObject)),
+                typeof(GameObjectEmitMessageTranslationPatch));
+
+            DummyMessagingEmitMessageTarget.MessageToSend = "The ワニ takes 1 damage from the 腐食性ガスの acid!";
+            DummyMessagingEmitMessageTarget.EmitMessage(new DummyGameObject(), "unused", 'W', false, false, false);
+
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("ワニは腐食性ガスの酸で1ダメージを受けた！"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
     public void ZoneManagerTryThawZone_TranslatesLeafMessage_WhenPatched()
     {
         WriteLeafDictionary(("ThawZone exception", "ゾーン解凍エラー"));
@@ -1053,5 +1163,20 @@ public sealed class CombatAndLogMessageQueuePatchTests
         return value
             .Replace("\\", "\\\\", StringComparison.Ordinal)
             .Replace("\"", "\\\"", StringComparison.Ordinal);
+    }
+
+    private static void UseRepositoryPatternDictionary()
+    {
+        var localizationRoot = Path.GetFullPath(
+            Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "Localization"));
+        LocalizationAssetResolver.SetLocalizationRootForTests(localizationRoot);
+        MessagePatternTranslator.SetPatternFileForTests(null);
     }
 }

--- a/Mods/QudJP/Localization/Dictionaries/messages.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/messages.ja.json
@@ -19,6 +19,16 @@
       "route": "message-frame"
     },
     {
+      "pattern": "^You hit \\((x\\d+)\\) for (\\d+) damage with your (.+?)[.!] \\[(.+?)\\]$",
+      "template": "{2}で{1}ダメージを与えた。({0}) [{3}]",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^You critically hit \\((x\\d+)\\) for (\\d+) damage with your (.+?)[.!] \\[(.+?)\\]$",
+      "template": "{2}で会心の一撃、{1}ダメージを与えた。({0}) [{3}]",
+      "route": "emit-message"
+    },
+    {
       "pattern": "^You critically hit (?:the |a |an )?(.+?) \\(x(\\d+)\\) with (?:a |an |the )?(.+?) for (\\d+) damage!$",
       "template": "{2}で{0}に会心の一撃、{3}ダメージを与えた！ (x{1})",
       "route": "emit-message"
@@ -141,6 +151,16 @@
     {
       "pattern": "^You take (\\d+) damage from (.+?)の freezing effect![.!]?$",
       "template": "{1}の凍結効果で{0}ダメージを受けた！",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^You take (\\d+) damage from (?:the )?(.+?)の acid![.!]?$",
+      "template": "{1}の酸で{0}ダメージを受けた！",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The )?(.+?) takes (\\d+) damage from (?:the )?(.+?)の acid![.!]?$",
+      "template": "{0}は{2}の酸で{1}ダメージを受けた！",
       "route": "emit-message"
     },
     {
@@ -346,16 +366,6 @@
     {
       "pattern": "^You recover (\\d+) HP[.!]?$",
       "template": "あなたは{0}HP回復した",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You hit \\((x\\d+)\\) for (\\d+) damage with your (.+?)[.!] \\[(.+?)\\]$",
-      "template": "{2}で{1}ダメージを与えた。({0}) [{3}]",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You critically hit \\((x\\d+)\\) for (\\d+) damage with your (.+?)[.!] \\[(.+?)\\]$",
-      "template": "{2}で会心の一撃、{1}ダメージを与えた。({0}) [{3}]",
       "route": "emit-message"
     },
     {


### PR DESCRIPTION
## Summary
- fix `You hit (xN) for D damage with your ... [ROLL]` by moving the dedicated player hit-with-roll patterns ahead of the broader `You hit ... with ...` patterns in `messages.ja.json`
- add shared combat log coverage for mixed-language acid-gas damage messages like `You take 1 damage from the 腐食性ガスの acid!` and `The ワニ takes 1 damage from the 腐食性ガスの acid!`
- add repository-dictionary L1/L2 tests for the exact observed runtime skeletons on the `GameObjectEmitMessage` route

## Audited skeleton families and owner routes
- `You hit (xN) for D damage with your WEAPON! [ROLL]` -> producer: `Combat.MeleeAttackWithWeaponInternal`; translation owner: `GameObjectEmitMessageTranslationPatch` via production `emit-message` patterns
- `You take D damage from the 腐食性ガスの acid!` -> producer chain: `GasDamaging.ApplyDamagingGasWithResult` -> `Physics.ProcessTakeDamage` -> `EmitMessage`; translation owner: shared `emit-message` patterns
- `The TARGET takes D damage from the 腐食性ガスの acid!` -> same shared damage route as above
- preserved families already covered and kept intact: enemy melee misses, incoming enemy hits with weapon/roll, player melee misses with weapon/roll

## Why these fix layers
- player hit-with-roll was a first-match ordering bug in the production pattern dictionary, so the correct fix was data ordering rather than a new code patch
- acid-gas damage is a shared `EmitMessage` family surfaced after possessive expansion in `Physics.ProcessTakeDamage`, so the minimal safe fix was shared mid-pipeline coverage on the existing `emit-message` translation path rather than sink-side compensation

## Verification
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~MessagePatternTranslatorTests|FullyQualifiedName~CombatAndLogMessageQueuePatchTests|FullyQualifiedName~MessageLogPatchTests'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 戦闘メッセージの日本語翻訳を改善しました。プレイヤーの武器攻撃メッセージおよびアシッドダメージに関連するメッセージの翻訳パターンを更新し、より正確で自然な日本語表記を実現しています。

* **テスト**
  * 翻訳システムの品質を保証するための検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->