### PR TITLE
fix: surface scoped dictionary duplicate overrides

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
@@ -218,21 +218,25 @@ public sealed class LocalizationCoverageTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(duplicateEntries["Randomize Selection"].Select(static entry => entry.Text).Distinct(StringComparer.Ordinal),
+            Assert.That(duplicateEntries.TryGetValue("Randomize Selection", out var randomizeSelectionEntries), Is.True);
+            Assert.That(randomizeSelectionEntries!.Select(static entry => entry.Text).Distinct(StringComparer.Ordinal),
                 Is.EquivalentTo(new[] { "ランダムに選択", "選択をランダムにする" }));
-            Assert.That(duplicateEntries["Randomize Selection"], Has.Length.EqualTo(3));
+            Assert.That(randomizeSelectionEntries, Has.Length.EqualTo(3));
 
-            Assert.That(duplicateEntries["Reset Selection"].Select(static entry => entry.Text).Distinct(StringComparer.Ordinal),
+            Assert.That(duplicateEntries.TryGetValue("Reset Selection", out var resetSelectionEntries), Is.True);
+            Assert.That(resetSelectionEntries!.Select(static entry => entry.Text).Distinct(StringComparer.Ordinal),
                 Is.EquivalentTo(new[] { "選択をリセット" }));
-            Assert.That(duplicateEntries["Reset Selection"], Has.Length.EqualTo(3));
+            Assert.That(resetSelectionEntries, Has.Length.EqualTo(3));
 
-            Assert.That(duplicateEntries["Sated"].Select(static entry => entry.Text).Distinct(StringComparer.Ordinal),
+            Assert.That(duplicateEntries.TryGetValue("Sated", out var satedEntries), Is.True);
+            Assert.That(satedEntries!.Select(static entry => entry.Text).Distinct(StringComparer.Ordinal),
                 Is.EquivalentTo(new[] { "満腹" }));
-            Assert.That(duplicateEntries["Sated"], Has.Length.EqualTo(2));
+            Assert.That(satedEntries, Has.Length.EqualTo(2));
 
-            Assert.That(duplicateEntries["Quenched"].Select(static entry => entry.Text).Distinct(StringComparer.Ordinal),
+            Assert.That(duplicateEntries.TryGetValue("Quenched", out var quenchedEntries), Is.True);
+            Assert.That(quenchedEntries!.Select(static entry => entry.Text).Distinct(StringComparer.Ordinal),
                 Is.EquivalentTo(new[] { "潤っている", "潤沢" }));
-            Assert.That(duplicateEntries["Quenched"], Has.Length.EqualTo(3));
+            Assert.That(quenchedEntries, Has.Length.EqualTo(3));
         });
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
@@ -205,6 +205,38 @@ public sealed class LocalizationCoverageTests
     }
 
     [Test]
+    public void KnownRuntimeNoisyDuplicateKeys_AreExplicitlyAudited()
+    {
+        var dictionariesRoot = Path.Combine(localizationRoot, "Dictionaries");
+        var duplicateEntries = LoadEntries(Path.Combine(dictionariesRoot, "ui-default.ja.json"))
+            .Concat(LoadEntries(Path.Combine(dictionariesRoot, "ui-phase3c-labels.ja.json")))
+            .Concat(LoadEntries(Path.Combine(dictionariesRoot, "ui-auto-generated.ja.json")))
+            .Concat(LoadEntries(Path.Combine(dictionariesRoot, "ui-chargen.ja.json")))
+            .Where(static entry => entry.Key is "Randomize Selection" or "Reset Selection" or "Sated" or "Quenched")
+            .GroupBy(static entry => entry.Key, StringComparer.Ordinal)
+            .ToDictionary(static group => group.Key, static group => group.ToArray(), StringComparer.Ordinal);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(duplicateEntries["Randomize Selection"].Select(static entry => entry.Text).Distinct(StringComparer.Ordinal),
+                Is.EquivalentTo(new[] { "ランダムに選択", "選択をランダムにする" }));
+            Assert.That(duplicateEntries["Randomize Selection"], Has.Length.EqualTo(3));
+
+            Assert.That(duplicateEntries["Reset Selection"].Select(static entry => entry.Text).Distinct(StringComparer.Ordinal),
+                Is.EquivalentTo(new[] { "選択をリセット" }));
+            Assert.That(duplicateEntries["Reset Selection"], Has.Length.EqualTo(3));
+
+            Assert.That(duplicateEntries["Sated"].Select(static entry => entry.Text).Distinct(StringComparer.Ordinal),
+                Is.EquivalentTo(new[] { "満腹" }));
+            Assert.That(duplicateEntries["Sated"], Has.Length.EqualTo(2));
+
+            Assert.That(duplicateEntries["Quenched"].Select(static entry => entry.Text).Distinct(StringComparer.Ordinal),
+                Is.EquivalentTo(new[] { "潤っている", "潤沢" }));
+            Assert.That(duplicateEntries["Quenched"], Has.Length.EqualTo(3));
+        });
+    }
+
+    [Test]
     public void UiDefaultDictionary_ContainsCurrentCalendarStatusKeys()
     {
         var uiDefaultKeys = LoadEntries(Path.Combine(localizationRoot, "Dictionaries", "ui-default.ja.json"))

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ScopedDictionaryLookupTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ScopedDictionaryLookupTests.cs
@@ -1,0 +1,91 @@
+using System.Text;
+
+namespace QudJP.Tests.L1;
+
+[TestFixture]
+[Category("L1")]
+[NonParallelizable]
+public sealed class ScopedDictionaryLookupTests
+{
+    private static readonly UTF8Encoding Utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    private string tempDirectory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempDirectory = Path.Combine(Path.GetTempPath(), "qudjp-scoped-dictionary-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+
+        Translator.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(tempDirectory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+
+        if (Directory.Exists(tempDirectory))
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void TranslateExactOrLowerAscii_LogsDuplicateKeyOverrides_WithinScopedDictionaryFile()
+    {
+        WriteDictionary(
+            "scoped.ja.json",
+            ("Hello", "こんにちは"),
+            ("Hello", "やあ"),
+            ("Inventory", "インベントリ"));
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+            Assert.That(
+                ScopedDictionaryLookup.TranslateExactOrLowerAscii("Hello", "scoped.ja.json"),
+                Is.EqualTo("やあ")));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(output, Does.Contain("ScopedDictionaryLookup duplicate key 'Hello'"));
+            Assert.That(output, Does.Contain("scoped.ja.json"));
+            Assert.That(output, Does.Contain("ScopedDictionaryLookup duplicate key overrides in"));
+            Assert.That(output, Does.Contain("Hello=1"));
+        });
+    }
+
+    private void WriteDictionary(string fileName, params (string key, string text)[] entries)
+    {
+        var builder = new StringBuilder();
+        builder.Append("{\"entries\":[");
+        AppendEntries(builder, entries);
+        builder.AppendLine("]}");
+        File.WriteAllText(Path.Combine(tempDirectory, fileName), builder.ToString(), Utf8WithoutBom);
+    }
+
+    private static void AppendEntries(StringBuilder builder, IReadOnlyList<(string key, string text)> entries)
+    {
+        for (var index = 0; index < entries.Count; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(',');
+            }
+
+            var (key, text) = entries[index];
+            builder.Append("{\"key\":\"");
+            builder.Append(EscapeJson(key));
+            builder.Append("\",\"text\":\"");
+            builder.Append(EscapeJson(text));
+            builder.Append("\"}");
+        }
+    }
+
+    private static string EscapeJson(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Translation/ScopedDictionaryLookup.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/ScopedDictionaryLookup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
@@ -64,6 +65,7 @@ internal static class ScopedDictionaryLookup
     private static IReadOnlyDictionary<string, string> ReadDictionary(string path)
     {
         var entries = new Dictionary<string, string>(StringComparer.Ordinal);
+        var duplicateKeyCounts = new Dictionary<string, int>(StringComparer.Ordinal);
         if (!File.Exists(path))
         {
             return entries;
@@ -87,7 +89,30 @@ internal static class ScopedDictionaryLookup
 
             var key = entry.Key!;
             var text = entry.Text!;
+            if (entries.ContainsKey(key))
+            {
+                var duplicateCount = duplicateKeyCounts.TryGetValue(key, out var currentDuplicateCount)
+                    ? currentDuplicateCount + 1
+                    : 1;
+                duplicateKeyCounts[key] = duplicateCount;
+                if (duplicateCount == 1)
+                {
+                    Trace.TraceWarning(
+                        "QudJP: ScopedDictionaryLookup duplicate key '{0}' in '{1}'.",
+                        key,
+                        path);
+                }
+            }
+
             entries[key] = text;
+        }
+
+        if (duplicateKeyCounts.Count > 0)
+        {
+            Trace.TraceWarning(
+                "QudJP: ScopedDictionaryLookup duplicate key overrides in '{0}': {1}.",
+                path,
+                ObservabilityHelpers.BuildRankedCounterBody(duplicateKeyCounts, 10));
         }
 
         return entries;


### PR DESCRIPTION
## Summary
- add duplicate-key warnings to `ScopedDictionaryLookup` without changing last-write-wins lookup behavior
- add an L1 regression test for scoped duplicate observability
- audit currently noisy duplicate runtime keys in localization coverage tests

## Testing
- dotnet build Mods/QudJP/Assemblies/QudJP.csproj
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "TestCategory!=L2G"

## Related
- Closes #342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 日本語ローカライゼーションの重複キー動作を検証する新しいテストを追加しました。
  * スコープ付き辞書の翻訳動作を検証するテストクラスを追加しました。

* **Bug Fixes**
  * 辞書解析時の重複キー検出とログ記録機能を強化し、キーのオーバーライド時に警告を発行するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->