### PR TITLE
feat: add phase-f runtime observability triage

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DynamicTextObservabilityTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DynamicTextObservabilityTests.cs
@@ -9,6 +9,7 @@ public sealed class DynamicTextObservabilityTests
     public void SetUp()
     {
         Translator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
     }
 
     [Test]
@@ -50,5 +51,70 @@ public sealed class DynamicTextObservabilityTests
             Assert.That(skipped, Does.Not.Contain("DynamicTextProbe/v1"));
             Assert.That(forced, Does.Contain("changed=false"));
         });
+    }
+
+    [Test]
+    public void RecordTransform_AppendsStructuredSuffixInFixedOrder_WhenPayloadFitsLimit()
+    {
+        using var _ = Translator.PushLogContext("DoesVerbRoute");
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+            DynamicTextObservability.RecordTransform(
+                "DoesVerbRoute",
+                "verb",
+                "You catch fire",
+                "あなたは燃え上がる"));
+
+        Assert.That(
+            output,
+            Does.Contain(
+                "[QudJP] DynamicTextProbe/v1: route='DoesVerbRoute' family='verb' hit=1 changed=true source='You catch fire' translated='あなたは燃え上がる'. (context: DoesVerbRoute); route=DoesVerbRoute; family=verb; template_id=<missing>; payload_mode=full; payload_excerpt=You catch fire; payload_sha256=<missing>"));
+    }
+
+    [Test]
+    public void RecordTransform_UsesPrefixHashStructuredSuffix_WhenPayloadExceedsLimit()
+    {
+        const string route = "DoesVerbRoute";
+        const string family = "verb";
+        var longPayload = new string('x', 600);
+        var expectedExcerpt = new string('x', 512);
+        var expectedHash = ComputeSha256Hex(longPayload);
+        using var _ = Translator.PushLogContext(route);
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+            DynamicTextObservability.RecordTransform(route, family, longPayload, "翻訳済み"));
+
+        Assert.That(
+            output,
+            Does.Contain(
+                "; route=DoesVerbRoute; family=verb; template_id=<missing>; payload_mode=prefix_hash; payload_excerpt="
+                + expectedExcerpt
+                + "; payload_sha256="
+                + expectedHash));
+    }
+
+    [Test]
+    public void RecordTransform_EscapesDelimiterLikePayloadContentInStructuredSuffix()
+    {
+        using var _ = Translator.PushLogContext("DoesVerbRoute");
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+            DynamicTextObservability.RecordTransform(
+                "DoesVerbRoute",
+                "verb",
+                "You catch fire; route=Spoofed; family=spoof=value",
+                "あなたは燃え上がる"));
+
+        Assert.That(
+            output,
+            Does.Contain(
+                "; route=DoesVerbRoute; family=verb; template_id=<missing>; payload_mode=full; payload_excerpt=You catch fire\\; route\\=Spoofed\\; family\\=spoof\\=value; payload_sha256=<missing>"));
+    }
+
+    private static string ComputeSha256Hex(string value)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(value);
+        var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+        return Convert.ToHexStringLower(hash);
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -900,6 +900,22 @@ public sealed class MessagePatternTranslatorTests
     }
 
     [Test]
+    public void Translate_NoPatternLog_AppendsStructuredPhaseFSuffixInExactOrder()
+    {
+        WritePatternDictionary(("^You equip (.+)[.!]?$", "{0}を装備した"));
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+            Assert.That(
+                MessagePatternTranslator.Translate("You catch fire", "MessagePattern"),
+                Is.EqualTo("You catch fire")));
+
+        Assert.That(
+            output,
+            Does.Contain(
+                "[QudJP] MessagePatternTranslator: no pattern for 'You catch fire' (hit 1). (context: MessagePattern); route=MessagePattern; family=message_pattern; template_id=<missing>; rendered_text_sample=You catch fire"));
+    }
+
+    [Test]
     public void Translate_ReturnsEmptyString_WhenInputIsNull()
     {
         WritePatternDictionary(("^You die![.!]?$", "あなたは死んだ！"));

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/SinkObservationTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/SinkObservationTests.cs
@@ -9,6 +9,7 @@ public sealed class SinkObservationTests
     public void SetUp()
     {
         Translator.ResetForTests();
+        SinkObservation.ResetForTests();
     }
 
     [Test]
@@ -70,7 +71,28 @@ public sealed class SinkObservationTests
         Assert.That(
             output,
             Does.Contain(
-                "[QudJP] SinkObserve/v1: sink='UITextSkinTranslationPatch' route='PopupTranslationPatch' detail='Translator' source='Line 1\\nLine 2' stripped='Line 1\\nLine 2'"));
+                "[QudJP] SinkObserve/v1: sink='UITextSkinTranslationPatch' route='PopupTranslationPatch' detail='Translator' source='Line 1\\nLine 2' stripped='Line 1\\nLine 2'; route=PopupTranslationPatch; family=sink_observe; template_id=<missing>; payload_mode=full; payload_excerpt=Line 1\\\\nLine 2; payload_sha256=<missing>"));
+    }
+
+    [Test]
+    public void LogUnclaimed_UsesPrefixHashStructuredSuffix_WhenPayloadExceedsLimit()
+    {
+        const string sink = "MessageLog";
+        const string route = "EmitMessage";
+        var longPayload = new string('z', 600);
+        var expectedExcerpt = new string('z', 512);
+        var expectedHash = ComputeSha256Hex(longPayload);
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+            SinkObservation.LogUnclaimed(sink, route, SinkObservation.ObservationOnlyDetail, longPayload, longPayload));
+
+        Assert.That(
+            output,
+            Does.Contain(
+                "; route=EmitMessage; family=sink_observe; template_id=<missing>; payload_mode=prefix_hash; payload_excerpt="
+                + expectedExcerpt
+                + "; payload_sha256="
+                + expectedHash));
     }
 
     [Test]
@@ -127,5 +149,12 @@ public sealed class SinkObservationTests
         }
 
         return count;
+    }
+
+    private static string ComputeSha256Hex(string value)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(value);
+        var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+        return Convert.ToHexStringLower(hash);
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/TranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/TranslatorTests.cs
@@ -104,6 +104,40 @@ public sealed class TranslatorTests
     }
 
     [Test]
+    public void Translate_MissingKeyLog_AppendsStructuredPhaseFSuffixInExactOrder()
+    {
+        WriteDictionary("ui-test.ja.json", "Hello", "こんにちは");
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+        {
+            using var context = Translator.PushLogContext("ExactKey");
+            _ = Translator.Translate("Put away");
+        });
+
+        Assert.That(
+            output,
+            Does.Contain(
+                "[QudJP] Translator: missing key 'Put away' (hit 1). (context: ExactKey); route=ExactKey; family=missing_key; template_id=<missing>; rendered_text_sample=Put away"));
+    }
+
+    [Test]
+    public void Translate_MissingKeyLog_EscapesDelimiterLikeStructuredValueContent()
+    {
+        WriteDictionary("ui-test.ja.json", "Hello", "こんにちは");
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+        {
+            using var context = Translator.PushLogContext("ExactKey");
+            _ = Translator.Translate("Put away; route=Spoofed; family=spoof=value");
+        });
+
+        Assert.That(
+            output,
+            Does.Contain(
+                "[QudJP] Translator: missing key 'Put away; route=Spoofed; family=spoof=value' (hit 1). (context: ExactKey); route=ExactKey; family=missing_key; template_id=<missing>; rendered_text_sample=Put away\\; route\\=Spoofed\\; family\\=spoof\\=value"));
+    }
+
+    [Test]
     public void Translate_PushMissingKeyLoggingSuppression_PreservesCounters()
     {
         WriteDictionary("ui-test.ja.json", "Hello", "こんにちは");

--- a/Mods/QudJP/Assemblies/src/Observability/DynamicTextObservability.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/DynamicTextObservability.cs
@@ -40,6 +40,7 @@ internal static class DynamicTextObservability
         }
 
         var normalizedRoute = ObservabilityHelpers.ExtractPrimaryContext(route);
+        var structuredRoute = route ?? ObservabilityHelpers.NoContextLabel;
         var counterKey = BuildCounterKey(normalizedRoute, family);
         var hitCount = AddOrUpdateCapped(RouteFamilyCounts, counterKey, MaxRouteFamilies);
         if (!ObservabilityHelpers.ShouldLogMissingHit(hitCount))
@@ -56,7 +57,7 @@ internal static class DynamicTextObservability
             " source='" + ObservabilityHelpers.SanitizeForLog(sourceValue, MaxValueLength) +
             "' translated='" + ObservabilityHelpers.SanitizeForLog(translatedValue, MaxValueLength) +
             "'." + Translator.GetCurrentLogContextSuffix()
-            + ObservabilityHelpers.BuildHelperStructuredSuffix(normalizedRoute, family, sourceValue));
+            + ObservabilityHelpers.BuildHelperStructuredSuffix(structuredRoute, family, sourceValue));
     }
 
     private static string BuildCounterKey(string route, string family)

--- a/Mods/QudJP/Assemblies/src/Observability/DynamicTextObservability.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/DynamicTextObservability.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Globalization;
-using System.Text;
 
 namespace QudJP;
 
@@ -54,9 +53,10 @@ internal static class DynamicTextObservability
             "' family='" + family +
             "' hit=" + hitCount.ToString(CultureInfo.InvariantCulture) +
             " changed=" + (changed ? "true" : "false") +
-            " source='" + SanitizeForLog(sourceValue) +
-            "' translated='" + SanitizeForLog(translatedValue) +
-            "'." + Translator.GetCurrentLogContextSuffix());
+            " source='" + ObservabilityHelpers.SanitizeForLog(sourceValue, MaxValueLength) +
+            "' translated='" + ObservabilityHelpers.SanitizeForLog(translatedValue, MaxValueLength) +
+            "'." + Translator.GetCurrentLogContextSuffix()
+            + ObservabilityHelpers.BuildHelperStructuredSuffix(normalizedRoute, family, sourceValue));
     }
 
     private static string BuildCounterKey(string route, string family)
@@ -72,47 +72,5 @@ internal static class DynamicTextObservability
         }
 
         return counters.AddOrUpdate(OverflowKey, 1, ObservabilityHelpers.IncrementCounter);
-    }
-
-    private static string SanitizeForLog(string value)
-    {
-#if NET48
-        var sanitized = value.Length > MaxValueLength
-            ? value.Substring(0, MaxValueLength) + "..."
-            : value;
-#else
-        var sanitized = value.Length > MaxValueLength
-            ? string.Concat(value.AsSpan(0, MaxValueLength), "...")
-            : value;
-#endif
-
-        var builder = new StringBuilder(sanitized.Length);
-        for (var index = 0; index < sanitized.Length; index++)
-        {
-            var character = sanitized[index];
-            if (character == '\n')
-            {
-                builder.Append("\\n");
-            }
-            else if (character == '\r')
-            {
-                builder.Append("\\r");
-            }
-            else if (character == '\t')
-            {
-                builder.Append("\\t");
-            }
-            else if (char.IsControl(character))
-            {
-                builder.Append("\\u");
-                builder.Append(((int)character).ToString("X4", CultureInfo.InvariantCulture));
-            }
-            else
-            {
-                builder.Append(character);
-            }
-        }
-
-        return builder.ToString();
     }
 }

--- a/Mods/QudJP/Assemblies/src/Observability/ObservabilityHelpers.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/ObservabilityHelpers.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace QudJP;
@@ -9,6 +11,8 @@ internal static class ObservabilityHelpers
 {
     internal const string ContextSeparator = " > ";
     internal const string NoContextLabel = "<no-context>";
+    private const string MissingStructuredValue = "<missing>";
+    private const int HelperPayloadExcerptLimit = 512;
 
     internal static string ComposeContext(string? primaryContext, params string?[] details)
     {
@@ -137,5 +141,112 @@ internal static class ObservabilityHelpers
 
         var trimmedContext = context.Trim();
         return trimmedContext.Length == 0 ? NoContextLabel : trimmedContext;
+    }
+
+    internal static string SanitizeForLog(string value, int maxLength)
+    {
+        var boundedValue = maxLength > 0 && value.Length > maxLength
+            ? TrimForLog(value, maxLength) + "..."
+            : value;
+        return EscapeControlCharacters(boundedValue);
+    }
+
+    internal static string BuildHelperStructuredSuffix(string route, string family, string payload)
+    {
+        var sanitizedPayload = EscapeControlCharacters(payload);
+        var escapedRoute = EscapeStructuredValue(route);
+        var escapedFamily = EscapeStructuredValue(family);
+        if (sanitizedPayload.Length <= HelperPayloadExcerptLimit)
+        {
+            return "; route=" + escapedRoute
+                + "; family=" + escapedFamily
+                + "; template_id=" + MissingStructuredValue
+                + "; payload_mode=full"
+                + "; payload_excerpt=" + EscapeStructuredValue(sanitizedPayload)
+                + "; payload_sha256=" + MissingStructuredValue;
+        }
+
+        return "; route=" + escapedRoute
+            + "; family=" + escapedFamily
+            + "; template_id=" + MissingStructuredValue
+            + "; payload_mode=prefix_hash"
+            + "; payload_excerpt=" + EscapeStructuredValue(TrimForLog(sanitizedPayload, HelperPayloadExcerptLimit))
+            + "; payload_sha256=" + ComputeSha256Hex(sanitizedPayload);
+    }
+
+    internal static string EscapeStructuredValue(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        for (var index = 0; index < value.Length; index++)
+        {
+            var character = value[index];
+            if (character is '\\' or ';' or '=')
+            {
+                builder.Append('\\');
+            }
+
+            builder.Append(character);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string EscapeControlCharacters(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        for (var index = 0; index < value.Length; index++)
+        {
+            var character = value[index];
+            if (character == '\n')
+            {
+                builder.Append("\\n");
+            }
+            else if (character == '\r')
+            {
+                builder.Append("\\r");
+            }
+            else if (character == '\t')
+            {
+                builder.Append("\\t");
+            }
+            else if (char.IsControl(character))
+            {
+                builder.Append("\\u");
+                builder.Append(((int)character).ToString("X4", CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                builder.Append(character);
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static string ComputeSha256Hex(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+#if NET48
+        using var sha256 = SHA256.Create();
+        var hash = sha256.ComputeHash(bytes);
+#else
+        var hash = SHA256.HashData(bytes);
+#endif
+        var builder = new StringBuilder(hash.Length * 2);
+        for (var index = 0; index < hash.Length; index++)
+        {
+            builder.Append(hash[index].ToString("x2", CultureInfo.InvariantCulture));
+        }
+
+        return builder.ToString();
+    }
+
+    private static string TrimForLog(string value, int maxLength)
+    {
+#if NET48
+        return value.Substring(0, maxLength);
+#else
+        return new string(value.AsSpan(0, maxLength));
+#endif
     }
 }

--- a/Mods/QudJP/Assemblies/src/Observability/SinkObservation.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/SinkObservation.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Collections.Concurrent;
-using System.Globalization;
-using System.Text;
 
 namespace QudJP;
 
 internal static class SinkObservation
 {
     internal const string ObservationOnlyDetail = "ObservationOnly";
+    private const string StructuredFamily = "sink_observe";
     private const string ProbeVersion = "v1";
     private const int MaxObservedEntries = 4096;
     private const int MaxValueLength = 200;
@@ -87,11 +86,12 @@ internal static class SinkObservation
 
         QudJPMod.LogToUnity(
             "[QudJP] SinkObserve/" + ProbeVersion +
-            ": sink='" + SanitizeForLog(normalizedSink) +
-            "' route='" + SanitizeForLog(normalizedRoute) +
-            "' detail='" + SanitizeForLog(normalizedDetail) +
-            "' source='" + SanitizeForLog(sourceValue) +
-            "' stripped='" + SanitizeForLog(strippedValue) + "'");
+            ": sink='" + ObservabilityHelpers.SanitizeForLog(normalizedSink, MaxValueLength) +
+            "' route='" + ObservabilityHelpers.SanitizeForLog(normalizedRoute, MaxValueLength) +
+            "' detail='" + ObservabilityHelpers.SanitizeForLog(normalizedDetail, MaxValueLength) +
+            "' source='" + ObservabilityHelpers.SanitizeForLog(sourceValue, MaxValueLength) +
+            "' stripped='" + ObservabilityHelpers.SanitizeForLog(strippedValue, MaxValueLength) + "'"
+            + ObservabilityHelpers.BuildHelperStructuredSuffix(normalizedRoute, StructuredFamily, sourceValue));
     }
 
     private static string BuildCounterKey(
@@ -121,49 +121,6 @@ internal static class SinkObservation
 
         return counters.AddOrUpdate(OverflowKey, 1, ObservabilityHelpers.IncrementCounter);
     }
-
-    private static string SanitizeForLog(string value)
-    {
-#if NET48
-        var sanitized = value.Length > MaxValueLength
-            ? value.Substring(0, MaxValueLength) + "..."
-            : value;
-#else
-        var sanitized = value.Length > MaxValueLength
-            ? string.Concat(value.AsSpan(0, MaxValueLength), "...")
-            : value;
-#endif
-
-        var builder = new StringBuilder(sanitized.Length);
-        for (var index = 0; index < sanitized.Length; index++)
-        {
-            var character = sanitized[index];
-            if (character == '\n')
-            {
-                builder.Append("\\n");
-            }
-            else if (character == '\r')
-            {
-                builder.Append("\\r");
-            }
-            else if (character == '\t')
-            {
-                builder.Append("\\t");
-            }
-            else if (char.IsControl(character))
-            {
-                builder.Append("\\u");
-                builder.Append(((int)character).ToString("X4", CultureInfo.InvariantCulture));
-            }
-            else
-            {
-                builder.Append(character);
-            }
-        }
-
-        return builder.ToString();
-    }
-
     private sealed class SuppressionScope : IDisposable
     {
         internal static readonly SuppressionScope Instance = new SuppressionScope();

--- a/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
@@ -221,7 +221,7 @@ internal static class MessagePatternTranslator
         {
             var sanitizedSource = SanitizeForLog(source);
             LogObservability(
-                $"[QudJP] MessagePatternTranslator: no pattern for '{sanitizedSource}' (hit {hitCount}).{Translator.GetCurrentLogContextSuffix()}");
+                $"[QudJP] MessagePatternTranslator: no pattern for '{sanitizedSource}' (hit {hitCount}).{Translator.GetCurrentLogContextSuffix()}{Translator.BuildTranslatorStructuredSuffix(Translator.ExtractCurrentRoute(), "message_pattern", sanitizedSource)}");
         }
 
         return spans is null || spans.Count == 0

--- a/Mods/QudJP/Assemblies/src/Translation/Translator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/Translator.cs
@@ -11,6 +11,8 @@ namespace QudJP;
 
 public static class Translator
 {
+    private const string MissingTemplateIdValue = "<missing>";
+
     private static readonly object SyncRoot = new object();
     private static readonly ConcurrentDictionary<string, string> TranslationCache =
         new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
@@ -171,7 +173,7 @@ public static class Translator
         if (!IsMissingKeyLoggingSuppressed() && ObservabilityHelpers.ShouldLogMissingHit(hitCount))
         {
             LogObservability(
-                $"[QudJP] Translator: missing key '{key}' (hit {hitCount}).{GetCurrentLogContextSuffix()}");
+                $"[QudJP] Translator: missing key '{key}' (hit {hitCount}).{GetCurrentLogContextSuffix()}{BuildTranslatorStructuredSuffix(ExtractCurrentRoute(), "missing_key", key)}");
         }
 
         return key;
@@ -335,6 +337,19 @@ public static class Translator
     private static void LogObservability(string message)
     {
         QudJPMod.LogToUnity(message);
+    }
+
+    internal static string BuildTranslatorStructuredSuffix(string route, string family, string renderedTextSample)
+    {
+        return "; route=" + ObservabilityHelpers.EscapeStructuredValue(route)
+            + "; family=" + ObservabilityHelpers.EscapeStructuredValue(family)
+            + "; template_id=" + MissingTemplateIdValue
+            + "; rendered_text_sample=" + ObservabilityHelpers.EscapeStructuredValue(renderedTextSample);
+    }
+
+    internal static string ExtractCurrentRoute()
+    {
+        return ObservabilityHelpers.ExtractPrimaryContext(GetCurrentLogContext());
     }
 
     [DataContract]

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -1,6 +1,6 @@
 # QudJP Rules
 
-This document is the canonical workflow and decision guide for translation patches, localization assets, runtime evidence, and deployment. `AGENTS.md` and `CLAUDE.md` point here instead of duplicating the same operating rules.
+This document is the canonical workflow and decision guide for translation patches, localization assets, runtime evidence, Phase F proof obligations, and deployment. `AGENTS.md` and `CLAUDE.md` point here instead of duplicating the same operating rules.
 
 ## Evidence order
 
@@ -13,6 +13,32 @@ Use evidence in this order:
 5. Older notes in `docs/archive/` and past investigations
 
 If a stale note conflicts with tests or fresh runtime evidence, follow tests first.
+
+## Phase F boundary and shared defaults
+
+Phase F means runtime route-proof evidence. It is distinct from static coverage, and it does not replace the source-first scanner or fixed-leaf workflow.
+
+For the first PR in issue #358:
+
+- keep the scope on runtime observability and triage
+- keep SoT cross-reference deferred until the post-#357 integration follow-up
+- keep `DynamicTextProbe` and `SinkObserve` as runtime evidence records, not static coverage verdicts
+
+Shared defaults for this boundary are fixed in the parent roadmap and repeated here for convenience:
+
+- `template_id` is a transport-slot field in this PR, and runtime emitters use `<missing>` until the #357 follow-up owns the canonical static SoT side
+- `family` uses the parent-roadmap vocabulary and is not renamed here
+- `route` is emitted verbatim and is not normalized
+
+Required verification commands for this boundary:
+
+```bash
+dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1
+pytest scripts/tests/test_triage_log_parser.py scripts/tests/test_triage_models.py scripts/tests/test_triage_classifier.py scripts/tests/test_triage_integration.py -q
+pytest scripts/tests/test_triage_integration.py -q -k sample_log_smoke
+```
+
+Use these commands when checking Phase F docs, runtime observability, or the first-PR boundary.
 
 ## Route ownership
 

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -3,6 +3,8 @@
 QudJP のテストは **3 層構造** を維持しつつ、L2 を `game-DLL-assisted TDD` に拡張して運用します。
 目的は、`Assembly-CSharp.dll` の実シグネチャと実メソッド解決を自動検証に取り込みながら、Unity ランタイム依存の表示確認だけを L3 に残すことです。
 
+Phase F の runtime route-proof boundary は `docs/RULES.md` が定義します。このページは層の使い分けを説明する場所で、Phase F を static coverage に置き換える定義はしません。
+
 ---
 
 ## 層の概要
@@ -24,6 +26,7 @@ QudJP のテストは **3 層構造** を維持しつつ、L2 を `game-DLL-assi
 - `using HarmonyLib` を含めない
 - `using UnityEngine` を含めない
 - `Assembly-CSharp.dll` の型を参照しない
+- Phase F の runtime route-proof evidence は L1 の static coverage ではなく、`docs/RULES.md` の boundary と verification commands に従う
 
 **対象コード**:
 - `Translator`

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -11,7 +11,7 @@ This area contains the Python and shell tooling used for validation, extraction,
   - `scripts/*.sh` for shell tooling
   - `scripts/tests/` for pytest coverage
   - `pyproject.toml` for Ruff and pytest configuration
-- Operating rules for deployment, Rosetta, logs, and runtime evidence live in `docs/RULES.md`.
+- Operating rules for deployment, Rosetta, logs, runtime evidence, Phase F first-PR boundaries, shared defaults, and required verification commands live in `docs/RULES.md`.
 
 ## How
 
@@ -32,3 +32,4 @@ python3.12 scripts/sync_mod.py
 - Prefer extending an existing script over creating a parallel tool for the same job.
 - Keep error paths explicit and actionable; these scripts support validation and deployment.
 - Python baseline is `3.12+`, with typed and documented public interfaces.
+- If a task touches Phase F observability or triage docs, treat `docs/RULES.md` as the source of truth and keep this guide aligned to it.

--- a/scripts/tests/test_triage_classifier.py
+++ b/scripts/tests/test_triage_classifier.py
@@ -125,3 +125,17 @@ def test_classify_dynamic_probe_is_logic_required() -> None:
     )
     assert result.classification == TriageClassification.LOGIC_REQUIRED
     assert result.slot_evidence == ["CharacterStatusFamily"]
+
+
+def test_classify_sink_observe_stays_non_actionable() -> None:
+    """SinkObserve observations are Phase F evidence, not actionable route/static verdicts."""
+    result = classify(
+        _mk(
+            "You catch fire",
+            route="EmitMessage",
+            kind=LogEntryKind.SINK_OBSERVE,
+            family="sink_observe",
+        ),
+    )
+    assert result.classification == TriageClassification.UNRESOLVED
+    assert "phase f" in result.reason.lower() or "non-actionable" in result.reason.lower()

--- a/scripts/tests/test_triage_integration.py
+++ b/scripts/tests/test_triage_integration.py
@@ -53,19 +53,6 @@ def _write_log(path: Path, lines: list[str]) -> None:
     path.write_text("\n".join(lines), encoding="utf-8")
 
 
-def _structured_suffix_dict(line: str) -> dict[str, str | None]:
-    """Normalize the fixed Phase F suffix into a structured mapping."""
-    _prefix, separator, suffix = line.partition("; ")
-    if not separator:
-        return {}
-
-    payload: dict[str, str | None] = {}
-    for token in suffix.split("; "):
-        key, value = token.split("=", maxsplit=1)
-        payload[key] = None if value == "<missing>" else value
-    return payload
-
-
 def test_cli_produces_json_report(tmp_path: Path) -> None:
     """CLI reads a log file and produces a grouped JSON report."""
     log = tmp_path / "Player.log"

--- a/scripts/tests/test_triage_integration.py
+++ b/scripts/tests/test_triage_integration.py
@@ -7,15 +7,63 @@ from pathlib import Path
 
 import pytest
 
+from scripts.triage.log_parser import parse_log
 from scripts.triage_untranslated import main
 
 _PLAYER_LOG = Path.home() / "Library" / "Logs" / "Freehold Games" / "CavesOfQud" / "Player.log"
+_MISSING_KEY_NEW = (
+    "[QudJP] Translator: missing key 'Put away' (hit 3). (context: ExactKey);"
+    " route=ExactKey; family=missing_key; template_id=<missing>; rendered_text_sample=Put away"
+)
+_NO_PATTERN_NEW = (
+    "[QudJP] MessagePatternTranslator: no pattern for 'You catch fire'"
+    " (hit 2). (context: MessagePattern); route=MessagePattern; family=message_pattern;"
+    " template_id=<missing>; rendered_text_sample=You catch fire"
+)
+_DYNAMIC_PROBE_NEW = (
+    "[QudJP] DynamicTextProbe/v1: route='DoesVerbRoute' family='verb' hit=1 changed=true"
+    " source='You catch fire' translated='あなたは燃え上がる'. (context: DoesVerbRoute);"
+    " route=DoesVerbRoute; family=verb; template_id=<missing>; payload_mode=full;"
+    " payload_excerpt=You catch fire; payload_sha256=<missing>"
+)
+_SINK_OBSERVE_NEW = (
+    "[QudJP] SinkObserve/v1: sink='MessageLog' route='EmitMessage' detail='ObservationOnly'"
+    " source='You catch fire' stripped='You catch fire'; route=EmitMessage;"
+    " family=sink_observe; template_id=<missing>; payload_mode=full;"
+    " payload_excerpt=You catch fire; payload_sha256=<missing>"
+)
+_MISSING_KEY_ESCAPED = (
+    "[QudJP] Translator: missing key 'Put away; route=Spoofed; family=spoof=value'"
+    " (hit 3). (context: ExactKey); route=ExactKey; family=missing_key;"
+    " template_id=<missing>; rendered_text_sample=Put away\\; route\\=Spoofed\\;"
+    " family\\=spoof\\=value"
+)
+_DYNAMIC_PROBE_ESCAPED = (
+    "[QudJP] DynamicTextProbe/v1: route='DoesVerbRoute' family='verb' hit=1 changed=true"
+    " source='You catch fire; route=Spoofed; family=spoof=value' translated='あなたは燃え上がる'."
+    " (context: DoesVerbRoute); route=DoesVerbRoute; family=verb; template_id=<missing>;"
+    " payload_mode=full; payload_excerpt=You catch fire\\; route\\=Spoofed\\;"
+    " family\\=spoof\\=value; payload_sha256=<missing>"
+)
 
 
 def _write_log(path: Path, lines: list[str]) -> None:
     """Write lines to a fake Player.log file."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _structured_suffix_dict(line: str) -> dict[str, str | None]:
+    """Normalize the fixed Phase F suffix into a structured mapping."""
+    _prefix, separator, suffix = line.partition("; ")
+    if not separator:
+        return {}
+
+    payload: dict[str, str | None] = {}
+    for token in suffix.split("; "):
+        key, value = token.split("=", maxsplit=1)
+        payload[key] = None if value == "<missing>" else value
+    return payload
 
 
 def test_cli_produces_json_report(tmp_path: Path) -> None:
@@ -88,6 +136,190 @@ def test_cli_ignores_dynamic_text_probe_entries(tmp_path: Path) -> None:
     assert all(
         entry["kind"] != "dynamic_text_probe" for entries in data["by_classification"].values() for entry in entries
     )
+    assert data["phase_f"]["summary"] == {"total": 1, "dynamic_text_probe": 1, "sink_observe": 0}
+    assert len(data["phase_f"]["entries"]) == 1
+    assert data["phase_f"]["entries"][0]["kind"] == "dynamic_text_probe"
+
+
+def test_cli_adds_structured_group_without_changing_actionable_categories(tmp_path: Path) -> None:
+    """Structured suffix fields are nested separately from the legacy actionable summary."""
+    log = tmp_path / "Player.log"
+    out = tmp_path / "triage.json"
+    _write_log(log, [_MISSING_KEY_NEW])
+
+    result = main(["--log", str(log), "--output", str(out)])
+    assert result == 0
+
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["summary"] == {
+        "total": 1,
+        "static_leaf": 1,
+        "route_patch": 0,
+        "logic_required": 0,
+        "unresolved": 0,
+    }
+    entry = data["by_classification"]["static_leaf"][0]
+    assert entry["text"] == "Put away"
+    assert entry["phase_f"] == {
+        "route": "ExactKey",
+        "family": "missing_key",
+        "template_id": None,
+        "rendered_text_sample": "Put away",
+    }
+
+
+def test_cli_reports_sink_observe_in_phase_f_section(tmp_path: Path) -> None:
+    """SinkObserve stays outside the actionable summary and appears only in Phase F output."""
+    log = tmp_path / "Player.log"
+    out = tmp_path / "triage.json"
+    _write_log(log, [_SINK_OBSERVE_NEW])
+
+    result = main(["--log", str(log), "--output", str(out)])
+    assert result == 0
+
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["summary"]["total"] == 0
+    assert data["phase_f"]["summary"] == {"total": 1, "dynamic_text_probe": 0, "sink_observe": 1}
+    assert data["phase_f"]["entries"][0]["kind"] == "sink_observe"
+    assert data["phase_f"]["entries"][0]["phase_f"] == {
+        "route": "EmitMessage",
+        "family": "sink_observe",
+        "template_id": None,
+        "payload_mode": "full",
+        "payload_excerpt": "You catch fire",
+        "payload_sha256": None,
+    }
+
+
+def test_cli_preserves_grouping_when_structured_values_contain_delimiter_like_text(tmp_path: Path) -> None:
+    """Escaped Phase F values do not hijack actionable grouping or Phase F routes."""
+    log = tmp_path / "Player.log"
+    out = tmp_path / "triage.json"
+    _write_log(log, [_MISSING_KEY_ESCAPED, _DYNAMIC_PROBE_ESCAPED])
+
+    result = main(["--log", str(log), "--output", str(out)])
+    assert result == 0
+
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["summary"]["total"] == 1
+    assert set(data["by_route"]) == {"ExactKey"}
+    actionable_entries = [entry for entries in data["by_route"]["ExactKey"].values() for entry in entries]
+    assert len(actionable_entries) == 1
+    actionable_entry = actionable_entries[0]
+    assert actionable_entry["phase_f"] == {
+        "route": "ExactKey",
+        "family": "missing_key",
+        "template_id": None,
+        "rendered_text_sample": "Put away; route=Spoofed; family=spoof=value",
+    }
+    assert data["phase_f"]["summary"] == {"total": 1, "dynamic_text_probe": 1, "sink_observe": 0}
+    assert data["phase_f"]["entries"][0]["route"] == "DoesVerbRoute"
+    assert data["phase_f"]["entries"][0]["phase_f"]["payload_excerpt"] == (
+        "You catch fire; route=Spoofed; family=spoof=value"
+    )
+
+
+def test_sample_log_smoke(tmp_path: Path) -> None:
+    """A frozen sample log can be parsed into structured Phase F expectations."""
+    log = tmp_path / "Player.log"
+    lines = [_MISSING_KEY_NEW, _NO_PATTERN_NEW, _DYNAMIC_PROBE_NEW, _SINK_OBSERVE_NEW]
+    _write_log(log, lines)
+
+    structured_output = []
+    for entry in parse_log(log):
+        payload = {
+            "kind": entry.kind.value,
+            "route": entry.route,
+            "text": entry.text,
+            "hits": entry.hits,
+            "line_number": entry.line_number,
+        }
+        if entry.family is not None:
+            payload["family"] = entry.family
+        if entry.translated_text is not None:
+            payload["translated_text"] = entry.translated_text
+        if entry.changed is not None:
+            payload["changed"] = entry.changed
+        structured = {
+            key: value
+            for key, value in {
+                "route": entry.route,
+                "family": entry.family,
+                "template_id": entry.template_id,
+                "rendered_text_sample": entry.rendered_text_sample,
+                "payload_mode": entry.payload_mode,
+                "payload_excerpt": entry.payload_excerpt,
+                "payload_sha256": entry.payload_sha256,
+            }.items()
+            if key == "route" or (key == "family" and entry.family is not None) or entry.has_structured_field(key)
+        }
+        payload["structured"] = structured
+        structured_output.append(payload)
+
+    assert structured_output == [
+        {
+            "kind": "missing_key",
+            "route": "ExactKey",
+            "text": "Put away",
+            "hits": 3,
+            "line_number": 1,
+            "family": "missing_key",
+            "structured": {
+                "route": "ExactKey",
+                "family": "missing_key",
+                "template_id": None,
+                "rendered_text_sample": "Put away",
+            },
+        },
+        {
+            "kind": "no_pattern",
+            "route": "MessagePattern",
+            "text": "You catch fire",
+            "hits": 2,
+            "line_number": 2,
+            "family": "message_pattern",
+            "structured": {
+                "route": "MessagePattern",
+                "family": "message_pattern",
+                "template_id": None,
+                "rendered_text_sample": "You catch fire",
+            },
+        },
+        {
+            "kind": "dynamic_text_probe",
+            "route": "DoesVerbRoute",
+            "text": "You catch fire",
+            "hits": 1,
+            "line_number": 3,
+            "family": "verb",
+            "translated_text": "あなたは燃え上がる",
+            "changed": True,
+            "structured": {
+                "route": "DoesVerbRoute",
+                "family": "verb",
+                "template_id": None,
+                "payload_mode": "full",
+                "payload_excerpt": "You catch fire",
+                "payload_sha256": None,
+            },
+        },
+        {
+            "kind": "sink_observe",
+            "route": "EmitMessage",
+            "text": "You catch fire",
+            "hits": None,
+            "line_number": 4,
+            "family": "sink_observe",
+            "structured": {
+                "route": "EmitMessage",
+                "family": "sink_observe",
+                "template_id": None,
+                "payload_mode": "full",
+                "payload_excerpt": "You catch fire",
+                "payload_sha256": None,
+            },
+        },
+    ]
 
 
 @pytest.mark.skipif(not _PLAYER_LOG.exists(), reason="No Player.log available")

--- a/scripts/tests/test_triage_log_parser.py
+++ b/scripts/tests/test_triage_log_parser.py
@@ -414,38 +414,39 @@ def test_parse_sink_observe(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("line", "expected_kind", "expected_route", "expected_family", "expected_field", "expected_value"),
+    ("line", "expected"),
     [
         (
             _MISSING_KEY_ESCAPED,
-            LogEntryKind.MISSING_KEY,
-            "ExactKey",
-            "missing_key",
-            "rendered_text_sample",
-            "Put away; route=Spoofed; family=spoof=value",
+            (
+                LogEntryKind.MISSING_KEY,
+                "ExactKey",
+                "missing_key",
+                "rendered_text_sample",
+                "Put away; route=Spoofed; family=spoof=value",
+            ),
         ),
         (
             _DYNAMIC_PROBE_ESCAPED,
-            LogEntryKind.DYNAMIC_TEXT_PROBE,
-            "DoesVerbRoute",
-            "verb",
-            "payload_excerpt",
-            "You catch fire; route=Spoofed; family=spoof=value",
+            (
+                LogEntryKind.DYNAMIC_TEXT_PROBE,
+                "DoesVerbRoute",
+                "verb",
+                "payload_excerpt",
+                "You catch fire; route=Spoofed; family=spoof=value",
+            ),
         ),
     ],
 )
 def test_parse_structured_suffix_unescapes_delimiter_like_values(
     tmp_path: Path,
     line: str,
-    expected_kind: LogEntryKind,
-    expected_route: str,
-    expected_family: str,
-    expected_field: str,
-    expected_value: str,
+    expected: tuple[LogEntryKind, str, str, str, str],
 ) -> None:
     """Escaped structured values round-trip without spoofing route/family fields."""
     log = tmp_path / "Player.log"
     _write_log(log, [line])
+    expected_kind, expected_route, expected_family, expected_field, expected_value = expected
 
     entries = parse_log(log)
 

--- a/scripts/tests/test_triage_log_parser.py
+++ b/scripts/tests/test_triage_log_parser.py
@@ -56,6 +56,30 @@ _DYNAMIC_PROBE_ESCAPED = (
     " payload_mode=full; payload_excerpt=You catch fire\\; route\\=Spoofed\\;"
     " family\\=spoof\\=value; payload_sha256=<missing>"
 )
+_MISSING_KEY_LITERAL_MISSING = (
+    "[QudJP] Translator: missing key 'Put away' (hit 3). (context: ExactKey);"
+    " route=ExactKey; family=missing_key; template_id=<missing>; rendered_text_sample=<missing>"
+)
+_DYNAMIC_PROBE_LITERAL_MISSING = (
+    "[QudJP] DynamicTextProbe/v1: route='DoesVerbRoute' family='verb' hit=1 changed=true"
+    " source='You catch fire' translated='あなたは燃え上がる'. (context: DoesVerbRoute);"
+    " route=DoesVerbRoute; family=verb; template_id=<missing>; payload_mode=full;"
+    " payload_excerpt=<missing>; payload_sha256=<missing>"
+)
+_DYNAMIC_PROBE_PREFIX_HASH_A = (
+    "[QudJP] DynamicTextProbe/v1: route='DoesVerbRoute' family='verb' hit=1 changed=true"
+    " source='Shared prefix payload' translated='あなたは燃え上がる'. (context: DoesVerbRoute);"
+    " route=DoesVerbRoute; family=verb; template_id=<missing>; payload_mode=prefix_hash;"
+    " payload_excerpt=Shared prefix payload;"
+    " payload_sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+)
+_DYNAMIC_PROBE_PREFIX_HASH_B = (
+    "[QudJP] DynamicTextProbe/v1: route='DoesVerbRoute' family='verb' hit=1 changed=true"
+    " source='Shared prefix payload' translated='あなたは燃え上がる'. (context: DoesVerbRoute);"
+    " route=DoesVerbRoute; family=verb; template_id=<missing>; payload_mode=prefix_hash;"
+    " payload_excerpt=Shared prefix payload;"
+    " payload_sha256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
 
 
 def _write_log(path: Path, lines: list[str]) -> None:
@@ -68,7 +92,9 @@ def _entry_snapshot(tmp_path: Path, line: str) -> dict[str, object | None]:
     """Parse a single fixture line and return the stable observable fields."""
     log = tmp_path / "Player.log"
     _write_log(log, [line])
-    entry = parse_log(log)[0]
+    entries = parse_log(log)
+    assert len(entries) == 1
+    entry = entries[0]
     return {
         "kind": entry.kind.value,
         "route": entry.route,
@@ -83,6 +109,7 @@ def _entry_snapshot(tmp_path: Path, line: str) -> dict[str, object | None]:
         "payload_mode": entry.payload_mode,
         "payload_excerpt": entry.payload_excerpt,
         "payload_sha256": entry.payload_sha256,
+        "structured_fields": sorted(entry.structured_fields),
     }
 
 
@@ -105,6 +132,7 @@ def _entry_snapshot(tmp_path: Path, line: str) -> dict[str, object | None]:
                 "payload_mode": None,
                 "payload_excerpt": None,
                 "payload_sha256": None,
+                "structured_fields": [],
             },
         ),
         (
@@ -123,6 +151,7 @@ def _entry_snapshot(tmp_path: Path, line: str) -> dict[str, object | None]:
                 "payload_mode": None,
                 "payload_excerpt": None,
                 "payload_sha256": None,
+                "structured_fields": ["family", "rendered_text_sample", "route", "template_id"],
             },
         ),
         (
@@ -141,6 +170,7 @@ def _entry_snapshot(tmp_path: Path, line: str) -> dict[str, object | None]:
                 "payload_mode": None,
                 "payload_excerpt": None,
                 "payload_sha256": None,
+                "structured_fields": [],
             },
         ),
         (
@@ -159,6 +189,7 @@ def _entry_snapshot(tmp_path: Path, line: str) -> dict[str, object | None]:
                 "payload_mode": None,
                 "payload_excerpt": None,
                 "payload_sha256": None,
+                "structured_fields": ["family", "rendered_text_sample", "route", "template_id"],
             },
         ),
         (
@@ -177,6 +208,7 @@ def _entry_snapshot(tmp_path: Path, line: str) -> dict[str, object | None]:
                 "payload_mode": None,
                 "payload_excerpt": None,
                 "payload_sha256": None,
+                "structured_fields": [],
             },
         ),
         (
@@ -195,6 +227,14 @@ def _entry_snapshot(tmp_path: Path, line: str) -> dict[str, object | None]:
                 "payload_mode": "full",
                 "payload_excerpt": "You catch fire",
                 "payload_sha256": None,
+                "structured_fields": [
+                    "family",
+                    "payload_excerpt",
+                    "payload_mode",
+                    "payload_sha256",
+                    "route",
+                    "template_id",
+                ],
             },
         ),
         (
@@ -213,6 +253,7 @@ def _entry_snapshot(tmp_path: Path, line: str) -> dict[str, object | None]:
                 "payload_mode": None,
                 "payload_excerpt": None,
                 "payload_sha256": None,
+                "structured_fields": [],
             },
         ),
         (
@@ -231,6 +272,14 @@ def _entry_snapshot(tmp_path: Path, line: str) -> dict[str, object | None]:
                 "payload_mode": "full",
                 "payload_excerpt": "You catch fire",
                 "payload_sha256": None,
+                "structured_fields": [
+                    "family",
+                    "payload_excerpt",
+                    "payload_mode",
+                    "payload_sha256",
+                    "route",
+                    "template_id",
+                ],
             },
         ),
     ],
@@ -455,3 +504,31 @@ def test_parse_structured_suffix_unescapes_delimiter_like_values(
     assert entries[0].route == expected_route
     assert entries[0].family == expected_family
     assert getattr(entries[0], expected_field) == expected_value
+
+
+def test_parse_structured_suffix_preserves_literal_missing_in_text_fields(tmp_path: Path) -> None:
+    """Literal `<missing>` survives for text-bearing fields while nullable slots stay ``None``."""
+    log = tmp_path / "Player.log"
+    _write_log(log, [_MISSING_KEY_LITERAL_MISSING, _DYNAMIC_PROBE_LITERAL_MISSING])
+
+    entries = parse_log(log)
+
+    assert len(entries) == 2
+    assert entries[0].rendered_text_sample == "<missing>"
+    assert entries[0].template_id is None
+    assert entries[1].payload_excerpt == "<missing>"
+    assert entries[1].payload_sha256 is None
+
+
+def test_parse_phase_f_deduplication_keeps_distinct_payload_identities(tmp_path: Path) -> None:
+    """Phase F helper records with distinct payload identities must not collapse together."""
+    log = tmp_path / "Player.log"
+    _write_log(log, [_DYNAMIC_PROBE_PREFIX_HASH_A, _DYNAMIC_PROBE_PREFIX_HASH_B])
+
+    entries = parse_log(log)
+
+    assert len(entries) == 2
+    assert {entry.payload_sha256 for entry in entries} == {
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    }

--- a/scripts/tests/test_triage_log_parser.py
+++ b/scripts/tests/test_triage_log_parser.py
@@ -4,17 +4,244 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from scripts.triage.log_parser import parse_log
 
 if TYPE_CHECKING:
     from pathlib import Path
 from scripts.triage.models import LogEntryKind
 
+_MISSING_KEY_OLD = "[QudJP] Translator: missing key 'Put away' (hit 3). (context: ExactKey)"
+_MISSING_KEY_NEW = (
+    "[QudJP] Translator: missing key 'Put away' (hit 3). (context: ExactKey);"
+    " route=ExactKey; family=missing_key; template_id=<missing>; rendered_text_sample=Put away"
+)
+_NO_PATTERN_OLD = "[QudJP] MessagePatternTranslator: no pattern for 'You catch fire' (hit 2). (context: MessagePattern)"
+_NO_PATTERN_NEW = (
+    "[QudJP] MessagePatternTranslator: no pattern for 'You catch fire'"
+    " (hit 2). (context: MessagePattern); route=MessagePattern; family=message_pattern;"
+    " template_id=<missing>; rendered_text_sample=You catch fire"
+)
+_DYNAMIC_PROBE_OLD = (
+    "[QudJP] DynamicTextProbe/v1: route='DoesVerbRoute' family='verb' hit=1 changed=true"
+    " source='You catch fire' translated='あなたは燃え上がる'. (context: DoesVerbRoute)"
+)
+_DYNAMIC_PROBE_NEW = (
+    "[QudJP] DynamicTextProbe/v1: route='DoesVerbRoute' family='verb' hit=1 changed=true"
+    " source='You catch fire' translated='あなたは燃え上がる'. (context: DoesVerbRoute);"
+    " route=DoesVerbRoute; family=verb; template_id=<missing>; payload_mode=full;"
+    " payload_excerpt=You catch fire; payload_sha256=<missing>"
+)
+_SINK_OBSERVE_OLD = (
+    "[QudJP] SinkObserve/v1: sink='MessageLog' route='EmitMessage' detail='ObservationOnly'"
+    " source='You catch fire' stripped='You catch fire'"
+)
+_SINK_OBSERVE_NEW = (
+    "[QudJP] SinkObserve/v1: sink='MessageLog' route='EmitMessage' detail='ObservationOnly'"
+    " source='You catch fire' stripped='You catch fire'; route=EmitMessage;"
+    " family=sink_observe; template_id=<missing>; payload_mode=full;"
+    " payload_excerpt=You catch fire; payload_sha256=<missing>"
+)
+_MISSING_KEY_ESCAPED = (
+    "[QudJP] Translator: missing key 'Put away; route=Spoofed; family=spoof=value'"
+    " (hit 3). (context: ExactKey); route=ExactKey; family=missing_key;"
+    " template_id=<missing>; rendered_text_sample=Put away\\; route\\=Spoofed\\;"
+    " family\\=spoof\\=value"
+)
+_DYNAMIC_PROBE_ESCAPED = (
+    "[QudJP] DynamicTextProbe/v1: route='DoesVerbRoute' family='verb' hit=1 changed=true"
+    " source='You catch fire; route=Spoofed; family=spoof=value' translated='あなたは燃え上がる'."
+    " (context: DoesVerbRoute); route=DoesVerbRoute; family=verb; template_id=<missing>;"
+    " payload_mode=full; payload_excerpt=You catch fire\\; route\\=Spoofed\\;"
+    " family\\=spoof\\=value; payload_sha256=<missing>"
+)
+
 
 def _write_log(path: Path, lines: list[str]) -> None:
     """Write lines to a fake Player.log file."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _entry_snapshot(tmp_path: Path, line: str) -> dict[str, object | None]:
+    """Parse a single fixture line and return the stable observable fields."""
+    log = tmp_path / "Player.log"
+    _write_log(log, [line])
+    entry = parse_log(log)[0]
+    return {
+        "kind": entry.kind.value,
+        "route": entry.route,
+        "text": entry.text,
+        "hits": entry.hits,
+        "line_number": entry.line_number,
+        "family": entry.family,
+        "translated_text": entry.translated_text,
+        "changed": entry.changed,
+        "template_id": entry.template_id,
+        "rendered_text_sample": entry.rendered_text_sample,
+        "payload_mode": entry.payload_mode,
+        "payload_excerpt": entry.payload_excerpt,
+        "payload_sha256": entry.payload_sha256,
+    }
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        (
+            _MISSING_KEY_OLD,
+            {
+                "kind": "missing_key",
+                "route": "ExactKey",
+                "text": "Put away",
+                "hits": 3,
+                "line_number": 1,
+                "family": None,
+                "translated_text": None,
+                "changed": None,
+                "template_id": None,
+                "rendered_text_sample": None,
+                "payload_mode": None,
+                "payload_excerpt": None,
+                "payload_sha256": None,
+            },
+        ),
+        (
+            _MISSING_KEY_NEW,
+            {
+                "kind": "missing_key",
+                "route": "ExactKey",
+                "text": "Put away",
+                "hits": 3,
+                "line_number": 1,
+                "family": "missing_key",
+                "translated_text": None,
+                "changed": None,
+                "template_id": None,
+                "rendered_text_sample": "Put away",
+                "payload_mode": None,
+                "payload_excerpt": None,
+                "payload_sha256": None,
+            },
+        ),
+        (
+            _NO_PATTERN_OLD,
+            {
+                "kind": "no_pattern",
+                "route": "MessagePattern",
+                "text": "You catch fire",
+                "hits": 2,
+                "line_number": 1,
+                "family": None,
+                "translated_text": None,
+                "changed": None,
+                "template_id": None,
+                "rendered_text_sample": None,
+                "payload_mode": None,
+                "payload_excerpt": None,
+                "payload_sha256": None,
+            },
+        ),
+        (
+            _NO_PATTERN_NEW,
+            {
+                "kind": "no_pattern",
+                "route": "MessagePattern",
+                "text": "You catch fire",
+                "hits": 2,
+                "line_number": 1,
+                "family": "message_pattern",
+                "translated_text": None,
+                "changed": None,
+                "template_id": None,
+                "rendered_text_sample": "You catch fire",
+                "payload_mode": None,
+                "payload_excerpt": None,
+                "payload_sha256": None,
+            },
+        ),
+        (
+            _DYNAMIC_PROBE_OLD,
+            {
+                "kind": "dynamic_text_probe",
+                "route": "DoesVerbRoute",
+                "text": "You catch fire",
+                "hits": 1,
+                "line_number": 1,
+                "family": "verb",
+                "translated_text": "あなたは燃え上がる",
+                "changed": True,
+                "template_id": None,
+                "rendered_text_sample": None,
+                "payload_mode": None,
+                "payload_excerpt": None,
+                "payload_sha256": None,
+            },
+        ),
+        (
+            _DYNAMIC_PROBE_NEW,
+            {
+                "kind": "dynamic_text_probe",
+                "route": "DoesVerbRoute",
+                "text": "You catch fire",
+                "hits": 1,
+                "line_number": 1,
+                "family": "verb",
+                "translated_text": "あなたは燃え上がる",
+                "changed": True,
+                "template_id": None,
+                "rendered_text_sample": None,
+                "payload_mode": "full",
+                "payload_excerpt": "You catch fire",
+                "payload_sha256": None,
+            },
+        ),
+        (
+            _SINK_OBSERVE_OLD,
+            {
+                "kind": "sink_observe",
+                "route": "EmitMessage",
+                "text": "You catch fire",
+                "hits": None,
+                "line_number": 1,
+                "family": None,
+                "translated_text": None,
+                "changed": None,
+                "template_id": None,
+                "rendered_text_sample": None,
+                "payload_mode": None,
+                "payload_excerpt": None,
+                "payload_sha256": None,
+            },
+        ),
+        (
+            _SINK_OBSERVE_NEW,
+            {
+                "kind": "sink_observe",
+                "route": "EmitMessage",
+                "text": "You catch fire",
+                "hits": None,
+                "line_number": 1,
+                "family": "sink_observe",
+                "translated_text": None,
+                "changed": None,
+                "template_id": None,
+                "rendered_text_sample": None,
+                "payload_mode": "full",
+                "payload_excerpt": "You catch fire",
+                "payload_sha256": None,
+            },
+        ),
+    ],
+)
+def test_parse_phase_f_old_and_new_examples_share_parser_expectations(
+    tmp_path: Path,
+    line: str,
+    expected: dict[str, object | None],
+) -> None:
+    """The fixed old/new plan examples remain parseable by the current prefix parser."""
+    assert _entry_snapshot(tmp_path, line) == expected
 
 
 def test_parse_missing_key(tmp_path: Path) -> None:
@@ -162,3 +389,68 @@ def test_parse_dynamic_text_probe(tmp_path: Path) -> None:
     assert entries[0].text == "Points Remaining: 12"
     assert entries[0].translated_text == "残りポイント: 12"
     assert entries[0].changed is True
+
+
+def test_parse_sink_observe(tmp_path: Path) -> None:
+    """SinkObserve lines are parsed as separate Phase F entries."""
+    log = tmp_path / "Player.log"
+    _write_log(
+        log,
+        [
+            "[QudJP] SinkObserve/v1:"
+            " sink='MessageLog'"
+            " route='EmitMessage'"
+            " detail='ObservationOnly'"
+            " source='Game saved!'"
+            " stripped='Game saved!'",
+        ],
+    )
+    entries = parse_log(log)
+    assert len(entries) == 1
+    assert entries[0].kind == LogEntryKind.SINK_OBSERVE
+    assert entries[0].route == "EmitMessage"
+    assert entries[0].text == "Game saved!"
+    assert entries[0].hits is None
+
+
+@pytest.mark.parametrize(
+    ("line", "expected_kind", "expected_route", "expected_family", "expected_field", "expected_value"),
+    [
+        (
+            _MISSING_KEY_ESCAPED,
+            LogEntryKind.MISSING_KEY,
+            "ExactKey",
+            "missing_key",
+            "rendered_text_sample",
+            "Put away; route=Spoofed; family=spoof=value",
+        ),
+        (
+            _DYNAMIC_PROBE_ESCAPED,
+            LogEntryKind.DYNAMIC_TEXT_PROBE,
+            "DoesVerbRoute",
+            "verb",
+            "payload_excerpt",
+            "You catch fire; route=Spoofed; family=spoof=value",
+        ),
+    ],
+)
+def test_parse_structured_suffix_unescapes_delimiter_like_values(
+    tmp_path: Path,
+    line: str,
+    expected_kind: LogEntryKind,
+    expected_route: str,
+    expected_family: str,
+    expected_field: str,
+    expected_value: str,
+) -> None:
+    """Escaped structured values round-trip without spoofing route/family fields."""
+    log = tmp_path / "Player.log"
+    _write_log(log, [line])
+
+    entries = parse_log(log)
+
+    assert len(entries) == 1
+    assert entries[0].kind == expected_kind
+    assert entries[0].route == expected_route
+    assert entries[0].family == expected_family
+    assert getattr(entries[0], expected_field) == expected_value

--- a/scripts/tests/test_triage_models.py
+++ b/scripts/tests/test_triage_models.py
@@ -40,7 +40,11 @@ _SINK_OBSERVE_NEW = (
 
 
 def _structured_suffix_items(line: str) -> list[tuple[str, str | None]]:
-    """Return ordered structured suffix fields with `<missing>` normalized to ``None``."""
+    r"""Return ordered structured suffix fields for unescaped fixture data only.
+
+    This helper intentionally does not handle escaped delimiters like ``\\;`` or ``\\=``;
+    those transport cases are covered by parser tests instead of this fixture splitter.
+    """
     _prefix, separator, suffix = line.partition("; ")
     if not separator:
         return []

--- a/scripts/tests/test_triage_models.py
+++ b/scripts/tests/test_triage_models.py
@@ -2,7 +2,54 @@
 
 from __future__ import annotations
 
+import pytest
+
 from scripts.triage.models import LogEntry, LogEntryKind, TriageClassification, TriageResult
+
+_MISSING_KEY_OLD = "[QudJP] Translator: missing key 'Put away' (hit 3). (context: ExactKey)"
+_MISSING_KEY_NEW = (
+    "[QudJP] Translator: missing key 'Put away' (hit 3). (context: ExactKey);"
+    " route=ExactKey; family=missing_key; template_id=<missing>; rendered_text_sample=Put away"
+)
+_NO_PATTERN_OLD = "[QudJP] MessagePatternTranslator: no pattern for 'You catch fire' (hit 2). (context: MessagePattern)"
+_NO_PATTERN_NEW = (
+    "[QudJP] MessagePatternTranslator: no pattern for 'You catch fire'"
+    " (hit 2). (context: MessagePattern); route=MessagePattern; family=message_pattern;"
+    " template_id=<missing>; rendered_text_sample=You catch fire"
+)
+_DYNAMIC_PROBE_OLD = (
+    "[QudJP] DynamicTextProbe/v1: route='DoesVerbRoute' family='verb' hit=1 changed=true"
+    " source='You catch fire' translated='あなたは燃え上がる'. (context: DoesVerbRoute)"
+)
+_DYNAMIC_PROBE_NEW = (
+    "[QudJP] DynamicTextProbe/v1: route='DoesVerbRoute' family='verb' hit=1 changed=true"
+    " source='You catch fire' translated='あなたは燃え上がる'. (context: DoesVerbRoute);"
+    " route=DoesVerbRoute; family=verb; template_id=<missing>; payload_mode=full;"
+    " payload_excerpt=You catch fire; payload_sha256=<missing>"
+)
+_SINK_OBSERVE_OLD = (
+    "[QudJP] SinkObserve/v1: sink='MessageLog' route='EmitMessage' detail='ObservationOnly'"
+    " source='You catch fire' stripped='You catch fire'"
+)
+_SINK_OBSERVE_NEW = (
+    "[QudJP] SinkObserve/v1: sink='MessageLog' route='EmitMessage' detail='ObservationOnly'"
+    " source='You catch fire' stripped='You catch fire'; route=EmitMessage;"
+    " family=sink_observe; template_id=<missing>; payload_mode=full;"
+    " payload_excerpt=You catch fire; payload_sha256=<missing>"
+)
+
+
+def _structured_suffix_items(line: str) -> list[tuple[str, str | None]]:
+    """Return ordered structured suffix fields with `<missing>` normalized to ``None``."""
+    _prefix, separator, suffix = line.partition("; ")
+    if not separator:
+        return []
+
+    items: list[tuple[str, str | None]] = []
+    for token in suffix.split("; "):
+        key, value = token.split("=", maxsplit=1)
+        items.append((key, None if value == "<missing>" else value))
+    return items
 
 
 def test_classification_values() -> None:
@@ -71,3 +118,84 @@ def test_dynamic_text_probe_fields_are_optional() -> None:
     )
     assert entry.family == "CharacterStatusFamily"
     assert entry.changed is True
+
+
+def test_phase_f_structured_fields_are_optional() -> None:
+    """Structured Phase F fields normalize missing template IDs and remain optional."""
+    entry = LogEntry(
+        kind=LogEntryKind.SINK_OBSERVE,
+        route="EmitMessage",
+        text="You catch fire",
+        hits=None,
+        line_number=41,
+        template_id=None,
+        payload_mode="full",
+        payload_excerpt="You catch fire",
+        payload_sha256=None,
+    )
+    assert entry.kind == LogEntryKind.SINK_OBSERVE
+    assert entry.template_id is None
+    assert entry.payload_mode == "full"
+    assert entry.payload_sha256 is None
+
+
+@pytest.mark.parametrize(
+    ("line", "expected_items"),
+    [
+        (
+            _MISSING_KEY_NEW,
+            [
+                ("route", "ExactKey"),
+                ("family", "missing_key"),
+                ("template_id", None),
+                ("rendered_text_sample", "Put away"),
+            ],
+        ),
+        (
+            _NO_PATTERN_NEW,
+            [
+                ("route", "MessagePattern"),
+                ("family", "message_pattern"),
+                ("template_id", None),
+                ("rendered_text_sample", "You catch fire"),
+            ],
+        ),
+        (
+            _DYNAMIC_PROBE_NEW,
+            [
+                ("route", "DoesVerbRoute"),
+                ("family", "verb"),
+                ("template_id", None),
+                ("payload_mode", "full"),
+                ("payload_excerpt", "You catch fire"),
+                ("payload_sha256", None),
+            ],
+        ),
+        (
+            _SINK_OBSERVE_NEW,
+            [
+                ("route", "EmitMessage"),
+                ("family", "sink_observe"),
+                ("template_id", None),
+                ("payload_mode", "full"),
+                ("payload_excerpt", "You catch fire"),
+                ("payload_sha256", None),
+            ],
+        ),
+    ],
+)
+def test_phase_f_structured_suffix_contract_is_frozen(
+    line: str,
+    expected_items: list[tuple[str, str | None]],
+) -> None:
+    """The fixed plan examples keep their exact field order and `<missing>` null mapping."""
+    assert _structured_suffix_items(line) == expected_items
+
+
+@pytest.mark.parametrize(
+    "line",
+    [_MISSING_KEY_OLD, _NO_PATTERN_OLD, _DYNAMIC_PROBE_OLD, _SINK_OBSERVE_OLD],
+)
+def test_phase_f_old_examples_remain_suffix_free(line: str) -> None:
+    """Old examples stay parseable without any structured Phase F suffix."""
+    assert _structured_suffix_items(line) == []

--- a/scripts/triage/classifier.py
+++ b/scripts/triage/classifier.py
@@ -50,6 +50,7 @@ def classify(entry: LogEntry) -> TriageResult:
     """Classify a single untranslated string observation."""
     classifiers: tuple[Callable[[LogEntry], TriageResult | None], ...] = (
         _classify_dynamic_probe,
+        _classify_sink_observe,
         _classify_fragment,
         _classify_japanese_text,
         _classify_no_pattern,
@@ -80,6 +81,17 @@ def _classify_dynamic_probe(entry: LogEntry) -> TriageResult | None:
         classification=TriageClassification.LOGIC_REQUIRED,
         reason=f"DynamicTextProbe reported family '{family}' — investigate upstream generator/template family",
         slot_evidence=[family],
+    )
+
+
+def _classify_sink_observe(entry: LogEntry) -> TriageResult | None:
+    """Classify SinkObserve observations as separate Phase F evidence."""
+    if entry.kind != LogEntryKind.SINK_OBSERVE:
+        return None
+    return TriageResult(
+        entry=entry,
+        classification=TriageClassification.UNRESOLVED,
+        reason="SinkObserve is Phase F route-proof evidence — keep it separate from actionable triage",
     )
 
 

--- a/scripts/triage/log_parser.py
+++ b/scripts/triage/log_parser.py
@@ -28,7 +28,7 @@ _SINK_OBSERVE_PATTERN = re.compile(
     r"detail='(?P<detail>.*?)' source='(?P<source>.*?)' stripped='(?P<stripped>.*?)'",
 )
 _STRUCTURED_SUFFIX_TOKEN = re.compile(
-    r"(?P<key>[a-z_][a-z0-9_]*)=(?P<value>.*?)(?=; [a-z_][a-z0-9_]*=|$)",
+    r"(?P<key>[a-z_][a-z0-9_]*)=(?P<value>[^\n]*?)(?=; [a-z_][a-z0-9_]*=|$)",
 )
 _NULLABLE_STRUCTURED_FIELDS = frozenset({"template_id", "payload_sha256"})
 
@@ -69,6 +69,8 @@ def _hits_value(hits: int | None) -> int:
 
 def _parse_structured_suffix(line: str, prefix_end: int) -> tuple[dict[str, str | None], frozenset[str]]:
     """Parse the deterministic `; key=value` suffix added by Phase F emitters."""
+    # Phase F suffix parsing assumes parse_log() has already split Player.log into
+    # one log entry per line, so structured values never span newlines here.
     suffix = line[prefix_end:]
     if not suffix.startswith("; "):
         return {}, frozenset()

--- a/scripts/triage/log_parser.py
+++ b/scripts/triage/log_parser.py
@@ -30,6 +30,7 @@ _SINK_OBSERVE_PATTERN = re.compile(
 _STRUCTURED_SUFFIX_TOKEN = re.compile(
     r"(?P<key>[a-z_][a-z0-9_]*)=(?P<value>.*?)(?=; [a-z_][a-z0-9_]*=|$)",
 )
+_NULLABLE_STRUCTURED_FIELDS = frozenset({"template_id", "payload_sha256"})
 
 
 def _extract_primary_context(context: str | None) -> str:
@@ -48,12 +49,17 @@ def _unescape_probe_value(value: str) -> str:
     )
 
 
-def _dedupe_key(entry: LogEntry) -> tuple[str, str, str, str]:
+def _dedupe_key(entry: LogEntry) -> tuple[str, str, str, str, str, str]:
     """Build the deduplication key for a parsed log entry."""
     family_key = entry.family or ""
+    payload_excerpt_key = ""
+    payload_sha256_key = ""
     if entry.kind in {LogEntryKind.MISSING_KEY, LogEntryKind.NO_PATTERN, LogEntryKind.SINK_OBSERVE}:
         family_key = ""
-    return (entry.kind.value, entry.route, entry.text, family_key)
+    if entry.kind in {LogEntryKind.DYNAMIC_TEXT_PROBE, LogEntryKind.SINK_OBSERVE}:
+        payload_excerpt_key = entry.payload_excerpt or ""
+        payload_sha256_key = entry.payload_sha256 or ""
+    return (entry.kind.value, entry.route, entry.text, family_key, payload_excerpt_key, payload_sha256_key)
 
 
 def _hits_value(hits: int | None) -> int:
@@ -73,7 +79,11 @@ def _parse_structured_suffix(line: str, prefix_end: int) -> tuple[dict[str, str 
         key = match.group("key")
         raw_value = match.group("value")
         present_fields.add(key)
-        parsed[key] = None if raw_value == "<missing>" else _unescape_structured_value(raw_value)
+        parsed[key] = (
+            None
+            if raw_value == "<missing>" and key in _NULLABLE_STRUCTURED_FIELDS
+            else _unescape_structured_value(raw_value)
+        )
     return parsed, frozenset(present_fields)
 
 
@@ -145,7 +155,7 @@ def parse_log(log_path: Path) -> list[LogEntry]:
     if not log_path.exists():
         return []
 
-    seen: dict[tuple[str, str, str, str], LogEntry] = {}
+    seen: dict[tuple[str, str, str, str, str, str], LogEntry] = {}
     for line_number, line in enumerate(
         log_path.read_text(encoding="utf-8", errors="replace").splitlines(),
         start=1,

--- a/scripts/triage/log_parser.py
+++ b/scripts/triage/log_parser.py
@@ -23,6 +23,13 @@ _DYNAMIC_TEXT_PROBE_PATTERN = re.compile(
     r"hit=(?P<hits>\d+) changed=(?P<changed>true|false) source='(?P<source>.*?)' "
     r"translated='(?P<translated>.*?)'\.(?: \(context: (?P<context>[^)]+)\))?",
 )
+_SINK_OBSERVE_PATTERN = re.compile(
+    r"\[QudJP\] SinkObserve/v\d+: sink='(?P<sink>.*?)' route='(?P<route>.*?)' "
+    r"detail='(?P<detail>.*?)' source='(?P<source>.*?)' stripped='(?P<stripped>.*?)'",
+)
+_STRUCTURED_SUFFIX_TOKEN = re.compile(
+    r"(?P<key>[a-z_][a-z0-9_]*)=(?P<value>.*?)(?=; [a-z_][a-z0-9_]*=|$)",
+)
 
 
 def _extract_primary_context(context: str | None) -> str:
@@ -43,7 +50,84 @@ def _unescape_probe_value(value: str) -> str:
 
 def _dedupe_key(entry: LogEntry) -> tuple[str, str, str, str]:
     """Build the deduplication key for a parsed log entry."""
-    return (entry.kind.value, entry.route, entry.text, entry.family or "")
+    family_key = entry.family or ""
+    if entry.kind in {LogEntryKind.MISSING_KEY, LogEntryKind.NO_PATTERN, LogEntryKind.SINK_OBSERVE}:
+        family_key = ""
+    return (entry.kind.value, entry.route, entry.text, family_key)
+
+
+def _hits_value(hits: int | None) -> int:
+    """Normalize hit counts for deduplication comparisons."""
+    return -1 if hits is None else hits
+
+
+def _parse_structured_suffix(line: str, prefix_end: int) -> tuple[dict[str, str | None], frozenset[str]]:
+    """Parse the deterministic `; key=value` suffix added by Phase F emitters."""
+    suffix = line[prefix_end:]
+    if not suffix.startswith("; "):
+        return {}, frozenset()
+
+    parsed: dict[str, str | None] = {}
+    present_fields: set[str] = set()
+    for match in _STRUCTURED_SUFFIX_TOKEN.finditer(suffix[2:]):
+        key = match.group("key")
+        raw_value = match.group("value")
+        present_fields.add(key)
+        parsed[key] = None if raw_value == "<missing>" else _unescape_structured_value(raw_value)
+    return parsed, frozenset(present_fields)
+
+
+def _unescape_structured_value(value: str) -> str:
+    """Decode structured-value escaping without touching existing control escapes."""
+    builder: list[str] = []
+    index = 0
+    while index < len(value):
+        character = value[index]
+        if character == "\\" and index + 1 < len(value) and value[index + 1] in {"\\", ";", "="}:
+            builder.append(value[index + 1])
+            index += 2
+            continue
+
+        builder.append(character)
+        index += 1
+
+    return "".join(builder)
+
+
+def _structured_value(
+    parsed_fields: dict[str, str | None],
+    present_fields: frozenset[str],
+    field_name: str,
+    default: str | None = None,
+) -> str | None:
+    """Return a structured suffix value when present, otherwise a default."""
+    if field_name in present_fields:
+        return parsed_fields.get(field_name)
+    return default
+
+
+def _entry_with_structured_fields(
+    entry: LogEntry,
+    parsed_fields: dict[str, str | None],
+    present_fields: frozenset[str],
+) -> LogEntry:
+    """Merge Phase F structured suffix data into a parsed log entry."""
+    return LogEntry(
+        kind=entry.kind,
+        route=_structured_value(parsed_fields, present_fields, "route", entry.route) or entry.route,
+        text=entry.text,
+        hits=entry.hits,
+        line_number=entry.line_number,
+        family=_structured_value(parsed_fields, present_fields, "family", entry.family),
+        translated_text=entry.translated_text,
+        changed=entry.changed,
+        template_id=_structured_value(parsed_fields, present_fields, "template_id"),
+        rendered_text_sample=_structured_value(parsed_fields, present_fields, "rendered_text_sample"),
+        payload_mode=_structured_value(parsed_fields, present_fields, "payload_mode"),
+        payload_excerpt=_structured_value(parsed_fields, present_fields, "payload_excerpt"),
+        payload_sha256=_structured_value(parsed_fields, present_fields, "payload_sha256"),
+        structured_fields=present_fields,
+    )
 
 
 def parse_log(log_path: Path) -> list[LogEntry]:
@@ -71,7 +155,7 @@ def parse_log(log_path: Path) -> list[LogEntry]:
             continue
         key = _dedupe_key(entry)
         existing = seen.get(key)
-        if existing is None or entry.hits > existing.hits:
+        if existing is None or _hits_value(entry.hits) > _hits_value(existing.hits):
             seen[key] = entry
 
     return sorted(seen.values(), key=lambda entry: (entry.line_number, entry.route, entry.text))
@@ -81,29 +165,33 @@ def _try_parse_line(line: str, line_number: int) -> LogEntry | None:
     """Try to parse a single log line into a ``LogEntry``."""
     missing_key_match = _MISSING_KEY_PATTERN.search(line)
     if missing_key_match:
-        return LogEntry(
+        entry = LogEntry(
             kind=LogEntryKind.MISSING_KEY,
             route=_extract_primary_context(missing_key_match.group("context")),
             text=missing_key_match.group("key"),
             hits=int(missing_key_match.group("hits")),
             line_number=line_number,
         )
+        parsed_fields, present_fields = _parse_structured_suffix(line, missing_key_match.end())
+        return _entry_with_structured_fields(entry, parsed_fields, present_fields)
 
     no_pattern_match = _NO_PATTERN_PATTERN.search(line)
     if no_pattern_match:
-        return LogEntry(
+        entry = LogEntry(
             kind=LogEntryKind.NO_PATTERN,
             route=_extract_primary_context(no_pattern_match.group("context")),
             text=no_pattern_match.group("source"),
             hits=int(no_pattern_match.group("hits")),
             line_number=line_number,
         )
+        parsed_fields, present_fields = _parse_structured_suffix(line, no_pattern_match.end())
+        return _entry_with_structured_fields(entry, parsed_fields, present_fields)
 
     dynamic_probe_match = _DYNAMIC_TEXT_PROBE_PATTERN.search(line)
     if dynamic_probe_match:
         context = dynamic_probe_match.group("context")
         route = dynamic_probe_match.group("route")
-        return LogEntry(
+        entry = LogEntry(
             kind=LogEntryKind.DYNAMIC_TEXT_PROBE,
             route=_extract_primary_context(context or route),
             text=_unescape_probe_value(dynamic_probe_match.group("source")),
@@ -113,5 +201,19 @@ def _try_parse_line(line: str, line_number: int) -> LogEntry | None:
             translated_text=_unescape_probe_value(dynamic_probe_match.group("translated")),
             changed=dynamic_probe_match.group("changed") == "true",
         )
+        parsed_fields, present_fields = _parse_structured_suffix(line, dynamic_probe_match.end())
+        return _entry_with_structured_fields(entry, parsed_fields, present_fields)
+
+    sink_observe_match = _SINK_OBSERVE_PATTERN.search(line)
+    if sink_observe_match:
+        entry = LogEntry(
+            kind=LogEntryKind.SINK_OBSERVE,
+            route=sink_observe_match.group("route"),
+            text=_unescape_probe_value(sink_observe_match.group("source")),
+            hits=None,
+            line_number=line_number,
+        )
+        parsed_fields, present_fields = _parse_structured_suffix(line, sink_observe_match.end())
+        return _entry_with_structured_fields(entry, parsed_fields, present_fields)
 
     return None

--- a/scripts/triage/models.py
+++ b/scripts/triage/models.py
@@ -12,6 +12,7 @@ class LogEntryKind(Enum):
     MISSING_KEY = "missing_key"
     NO_PATTERN = "no_pattern"
     DYNAMIC_TEXT_PROBE = "dynamic_text_probe"
+    SINK_OBSERVE = "sink_observe"
 
 
 class TriageClassification(Enum):
@@ -36,11 +37,25 @@ class LogEntry:
     kind: LogEntryKind
     route: str
     text: str
-    hits: int
+    hits: int | None
     line_number: int
     family: str | None = None
     translated_text: str | None = None
     changed: bool | None = None
+    template_id: str | None = None
+    rendered_text_sample: str | None = None
+    payload_mode: str | None = None
+    payload_excerpt: str | None = None
+    payload_sha256: str | None = None
+    structured_fields: frozenset[str] = field(default_factory=frozenset)
+
+    def has_structured_field(self, field_name: str) -> bool:
+        """Return whether the structured Phase F suffix explicitly carried ``field_name``."""
+        return field_name in self.structured_fields
+
+    def has_structured_phase_f_data(self) -> bool:
+        """Return whether the entry carried any structured Phase F suffix fields."""
+        return bool(self.structured_fields)
 
 
 @dataclass(frozen=True)

--- a/scripts/triage_untranslated.py
+++ b/scripts/triage_untranslated.py
@@ -20,6 +20,8 @@ from scripts.triage.log_parser import parse_log
 from scripts.triage.models import LogEntry, LogEntryKind, TriageClassification, TriageResult
 
 _DEFAULT_LOG = Path.home() / "Library" / "Logs" / "Freehold Games" / "CavesOfQud" / "Player.log"
+_ACTIONABLE_KINDS = frozenset({LogEntryKind.MISSING_KEY, LogEntryKind.NO_PATTERN})
+_PHASE_F_ONLY_KINDS = frozenset({LogEntryKind.DYNAMIC_TEXT_PROBE, LogEntryKind.SINK_OBSERVE})
 
 
 def _find_project_root() -> Path:
@@ -70,8 +72,9 @@ def main(argv: list[str] | None = None) -> int:
     try:
         _validate_log_path(args.log)
         entries = parse_log(args.log)
-        results = [classify(entry) for entry in _iter_actionable_entries(entries)]
-        report = _build_report(results)
+        actionable_results = [classify(entry) for entry in _iter_actionable_entries(entries)]
+        phase_f_results = [classify(entry) for entry in _iter_phase_f_entries(entries)]
+        report = _build_report(actionable_results, phase_f_results)
         report_json = json.dumps(report, ensure_ascii=False, indent=2)
     except (FileNotFoundError, ValueError) as exc:
         print(f"Error: {exc}", file=sys.stderr)  # noqa: T201
@@ -89,12 +92,20 @@ def main(argv: list[str] | None = None) -> int:
 
 def _iter_actionable_entries(entries: list[LogEntry]) -> list[LogEntry]:
     """Return only untranslated observations that should become triage items."""
-    return [entry for entry in entries if entry.kind != LogEntryKind.DYNAMIC_TEXT_PROBE]
+    return [entry for entry in entries if entry.kind in _ACTIONABLE_KINDS]
 
 
-def _build_report(results: list[TriageResult]) -> dict[str, Any]:
+def _iter_phase_f_entries(entries: list[LogEntry]) -> list[LogEntry]:
+    """Return Phase F-only observations that must stay separate from actionable triage."""
+    return [entry for entry in entries if entry.kind in _PHASE_F_ONLY_KINDS]
+
+
+def _build_report(
+    actionable_results: list[TriageResult],
+    phase_f_results: list[TriageResult],
+) -> dict[str, Any]:
     """Build a grouped JSON-serializable report from triage results."""
-    summary: dict[str, int] = {"total": len(results)}
+    summary: dict[str, int] = {"total": len(actionable_results)}
     by_classification: dict[str, list[dict[str, Any]]] = {
         classification.value: [] for classification in TriageClassification
     }
@@ -104,10 +115,10 @@ def _build_report(results: list[TriageResult]) -> dict[str, Any]:
 
     for classification in TriageClassification:
         summary[classification.value] = sum(
-            1 for result in results if result.classification == classification
+            1 for result in actionable_results if result.classification == classification
         )
 
-    for result in sorted(results, key=_result_sort_key):
+    for result in sorted(actionable_results, key=_result_sort_key):
         entry_data = _serialize_result(result)
         by_classification[result.classification.value].append(entry_data)
         by_route[result.entry.route][result.classification.value].append(entry_data)
@@ -116,7 +127,24 @@ def _build_report(results: list[TriageResult]) -> dict[str, Any]:
         "summary": summary,
         "by_classification": by_classification,
         "by_route": dict(sorted(by_route.items())),
+        "phase_f": _build_phase_f_report(phase_f_results),
     }
+
+
+def _build_phase_f_report(results: list[TriageResult]) -> dict[str, Any]:
+    """Build the separate Phase F report section for non-actionable runtime evidence."""
+    summary = {
+        "total": len(results),
+        LogEntryKind.DYNAMIC_TEXT_PROBE.value: sum(
+            1 for result in results if result.entry.kind == LogEntryKind.DYNAMIC_TEXT_PROBE
+        ),
+        LogEntryKind.SINK_OBSERVE.value: sum(1 for result in results if result.entry.kind == LogEntryKind.SINK_OBSERVE),
+    }
+    entries = [
+        _serialize_result(result, include_phase_f_runtime_fields=True)
+        for result in sorted(results, key=_result_sort_key)
+    ]
+    return {"summary": summary, "entries": entries}
 
 
 def _result_sort_key(result: TriageResult) -> tuple[str, int, str, str]:
@@ -129,17 +157,22 @@ def _result_sort_key(result: TriageResult) -> tuple[str, int, str, str]:
     )
 
 
-def _serialize_result(result: TriageResult) -> dict[str, Any]:
+def _serialize_result(
+    result: TriageResult,
+    *,
+    include_phase_f_runtime_fields: bool = False,
+) -> dict[str, Any]:
     """Serialize a single triage result into JSON-compatible data."""
     entry = result.entry
     payload: dict[str, Any] = {
         "text": entry.text,
         "route": entry.route,
         "kind": entry.kind.value,
-        "hits": entry.hits,
         "line_number": entry.line_number,
         "reason": result.reason,
     }
+    if entry.hits is not None:
+        payload["hits"] = entry.hits
     if entry.family is not None:
         payload["family"] = entry.family
     if entry.translated_text is not None:
@@ -148,6 +181,35 @@ def _serialize_result(result: TriageResult) -> dict[str, Any]:
         payload["changed"] = entry.changed
     if result.slot_evidence:
         payload["slot_evidence"] = result.slot_evidence
+    phase_f = _serialize_phase_f_fields(entry, include_runtime_fields=include_phase_f_runtime_fields)
+    if phase_f:
+        payload["phase_f"] = phase_f
+    return payload
+
+
+def _serialize_phase_f_fields(
+    entry: LogEntry,
+    *,
+    include_runtime_fields: bool,
+) -> dict[str, Any]:
+    """Serialize structured Phase F fields without mutating the legacy actionable shape."""
+    payload: dict[str, Any] = {}
+
+    if include_runtime_fields or entry.has_structured_phase_f_data():
+        payload["route"] = entry.route
+    if entry.family is not None and (include_runtime_fields or entry.has_structured_field("family")):
+        payload["family"] = entry.family
+
+    for field_name in (
+        "template_id",
+        "rendered_text_sample",
+        "payload_mode",
+        "payload_excerpt",
+        "payload_sha256",
+    ):
+        if entry.has_structured_field(field_name):
+            payload[field_name] = getattr(entry, field_name)
+
     return payload
 
 


### PR DESCRIPTION
Closes #358

## Summary
- add the issue-358 first PR contract for structured Phase F runtime observability across translator-origin and helper-origin emissions
- extend triage parsing, classification, and CLI reporting so old logs still parse while Phase F runtime-proof data stays separate from actionable triage
- document the runtime-proof boundary and cover the contract with L1 and pytest regression suites, including delimiter-escape regressions

## Verification
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1
- pytest scripts/tests/test_triage_log_parser.py scripts/tests/test_triage_models.py scripts/tests/test_triage_classifier.py scripts/tests/test_triage_integration.py -q
- pytest scripts/tests/test_triage_integration.py -q -k sample_log_smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Phase F（DynamicTextProbe/SinkObserve/欠落キー/ノーパターン）向けの単体・統合・パーサー・モデル・分類テスト群を追加・拡充

* **Documentation**
  * Phase F 境界、共有デフォルト、検証コマンド群を RULES.md と関連ドキュメントに追記

* **New Features**
  * ログに route/family/template_id/payload_mode/payload_excerpt/payload_sha256 を含む構造化サフィックスを付与
  * SinkObserve の識別・解析・出力対応と、トライアージ出力に phase_f セクションを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->