### PR TITLE
[codex] Normalize watervine localization terms

### DIFF
--- a/Mods/QudJP/Localization/Conversations.jp.xml
+++ b/Mods/QudJP/Localization/Conversations.jp.xml
@@ -4859,7 +4859,7 @@
     </node>
     <node ID="Bethesda">
       <text>
-        こんな感じ。ベテルのところに行ってこう言うの。「ねえ、密林のビーズの腕輪は全部どこ？ 水蔓湿原の腕輪はどこ？ スヴィ川のは？」
+        こんな感じ。ベテルのところに行ってこう言うの。「ねえ、密林のビーズの腕輪は全部どこ？ ウォーターヴァイン湿原の腕輪はどこ？ スヴィ川のは？」
         
         そうすると教えてくれるから、腕輪を取りに行くの。
       </text>
@@ -5147,7 +5147,7 @@
       <text>
         -ここか？ オアシスの集落だ。世界の棚の下。モグラヤイの大塩砂漠を、風が塩の息を百万と積んでは吐き出す。東には腐臭ただようクッドの密林がある。
 
-        その二つの裂け目で水蔓が育つ。私たちはそれを育てているのだよ、=player.formalAddressTerm=。
+        その二つの裂け目でウォーターヴァインが育つ。私たちはそれを育てているのだよ、=player.formalAddressTerm=。
       </text>
       <choice Target="Qud" Priority="1">クッドのことを教えてくれ。</choice>
     </node>
@@ -5167,7 +5167,7 @@
     </node>
     <node ID="Work" Inherits="Start">
       <text>
-        -んむ、仕事？ 農夫たちは洞窟の害獣に悩まされている。南の水蔓畑にいるメフメトと話してみなさい。
+        -んむ、仕事？ 農夫たちは洞窟の害獣に悩まされている。南のウォーターヴァイン畑にいるメフメトと話してみなさい。
 
         それからアージヴだ、=player.formalAddressTerm=。工匠さ。いつだって何か小物をつなぐ相手を探している。南西のブリキ小屋へ行くといい。
       </text>
@@ -5246,7 +5246,7 @@
     </node>
     <node ID="Apology">
       <text>
-        -んむ？ いや、=player.formalAddressTerm=! 君の報せは我らにとって大きな価値がある。私たちは貧しい農夫で、水蔓刈りの鎌を研ぐことくらいしかできない。だが、ほかの者なら？ きっと何とかしてくれるだろう。
+        -んむ？ いや、=player.formalAddressTerm=! 君の報せは我らにとって大きな価値がある。私たちは貧しい農夫で、ウォーターヴァイン刈りの鎌を研ぐことくらいしかできない。だが、ほかの者なら？ きっと何とかしてくれるだろう。
 
         感謝としてこの刺々しい恩寵を受け取りなさい。んむ、私はこの恩を忘れないよ、=name=. さあ、私に考える時間をくれ……
       </text>
@@ -5294,7 +5294,7 @@
       <text>
         生きて飲め、=name=。レッドロックから何か知らせは？
       </text>
-      <choice Priority="1" Target="BackFromRedrock" IfHaveActiveQuest="What's Eating the Watervine?" IfFinishedQuestStep="What's Eating the Watervine?~Travel to Red Rock" IfHaveItemDescendsFrom="Girshling Corpse">ああ。害獣と、齧られた水蔓の痕跡を見つけた。その死骸を持ってきた。</choice>
+      <choice Priority="1" Target="BackFromRedrock" IfHaveActiveQuest="What's Eating the Watervine?" IfFinishedQuestStep="What's Eating the Watervine?~Travel to Red Rock" IfHaveItemDescendsFrom="Girshling Corpse">ああ。害獣と、齧られたウォーターヴァインの痕跡を見つけた。その死骸を持ってきた。</choice>
       <choice Priority="1" Target="Aye" IfHaveActiveQuest="What's Eating the Watervine?">まだ何もない。</choice>
       <choice ID="MehmetIntroduce" Load="Remove" />
     </start>
@@ -5321,7 +5321,7 @@
     </node>
     <node ID="Village">
       <text>
-        沼地の膝で水蔓を育てている。水蔓ウェハをしゃぶったことはあるか？ あの草をここで世話しているんだ。
+        沼地の膝でウォーターヴァインを育てている。ウォーターヴァインウェハをしゃぶったことはあるか？ あの草をここで世話しているんだ。
       </text>
       <choice Target="VillageMore">……</choice>
     </node>
@@ -5336,7 +5336,7 @@
       <text>
         ああ？ それなら頼みがある。
 
-        何かが水蔓を食ってるんだ、ビートルムーンのあたりで。クルーンは蜘蛛みたいなやつが塩水に潜んでるのを見たと言ってる。でも洞窟蜘蛛がワーデンの足音近くまで来るはずがない。
+        何かがウォーターヴァインを食ってるんだ、ビートルムーンのあたりで。クルーンは蜘蛛みたいなやつが塩水に潜んでるのを見たと言ってる。でも洞窟蜘蛛がワーデンの足音近くまで来るはずがない。
 
         貯水池を舐めたら赤い粒があった。レッドロックの土で見かける頁岩さ……
       </text>

--- a/Mods/QudJP/Localization/ObjectBlueprints/Furniture.jp.xml
+++ b/Mods/QudJP/Localization/ObjectBlueprints/Furniture.jp.xml
@@ -3718,7 +3718,7 @@
 
   <object Name="Bed" Inherits="BaseBed" Replace="true">
     <part Name="Render" DisplayName="ベッド" ColorString="&amp;w" DetailColor="Y" Tile="Items/sw_bed.bmp" Occluding="false" RenderIfDark="true" />
-    <part Name="Description" Short="布地には水蔓の殻が詰められ、丘の民のスタイルで木の板の上に置かれました。" />
+    <part Name="Description" Short="布地にはウォーターヴァインの殻が詰められ、丘の民のスタイルで木の板の上に置かれました。" />
     <tag Name="Tier" Value="0" />
     <stag Name="Basic" />
   </object>
@@ -3901,7 +3901,7 @@
   <object Name="Floor Cushion" Inherits="BaseChair" Replace="true">
     <part Name="Render" DisplayName="フロアクッション" ColorString="&amp;w" DetailColor="y" RenderString="009" Tile="Items/sw_floor_cushion.png" />
     <builder Name="RandomTile" Tiles="Items/sw_cushion1.bmp,Items/sw_cushion2.bmp,Items/sw_cushion3.bmp,Items/sw_cushion4.bmp" />
-    <part Name="Description" Short="水蔓の殻とツチガラスの羽が詰められたこのボタン付きの枕は、人々が足を組んで休める。" />
+    <part Name="Description" Short="ウォーターヴァインの殻とツチガラスの羽が詰められたこのボタン付きの枕は、人々が足を組んで休める。" />
     <part Name="Physics" Weight="2" />
     <part Name="Commerce" Value="1" />
     <part Name="Chair" Level="-1" />
@@ -3951,7 +3951,7 @@
   <object Name="Canvas Folding Chair" Inherits="BasePortableChair" Replace="true">
     <part Name="Render" DisplayName="キャンバス製折りたたみ椅子" ColorString="&amp;w" DetailColor="y" Tile="Items/sw_chair_canvas.bmp" />
     <part Name="Physics" Weight="2" />
-    <part Name="Description" Short="木材と編んだ水蔓を組み合わせて、お尻のための可動式の波止場を作る。" />
+    <part Name="Description" Short="木材と編んだウォーターヴァインを組み合わせて、お尻のための可動式の波止場を作る。" />
     <tag Name="Tier" Value="0" />
     <stag Name="Contemporary" />
   </object>
@@ -4220,7 +4220,7 @@
   <object Name="Sofa" Inherits="BaseChair" Replace="true">
     <part Name="Render" DisplayName="ソファー" ColorString="&amp;g" DetailColor="W" Tile="Items/sw_sofa_l.bmp" />
     <part Name="Physics" Weight="100" />
-    <part Name="Description" Short="豊かな緑の房を高密度で柔らかい格子状に織り、水蔓の殻とツチクロウの羽を詰めて、角度のついた木製フレームに掛ける。" />
+    <part Name="Description" Short="豊かな緑の房を高密度で柔らかい格子状に織り、ウォーターヴァインの殻とツチクロウの羽を詰めて、角度のついた木製フレームに掛ける。" />
     <part Name="Chair" Level="3" />
     <stat Name="AV" Value="4" />
     <stat Name="Hitpoints" Value="200" />

--- a/Mods/QudJP/Localization/Subtypes.jp.xml
+++ b/Mods/QudJP/Localization/Subtypes.jp.xml
@@ -312,7 +312,7 @@
       <extrainfo>交易品を所持して開始</extrainfo>
     </subtype>
 
-    <subtype Name="Watervine Farmer" DisplayName="ウォーターバイン農家" Gear="StartingGear_WatervineFarmer" Tile="creatures/caste_24.bmp" DetailColor="y">
+    <subtype Name="Watervine Farmer" DisplayName="ウォーターヴァイン農家" Gear="StartingGear_WatervineFarmer" Tile="creatures/caste_24.bmp" DetailColor="y">
       <stat Name="Toughness" Bonus="2" />
       <skills>
         <skill Name="CookingAndGathering" />


### PR DESCRIPTION
## Summary
- normalize remaining Watervine-related localization terms to `ウォーターヴァイン` in conversation, furniture, and subtype assets
- keep the change scoped to stable XML localization assets only

## Validation
- `xmllint --noout Mods/QudJP/Localization/Conversations.jp.xml`
- `xmllint --noout Mods/QudJP/Localization/ObjectBlueprints/Furniture.jp.xml`
- `xmllint --noout Mods/QudJP/Localization/Subtypes.jp.xml`
- `git diff --check`