### PR TITLE
fix: translate upstream status description fragments

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
@@ -104,7 +104,7 @@ internal static class ColorRouteCatalog
             ["Mods/QudJP/Assemblies/src/Patches/DeathWrapperFamilyTranslator.cs|GetDisplayNameRouteTranslator.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/DescriptionLongDescriptionPatch.cs|DescriptionTextTranslator.TranslateLongDescription("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/DescriptionTextTranslator.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
-            ["Mods/QudJP/Assemblies/src/Patches/DescriptionTextTranslator.cs|MessagePatternTranslator.Translate("] = 1,
+            ["Mods/QudJP/Assemblies/src/Patches/DescriptionTextTranslator.cs|MessagePatternTranslator.Translate("] = 2,
             ["Mods/QudJP/Assemblies/src/Patches/EquipmentLineTranslationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/GetDisplayNamePatch.cs|GetDisplayNameRouteTranslator.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/GetDisplayNameProcessPatch.cs|GetDisplayNameRouteTranslator.TranslatePreservingColors("] = 1,

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DescriptionTextTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DescriptionTextTranslatorTests.cs
@@ -71,6 +71,26 @@ public sealed class DescriptionTextTranslatorTests
     }
 
     [Test]
+    public void TranslateLongDescription_PreservesWholeLineWrapper_InDispositionLine()
+    {
+        var translated = DescriptionTextTranslator.TranslateLongDescription(
+            "{{W|Loved by {{C|the Barathrumites}}.}}",
+            "DescriptionTextTranslatorTests");
+
+        Assert.That(translated, Is.EqualTo("{{W|{{C|the Barathrumites}}に愛されている。}}"));
+    }
+
+    [Test]
+    public void TranslateLongDescription_PreservesRelationWrapper_InDispositionLine()
+    {
+        var translated = DescriptionTextTranslator.TranslateLongDescription(
+            "{{C|Loved by}} the Barathrumites.",
+            "DescriptionTextTranslatorTests");
+
+        Assert.That(translated, Is.EqualTo("the Barathrumitesに{{C|愛されている}}。"));
+    }
+
+    [Test]
     public void TranslateLongDescription_TranslatesReasonBearingDispositionLine()
     {
         WriteExactDictionary(("giving alms to pilgrims", "巡礼者に施しをしたため"));

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DescriptionTextTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DescriptionTextTranslatorTests.cs
@@ -82,6 +82,36 @@ public sealed class DescriptionTextTranslatorTests
         Assert.That(translated, Is.EqualTo("{{C|the Mechanimists}}に敬愛されている。理由: 巡礼者に施しをしたため。"));
     }
 
+    [Test]
+    public void TranslateLongDescription_FallbackToEnglish_WhenNoTranslationMatches()
+    {
+        var translated = DescriptionTextTranslator.TranslateLongDescription(
+            "Admired by {{C|the Mechanimists}} for an unknown deed.",
+            "DescriptionTextTranslatorTests");
+
+        Assert.That(translated, Is.EqualTo("{{C|the Mechanimists}}に敬愛されている。理由: an unknown deed。"));
+    }
+
+    [Test]
+    public void TranslateLongDescription_EmptyInputReturnsEmpty()
+    {
+        var translated = DescriptionTextTranslator.TranslateLongDescription(
+            string.Empty,
+            "DescriptionTextTranslatorTests");
+
+        Assert.That(translated, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void TranslateLongDescription_PreservesDirectTranslationMarker()
+    {
+        var translated = DescriptionTextTranslator.TranslateLongDescription(
+            "\u0001Already translated",
+            "DescriptionTextTranslatorTests");
+
+        Assert.That(translated, Is.EqualTo("\u0001Already translated"));
+    }
+
     private void WritePatternDictionary(params (string pattern, string template)[] patterns)
     {
         var builder = new StringBuilder();

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DescriptionTextTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DescriptionTextTranslatorTests.cs
@@ -27,6 +27,7 @@ public sealed class DescriptionTextTranslatorTests
         Translator.SetDictionaryDirectoryForTests(dictionaryDirectory);
         MessagePatternTranslator.ResetForTests();
         MessagePatternTranslator.SetPatternFileForTests(patternFilePath);
+        File.WriteAllText(patternFilePath, "{\"patterns\":[]}\n", Utf8WithoutBom);
     }
 
     [TearDown]
@@ -57,6 +58,28 @@ public sealed class DescriptionTextTranslatorTests
             "DescriptionTextTranslatorTests");
 
         Assert.That(translated, Is.EqualTo("sun-baked ruins、ある組織とその血縁の会合がある。"));
+    }
+
+    [Test]
+    public void TranslateLongDescription_PreservesColoredFactionTarget_InDispositionLine()
+    {
+        var translated = DescriptionTextTranslator.TranslateLongDescription(
+            "Loved by {{C|the Barathrumites}}.",
+            "DescriptionTextTranslatorTests");
+
+        Assert.That(translated, Is.EqualTo("{{C|the Barathrumites}}に愛されている。"));
+    }
+
+    [Test]
+    public void TranslateLongDescription_TranslatesReasonBearingDispositionLine()
+    {
+        WriteExactDictionary(("giving alms to pilgrims", "巡礼者に施しをしたため"));
+
+        var translated = DescriptionTextTranslator.TranslateLongDescription(
+            "Admired by {{C|the Mechanimists}} for giving alms to pilgrims.",
+            "DescriptionTextTranslatorTests");
+
+        Assert.That(translated, Is.EqualTo("{{C|the Mechanimists}}に敬愛されている。理由: 巡礼者に施しをしたため。"));
     }
 
     private void WritePatternDictionary(params (string pattern, string template)[] patterns)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
@@ -194,6 +194,9 @@ public sealed class LocalizationCoverageTests
         var uiDefaultKeys = LoadEntries(Path.Combine(dictionariesRoot, "ui-default.ja.json"))
             .Select(static entry => entry.Key)
             .ToHashSet(StringComparer.Ordinal);
+        var worldEffectsStatusKeys = LoadEntries(Path.Combine(dictionariesRoot, "world-effects-status.ja.json"))
+            .Select(static entry => entry.Key)
+            .ToHashSet(StringComparer.Ordinal);
 
         Assert.Multiple(() =>
         {
@@ -201,6 +204,7 @@ public sealed class LocalizationCoverageTests
             Assert.That(skillsAndPowersKeys, Does.Contain("page {0} of {1}"));
             Assert.That(uiDefaultKeys, Does.Contain("Active Effects - {0}"));
             Assert.That(uiDefaultKeys, Does.Contain("No active effects."));
+            Assert.That(worldEffectsStatusKeys, Does.Contain("corrected vision"));
         });
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/DescriptionLongDescriptionPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/DescriptionLongDescriptionPatchTests.cs
@@ -226,6 +226,23 @@ public sealed class DescriptionLongDescriptionPatchTests
         });
     }
 
+    [Test]
+    public void Postfix_TranslatesPhysicalFeaturesAndEquippedLines_WhenPatched()
+    {
+        WriteDictionary(
+            ("stinger", "毒針"),
+            ("black robe", "黒のローブ"));
+
+        RunWithDescriptionPatch(() =>
+        {
+            var target = new DummyDescriptionTarget("Physical features: stinger\nEquipped: black robe");
+            var builder = new StringBuilder();
+            target.GetLongDescription(builder);
+
+            Assert.That(builder.ToString(), Is.EqualTo("身体的特徴: 毒針\n装備: 黒のローブ"));
+        });
+    }
+
     private static string CreateHarmonyId()
     {
         return $"qudjp.tests.{Guid.NewGuid():N}";

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/DescriptionLongDescriptionPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/DescriptionLongDescriptionPatchTests.cs
@@ -243,6 +243,21 @@ public sealed class DescriptionLongDescriptionPatchTests
         });
     }
 
+    [Test]
+    public void Postfix_TranslatesReasonBearingDispositionLine_WithColoredFactionTarget_WhenPatched()
+    {
+        WriteDictionary(("giving alms to pilgrims", "巡礼者に施しをしたため"));
+
+        RunWithDescriptionPatch(() =>
+        {
+            var target = new DummyDescriptionTarget("Admired by {{C|the Mechanimists}} for giving alms to pilgrims.");
+            var builder = new StringBuilder();
+            target.GetLongDescription(builder);
+
+            Assert.That(builder.ToString(), Is.EqualTo("{{C|the Mechanimists}}に敬愛されている。理由: 巡礼者に施しをしたため。"));
+        });
+    }
+
     private static string CreateHarmonyId()
     {
         return $"qudjp.tests.{Guid.NewGuid():N}";

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/DescriptionShortDescriptionPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/DescriptionShortDescriptionPatchTests.cs
@@ -200,6 +200,40 @@ public sealed class DescriptionShortDescriptionPatchTests
         }
     }
 
+    [Test]
+    public void DescriptionShortDescriptionPatch_TranslatesFactionDispositionLines_WhenPatched()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyDescriptionShortDescriptionTarget), nameof(DummyDescriptionShortDescriptionTarget.GetShortDescription)),
+                postfix: new HarmonyMethod(RequirePostfix(typeof(DescriptionShortDescriptionPatch), nameof(DescriptionShortDescriptionPatch.Postfix))));
+
+            var lovedTarget = new DummyDescriptionShortDescriptionTarget("Loved by the Joppa villagers.");
+            var hatedTarget = new DummyDescriptionShortDescriptionTarget("Hated by apes.");
+            var dislikedTarget = new DummyDescriptionShortDescriptionTarget("Disliked by goatfolk.");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    lovedTarget.GetShortDescription(useShort: true, useLong: false, prefix: string.Empty),
+                    Is.EqualTo("the Joppa villagersに愛されている。"));
+                Assert.That(
+                    hatedTarget.GetShortDescription(useShort: true, useLong: false, prefix: string.Empty),
+                    Is.EqualTo("apesに憎まれている。"));
+                Assert.That(
+                    dislikedTarget.GetShortDescription(useShort: true, useLong: false, prefix: string.Empty),
+                    Is.EqualTo("goatfolkに嫌われている。"));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
     private static string CreateHarmonyId()
     {
         return $"qudjp.tests.{Guid.NewGuid():N}";

--- a/Mods/QudJP/Assemblies/src/Patches/DescriptionTextTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/DescriptionTextTranslator.cs
@@ -5,6 +5,12 @@ namespace QudJP.Patches;
 
 internal static class DescriptionTextTranslator
 {
+    private static readonly Regex FactionDispositionPattern =
+        new Regex("^(?<relation>Loved by|Hated by|Disliked by) (?<target>.+?)\\.$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex LabeledListPattern =
+        new Regex("^(?<label>Physical features:|Equipped:) (?<items>.+)$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
     private static readonly Regex StatAbbreviationPattern =
         new Regex("^[A-Z]{2,4}$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
@@ -70,6 +76,16 @@ internal static class DescriptionTextTranslator
 
     private static bool TryTranslateVisibleSegment(string source, string route, out string translated)
     {
+        if (TryTranslateFactionDispositionLine(source, route, out translated))
+        {
+            return true;
+        }
+
+        if (TryTranslateLabeledList(source, route, out translated))
+        {
+            return true;
+        }
+
         if (WorldModsTextTranslator.TryTranslate(source, route, "Description.WorldMods", out translated))
         {
             return true;
@@ -112,6 +128,71 @@ internal static class DescriptionTextTranslator
 
         translated = source;
         return false;
+    }
+
+    private static bool TryTranslateFactionDispositionLine(string source, string route, out string translated)
+    {
+        var match = FactionDispositionPattern.Match(source);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        var target = match.Groups["target"].Value;
+        var relation = match.Groups["relation"].Value switch
+        {
+            "Loved by" => "愛されている",
+            "Hated by" => "憎まれている",
+            "Disliked by" => "嫌われている",
+            _ => string.Empty,
+        };
+
+        if (string.IsNullOrEmpty(relation))
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = target + "に" + relation + "。";
+        DynamicTextObservability.RecordTransform(route, "Description.FactionDisposition", source, translated);
+        return true;
+    }
+
+    private static bool TryTranslateLabeledList(string source, string route, out string translated)
+    {
+        var match = LabeledListPattern.Match(source);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        var label = match.Groups["label"].Value switch
+        {
+            "Physical features:" => "身体的特徴:",
+            "Equipped:" => "装備:",
+            _ => string.Empty,
+        };
+
+        if (string.IsNullOrEmpty(label))
+        {
+            translated = source;
+            return false;
+        }
+
+        var parts = match.Groups["items"].Value.Split(new[] { ", " }, StringSplitOptions.None);
+        for (var index = 0; index < parts.Length; index++)
+        {
+            if (StringHelpers.TryGetTranslationExactOrLowerAscii(parts[index], out var translatedPart))
+            {
+                parts[index] = translatedPart;
+            }
+        }
+
+        translated = label + " " + string.Join("、", parts);
+        DynamicTextObservability.RecordTransform(route, "Description.LabeledList", source, translated);
+        return true;
     }
 
     private static bool ShouldSkipExactLeafTranslation(string source)

--- a/Mods/QudJP/Assemblies/src/Patches/DescriptionTextTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/DescriptionTextTranslator.cs
@@ -6,7 +6,7 @@ namespace QudJP.Patches;
 internal static class DescriptionTextTranslator
 {
     private static readonly Regex FactionDispositionPattern =
-        new Regex("^(?<relation>Loved by|Hated by|Disliked by) (?<target>.+?)\\.$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+        new Regex("^(?<relation>Loved by|Admired by|Hated by|Disliked by) (?<target>.+?)(?: for (?<reason>.+?))?\\.$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
     private static readonly Regex LabeledListPattern =
         new Regex("^(?<label>Physical features:|Equipped:) (?<items>.+)$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
@@ -66,6 +66,11 @@ internal static class DescriptionTextTranslator
 
     private static bool TryTranslateSegmentPreservingColors(string source, string route, out string translated)
     {
+        if (TryTranslateFactionDispositionLinePreservingColors(source, route, out translated))
+        {
+            return true;
+        }
+
         translated = ColorAwareTranslationComposer.TranslatePreservingColors(
             source,
             visible => TryTranslateVisibleSegment(visible, route, out var candidate)
@@ -76,11 +81,6 @@ internal static class DescriptionTextTranslator
 
     private static bool TryTranslateVisibleSegment(string source, string route, out string translated)
     {
-        if (TryTranslateFactionDispositionLine(source, route, out translated))
-        {
-            return true;
-        }
-
         if (TryTranslateLabeledList(source, route, out translated))
         {
             return true;
@@ -130,19 +130,20 @@ internal static class DescriptionTextTranslator
         return false;
     }
 
-    private static bool TryTranslateFactionDispositionLine(string source, string route, out string translated)
+    private static bool TryTranslateFactionDispositionLinePreservingColors(string source, string route, out string translated)
     {
-        var match = FactionDispositionPattern.Match(source);
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
+        var match = FactionDispositionPattern.Match(stripped);
         if (!match.Success)
         {
             translated = source;
             return false;
         }
 
-        var target = match.Groups["target"].Value;
         var relation = match.Groups["relation"].Value switch
         {
             "Loved by" => "愛されている",
+            "Admired by" => "敬愛されている",
             "Hated by" => "憎まれている",
             "Disliked by" => "嫌われている",
             _ => string.Empty,
@@ -154,9 +155,37 @@ internal static class DescriptionTextTranslator
             return false;
         }
 
-        translated = target + "に" + relation + "。";
+        var target = ColorAwareTranslationComposer.RestoreCapture(match.Groups["target"].Value, spans, match.Groups["target"]);
+        var reasonGroup = match.Groups["reason"];
+        if (!reasonGroup.Success)
+        {
+            translated = target + "に" + relation + "。";
+            DynamicTextObservability.RecordTransform(route, "Description.FactionDisposition", source, translated);
+            return true;
+        }
+
+        var reason = TranslateDispositionReason(reasonGroup.Value, route);
+        reason = ColorAwareTranslationComposer.RestoreCapture(reason, spans, reasonGroup);
+        translated = target + "に" + relation + "。理由: " + reason + "。";
         DynamicTextObservability.RecordTransform(route, "Description.FactionDisposition", source, translated);
         return true;
+    }
+
+    private static string TranslateDispositionReason(string source, string route)
+    {
+        if (ShouldSkipExactLeafTranslation(source))
+        {
+            return source;
+        }
+
+        if (StringHelpers.TryGetTranslationExactOrLowerAscii(source, out var translated)
+            && !string.Equals(source, translated, StringComparison.Ordinal))
+        {
+            return translated;
+        }
+
+        translated = MessagePatternTranslator.Translate(source, route);
+        return translated;
     }
 
     private static bool TryTranslateLabeledList(string source, string route, out string translated)

--- a/Mods/QudJP/Assemblies/src/Patches/DescriptionTextTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/DescriptionTextTranslator.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace QudJP.Patches;
@@ -155,20 +157,140 @@ internal static class DescriptionTextTranslator
             return false;
         }
 
-        var target = ColorAwareTranslationComposer.RestoreCapture(match.Groups["target"].Value, spans, match.Groups["target"]);
+        relation = RestoreBalancedCapture(relation, spans, match.Groups["relation"]);
+        var target = RestoreBalancedCapture(match.Groups["target"].Value, spans, match.Groups["target"]);
         var reasonGroup = match.Groups["reason"];
         if (!reasonGroup.Success)
         {
             translated = target + "に" + relation + "。";
+            translated = RestoreWholeLineBoundaryWrappers(translated, spans, stripped.Length);
             DynamicTextObservability.RecordTransform(route, "Description.FactionDisposition", source, translated);
             return true;
         }
 
         var reason = TranslateDispositionReason(reasonGroup.Value, route);
-        reason = ColorAwareTranslationComposer.RestoreCapture(reason, spans, reasonGroup);
+        reason = RestoreBalancedCapture(reason, spans, reasonGroup);
         translated = target + "に" + relation + "。理由: " + reason + "。";
+        translated = RestoreWholeLineBoundaryWrappers(translated, spans, stripped.Length);
         DynamicTextObservability.RecordTransform(route, "Description.FactionDisposition", source, translated);
         return true;
+    }
+
+    private static string RestoreBalancedCapture(string value, IReadOnlyList<ColorSpan>? spans, Group group)
+    {
+        if (spans is null || spans.Count == 0 || !group.Success)
+        {
+            return value;
+        }
+
+        var captureSpans = ColorCodePreserver.SliceSpans(spans, group.Index, group.Length);
+        captureSpans.AddRange(ColorCodePreserver.SliceAdjacentCaptureBoundarySpans(spans, group.Index, group.Length));
+        captureSpans = FilterBalancedBoundarySpans(captureSpans);
+        return captureSpans.Count == 0
+            ? value
+            : ColorAwareTranslationComposer.Restore(value, captureSpans);
+    }
+
+    private static List<ColorSpan> FilterBalancedBoundarySpans(List<ColorSpan> spans)
+    {
+        if (spans.Count == 0)
+        {
+            return spans;
+        }
+
+        var keep = new bool[spans.Count];
+        var openingStack = new Stack<int>();
+        for (var index = 0; index < spans.Count; index++)
+        {
+            var span = spans[index];
+            if (ColorCodePreserver.IsOpeningBoundaryToken(span.Token))
+            {
+                openingStack.Push(index);
+                continue;
+            }
+
+            if (!ColorCodePreserver.IsClosingBoundaryToken(span.Token) || openingStack.Count == 0)
+            {
+                continue;
+            }
+
+            var openingIndex = openingStack.Pop();
+            keep[openingIndex] = true;
+            keep[index] = true;
+        }
+
+        var filtered = new List<ColorSpan>();
+        for (var index = 0; index < spans.Count; index++)
+        {
+            if (keep[index])
+            {
+                filtered.Add(spans[index]);
+            }
+        }
+
+        return filtered;
+    }
+
+    private static string RestoreWholeLineBoundaryWrappers(string translated, IReadOnlyList<ColorSpan>? spans, int sourceLength)
+    {
+        if (spans is null || spans.Count == 0)
+        {
+            return translated;
+        }
+
+        var wholeLineSpans = SliceWholeLineBoundarySpans(spans, sourceLength, translated.Length);
+        return wholeLineSpans.Count == 0
+            ? translated
+            : ColorAwareTranslationComposer.Restore(translated, wholeLineSpans);
+    }
+
+    private static List<ColorSpan> SliceWholeLineBoundarySpans(IReadOnlyList<ColorSpan> spans, int sourceLength, int translatedLength)
+    {
+        var wholeLinePairs = new List<(ColorSpan Opening, int OpeningOrder, ColorSpan Closing, int ClosingOrder)>();
+        var openingStack = new Stack<(ColorSpan Span, int Order)>();
+
+        for (var index = 0; index < spans.Count; index++)
+        {
+            var span = spans[index];
+            if (ColorCodePreserver.IsOpeningBoundaryToken(span.Token))
+            {
+                openingStack.Push((span, index));
+                continue;
+            }
+
+            if (!ColorCodePreserver.IsClosingBoundaryToken(span.Token) || openingStack.Count == 0)
+            {
+                continue;
+            }
+
+            var opening = openingStack.Pop();
+            if (opening.Span.Index == 0 && span.Index == sourceLength)
+            {
+                wholeLinePairs.Add((opening.Span, opening.Order, span, index));
+            }
+        }
+
+        if (wholeLinePairs.Count == 0)
+        {
+            return new List<ColorSpan>();
+        }
+
+        var result = new List<ColorSpan>(wholeLinePairs.Count * 2);
+        var openingOrderedPairs = wholeLinePairs.OrderBy(static pair => pair.OpeningOrder).ToArray();
+        for (var index = 0; index < openingOrderedPairs.Length; index++)
+        {
+            var pair = openingOrderedPairs[index];
+            result.Add(new ColorSpan(0, pair.Opening.Token));
+        }
+
+        var closingOrderedPairs = wholeLinePairs.OrderBy(static pair => pair.ClosingOrder).ToArray();
+        for (var index = 0; index < closingOrderedPairs.Length; index++)
+        {
+            var pair = closingOrderedPairs[index];
+            result.Add(new ColorSpan(translatedLength, pair.Closing.Token));
+        }
+
+        return result;
     }
 
     private static string TranslateDispositionReason(string source, string route)

--- a/Mods/QudJP/Localization/Dictionaries/world-effects-status.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/world-effects-status.ja.json
@@ -154,6 +154,11 @@
             "text": "支配された"
         },
         {
+            "key": "corrected vision",
+            "context": "XRL.World.Effects.Spectacles.Description",
+            "text": "矯正視界"
+        },
+        {
             "key": "Under someone else's control.",
             "context": "XRL.World.Effects.Dominated.Details",
             "text": "他者に操られている。"


### PR DESCRIPTION
## Summary
- translate description disposition lines upstream, including color-tagged faction targets and reason-bearing `Admired/Loved/Disliked/Hated by ... for ... .` forms
- add L1/L2 regressions for colored faction targets and reason-bearing description lines so the route stays owner-side instead of falling back downstream
- update the color route catalog to reflect the added description pattern translation callsite

## Verification
- dotnet build Mods/QudJP/Assemblies/QudJP.csproj
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter \"FullyQualifiedName~DescriptionTextTranslatorTests|FullyQualifiedName~DescriptionLongDescriptionPatchTests|FullyQualifiedName~DescriptionShortDescriptionPatchTests\"
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter \"TestCategory!=L2G\"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 派閥の好感度行や「Physical features」「Equipped」などの項目を日本語に翻訳し、色付き表記を保持して出力する翻訳処理を追加しました。

* **テスト**
  * 長文・短文翻訳やパッチ適用時の振る舞い、空文字・既翻訳マーカーの扱いなどを含む多くの単体テストを追加／強化しました。

* **ローカライゼーション**
  * 辞書に「corrected vision（矯正視界）」の日本語エントリを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->