### PR TITLE
fix: guard CherubimSpawner description replacement

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCherubimSpawnerTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCherubimSpawnerTargets.cs
@@ -1,0 +1,75 @@
+namespace QudJP.Tests.DummyTargets
+{
+    internal sealed class DummyCherubimDescriptionPart
+    {
+        public string _Short = string.Empty;
+    }
+}
+
+namespace QudJP.Tests.DummyTargets
+{
+    internal sealed class DummyCherubimRender
+    {
+        public string DisplayName { get; set; } = string.Empty;
+    }
+
+    internal sealed class DummyCherubimGameObject
+    {
+        private readonly Dictionary<string, string> tags = new(StringComparer.Ordinal);
+        private readonly Dictionary<(string Category, string Name), string> xTags = new();
+        private readonly DummyCherubimDescriptionPart description = new();
+
+        public DummyCherubimRender Render { get; } = new();
+
+        public DummyCherubimDescriptionPart DescriptionPart => description;
+
+        public bool HasTag(string name)
+        {
+            return tags.ContainsKey(name);
+        }
+
+        public string GetTag(string name)
+        {
+            return tags[name];
+        }
+
+        public string GetxTag(string category, string name)
+        {
+            return xTags.TryGetValue((category, name), out var value) ? value : string.Empty;
+        }
+
+        public T GetPart<T>() where T : class
+        {
+            if (typeof(T) == typeof(DummyCherubimDescriptionPart))
+            {
+                return (T)(object)description;
+            }
+
+            throw new InvalidOperationException($"Unsupported part type: {typeof(T).FullName}");
+        }
+
+        public void SetTag(string name, string value)
+        {
+            tags[name] = value;
+        }
+
+        public void SetxTag(string category, string name, string value)
+        {
+            xTags[(category, name)] = value;
+        }
+    }
+
+    internal static class DummyCherubimSpawnerTarget
+    {
+        public static void ReplaceDescription(DummyCherubimGameObject Object, string Description, string Features)
+        {
+            var creatureType = Object.HasTag("AlternateCreatureType")
+                ? Object.GetTag("AlternateCreatureType")
+                : Object.Render.DisplayName.Substring(0, Object.Render.DisplayName.IndexOf(' '));
+            Object.GetPart<DummyCherubimDescriptionPart>()._Short = Description
+                .Replace("*skin*", Object.GetxTag("TextFragments", "Skin"))
+                .Replace("*creatureType*", creatureType)
+                .Replace("*features*", Features);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCherubimSpawnerTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCherubimSpawnerTargets.cs
@@ -13,7 +13,7 @@ namespace QudJP.Tests.DummyTargets
         public string DisplayName { get; set; } = string.Empty;
     }
 
-    internal sealed class DummyCherubimGameObject
+    internal class DummyCherubimGameObject
     {
         private readonly Dictionary<string, string> tags = new(StringComparer.Ordinal);
         private readonly Dictionary<(string Category, string Name), string> xTags = new();
@@ -56,6 +56,14 @@ namespace QudJP.Tests.DummyTargets
         public void SetxTag(string category, string name, string value)
         {
             xTags[(category, name)] = value;
+        }
+    }
+
+    internal sealed class DummyCherubimGameObjectWithNullSkin : DummyCherubimGameObject
+    {
+        public new string? GetxTag(string category, string name)
+        {
+            return null;
         }
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CherubimSpawnerReplaceDescriptionPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CherubimSpawnerReplaceDescriptionPatchTests.cs
@@ -1,0 +1,77 @@
+using System.Reflection;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class CherubimSpawnerReplaceDescriptionPatchTests
+{
+    [Test]
+    public void Prefix_GuardsNoSpaceDisplayName_WhenPatched()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyCherubimSpawnerTarget), nameof(DummyCherubimSpawnerTarget.ReplaceDescription)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(CherubimSpawnerReplaceDescriptionPatch), nameof(CherubimSpawnerReplaceDescriptionPatch.Prefix))));
+
+            var gameObject = new DummyCherubimGameObject();
+            gameObject.Render.DisplayName = "cherub";
+            gameObject.SetxTag("TextFragments", "Skin", "gleaming");
+
+            Assert.DoesNotThrow(() => DummyCherubimSpawnerTarget.ReplaceDescription(
+                gameObject,
+                "A *skin* *creatureType* with *features*.",
+                "wings"));
+            Assert.That(gameObject.DescriptionPart._Short, Is.EqualTo("A gleaming cherub with wings."));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void Prefix_PreservesOriginalBehavior_WhenDisplayNameContainsSpace()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyCherubimSpawnerTarget), nameof(DummyCherubimSpawnerTarget.ReplaceDescription)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(CherubimSpawnerReplaceDescriptionPatch), nameof(CherubimSpawnerReplaceDescriptionPatch.Prefix))));
+
+            var gameObject = new DummyCherubimGameObject();
+            gameObject.Render.DisplayName = "ape cherub";
+            gameObject.SetxTag("TextFragments", "Skin", "gleaming");
+
+            Assert.DoesNotThrow(() => DummyCherubimSpawnerTarget.ReplaceDescription(
+                gameObject,
+                "A *skin* *creatureType* with *features*.",
+                "wings"));
+            Assert.That(gameObject.DescriptionPart._Short, Is.EqualTo("A gleaming ape with wings."));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName)
+    {
+        return AccessTools.Method(type, methodName)
+            ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CherubimSpawnerReplaceDescriptionPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CherubimSpawnerReplaceDescriptionPatchTests.cs
@@ -64,6 +64,59 @@ public sealed class CherubimSpawnerReplaceDescriptionPatchTests
         }
     }
 
+    [Test]
+    public void Prefix_SkipsOriginalCrashPath_WhenDisplayNameIsEmpty()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyCherubimSpawnerTarget), nameof(DummyCherubimSpawnerTarget.ReplaceDescription)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(CherubimSpawnerReplaceDescriptionPatch), nameof(CherubimSpawnerReplaceDescriptionPatch.Prefix))));
+
+            var gameObject = new DummyCherubimGameObject();
+            gameObject.Render.DisplayName = string.Empty;
+            gameObject.SetxTag("TextFragments", "Skin", "gleaming");
+
+            Assert.DoesNotThrow(() => DummyCherubimSpawnerTarget.ReplaceDescription(
+                gameObject,
+                "A *skin* *creatureType* with *features*.",
+                "wings"));
+            Assert.That(gameObject.DescriptionPart._Short, Is.EqualTo(string.Empty));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void Prefix_DoesNotReenterOriginal_WhenGuardedNoSpaceReplacementFails()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyCherubimSpawnerTarget), nameof(DummyCherubimSpawnerTarget.ReplaceDescription)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(CherubimSpawnerReplaceDescriptionPatch), nameof(CherubimSpawnerReplaceDescriptionPatch.Prefix))));
+
+            var gameObject = new DummyCherubimGameObjectWithNullSkin();
+            gameObject.Render.DisplayName = "cherub";
+
+            Assert.DoesNotThrow(() => DummyCherubimSpawnerTarget.ReplaceDescription(
+                gameObject,
+                "A *skin* *creatureType* with *features*.",
+                "wings"));
+            Assert.That(gameObject.DescriptionPart._Short, Is.EqualTo(string.Empty));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
     private static string CreateHarmonyId()
     {
         return $"qudjp.tests.{Guid.NewGuid():N}";

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -154,6 +154,7 @@ public sealed class TargetMethodResolutionTests
     [TestCase(typeof(AbilityBarUpdateAbilitiesTextPatch), "UpdateAbilitiesText", "Qud.UI.AbilityBar", "System.Void", new string[0])]
     [TestCase(typeof(EffectDescriptionPatch), "GetDescription", "XRL.World.Effect", "System.String", new string[0])]
     [TestCase(typeof(EffectDetailsPatch), "GetDetails", "XRL.World.Effect", "System.String", new string[0])]
+    [TestCase(typeof(CherubimSpawnerReplaceDescriptionPatch), "ReplaceDescription", "XRL.World.Parts.CherubimSpawner", "System.Void", new[] { "XRL.World.GameObject", "System.String", "System.String" })]
     [TestCase(typeof(CharacterStatusScreenHighlightEffectPatch), "HandleHighlightEffect", "Qud.UI.CharacterStatusScreen", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]
     [TestCase(typeof(GameObjectShowActiveEffectsPatch), "ShowActiveEffects", "XRL.World.GameObject", "System.Void", new string[0])]
     [TestCase(typeof(DescriptionShortDescriptionPatch), "GetShortDescription", "XRL.World.Parts.Description", "System.String", new[] { "System.Boolean", "System.Boolean", "System.String" })]

--- a/Mods/QudJP/Assemblies/src/Patches/CherubimSpawnerReplaceDescriptionPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/CherubimSpawnerReplaceDescriptionPatch.cs
@@ -43,12 +43,22 @@ public static class CherubimSpawnerReplaceDescriptionPatch
             }
 
             var displayName = GetDisplayName(__0);
-            if (displayName is null || displayName.Length == 0 || displayName.Any(static c => c == ' '))
+            if (displayName is null || displayName.Length == 0)
+            {
+                return false;
+            }
+
+            if (displayName.Any(static c => c == ' '))
             {
                 return true;
             }
 
-            return !TryReplaceDescription(__0, Description, Features, displayName);
+            if (!TryReplaceDescription(__0, Description, Features, displayName))
+            {
+                Trace.TraceError("QudJP: CherubimSpawnerReplaceDescriptionPatch failed to apply guarded no-space replacement.");
+            }
+
+            return false;
         }
         catch (Exception ex)
         {

--- a/Mods/QudJP/Assemblies/src/Patches/CherubimSpawnerReplaceDescriptionPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/CherubimSpawnerReplaceDescriptionPatch.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class CherubimSpawnerReplaceDescriptionPatch
+{
+    private const string TargetTypeName = "XRL.World.Parts.CherubimSpawner";
+    private const string GameObjectTypeName = "XRL.World.GameObject";
+    private const string DescriptionPartTypeName = "XRL.World.Parts.Description";
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = AccessTools.TypeByName(TargetTypeName);
+        var gameObjectType = AccessTools.TypeByName(GameObjectTypeName);
+        if (targetType is null || gameObjectType is null)
+        {
+            Trace.TraceError("QudJP: CherubimSpawnerReplaceDescriptionPatch failed to resolve CherubimSpawner or GameObject.");
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "ReplaceDescription", [gameObjectType, typeof(string), typeof(string)]);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: CherubimSpawnerReplaceDescriptionPatch.ReplaceDescription(GameObject,string,string) not found.");
+        }
+
+        return method;
+    }
+
+    public static bool Prefix(object? __0, string Description, string Features)
+    {
+        try
+        {
+            if (__0 is null || HasAlternateCreatureType(__0))
+            {
+                return true;
+            }
+
+            var displayName = GetDisplayName(__0);
+            if (displayName is null || displayName.Length == 0 || displayName.Contains(' '))
+            {
+                return true;
+            }
+
+            return !TryReplaceDescription(__0, Description, Features, displayName);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: CherubimSpawnerReplaceDescriptionPatch.Prefix failed: {0}", ex);
+            return true;
+        }
+    }
+
+    private static bool TryReplaceDescription(object gameObject, string description, string features, string creatureType)
+    {
+        var descriptionPart = GetDescriptionPart(gameObject);
+        if (descriptionPart is null)
+        {
+            return false;
+        }
+
+        var skin = InvokeStringMethod(gameObject, "GetxTag", "TextFragments", "Skin");
+        if (skin is null)
+        {
+            Trace.TraceWarning("QudJP: CherubimSpawnerReplaceDescriptionPatch could not resolve TextFragments/Skin.");
+            return false;
+        }
+
+        var shortDescription = description
+            .Replace("*skin*", skin)
+            .Replace("*creatureType*", creatureType)
+            .Replace("*features*", features);
+
+        return SetStringMemberValue(descriptionPart, "_Short", shortDescription);
+    }
+
+    private static bool HasAlternateCreatureType(object gameObject)
+    {
+        return InvokeBoolMethod(gameObject, "HasTag", "AlternateCreatureType");
+    }
+
+    private static string? GetDisplayName(object gameObject)
+    {
+        var render = GetMemberValue(gameObject, "Render");
+        return render is null ? null : GetMemberValue(render, "DisplayName") as string;
+    }
+
+    private static object? GetDescriptionPart(object gameObject)
+    {
+        var descriptionPartType = AccessTools.TypeByName(DescriptionPartTypeName);
+        if (descriptionPartType is not null)
+        {
+            var getPartMethod = AccessTools.GetDeclaredMethods(gameObject.GetType())
+                .FirstOrDefault(static method => method.IsGenericMethodDefinition
+                    && string.Equals(method.Name, "GetPart", StringComparison.Ordinal)
+                    && method.GetParameters().Length == 0);
+            var part = getPartMethod?.MakeGenericMethod(descriptionPartType).Invoke(gameObject, null);
+            if (part is not null)
+            {
+                return part;
+            }
+        }
+
+        var descriptionPart = GetMemberValue(gameObject, "DescriptionPart");
+        if (descriptionPart is not null)
+        {
+            return descriptionPart;
+        }
+
+        Trace.TraceWarning("QudJP: CherubimSpawnerReplaceDescriptionPatch falling back to Description member lookup.");
+        return GetMemberValue(gameObject, "Description");
+    }
+
+    private static object? GetMemberValue(object instance, string memberName)
+    {
+        var type = instance.GetType();
+        var property = AccessTools.Property(type, memberName);
+        if (property is not null && property.CanRead)
+        {
+            return property.GetValue(instance);
+        }
+
+        var field = AccessTools.Field(type, memberName);
+        return field?.GetValue(instance);
+    }
+
+    private static bool SetStringMemberValue(object instance, string memberName, string value)
+    {
+        var type = instance.GetType();
+        var property = AccessTools.Property(type, memberName);
+        if (property is not null && property.CanWrite && property.PropertyType == typeof(string))
+        {
+            property.SetValue(instance, value);
+            return true;
+        }
+
+        var field = AccessTools.Field(type, memberName);
+        if (field is not null && field.FieldType == typeof(string))
+        {
+            field.SetValue(instance, value);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool InvokeBoolMethod(object instance, string methodName, params object[] args)
+    {
+        var method = AccessTools.Method(instance.GetType(), methodName, args.Select(static arg => arg.GetType()).ToArray());
+        return method?.Invoke(instance, args) as bool? ?? false;
+    }
+
+    private static string? InvokeStringMethod(object instance, string methodName, params object[] args)
+    {
+        var method = AccessTools.Method(instance.GetType(), methodName, args.Select(static arg => arg.GetType()).ToArray());
+        return method?.Invoke(instance, args) as string;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/CherubimSpawnerReplaceDescriptionPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/CherubimSpawnerReplaceDescriptionPatch.cs
@@ -43,7 +43,7 @@ public static class CherubimSpawnerReplaceDescriptionPatch
             }
 
             var displayName = GetDisplayName(__0);
-            if (displayName is null || displayName.Length == 0 || displayName.Contains(' '))
+            if (displayName is null || displayName.Length == 0 || displayName.Any(static c => c == ' '))
             {
                 return true;
             }


### PR DESCRIPTION
## Summary
- patch `CherubimSpawner.ReplaceDescription` to avoid crashing when a display name has no space delimiter
- add focused L2 regression coverage for both no-space and normal display-name cases
- add L2G coverage proving the patch resolves the live game target

## Testing
- dotnet build Mods/QudJP/Assemblies/QudJP.csproj
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "TestCategory!=L2G"
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~CherubimSpawnerReplaceDescriptionPatch|CherubimSpawnerReplaceDescriptionPatchTests"

## Related
- Closes #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * クリーチャーの短い説明文の生成を改善し、表示名に空白がないケースでも意図した置換（皮膚・種名・特徴）を適用するよう安定化しました。

* **テスト**
  * 説明文置換の動作を検証する新しいテストを追加し、空白あり／なしの表示名それぞれで期待どおりの出力になることを検証しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->