### PR TITLE
fix: support non-macOS deployment and L2G paths (#331, #333)

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj
@@ -7,7 +7,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AnalysisLevel>latest-all</AnalysisLevel>
     <IsPackable>false</IsPackable>
-    <AssemblyCSharpPath>$(HOME)/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/Resources/Data/Managed/Assembly-CSharp.dll</AssemblyCSharpPath>
+    <GameDir Condition="'$(GameDir)' == ''">$(HOME)/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/Resources/Data</GameDir>
+    <AssemblyCSharpPath Condition="'$(AssemblyCSharpPath)' == ''">$(GameDir)/Managed/Assembly-CSharp.dll</AssemblyCSharpPath>
     <ManagedDir>$([System.IO.Path]::GetDirectoryName('$(AssemblyCSharpPath)'))</ManagedDir>
   </PropertyGroup>
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -167,9 +167,7 @@ python3.12 scripts/sync_mod.py --dry-run
 python3.12 scripts/sync_mod.py --exclude-fonts
 ```
 
-`scripts/sync_mod.py` deploys only game-essential files to:
-
-`~/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/Resources/Data/StreamingAssets/Mods/QudJP/`
+`scripts/sync_mod.py` deploys only game-essential files to the platform default mod directory. Use `--destination` if your install uses a non-standard path.
 
 Do not deploy arbitrary source files. The game will try to compile any `.cs` file it finds, and only `Bootstrap.cs` is meant to be game-compiled.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -66,7 +66,7 @@ dotnet build Mods/QudJP/Assemblies/QudJP.csproj \
   -p:GameDir="$HOME/.steam/steam/steamapps/common/Caves of Qud/CoQ_Data"
 ```
 
-> **既知の課題**: `Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj` の `<AssemblyCSharpPath>` は macOS パスをハードコードしており、MSBuild オーバーライドがまだ用意されていません。非 macOS 環境では `Exists()` チェックが false となり、L2G テストはエラーを出さずに自動的にスキップされます。非 macOS で L2G を走らせる場合、現状は csproj を一時的に書き換えるか、`~/Library/...` 配下にシンボリックリンクを張るなどの workaround が必要です。Issue として整理予定です。
+> `Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj` も `QudJP.csproj` と同様に `-p:GameDir=...` を受け付けます。`Managed/Assembly-CSharp.dll` を直接指したい場合は `-p:AssemblyCSharpPath=...` でも上書きできます。
 
 ### 3. ビルドを確認する
 
@@ -93,6 +93,14 @@ pytest scripts/tests/
 ```
 
 全テストがパスすれば環境構築完了です。
+
+非 macOS で L2G を走らせる場合は、ビルドと同じ `GameDir` を渡してください。例:
+
+```bash
+dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj \
+  --filter TestCategory=L2G \
+  -p:GameDir="/mnt/c/Program Files (x86)/Steam/steamapps/common/Caves of Qud/CoQ_Data"
+```
 
 ---
 
@@ -242,19 +250,13 @@ python3 -m json.tool \
 
 ゲーム内で実際に反映されることを確認するため、Mod をゲームの Mods ディレクトリにデプロイして L3 (手動プレイ) で最終検証してください。
 
-**macOS**: `python3.12 scripts/sync_mod.py` がそのまま使えます (デプロイ先が macOS Steam パスに固定されているため)。
+`python3.12 scripts/sync_mod.py` は macOS / Windows / WSL2 / Linux の既定パスを解決します。`rsync` が無い環境では Python コピー実装に自動フォールバックします。
 
-**Windows / WSL2 / Linux**: `sync_mod.py` は現状 macOS 専用です。手動で rsync もしくはファイルコピーしてください。例 (WSL2):
+非標準パスへ出したい場合は `--destination` (`--dest`) を使ってください。例:
 
 ```bash
-rsync -av --delete \
-  --include=manifest.json --include=Bootstrap.cs \
-  --include=Assemblies/ --include=Assemblies/QudJP.dll \
-  --include=Localization/ --include='Localization/**' \
-  --include=Fonts/ --include='Fonts/**' \
-  --exclude='*' \
-  Mods/QudJP/ \
-  "/mnt/c/Users/<name>/AppData/LocalLow/Freehold Games/CavesOfQud/Mods/QudJP/"
+python3.12 scripts/sync_mod.py \
+  --destination "/mnt/c/Users/<name>/AppData/LocalLow/Freehold Games/CavesOfQud/Mods/QudJP"
 ```
 
 ---

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,7 +6,7 @@ How to deploy the QudJP mod to the Caves of Qud game directory.
 
 ## Prerequisites
 
-- Caves of Qud installed (Steam, macOS)
+- Caves of Qud installed (Steam, macOS / Windows / WSL2 / Linux)
 - `QudJP.dll` built via `dotnet build`
 
 ---
@@ -25,7 +25,7 @@ python3.12 scripts/sync_mod.py
 
 `sync_mod.py` requires Python `>=3.12` per `pyproject.toml`. `python3` may resolve to an older interpreter on macOS, so prefer `python3.12` unless your shell already points `python3` at Python 3.12+.
 
-`sync_mod.py` uses an rsync include-first strategy to deploy only game-essential files.
+`sync_mod.py` resolves a platform-appropriate default destination on macOS / Windows / WSL2 / Linux. It uses `rsync` when available and otherwise falls back to a pure-Python copy implementation.
 
 **Dry run** (preview without copying):
 
@@ -37,6 +37,12 @@ python3.12 scripts/sync_mod.py --dry-run
 
 ```bash
 python3.12 scripts/sync_mod.py --exclude-fonts
+```
+
+**Override the destination** (non-standard install paths):
+
+```bash
+python3.12 scripts/sync_mod.py --destination /path/to/Mods/QudJP
 ```
 
 ### Method 2: Manual Copy
@@ -86,12 +92,12 @@ The game requires exactly five types of files:
 
 ---
 
-## Deployment Target Path (macOS Steam)
+## Deployment Target Paths
 
-```
-~/Library/Application Support/Steam/steamapps/common/
-  Caves of Qud/CoQ.app/Contents/Resources/Data/StreamingAssets/Mods/QudJP/
-```
+- macOS Steam: `~/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/Resources/Data/StreamingAssets/Mods/QudJP/`
+- Windows: `%USERPROFILE%\AppData\LocalLow\Freehold Games\CavesOfQud\Mods\QudJP\`
+- WSL2: `/mnt/c/Users/<name>/AppData/LocalLow/Freehold Games/CavesOfQud/Mods/QudJP/`
+- Linux: `~/.config/unity3d/Freehold Games/CavesOfQud/Mods/QudJP/`
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -151,9 +151,9 @@ python scripts/extract_base.py --game-base /path/to/StreamingAssets/Base
 
 ## sync_mod.py
 
-`Mods/QudJP/` の内容をゲームの Mods ディレクトリに rsync で同期します。L3 ゲームスモークテストの前に実行します。
+`Mods/QudJP/` の内容をゲームの Mods ディレクトリに同期します。L3 ゲームスモークテストの前に実行します。
 
-**前提**: Caves of Qud が macOS の Steam デフォルトパスにインストールされていること
+**対応環境**: macOS / Windows / WSL2 / Linux
 
 **使い方**:
 
@@ -164,9 +164,14 @@ python scripts/sync_mod.py
 # 同期先を明示的に指定
 python scripts/sync_mod.py --dest /path/to/Mods/QudJP
 
+# 非標準インストール先にデプロイ
+python scripts/sync_mod.py --destination /path/to/Mods/QudJP
+
 # ドライラン（実際にはコピーしない）
 python scripts/sync_mod.py --dry-run
 ```
+
+`rsync` が利用可能な環境では rsync を使い、無い環境では Python コピー実装に自動フォールバックします。
 
 **終了コード**: 0 = 正常終了、1 = エラー
 

--- a/scripts/sync_mod.py
+++ b/scripts/sync_mod.py
@@ -217,7 +217,8 @@ def _run_python_sync(
     lines = ["Using Python copy fallback."]
 
     if dry_run:
-        lines.append(f"Would replace {destination}")
+        action = "replace" if destination.exists() else "create"
+        lines.append(f"Would {action} {destination}")
         lines.extend(
             f"Would copy {file_path.relative_to(source)}"
             for file_path in file_paths

--- a/scripts/sync_mod.py
+++ b/scripts/sync_mod.py
@@ -27,6 +27,7 @@ _RSYNC_INCLUDES: tuple[str, ...] = (
 )
 
 _RSYNC_EXCLUDES: tuple[str, ...] = ("*",)
+_WINDOWS_DRIVE_PREFIX_LENGTH = 2
 
 _MACOS_MODS_SUFFIX = (
     Path("Library")
@@ -88,11 +89,11 @@ def _is_wsl(release: str | None = None) -> bool:
 
 
 def _translate_windows_path_for_wsl(raw_path: str) -> Path:
-    """Translate a Windows path like ``C:\\Users\\name`` to WSL style."""
+    r"""Translate a Windows path like ``C:\\Users\\name`` to WSL style."""
     normalized = raw_path.strip().replace("\\", "/")
-    if len(normalized) >= 2 and normalized[1] == ":":
+    if len(normalized) >= _WINDOWS_DRIVE_PREFIX_LENGTH and normalized[1] == ":":
         drive = normalized[0].lower()
-        remainder = normalized[2:].lstrip("/")
+        remainder = normalized[_WINDOWS_DRIVE_PREFIX_LENGTH :].lstrip("/")
         return Path("/mnt") / drive / remainder
     return Path(normalized)
 
@@ -186,16 +187,20 @@ def _iter_sync_files(source: Path, *, exclude_fonts: bool) -> list[Path]:
 
     localization_dir = source / "Localization"
     if localization_dir.is_dir():
-        for file_path in sorted(localization_dir.rglob("*")):
-            if file_path.is_file():
-                file_paths.append(file_path)
+        file_paths.extend(
+            file_path
+            for file_path in sorted(localization_dir.rglob("*"))
+            if file_path.is_file()
+        )
 
     if not exclude_fonts:
         fonts_dir = source / "Fonts"
         if fonts_dir.is_dir():
-            for file_path in sorted(fonts_dir.rglob("*")):
-                if file_path.is_file():
-                    file_paths.append(file_path)
+            file_paths.extend(
+                file_path
+                for file_path in sorted(fonts_dir.rglob("*"))
+                if file_path.is_file()
+            )
 
     return file_paths
 

--- a/scripts/sync_mod.py
+++ b/scripts/sync_mod.py
@@ -1,8 +1,12 @@
-"""Sync QudJP mod files to the Caves of Qud game directory via rsync."""
+"""Sync QudJP mod files to the Caves of Qud game directory."""
 
 import argparse
+import os
+import platform
+import shutil
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 
 # Only game-essential files are deployed.  The game's Unity/Mono compiler will
@@ -24,9 +28,8 @@ _RSYNC_INCLUDES: tuple[str, ...] = (
 
 _RSYNC_EXCLUDES: tuple[str, ...] = ("*",)
 
-_GAME_MODS_DIR = (
-    Path.home()
-    / "Library"
+_MACOS_MODS_SUFFIX = (
+    Path("Library")
     / "Application Support"
     / "Steam"
     / "steamapps"
@@ -37,6 +40,24 @@ _GAME_MODS_DIR = (
     / "Resources"
     / "Data"
     / "StreamingAssets"
+    / "Mods"
+    / "QudJP"
+)
+
+_WINDOWS_MODS_SUFFIX = (
+    Path("AppData")
+    / "LocalLow"
+    / "Freehold Games"
+    / "CavesOfQud"
+    / "Mods"
+    / "QudJP"
+)
+
+_LINUX_MODS_SUFFIX = (
+    Path(".config")
+    / "unity3d"
+    / "Freehold Games"
+    / "CavesOfQud"
     / "Mods"
     / "QudJP"
 )
@@ -58,6 +79,170 @@ def _find_project_root() -> Path:
         current = current.parent
     msg = "Could not find project root (no pyproject.toml found)"
     raise FileNotFoundError(msg)
+
+
+def _is_wsl(release: str | None = None) -> bool:
+    """Return whether the current Linux environment is WSL."""
+    release_name = (release or platform.uname().release).lower()
+    return "microsoft" in release_name or "wsl" in release_name
+
+
+def _translate_windows_path_for_wsl(raw_path: str) -> Path:
+    """Translate a Windows path like ``C:\\Users\\name`` to WSL style."""
+    normalized = raw_path.strip().replace("\\", "/")
+    if len(normalized) >= 2 and normalized[1] == ":":
+        drive = normalized[0].lower()
+        remainder = normalized[2:].lstrip("/")
+        return Path("/mnt") / drive / remainder
+    return Path(normalized)
+
+
+def _resolve_windows_home(
+    env: Mapping[str, str],
+    *,
+    wsl: bool,
+) -> Path | None:
+    """Resolve the Windows home directory from environment variables."""
+    user_profile = env.get("USERPROFILE")
+    if user_profile:
+        return (
+            _translate_windows_path_for_wsl(user_profile)
+            if wsl
+            else Path(user_profile)
+        )
+
+    home_drive = env.get("HOMEDRIVE")
+    home_path = env.get("HOMEPATH")
+    if home_drive and home_path:
+        combined = f"{home_drive}{home_path}"
+        return _translate_windows_path_for_wsl(combined) if wsl else Path(combined)
+    return None
+
+
+def resolve_default_destination(
+    *,
+    system: str | None = None,
+    home: Path | None = None,
+    env: Mapping[str, str] | None = None,
+    release: str | None = None,
+) -> Path:
+    """Resolve the default mod destination for the current platform.
+
+    Args:
+        system: Optional platform override for tests.
+        home: Optional home directory override for tests.
+        env: Optional environment override for tests.
+        release: Optional kernel release override for WSL detection.
+
+    Returns:
+        The default destination path for the detected platform.
+
+    Raises:
+        ValueError: If the platform is unsupported or Windows home cannot be
+            determined in WSL/native Windows.
+    """
+    detected_system = system or platform.system()
+    current_home = home or Path.home()
+    current_env = env or os.environ
+
+    if detected_system == "Darwin":
+        return current_home / _MACOS_MODS_SUFFIX
+
+    if detected_system == "Windows":
+        windows_home = _resolve_windows_home(current_env, wsl=False)
+        if windows_home is None:
+            msg = "Could not determine %USERPROFILE%; pass --destination explicitly."
+            raise ValueError(msg)
+        return windows_home / _WINDOWS_MODS_SUFFIX
+
+    if detected_system == "Linux":
+        if _is_wsl(release):
+            windows_home = _resolve_windows_home(current_env, wsl=True)
+            if windows_home is None:
+                msg = (
+                    "Could not determine Windows home from WSL environment; "
+                    "pass --destination explicitly."
+                )
+                raise ValueError(msg)
+            return windows_home / _WINDOWS_MODS_SUFFIX
+        return current_home / _LINUX_MODS_SUFFIX
+
+    msg = f"Unsupported platform: {detected_system}"
+    raise ValueError(msg)
+
+
+def _iter_sync_files(source: Path, *, exclude_fonts: bool) -> list[Path]:
+    """Collect files that should be deployed to the game Mods directory."""
+    file_paths: list[Path] = []
+
+    for relative in (
+        Path("manifest.json"),
+        Path("Bootstrap.cs"),
+        Path("Assemblies") / "QudJP.dll",
+    ):
+        candidate = source / relative
+        if candidate.is_file():
+            file_paths.append(candidate)
+
+    localization_dir = source / "Localization"
+    if localization_dir.is_dir():
+        for file_path in sorted(localization_dir.rglob("*")):
+            if file_path.is_file():
+                file_paths.append(file_path)
+
+    if not exclude_fonts:
+        fonts_dir = source / "Fonts"
+        if fonts_dir.is_dir():
+            for file_path in sorted(fonts_dir.rglob("*")):
+                if file_path.is_file():
+                    file_paths.append(file_path)
+
+    return file_paths
+
+
+def _run_python_sync(
+    source: Path,
+    destination: Path,
+    *,
+    dry_run: bool,
+    exclude_fonts: bool,
+) -> subprocess.CompletedProcess[str]:
+    """Synchronize files with a pure-Python copy fallback."""
+    file_paths = _iter_sync_files(source, exclude_fonts=exclude_fonts)
+    lines = ["Using Python copy fallback."]
+
+    if dry_run:
+        lines.append(f"Would replace {destination}")
+        lines.extend(
+            f"Would copy {file_path.relative_to(source)}"
+            for file_path in file_paths
+        )
+        return subprocess.CompletedProcess(
+            args=["python-copy"],
+            returncode=0,
+            stdout="\n".join(lines),
+            stderr="",
+        )
+
+    if destination.exists():
+        if destination.is_dir():
+            shutil.rmtree(destination)
+        else:
+            destination.unlink()
+
+    for file_path in file_paths:
+        relative_path = file_path.relative_to(source)
+        target_path = destination / relative_path
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(file_path, target_path)
+
+    lines.append(f"Copied {len(file_paths)} files to {destination}")
+    return subprocess.CompletedProcess(
+        args=["python-copy"],
+        returncode=0,
+        stdout="\n".join(lines),
+        stderr="",
+    )
 
 
 def build_rsync_command(
@@ -96,7 +281,7 @@ def run_sync(
     dry_run: bool = False,
     exclude_fonts: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    """Execute rsync to sync mod files to the game directory.
+    """Execute sync to copy mod files into the game directory.
 
     Args:
         source: Source directory to sync from.
@@ -105,7 +290,7 @@ def run_sync(
         exclude_fonts: If True, exclude Fonts/ directory.
 
     Returns:
-        Completed process result from rsync.
+        Completed process result from rsync or the Python fallback.
 
     Raises:
         FileNotFoundError: If source directory does not exist.
@@ -114,6 +299,14 @@ def run_sync(
     if not source.is_dir():
         msg = f"Source directory not found: {source}"
         raise FileNotFoundError(msg)
+
+    if shutil.which("rsync") is None:
+        return _run_python_sync(
+            source,
+            destination,
+            dry_run=dry_run,
+            exclude_fonts=exclude_fonts,
+        )
 
     cmd = build_rsync_command(
         source,
@@ -146,6 +339,16 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Exclude Fonts/ directory from sync.",
     )
+    parser.add_argument(
+        "--destination",
+        "--dest",
+        type=Path,
+        default=None,
+        help=(
+            "Override the destination Mods/QudJP directory. If omitted, the "
+            "platform default path is used."
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -154,11 +357,17 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: {exc}", file=sys.stderr)  # noqa: T201
         return 1
 
+    try:
+        destination = args.destination or resolve_default_destination()
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)  # noqa: T201
+        return 1
+
     source = project_root / "Mods" / "QudJP"
     try:
         result = run_sync(
             source,
-            _GAME_MODS_DIR,
+            destination,
             dry_run=args.dry_run,
             exclude_fonts=args.exclude_fonts,
         )

--- a/scripts/tests/test_sync_mod.py
+++ b/scripts/tests/test_sync_mod.py
@@ -1,5 +1,6 @@
 """Tests for the sync_mod module."""
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -9,6 +10,8 @@ from scripts.sync_mod import (
     _RSYNC_EXCLUDES,
     _RSYNC_INCLUDES,
     build_rsync_command,
+    main,
+    resolve_default_destination,
     run_sync,
 )
 
@@ -128,10 +131,13 @@ class TestRunSync:
         source = tmp_path / "source"
         source.mkdir()
         mock_result = MagicMock(stdout="", stderr="", returncode=0)
-        with patch(
-            "scripts.sync_mod.subprocess.run",
-            return_value=mock_result,
-        ) as mock_run:
+        with (
+            patch("scripts.sync_mod.shutil.which", return_value="/usr/bin/rsync"),
+            patch(
+                "scripts.sync_mod.subprocess.run",
+                return_value=mock_result,
+            ) as mock_run,
+        ):
             run_sync(source, tmp_path / "dest")
             mock_run.assert_called_once()
             cmd = mock_run.call_args[0][0]
@@ -142,10 +148,169 @@ class TestRunSync:
         source = tmp_path / "source"
         source.mkdir()
         mock_result = MagicMock(stdout="", stderr="", returncode=0)
-        with patch(
-            "scripts.sync_mod.subprocess.run",
-            return_value=mock_result,
-        ) as mock_run:
+        with (
+            patch("scripts.sync_mod.shutil.which", return_value="/usr/bin/rsync"),
+            patch(
+                "scripts.sync_mod.subprocess.run",
+                return_value=mock_result,
+            ) as mock_run,
+        ):
             run_sync(source, tmp_path / "dest", dry_run=True)
             cmd = mock_run.call_args[0][0]
             assert "--dry-run" in cmd
+
+    def test_python_fallback_copies_expected_files(self, tmp_path: Path) -> None:
+        """Fallback mode copies only deployable files when rsync is unavailable."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        (source / "Assemblies").mkdir(parents=True)
+        (source / "Localization").mkdir()
+        (source / "Fonts").mkdir()
+        (source / "manifest.json").write_text("{}", encoding="utf-8")
+        (source / "Bootstrap.cs").write_text("// bootstrap", encoding="utf-8")
+        (source / "Assemblies" / "QudJP.dll").write_bytes(b"dll")
+        (source / "Localization" / "Creatures.jp.xml").write_text(
+            "<objects/>",
+            encoding="utf-8",
+        )
+        (source / "Fonts" / "Font.otf").write_bytes(b"font")
+        (source / "src.cs").write_text("// do not copy", encoding="utf-8")
+        destination.mkdir()
+        (destination / "stale.txt").write_text("stale", encoding="utf-8")
+
+        with patch("scripts.sync_mod.shutil.which", return_value=None):
+            result = run_sync(source, destination)
+
+        assert result.returncode == 0
+        assert (destination / "manifest.json").exists()
+        assert (destination / "Bootstrap.cs").exists()
+        assert (destination / "Assemblies" / "QudJP.dll").exists()
+        assert (destination / "Localization" / "Creatures.jp.xml").exists()
+        assert (destination / "Fonts" / "Font.otf").exists()
+        assert not (destination / "src.cs").exists()
+        assert not (destination / "stale.txt").exists()
+
+    def test_python_fallback_respects_exclude_fonts(self, tmp_path: Path) -> None:
+        """Fallback mode skips Fonts/ when exclude_fonts is requested."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        (source / "Fonts").mkdir(parents=True)
+        (source / "Fonts" / "Font.otf").write_bytes(b"font")
+
+        with patch("scripts.sync_mod.shutil.which", return_value=None):
+            run_sync(source, destination, exclude_fonts=True)
+
+        assert not (destination / "Fonts").exists()
+
+    def test_python_fallback_dry_run_does_not_modify_destination(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Dry-run fallback reports planned work without writing files."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        source.mkdir()
+
+        with patch("scripts.sync_mod.shutil.which", return_value=None):
+            result = run_sync(source, destination, dry_run=True)
+
+        assert result.returncode == 0
+        assert "Would replace" in result.stdout
+        assert not destination.exists()
+
+
+class TestResolveDefaultDestination:
+    """Tests for platform-specific default destination resolution."""
+
+    def test_macos_uses_streaming_assets_mods(self, tmp_path: Path) -> None:
+        """macOS defaults to the Steam app bundle Mods directory."""
+        destination = resolve_default_destination(system="Darwin", home=tmp_path)
+        assert destination == (
+            tmp_path
+            / "Library"
+            / "Application Support"
+            / "Steam"
+            / "steamapps"
+            / "common"
+            / "Caves of Qud"
+            / "CoQ.app"
+            / "Contents"
+            / "Resources"
+            / "Data"
+            / "StreamingAssets"
+            / "Mods"
+            / "QudJP"
+        )
+
+    def test_windows_uses_locallow_mods(self) -> None:
+        """Windows defaults to the LocalLow mods directory."""
+        destination = resolve_default_destination(
+            system="Windows",
+            env={"USERPROFILE": r"C:\Users\TestUser"},
+        )
+        assert str(destination).replace("\\", "/").endswith(
+            "C:/Users/TestUser/AppData/LocalLow/Freehold Games/CavesOfQud/Mods/QudJP",
+        )
+
+    def test_wsl_uses_translated_windows_profile(self) -> None:
+        """WSL defaults to the Windows LocalLow mods directory."""
+        destination = resolve_default_destination(
+            system="Linux",
+            env={"USERPROFILE": r"C:\Users\TestUser"},
+            release="5.15.167.4-microsoft-standard-WSL2",
+        )
+        assert destination == (
+            Path("/mnt/c/Users/TestUser")
+            / "AppData"
+            / "LocalLow"
+            / "Freehold Games"
+            / "CavesOfQud"
+            / "Mods"
+            / "QudJP"
+        )
+
+    def test_linux_uses_unity3d_mods(self, tmp_path: Path) -> None:
+        """Native Linux defaults to the Unity user-data Mods directory."""
+        destination = resolve_default_destination(
+            system="Linux",
+            home=tmp_path,
+            release="6.8.0-generic",
+        )
+        assert destination == (
+            tmp_path
+            / ".config"
+            / "unity3d"
+            / "Freehold Games"
+            / "CavesOfQud"
+            / "Mods"
+            / "QudJP"
+        )
+
+
+class TestMain:
+    """Tests for the sync_mod CLI entry point."""
+
+    def test_destination_override_is_forwarded(self, tmp_path: Path) -> None:
+        """--dest forwards the chosen path to run_sync."""
+        project_root = tmp_path / "repo"
+        source = project_root / "Mods" / "QudJP"
+        source.mkdir(parents=True)
+        destination = tmp_path / "custom-dest"
+
+        with (
+            patch("scripts.sync_mod._find_project_root", return_value=project_root),
+            patch(
+                "scripts.sync_mod.run_sync",
+                return_value=subprocess.CompletedProcess(
+                    args=["sync"],
+                    returncode=0,
+                    stdout="",
+                    stderr="",
+                ),
+            ) as mock_run,
+        ):
+            result = main(["--dest", str(destination)])
+
+        assert result == 0
+        assert mock_run.call_args.args[0] == source
+        assert mock_run.call_args.args[1] == destination

--- a/scripts/tests/test_sync_mod.py
+++ b/scripts/tests/test_sync_mod.py
@@ -215,8 +215,24 @@ class TestRunSync:
             result = run_sync(source, destination, dry_run=True)
 
         assert result.returncode == 0
-        assert "Would replace" in result.stdout
+        assert "Would create" in result.stdout
         assert not destination.exists()
+
+    def test_python_fallback_dry_run_reports_replace_for_existing_destination(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Dry-run fallback reports replacement when destination already exists."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        source.mkdir()
+        destination.mkdir()
+
+        with patch("scripts.sync_mod.shutil.which", return_value=None):
+            result = run_sync(source, destination, dry_run=True)
+
+        assert result.returncode == 0
+        assert "Would replace" in result.stdout
 
 
 class TestResolveDefaultDestination:

--- a/scripts/tests/test_sync_mod.py
+++ b/scripts/tests/test_sync_mod.py
@@ -223,7 +223,7 @@ class TestResolveDefaultDestination:
     """Tests for platform-specific default destination resolution."""
 
     def test_macos_uses_streaming_assets_mods(self, tmp_path: Path) -> None:
-        """macOS defaults to the Steam app bundle Mods directory."""
+        """MacOS defaults to the Steam app bundle Mods directory."""
         destination = resolve_default_destination(system="Darwin", home=tmp_path)
         assert destination == (
             tmp_path


### PR DESCRIPTION
## Summary
- make `scripts/sync_mod.py` resolve platform-specific default mod paths on macOS, Windows, WSL2, and Linux
- add `--destination` / `--dest` and a Python copy fallback when `rsync` is unavailable
- let `QudJP.Tests.csproj` accept `-p:GameDir=...` or `-p:AssemblyCSharpPath=...` so non-macOS L2G runs are supported
- update contributor and deployment docs to match the new workflow

## Testing
- `python3 -m compileall scripts/sync_mod.py scripts/tests/test_sync_mod.py`
- Python smoke test for Linux/WSL destination resolution
- Python smoke test for `run_sync(...)` fallback copy path

## Not Run
- `pytest scripts/tests/test_sync_mod.py` (pytest not available in this environment)
- `dotnet build` / `dotnet test` (dotnet not available in this environment)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * macOS、Windows、WSL2、Linuxでのクロスプラットフォームデプロイメント対応を追加しました
  * rsync未利用時にPythonフォールバック実装を追加しました

* **改善**
  * ビルド構成をより柔軟に調整可能にしました
  * デプロイメント先ディレクトリのカスタマイズオプションを拡張しました

* **ドキュメント**
  * 複数プラットフォーム対応の手順を更新しました
  * CLIコマンドとカスタマイズ例を追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->