### PR TITLE
[codex] Fix stinger mutation picker translation timing

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyQudMutationsModuleWindow.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyQudMutationsModuleWindow.cs
@@ -2,16 +2,34 @@ namespace QudJP.Tests.DummyTargets;
 
 internal sealed class DummyQudMutationsModuleWindow
 {
+    public DummyMutationCategoryMenusScroller prefabComponent = new();
+
     public List<DummyMutationCategoryMenuData> categoryMenus =
     [
         new DummyMutationCategoryMenuData(
             new DummyMutationMenuOption("Esper", "Esper", "You only manifest mental mutations, and all of your mutation choices when manifesting a new mutation are mental."),
             new DummyMutationMenuOption("Adrenal Control", "Adrenal Control", "You can regulate your adrenal glands at will.\n\nCooldown: 200 rounds."),
-            new DummyMutationMenuOption("Stinger (Confusing Venom)", "Stinger (Confusing Venom) [{{W|V}}]", "Sting things.")),
+            new DummyMutationMenuOption("Stinger (Confusing Venom)", "Stinger (Confusing Venom) [{{W|V}}]", "Sting things.", hasVariantSelector: true)),
     ];
 
     public void UpdateControls()
     {
+        foreach (var categoryMenu in categoryMenus)
+        {
+            foreach (var menuOption in categoryMenu.menuOptions)
+            {
+                menuOption.Description = FormatNodeDescription(menuOption, menuOption.Id);
+            }
+        }
+
+        prefabComponent.BeforeShow(null, categoryMenus);
+    }
+
+    private static string FormatNodeDescription(DummyMutationMenuOption menuOption, string entryId)
+    {
+        return menuOption.HasVariantSelector
+            ? string.Concat(entryId, " [{{W|V}}]")
+            : entryId;
     }
 }
 
@@ -27,11 +45,12 @@ internal sealed class DummyMutationCategoryMenuData
 
 internal sealed class DummyMutationMenuOption
 {
-    public DummyMutationMenuOption(string id, string description, string longDescription)
+    public DummyMutationMenuOption(string id, string description, string longDescription, bool hasVariantSelector = false)
     {
         Id = id;
         Description = description;
         LongDescription = longDescription;
+        HasVariantSelector = hasVariantSelector;
     }
 
     public string Id { get; set; }
@@ -39,4 +58,19 @@ internal sealed class DummyMutationMenuOption
     public string Description { get; set; }
 
     public string LongDescription { get; set; }
+
+    public bool HasVariantSelector { get; }
+}
+
+internal sealed class DummyMutationCategoryMenusScroller
+{
+    public List<string> LastRenderedDescriptions { get; } = [];
+
+    public void BeforeShow(object? descriptor, IEnumerable<DummyMutationCategoryMenuData> selections)
+    {
+        LastRenderedDescriptions.Clear();
+        LastRenderedDescriptions.AddRange(
+            selections.SelectMany(static categoryMenu => categoryMenu.menuOptions)
+                .Select(static menuOption => menuOption.Description));
+    }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ChargenStructuredTextTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ChargenStructuredTextTranslatorTests.cs
@@ -128,6 +128,24 @@ public sealed class ChargenStructuredTextTranslatorTests
     }
 
     [Test]
+    public void TryTranslateMutationLongDescription_UsesVariantMutationNameKey()
+    {
+        WriteDictionary(
+            ("mutation:Stinger (Confusing Venom)", "臀部の毒針を持つ。"),
+            ("mutation:Stinger (Confusing Venom):rank:1", "刺突では混乱毒を与える。"));
+
+        var translated = ChargenStructuredTextTranslator.TryTranslateMutationLongDescription(
+            "Stinger (Confusing Venom)",
+            out var result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(result, Is.EqualTo("臀部の毒針を持つ。\n\n刺突では混乱毒を与える。"));
+        });
+    }
+
+    [Test]
     public void Translate_TranslatesPointsRemainingLine()
     {
         WriteDictionary(("Points Remaining:", "残りポイント:"));

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudMutationsModuleWindowTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudMutationsModuleWindowTranslationPatchTests.cs
@@ -40,7 +40,7 @@ public sealed class QudMutationsModuleWindowTranslationPatchTests
     }
 
     [Test]
-    public void Postfix_TranslatesMutationMenuDescriptionAndLongDescription_WhenPatched()
+    public void Patch_TranslatesMutationMenuRowsBeforeBeforeShowAndUpdatesLongDescription()
     {
         WriteXmlFile(
             "Mutations.jp.xml",
@@ -66,8 +66,14 @@ public sealed class QudMutationsModuleWindowTranslationPatchTests
 
         try
         {
+            var transpiler = AccessTools.Method(
+                typeof(QudMutationsModuleWindowTranslationPatch),
+                "Transpiler",
+                [typeof(IEnumerable<CodeInstruction>)]);
+
             harmony.Patch(
                 original: RequireMethod(typeof(DummyQudMutationsModuleWindow), nameof(DummyQudMutationsModuleWindow.UpdateControls)),
+                transpiler: transpiler is null ? null : new HarmonyMethod(transpiler),
                 postfix: new HarmonyMethod(RequireMethod(typeof(QudMutationsModuleWindowTranslationPatch), nameof(QudMutationsModuleWindowTranslationPatch.Postfix))));
 
             var window = new DummyQudMutationsModuleWindow();
@@ -79,6 +85,12 @@ public sealed class QudMutationsModuleWindowTranslationPatchTests
 
             Assert.Multiple(() =>
             {
+                Assert.That(window.prefabComponent.LastRenderedDescriptions, Is.EqualTo(new[]
+                {
+                    "エスパー",
+                    "アドレナリン制御",
+                    "毒針（混乱毒） [{{W|V}}]",
+                }));
                 Assert.That(esper.Description, Is.EqualTo("エスパー"));
                 Assert.That(esper.LongDescription, Is.EqualTo("精神突然変異しか発現しない。"));
                 Assert.That(adrenalControl.Description, Is.EqualTo("アドレナリン制御"));

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudMutationsModuleWindowTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudMutationsModuleWindowTranslationPatchTests.cs
@@ -40,7 +40,7 @@ public sealed class QudMutationsModuleWindowTranslationPatchTests
     }
 
     [Test]
-    public void Patch_TranslatesMutationMenuRowsBeforeBeforeShowAndUpdatesLongDescription()
+    public void Patch_TranslatesMutationMenuRowsBeforeShowAndUpdatesLongDescription()
     {
         WriteXmlFile(
             "Mutations.jp.xml",
@@ -107,7 +107,7 @@ public sealed class QudMutationsModuleWindowTranslationPatchTests
     }
 
     [Test]
-    public void TranslateFormattedDescription_ReturnsSource_WhenTranslationThrows()
+    public void TranslateFormattedDescription_ReturnsSource_ForMissingDictionaries()
     {
         Translator.SetDictionaryDirectoryForTests(Path.Combine(tempRoot, "missing-dictionaries"));
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudMutationsModuleWindowTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudMutationsModuleWindowTranslationPatchTests.cs
@@ -111,9 +111,10 @@ public sealed class QudMutationsModuleWindowTranslationPatchTests
     {
         Translator.SetDictionaryDirectoryForTests(Path.Combine(tempRoot, "missing-dictionaries"));
 
-        var translated = QudMutationsModuleWindowTranslationPatch.TranslateFormattedDescription("Esper");
+        var source = "Esper [{{W|V}}]";
+        var translated = QudMutationsModuleWindowTranslationPatch.TranslateFormattedDescription(source);
 
-        Assert.That(translated, Is.EqualTo("Esper"));
+        Assert.That(translated, Is.EqualTo(source));
     }
 
     private static MethodInfo RequireMethod(Type type, string methodName)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudMutationsModuleWindowTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudMutationsModuleWindowTranslationPatchTests.cs
@@ -70,10 +70,11 @@ public sealed class QudMutationsModuleWindowTranslationPatchTests
                 typeof(QudMutationsModuleWindowTranslationPatch),
                 "Transpiler",
                 [typeof(IEnumerable<CodeInstruction>)]);
+            Assert.That(transpiler, Is.Not.Null, "Transpiler method should be found");
 
             harmony.Patch(
                 original: RequireMethod(typeof(DummyQudMutationsModuleWindow), nameof(DummyQudMutationsModuleWindow.UpdateControls)),
-                transpiler: transpiler is null ? null : new HarmonyMethod(transpiler),
+                transpiler: new HarmonyMethod(transpiler!),
                 postfix: new HarmonyMethod(RequireMethod(typeof(QudMutationsModuleWindowTranslationPatch), nameof(QudMutationsModuleWindowTranslationPatch.Postfix))));
 
             var window = new DummyQudMutationsModuleWindow();
@@ -103,6 +104,16 @@ public sealed class QudMutationsModuleWindowTranslationPatchTests
         {
             harmony.UnpatchAll(harmonyId);
         }
+    }
+
+    [Test]
+    public void TranslateFormattedDescription_ReturnsSource_WhenTranslationThrows()
+    {
+        Translator.SetDictionaryDirectoryForTests(Path.Combine(tempRoot, "missing-dictionaries"));
+
+        var translated = QudMutationsModuleWindowTranslationPatch.TranslateFormattedDescription("Esper");
+
+        Assert.That(translated, Is.EqualTo("Esper"));
     }
 
     private static MethodInfo RequireMethod(Type type, string methodName)

--- a/Mods/QudJP/Assemblies/src/Patches/QudMutationsModuleWindowTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/QudMutationsModuleWindowTranslationPatch.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
+using System.Reflection.Emit;
 using HarmonyLib;
 
 namespace QudJP.Patches;
@@ -9,6 +11,10 @@ namespace QudJP.Patches;
 [HarmonyPatch]
 public static class QudMutationsModuleWindowTranslationPatch
 {
+    private static readonly MethodInfo TranslateFormattedDescriptionMethod =
+        AccessTools.Method(typeof(QudMutationsModuleWindowTranslationPatch), nameof(TranslateFormattedDescription))
+        ?? throw new InvalidOperationException("TranslateFormattedDescription method not found.");
+
     [HarmonyTargetMethod]
     private static MethodBase? TargetMethod()
     {
@@ -30,6 +36,31 @@ public static class QudMutationsModuleWindowTranslationPatch
         return method;
     }
 
+    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        var rewritten = new List<CodeInstruction>();
+        var injectedTranslation = false;
+
+        foreach (var instruction in instructions)
+        {
+            rewritten.Add(instruction);
+
+            if (IsFormatNodeDescriptionCall(instruction))
+            {
+                rewritten.Add(new CodeInstruction(OpCodes.Call, TranslateFormattedDescriptionMethod));
+                injectedTranslation = true;
+            }
+        }
+
+        if (!injectedTranslation)
+        {
+            Trace.TraceWarning(
+                "QudJP: QudMutationsModuleWindowTranslationPatch.Transpiler could not find FormatNodeDescription call; leaving instructions unchanged.");
+        }
+
+        return rewritten;
+    }
+
     public static void Postfix(object? __instance)
     {
         try
@@ -45,6 +76,11 @@ public static class QudMutationsModuleWindowTranslationPatch
         {
             Trace.TraceError("QudJP: QudMutationsModuleWindowTranslationPatch.Postfix failed: {0}", ex);
         }
+    }
+
+    public static string TranslateFormattedDescription(string source)
+    {
+        return ChargenStructuredTextTranslator.TranslateMutationMenuDescription(source);
     }
 
     private static void TranslateMenuOptions(object instance)
@@ -102,6 +138,19 @@ public static class QudMutationsModuleWindowTranslationPatch
         {
             SetStringMemberValue(menuOption, "LongDescription", translatedLongDescription);
         }
+    }
+
+    private static bool IsFormatNodeDescriptionCall(CodeInstruction instruction)
+    {
+        if ((instruction.opcode != OpCodes.Call && instruction.opcode != OpCodes.Callvirt)
+            || instruction.operand is not MethodInfo method)
+        {
+            return false;
+        }
+
+        return string.Equals(method.Name, "FormatNodeDescription", StringComparison.Ordinal)
+               && method.ReturnType == typeof(string)
+               && method.GetParameters().Length == 2;
     }
 
     private static bool TryGetMemberValue(object instance, string memberName, out object? value)

--- a/Mods/QudJP/Assemblies/src/Patches/QudMutationsModuleWindowTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/QudMutationsModuleWindowTranslationPatch.cs
@@ -80,7 +80,15 @@ public static class QudMutationsModuleWindowTranslationPatch
 
     public static string TranslateFormattedDescription(string source)
     {
-        return ChargenStructuredTextTranslator.TranslateMutationMenuDescription(source);
+        try
+        {
+            return ChargenStructuredTextTranslator.TranslateMutationMenuDescription(source);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: QudMutationsModuleWindowTranslationPatch.TranslateFormattedDescription failed: {0}", ex);
+            return source;
+        }
     }
 
     private static void TranslateMenuOptions(object instance)


### PR DESCRIPTION
## Summary
- translate stinger mutation picker rows before `BeforeShow(...)` consumes the formatted node description
- keep the long-description route covered and add regression tests around the variant mutation name key
- pin the first-paint behavior with an L2 test for the mutation picker window

## Root cause
`QudMutationsModuleWindow.UpdateControls()` rebuilt row descriptions and immediately bound them to the UI before the old postfix-based translation route could affect first paint.

## Validation
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter QudMutationsModuleWindowTranslationPatchTests --no-restore`

Closes #328


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ミュータントメニューに「変種」選択を示すフォーマット（例: 末尾に [V] 表示）を追加し、レンダリング済み行の追跡機能を導入しました。

* **テスト**
  * 変種付きミュータントの説明・長文翻訳を検証するユニットテストを追加・強化しました。
  * 翻訳処理が例外を投げた場合に元の文を返すフォールバック動作を検証するテストを追加しました。

* **改善**
  * メニュー表示の更新時に説明文の翻訳呼び出しが確実に反映されるよう適用箇所を拡張しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->