### PR TITLE
fix: prevent translated text from re-entering lookup

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/StringHelpersTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/StringHelpersTests.cs
@@ -59,6 +59,20 @@ public sealed class StringHelpersTests
     }
 
     [Test]
+    public void TranslateExactOrLowerAscii_FallsBackToLowerAsciiKeyWithoutMissingKeyNoise()
+    {
+        WriteDictionary(("desecrate", "冒涜する"));
+
+        var translated = StringHelpers.TranslateExactOrLowerAscii("Desecrate");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.EqualTo("冒涜する"));
+            Assert.That(Translator.GetMissingKeyHitCountForTests("Desecrate"), Is.EqualTo(0));
+        });
+    }
+
+    [Test]
     public void TryGetTranslationExactOrLowerAscii_FallsBackToLowerAsciiKeyWithoutMissingKeyNoise()
     {
         WriteDictionary(("flower fields", "花畑"));

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/LoadingStatusTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/LoadingStatusTranslationPatchTests.cs
@@ -132,6 +132,34 @@ public sealed class LoadingStatusTranslationPatchTests
         }
     }
 
+    [Test]
+    public void Prefix_UsesLowerAsciiFallbackWithoutMissingKeyNoise_WhenPatched()
+    {
+        WriteDictionary(("initializing protocols...", "プロトコルを初期化しています..."));
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyLoadingTarget), nameof(DummyLoadingTarget.SetLoadingStatus)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(LoadingStatusTranslationPatch), nameof(LoadingStatusTranslationPatch.Prefix))));
+
+            DummyLoadingTarget.SetLoadingStatus("Initializing protocols...", waitForUiUpdate: true);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyLoadingTarget.LastDescription, Is.EqualTo("プロトコルを初期化しています..."));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("Initializing protocols..."), Is.EqualTo(0));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
     private static string CreateHarmonyId()
     {
         return $"qudjp.tests.{Guid.NewGuid():N}";

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PlayerStatusBarProducerTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PlayerStatusBarProducerTranslationPatchTests.cs
@@ -87,6 +87,48 @@ public sealed class PlayerStatusBarProducerTranslationPatchTests
     }
 
     [Test]
+    public void Postfix_UsesLowerAsciiFallbackWithoutMissingKeyNoise_ForProducerStringData()
+    {
+        WriteDictionary(
+            ("sated", "満腹"),
+            ("quenched", "潤沢"),
+            ("harvest dawn", "ハーヴェスト・ドーン"),
+            ("kisu ux", "キス・ウクス"));
+
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyPlayerStatusBarTarget), nameof(DummyPlayerStatusBarTarget.BeginEndTurn)),
+                postfix: new HarmonyMethod(RequirePatchMethod("Postfix", typeof(object), typeof(MethodBase))));
+
+            var instance = new DummyPlayerStatusBarTarget
+            {
+                NextFoodWater = "Sated Quenched",
+                NextTime = "Harvest Dawn 16th of Kisu Ux",
+            };
+
+            instance.BeginEndTurn(core: null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(instance.GetStringData("FoodWater"), Is.EqualTo("満腹 潤沢"));
+                Assert.That(instance.GetStringData("Time"), Is.EqualTo("ハーヴェスト・ドーン キス・ウクス16日"));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("Sated"), Is.EqualTo(0));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("Quenched"), Is.EqualTo(0));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("Harvest Dawn"), Is.EqualTo(0));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("Kisu Ux"), Is.EqualTo(0));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
     public void Postfix_RecordsProducerStringDataOwnerRouteTransforms_WithoutUITextSkinSinkObservation()
     {
         WriteDictionary(

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/WorldCreationProgressTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/WorldCreationProgressTranslationPatchTests.cs
@@ -187,6 +187,34 @@ public sealed class WorldCreationProgressTranslationPatchTests
         }
     }
 
+    [Test]
+    public void Prefix_UsesLowerAsciiFallbackWithoutMissingKeyNoise_WhenPatched()
+    {
+        WriteDictionary(("initializing protocols...", "プロトコルを初期化しています..."));
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyWorldCreationProgressTarget), nameof(DummyWorldCreationProgressTarget.NextStep)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(WorldCreationProgressTranslationPatch), nameof(WorldCreationProgressTranslationPatch.Prefix))));
+
+            DummyWorldCreationProgressTarget.NextStep("Initializing protocols...", 1);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyWorldCreationProgressTarget.LastNextStepText, Is.EqualTo("プロトコルを初期化しています..."));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("Initializing protocols..."), Is.EqualTo(0));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
     private static string CreateHarmonyId()
     {
         return $"qudjp.tests.{Guid.NewGuid():N}";

--- a/Mods/QudJP/Assemblies/src/Translation/StringHelpers.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/StringHelpers.cs
@@ -58,23 +58,24 @@ internal static class StringHelpers
 
     internal static string? TranslateExactOrLowerAscii(string source)
     {
-        var direct = Translator.Translate(source);
-        if (!string.Equals(direct, source, StringComparison.Ordinal))
+        if (Translator.TryGetTranslation(source, out var direct)
+            && !string.Equals(direct, source, StringComparison.Ordinal))
         {
             return direct;
         }
 
         var lowered = LowerAscii(source);
-        if (!string.Equals(lowered, source, StringComparison.Ordinal))
+        if (!string.Equals(lowered, source, StringComparison.Ordinal)
+            && Translator.TryGetTranslation(lowered, out var loweredTranslation)
+            && !string.Equals(loweredTranslation, lowered, StringComparison.Ordinal))
         {
-            var loweredTranslation = Translator.Translate(lowered);
-            if (!string.Equals(loweredTranslation, lowered, StringComparison.Ordinal))
-            {
-                return loweredTranslation;
-            }
+            return loweredTranslation;
         }
 
-        return null;
+        var translated = Translator.Translate(source);
+        return string.Equals(translated, source, StringComparison.Ordinal)
+            ? null
+            : translated;
     }
 
     internal static bool TryGetTranslationExactOrLowerAscii(string source, out string translated)


### PR DESCRIPTION
## Summary
- suppress duplicate missing-key noise when lower-ascii fallback resolves a translation
- add helper-level regression coverage for the fallback contract
- add route-level proofs for loading progress and HUD producer paths

## Testing
- dotnet build Mods/QudJP/Assemblies/QudJP.csproj
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "TestCategory!=L2G"

## Related
- Closes #346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 翻訳ロジックの大文字小文字フォールバック動作に関する複数のテストケースを追加
  * 翻訳辞書の検索精度を検証するテストを実装

* **Bug Fixes**
  * 翻訳フォールバック機能の動作を改善し、より正確な翻訳マッチングを実現

<!-- end of auto-generated comment: release notes by coderabbit.ai -->