### PR TITLE
[codex] Fix AbilityBar active-effects color restoration

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarAfterRenderTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarAfterRenderTranslationPatchTests.cs
@@ -135,6 +135,30 @@ public sealed class AbilityBarAfterRenderTranslationPatchTests
     }
 
     [Test]
+    public void Postfix_PreservesPerEffectTmpSegments_ForMixedTmpAndQudActiveEffects()
+    {
+        WriteDictionary(
+            ("ACTIVE EFFECTS:", "アクティブ効果:"),
+            ("wet", "濡れた"));
+
+        RunWithPostfixPatch(() =>
+        {
+            var target = new DummyAbilityBarAfterRenderTarget
+            {
+                NextEffectText =
+                    "<color=#FFFFFFFF><color=#508d75>ACTIVE EFFECTS:</color></color> <color=#0096FFFF>swimming</color>, <color=#B1C9C3FF>{{B|wet}}</color>",
+            };
+
+            target.AfterRender(core: null, sb: null);
+
+            Assert.That(
+                target.GetEffectText(),
+                Is.EqualTo(
+                    "<color=#FFFFFFFF><color=#508d75>アクティブ効果:</color></color> <color=#0096FFFF>swimming</color>、<color=#B1C9C3FF>{{B|濡れた}}</color>"));
+        });
+    }
+
+    [Test]
     public void Postfix_RecordsOwnerRouteTransforms_WithoutUITextSkinSinkObservation()
     {
         WriteDictionary(

--- a/Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -109,16 +110,7 @@ public static class AbilityBarAfterRenderTranslationPatch
         var tailGroup = match.Groups["tail"];
         if (tailGroup.Success)
         {
-            var parts = tailGroup.Value.Split(new[] { ", " }, StringSplitOptions.RemoveEmptyEntries);
-            var translatedParts = new string[parts.Length];
-            for (var index = 0; index < parts.Length; index++)
-            {
-                var translatedPart = StringHelpers.TranslateExactOrLowerAscii(parts[index]);
-                translatedParts[index] = translatedPart ?? parts[index];
-            }
-
-            var translatedTail = string.Join("、", translatedParts);
-            translated += " " + ColorAwareTranslationComposer.RestoreCapture(translatedTail, spans, tailGroup);
+            translated += " " + TranslateActiveEffectTailParts(tailGroup.Value, spans, tailGroup.Index);
         }
 
         if (string.Equals(translated, source, StringComparison.Ordinal))
@@ -128,6 +120,33 @@ public static class AbilityBarAfterRenderTranslationPatch
 
         DynamicTextObservability.RecordTransform(route, "AbilityBar.ActiveEffects", source, translated);
         return true;
+    }
+
+    private static string TranslateActiveEffectTailParts(string tail, IReadOnlyList<ColorSpan>? spans, int startIndex)
+    {
+        var translatedParts = new List<string>();
+        var partStart = 0;
+
+        while (partStart < tail.Length)
+        {
+            var separatorIndex = tail.IndexOf(", ", partStart, StringComparison.Ordinal);
+            var partLength = separatorIndex >= 0 ? separatorIndex - partStart : tail.Length - partStart;
+            if (partLength > 0)
+            {
+                var part = tail.Substring(partStart, partLength);
+                var translatedPart = StringHelpers.TranslateExactOrLowerAscii(part);
+                translatedParts.Add(ColorAwareTranslationComposer.RestoreSlice(translatedPart ?? part, spans, startIndex + partStart, partLength));
+            }
+
+            if (separatorIndex < 0)
+            {
+                break;
+            }
+
+            partStart = separatorIndex + 2;
+        }
+
+        return string.Join("、", translatedParts);
     }
 
     private static bool TryTranslateTargetText(string source, string route, out string translated)


### PR DESCRIPTION
Closes #308

## Summary
- add a regression test for mixed TMP/Qud active-effects lines in AbilityBar.AfterRender
- preserve TMP color boundaries per active-effect segment instead of restoring the whole tail at once
- keep existing AbilityBar active-effects, target text, and target health tests green

## Root cause
The active-effects patch restored color spans across the whole translated tail capture. When the live string contained one TMP-colored segment per effect, that relative restore could move closing tags into the wrong character position and corrupt the rendered markup.

## Validation
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~AbilityBarAfterRenderTranslationPatch'
