### PR TITLE
fix: restore chargen menu option owner routes

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/CharGenProducerTranslationPatchResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/CharGenProducerTranslationPatchResolutionTests.cs
@@ -46,6 +46,7 @@ public sealed class CharGenProducerTranslationPatchResolutionTests
                 "XRL.CharacterBuilds.Qud.UI.QudAttributesModuleWindow|GetKeyMenuBar|",
                 "XRL.CharacterBuilds.Qud.UI.QudBuildLibraryModuleWindow|GetKeyMenuBar|",
                 "XRL.CharacterBuilds.Qud.UI.QudBuildSummaryModuleWindow|GetKeyMenuBar|",
+                "XRL.CharacterBuilds.AbstractBuilderModuleWindowBase|GetKeyMenuBar|",
                 "XRL.CharacterBuilds.Qud.UI.QudGamemodeModuleWindow|GetKeyMenuBar|",
                 "XRL.CharacterBuilds.Qud.UI.QudMutationsModuleWindow|GetKeyMenuBar|",
             });

--- a/Mods/QudJP/Assemblies/src/Patches/CharGenMenuOptionTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/CharGenMenuOptionTranslationPatch.cs
@@ -17,13 +17,21 @@ public static class CharGenMenuOptionTranslationPatch
         "XRL.CharacterBuilds.Qud.UI.QudAttributesModuleWindow",
         "XRL.CharacterBuilds.Qud.UI.QudBuildLibraryModuleWindow",
         "XRL.CharacterBuilds.Qud.UI.QudBuildSummaryModuleWindow",
+        "XRL.CharacterBuilds.Qud.UI.QudChartypeModuleWindow",
+        "XRL.CharacterBuilds.Qud.UI.QudChooseStartingLocationModuleWindow",
+        "XRL.CharacterBuilds.Qud.UI.QudCustomizeCharacterModuleWindow",
+        "XRL.CharacterBuilds.Qud.UI.QudCyberneticsModuleWindow",
         "XRL.CharacterBuilds.Qud.UI.QudGamemodeModuleWindow",
+        "XRL.CharacterBuilds.Qud.UI.QudGenotypeModuleWindow",
         "XRL.CharacterBuilds.Qud.UI.QudMutationsModuleWindow",
+        "XRL.CharacterBuilds.Qud.UI.QudPregenModuleWindow",
+        "XRL.CharacterBuilds.Qud.UI.QudSubtypeModuleWindow",
     };
 
     [HarmonyTargetMethods]
     private static IEnumerable<MethodBase> TargetMethods()
     {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
         foreach (var typeName in TargetTypeNames)
         {
             var type = AccessTools.TypeByName(typeName);
@@ -40,8 +48,20 @@ public static class CharGenMenuOptionTranslationPatch
                 continue;
             }
 
-            yield return method;
+            if (seen.Add(BuildMethodKey(method)))
+            {
+                yield return method;
+            }
         }
+    }
+
+    private static string BuildMethodKey(MethodBase method)
+    {
+        return (method.DeclaringType?.FullName ?? string.Empty)
+            + "|"
+            + method.Name
+            + "|"
+            + string.Join(",", Array.ConvertAll(method.GetParameters(), static parameter => parameter.ParameterType.FullName ?? string.Empty));
     }
 
     public static IEnumerable? Postfix(IEnumerable? values)


### PR DESCRIPTION
## Summary
- expand chargen menu option owner targets to cover the chargen module window set
- dedupe inherited `GetKeyMenuBar` method targets so base implementations are patched once
- add/update resolution coverage for the expanded chargen owner route set

## Testing
- dotnet build Mods/QudJP/Assemblies/QudJP.csproj
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "TestCategory!=L2G"
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~CharGenProducerTranslationPatchResolutionTests"

## Related
- Closes #345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正・改善**
  * キャラクター生成処理の信頼性が向上しました。複数のウィンドウタイプに対応し、内部の処理効率が強化されています。

* **テスト**
  * テスト仕様が更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->