### PR TITLE
Expand stable emit-message family proof for issue #315

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -450,6 +450,26 @@ public sealed class MessagePatternTranslatorTests
     }
 
     [Test]
+    public void Translate_RepositoryDictionary_TranslatesPlayerBleedingDamageMessage()
+    {
+        UseRepositoryPatternDictionary();
+
+        var translated = MessagePatternTranslator.Translate("You take 1 damage from bleeding.");
+
+        Assert.That(translated, Is.EqualTo("あなたは出血で1ダメージを受けた。"));
+    }
+
+    [Test]
+    public void Translate_RepositoryDictionary_UsesSpecificWoundStopBleedingPatternBeforeGenericBleedingStopPattern()
+    {
+        UseRepositoryPatternDictionary();
+
+        var translated = MessagePatternTranslator.Translate("One of タムの wounds stops bleeding.");
+
+        Assert.That(translated, Is.EqualTo("タムの傷のひとつの出血が止まった。"));
+    }
+
+    [Test]
     public void Translate_AppliesPassByPattern()
     {
         WritePatternDictionary(("^You pass by a (.+?)[.!]?$", "{0}のそばを通り過ぎた。"));

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
@@ -696,6 +696,53 @@ public sealed class CombatAndLogMessageQueuePatchTests
         }
     }
 
+    [TestCase("You take 1 damage from bleeding.", "あなたは出血で1ダメージを受けた。")]
+    [TestCase("The ワニ hits (x1) for 2 damage with his 噛みつき. [18]", "ワニの噛みつきで2ダメージを受けた。(x1) [18]")]
+    [TestCase("You hit glowfish for 3 damage.", "glowfishに3ダメージを与えた")]
+    [TestCase("The タム fails to penetrate your armor [17]!", "タムはあなたの装甲を貫けなかった！ [17]")]
+    [TestCase("The ワニ cannot reach the スナップジョー.", "ワニはスナップジョーに届かない")]
+    [TestCase("Your attack passes through the ワニ!", "あなたの攻撃はワニをすり抜けた！")]
+    [TestCase("One of タムの wounds stops bleeding.", "タムの傷のひとつの出血が止まった。")]
+    [TestCase("The タム's nose begins to bleed.", "タムの鼻から血が流れ始めた")]
+    [TestCase("The タム's brain begins to hemorrhage.", "タムの脳から出血が始まった")]
+    [TestCase("You lose 3 HP.", "あなたは3HPを失った")]
+    [TestCase("You recover 5 HP.", "あなたは5HP回復した")]
+    [TestCase("You harvest a ヴァインウェイファー from the ワーターヴァイン.", "ワーターヴァインからヴァインウェイファーを収穫した")]
+    public void MessagingEmitMessage_TranslatesStableRepositoryFamilies_WhenPatched(string message, string expected)
+    {
+        UseRepositoryPatternDictionary();
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(
+                    typeof(DummyMessagingEmitMessageTarget),
+                    nameof(DummyMessagingEmitMessageTarget.EmitMessage),
+                    typeof(DummyGameObject),
+                    typeof(string),
+                    typeof(char),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(DummyGameObject),
+                    typeof(DummyGameObject)),
+                typeof(GameObjectEmitMessageTranslationPatch));
+
+            DummyMessagingEmitMessageTarget.MessageToSend = message;
+            DummyMessagingEmitMessageTarget.EmitMessage(new DummyGameObject(), "unused", 'W', false, false, false);
+
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(expected));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
     [Test]
     public void ZoneManagerTryThawZone_TranslatesLeafMessage_WhenPatched()
     {

--- a/Mods/QudJP/Localization/Dictionaries/messages.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/messages.ja.json
@@ -769,13 +769,18 @@
       "route": "emit-message"
     },
     {
+      "pattern": "^One of (.+?)の wounds stops bleeding[.!]?$",
+      "template": "{0}の傷のひとつの出血が止まった。",
+      "route": "emit-message"
+    },
+    {
       "pattern": "^(.+) stops bleeding[.!]?$",
       "template": "{0}の出血は止まった。",
       "route": "emit-message"
     },
     {
-      "pattern": "^One of (.+?)の wounds stops bleeding[.!]?$",
-      "template": "{0}の傷のひとつの出血が止まった。",
+      "pattern": "^You take (\\d+) damage from bleeding[.!]?$",
+      "template": "あなたは出血で{0}ダメージを受けた。",
       "route": "emit-message"
     },
     {

--- a/docs/emit-message-coverage-audit.md
+++ b/docs/emit-message-coverage-audit.md
@@ -31,10 +31,10 @@ That prevents downstream double-translation, but it does **not** prove the repos
 ### Current guarantees
 
 - **Guaranteed by L2 tests:** both emit entrypoints are wired correctly and can claim queued messages while `activeDepth > 0`.[^l2-emit]
-- **Guaranteed by repository tests:** the repo dictionary translates the tested player hit-with-roll family and the tested `acid!`-terminated player and third-person acid families through the emit route.[^l1-repo][^l2-hit-acid]
+- **Guaranteed by repository tests:** the repo dictionary now translates tested player and incoming hit families, a representative armor-penetration failure, cannot-reach, pass-through, bleeding stop / exact nosebleed / hemorrhage, HP lose/recover, singular harvest, self-bleeding, and `acid!`-terminated acid families through the emit route.[^l1-repo][^l2-hit-acid]
 - **Maintained invariant:** the hit-with-roll family is only correct while its specific patterns remain ordered ahead of the generic hit patterns in `messages.ja.json`.[^l1-ordering]
-- **Guaranteed only structurally, not universally:** mixed-language emit messages can be claimed and marked direct without double-processing, but only a narrow subset is explicitly exercised by tests.[^l2-mixed]
-- **Not guaranteed:** any family that is only represented by a regex in `messages.ja.json` but lacks an emit-route L2 test is only partially evidenced.
+- **Guaranteed only for the exercised subset, not universally:** mixed-language emit messages can be claimed and marked direct without double-processing, and the repository now exercises one incoming hit-with-roll family against the production dictionary end-to-end.[^l2-mixed][^l2-hit-acid]
+- **Not guaranteed:** any family that is only represented by a regex in `messages.ja.json` but still lacks an emit-route L2 test remains only partially evidenced.
 - **Not guaranteed:** `"route"` in `messages.ja.json` has runtime meaning. The loader ignores it and uses flat first-match ordering instead.[^route-blind]
 
 ## Producer inventory
@@ -72,14 +72,16 @@ The current decompiled audit pass grouped the emit surface into six broad produc
 | Structural emit-route wiring | `You are surrounded by baboons.` | emit-message owner patch | End-to-end route proven for both signatures | L2 tests patch both target signatures and assert translated queue output.[^l2-emit] | n/a | **covered** |
 | Player hit-with-roll | `You hit (x1) for 1 damage with your レンチ! [18]` | `Messaging.EmitMessage` combat route | Repository pattern proven through emit route | L1 repo-dict translator test, L2 emit-route test, and current runtime evidence all exist. This guarantee depends on the specific hit-with-roll pattern staying ordered ahead of the generic hit patterns.[^l1-repo][^l1-ordering][^l2-hit-acid][^runtime-hit] | emit-pattern-dict | **covered** |
 | Acid damage (tested `acid!` forms) | `You take 1 damage from the 腐食性ガスの acid!` / `The ワニ takes 1 damage...` | liquid/environment route through emit | Repository patterns proven through emit route for the currently tested exclamation-terminated shapes | L1 repo-dict translator tests and L2 emit-route tests cover both `acid!` shapes. Current runtime log still contains historical `no pattern` lines, so tests outrank logs here. Period-terminated or bare `acid` variants are not proven by this audit.[^l1-repo][^l2-hit-acid][^runtime-acid][^messages-acid] | emit-pattern-dict + upstream possessive normalization | **covered** |
-| Mixed-language incoming hit-with-roll | `The ウォーターヴァイン農家 hits (x2) for 4 damage with his 鉄の蔓刈り斧. [17]` | `Messaging.EmitMessage` combat route | Route and mixed-JP handling are proven, but repo-dict ownership is only indirectly evidenced | L2 isolated-pattern test proves the route; current and previous logs show live emit-route translations; there is no repo-dict L2 assertion for this exact family.[^l2-mixed][^runtime-hit][^runtime-prev-hit] | emit-pattern-dict | **partial** |
-| Broad projectile/melee combat families | hit/crit/miss/armor-pen/suppressive-fire/pass-by variants | `MissileWeapon.cs`, `Combat.cs` | Large pattern surface exists, but only a narrow subset is route-proven | Decompiled producers show the family volume; the current proven emit-route test set is much smaller.[^missile][^combat][^l2-emit] | emit-pattern-dict | **partial** |
-| Reach / pass-through combat failures | `X cannot reach Y.` / `X's attack passes through Y!` | `Combat.cs` | Patternable, not emit-route-proven | Decompiled producers are stable; no emit-route L2 proof exists for these families today.[^combat][^l2-emit] | emit-pattern-dict | **partial** |
-| Bleeding start/stop and nose/hemorrhage phrasing | `One of X wounds stops bleeding.` / `X nose begins bleeding.` / `X brain begins to hemorrhage.` | `Bleeding.cs`, `Nosebleed.cs`, `SunderMind.cs` | Dictionary patterns exist, but emit-route proof is missing | Current dictionary includes multiple bleeding/nosebleed patterns; decompiled producers show stable families; emit-route L2 proof does not extend to them yet.[^messages-bleed][^status][^l2-emit] | emit-pattern-dict | **partial** |
-| HP lose / recover exact forms | `You lose N HP.` / `You recover N HP.` | emit-message status/feedback route | Active patterns exist, but emit-route proof is missing | Active emit-message patterns exist in the current dictionary for both forms, but the audit found no emit-route L2 proof for them.[^messages-hp][^l2-emit] | emit-pattern-dict | **partial** |
-| Harvest family | `You harvest ...` / `There is nothing left to harvest.` | `Harvestable.cs` | Patternable, not route-proven | Decompiled producer family is stable enough for emit patterns, but the repo does not currently prove the route end-to-end.[^harvest][^l2-emit] | emit-pattern-dict | **partial** |
+| Mixed-language incoming hit-with-roll | `The ウォーターヴァイン農家 hits (x2) for 4 damage with his 鉄の蔓刈り斧. [17]` | `Messaging.EmitMessage` combat route | Repository pattern proven through emit route | The repo now has both an isolated-pattern L2 proof and a production-dictionary L2 assertion for an incoming hit-with-roll family; current and previous logs still provide live corroboration.[^l2-mixed][^l2-hit-acid][^runtime-hit][^runtime-prev-hit] | emit-pattern-dict | **covered** |
+| Outgoing hit-with-damage (tested representative shape) | `You hit glowfish for 3 damage.` | `Combat.cs` / `Messaging.EmitMessage` combat route | Tested representative shape is proven through emit route | The repo now has a production-dictionary L2 assertion for a plain player hit-damage message, extending proof beyond the previously tested hit-with-roll family.[^combat][^l2-hit-acid] | emit-pattern-dict | **covered** |
+| Armor-penetration failure (tested representative shape) | `The タム fails to penetrate your armor [17]!` | `Combat.cs` | Tested representative shape is proven through emit route | The repo now has a production-dictionary L2 assertion for a stable armor-penetration failure message through the emit route, moving this representative family from dictionary inventory to explicit proof.[^combat][^l2-hit-acid] | emit-pattern-dict | **covered** |
+| Broad projectile/melee combat families | hit/crit/miss/armor-pen/suppressive-fire/pass-by variants | `MissileWeapon.cs`, `Combat.cs` | Large pattern surface exists, but only a representative subset is route-proven | Decompiled producers show the family volume; even after the added hit-damage and armor-penetration proofs, much of the projectile/melee surface still lacks explicit emit-route tests.[^missile][^combat][^l2-emit] | emit-pattern-dict | **partial** |
+| Reach / pass-through combat failures (tested representative shapes) | `X cannot reach Y.` / `X's attack passes through Y!` | `Combat.cs` | Tested representative shapes are proven through emit route | The repo now has production-dictionary L2 assertions for a third-person `cannot reach` shape and the player `attack passes through` shape, giving explicit emit-route proof for this stable subset.[^combat][^l2-hit-acid] | emit-pattern-dict | **covered** |
+| Bleeding stop / exact nosebleed / hemorrhage representative shapes | `One of X wounds stops bleeding.` / `X's nose begins to bleed.` / `X's brain begins to hemorrhage.` | `Bleeding.cs`, `Nosebleed.cs`, `SunderMind.cs` | Tested representative shapes are proven through emit route | The repo now has production-dictionary L1/L2 assertions for the wound-stop ordering-sensitive shape and production-dictionary L2 assertions for exact nosebleed and hemorrhage shapes, giving explicit emit-route proof for this stable subset.[^l1-repo][^messages-bleed][^status][^l2-hit-acid] | emit-pattern-dict | **covered** |
+| HP lose / recover exact forms | `You lose N HP.` / `You recover N HP.` | emit-message status/feedback route | Exact forms are proven through emit route | The repo now has production-dictionary L2 assertions for both exact HP feedback forms, upgrading them from dictionary-only evidence to explicit emit-route proof.[^messages-hp][^l2-hit-acid] | emit-pattern-dict | **covered** |
+| Harvest family (tested singular shape) | `You harvest ...` / `There is nothing left to harvest.` | `Harvestable.cs` | Tested singular harvest shape is proven through emit route | The repo now has a production-dictionary L2 assertion for a singular `You harvest ... from ...` message, upgrading that stable subset from inventory-only evidence to explicit emit-route proof.[^harvest][^l2-hit-acid] | emit-pattern-dict | **covered** |
 | Say/yell outer frames | `The X yells, '...'.` / `X says, '{{|...}}'.` | `Chat.cs`, zealot/E-Ros family | Outer frame is partially patternable, payload remains separate | Emit-message yell patterns exist and `Player-prev.log` shows an outer yell frame translating via `GameObjectEmitMessageTranslationPatch`, but the broader say/yell family is not fully proven by tests.[^messages-yell][^runtime-yell][^chat] | emit-pattern-dict | **partial** |
-| Bleeding self-damage tick | `You take 1 damage from bleeding.` | emit-message status route | Second-person self-damage shape is currently missing | The repo dictionary includes `^(.+) takes (\\d+) damage from bleeding...` but not the `^You take ...` form; `Player-prev.log` records repeated `no pattern` hits for this exact message under `GameObjectEmitMessageTranslationPatch`.[^messages-bleed][^runtime-bleed] | emit-pattern-dict | **missing** |
+| Bleeding self-damage tick | `You take 1 damage from bleeding.` | emit-message status route | Repository pattern proven through emit route | The repo now includes a dedicated `^You take ... damage from bleeding` pattern plus L1 and L2 regression tests, replacing the prior `no pattern` gap with direct production-dictionary evidence.[^l1-repo][^l2-hit-acid][^messages-bleed][^runtime-bleed] | emit-pattern-dict | **covered** |
 | Door open/close/obstruction failures | `You cannot open ...` / `... cannot be closed with ... in the way.` | `Door.cs` | No current proof of coverage; likely uncovered | Decompiled producers are stable, but this family is outside the current proven emit set and not clearly backed by current dictionary/test evidence.[^door] | emit-pattern-dict | **missing** |
 | Power/access/tag-driven device messages | `GameText.VariableReplace(KeyObjectAccessMessage, ...)`, `PsychometryAccessMessage`, `AccessFailureMessage` | `PowerSwitch.cs`, `RemotePowerSwitch.cs`, `ForceProjector.cs` | Generic emit route does not guarantee these content-owned strings | Producers forward data/tag strings rather than one narrow stable skeleton, so coverage depends on upstream content rather than an owned emit family.[^passthrough] | producer-side-normalization | **missing** |
 | Builder-heavy liquid/environment/procedural text | collection/purification/static-effect StringBuilder output | `LiquidVolume.cs`, `LiquidWarmStatic.cs`, `Physics.cs` | Generic emit route cannot honestly guarantee these shapes | These producers build messages incrementally with StringBuilder or mutable state, so the sink sees many procedural variants.[^dynamic-builders] | mid-pipeline-helper | **missing** |
@@ -111,7 +113,7 @@ The repository currently **fails or remains uncertain** when the producer:
 ## Known gaps
 
 1. **Projectile combat is under-proven.** It dominates the producer surface, but only a few families are emit-route-tested.
-2. **Bleeding has an asymmetry gap.** Start/stop phrasing has patterns, but the second-person self-damage tick currently misses.
+2. **Bleeding still has under-proven variants.** The exact second-person self-damage tick is now covered, but other bleed-start / another-wound / heavier-or-lighter nosebleed variants still lack explicit emit-route proof.
 3. **Door/access/item-state families are not presently guaranteed.** Many look patternable, but the repo does not prove them.
 4. **Data-driven access/tag messages sit outside the reliable emit boundary.** These need producer/content normalization rather than more sink regexes alone.
 5. **Builder-heavy liquid/procedural messages want a helper layer.** They are too dynamic to audit honestly as simple pattern coverage.
@@ -119,8 +121,8 @@ The repository currently **fails or remains uncertain** when the producer:
 
 ## Next steps
 
-1. Add focused L2 emit-route tests for the highest-volume stable projectile families: incoming hit-with-roll, outgoing hit-with-damage, armor-penetration failures, and “shot goes wild”.
-2. Add a second L2 emit-route matrix for status/effect families already represented in the dictionary: bleeding self-damage, bleed start/stop, nosebleed/hemorrhage, harvest, and freezing-effect damage.
+1. Add focused L2 emit-route tests for the remaining high-volume projectile families, especially crit/miss variants, suppressive-fire, and “shot goes wild”.
+2. Expand status/effect proof from the newly tested representative shapes to the remaining bleed-start / another-wound / heavier-or-lighter nosebleed variants, plus freezing-effect damage.
 3. Split data-driven emit producers into an explicit “content-owned / helper-owned” catalog so future work does not overuse sink-side regexes for blueprint/tag strings.
 4. Either remove or separately track dead `"needs-harmony-patch"` rows that currently have no active owner path, so the dictionary stops overstating the live audit surface.
 
@@ -132,24 +134,24 @@ Targeted validation for this audit:
 dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~MessagePatternTranslatorTests|FullyQualifiedName~CombatAndLogMessageQueuePatchTests'
 ```
 
-Current result: **114 tests, 0 failures, 0 skipped**.
+Current result: **128 tests, 0 failures, 0 skipped**.
 
 [^emit-patch]: `Mods/QudJP/Assemblies/src/Patches/GameObjectEmitMessageTranslationPatch.cs:17-105`
 [^queue-patch]: `Mods/QudJP/Assemblies/src/Patches/CombatAndLogMessageQueuePatch.cs:25-50`
 [^helpers]: `Mods/QudJP/Assemblies/src/Patches/MessageLogProducerTranslationHelpers.cs:215-252`
 [^route-blind]: `Mods/QudJP/Assemblies/src/MessagePatternTranslator.cs:199-217,251-306`
-[^l1-repo]: `Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs:422-449`
+[^l1-repo]: `Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs:422-469`
 [^l1-ordering]: `Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs:422-430`
 [^l2-emit]: `Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs:486-697`
 [^l2-mixed]: `Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs:554-589`
-[^l2-hit-acid]: `Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs:591-697`
+[^l2-hit-acid]: `Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs:591-744`
 [^runtime-hit]: `~/Library/Logs/Freehold Games/CavesOfQud/Player.log:631-649`
 [^runtime-prev-hit]: `~/Library/Logs/Freehold Games/CavesOfQud/Player-prev.log:1399-1427,1776-1807`
 [^runtime-acid]: `~/Library/Logs/Freehold Games/CavesOfQud/Player.log:746-801`
 [^runtime-bleed]: `~/Library/Logs/Freehold Games/CavesOfQud/Player-prev.log:1815-1834`
 [^runtime-yell]: `~/Library/Logs/Freehold Games/CavesOfQud/Player-prev.log:1525-1526`
 [^messages-acid]: `Mods/QudJP/Localization/Dictionaries/messages.ja.json:157-165`
-[^messages-bleed]: `Mods/QudJP/Localization/Dictionaries/messages.ja.json:707-787`
+[^messages-bleed]: `Mods/QudJP/Localization/Dictionaries/messages.ja.json:707-792`
 [^messages-hp]: `Mods/QudJP/Localization/Dictionaries/messages.ja.json:362-368`
 [^messages-yell]: `Mods/QudJP/Localization/Dictionaries/messages.ja.json:972-985`
 [^messages-needs]: `Mods/QudJP/Localization/Dictionaries/messages.ja.json:187-214,1732-1818`


### PR DESCRIPTION
Closes #315.

## Summary
- add repo-dictionary L1/L2 proof for representative stable emit-message families
- add the missing `You take N damage from bleeding.` pattern and fix wound-stop ordering
- update the emit-message coverage audit to reflect the stronger but still bounded proof surface

## Covered representative families
- incoming and outgoing hit families
- armor-penetration failure
- cannot-reach and pass-through failures
- self-bleeding, wound-stop, exact nosebleed, hemorrhage
- HP lose/recover exact forms
- singular harvest from-source shape

## Validation
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj --nologo`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~MessagePatternTranslatorTests|FullyQualifiedName~CombatAndLogMessageQueuePatchTests' --nologo`\n- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1 --nologo`\n- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2 --nologo`\n\n## Review\n- oracle review converged with no substantive issues after correcting one stale audit bullet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * 日本語メッセージパターン翻訳の包括的なテストカバレッジを拡張しました。

* **ローカライゼーション**
  * 出血に関連するゲームメッセージの日本語翻訳パターンを改善しました。

* **ドキュメント**
  * メッセージ翻訳のカバレッジ監査を更新し、拡張されたテスト対応状況を反映しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->