### PR TITLE
[codex] Add translation verification triage coverage

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/StatusScreenBindingOwnerPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/StatusScreenBindingOwnerPatchTests.cs
@@ -52,8 +52,19 @@ public sealed class StatusScreenBindingOwnerPatchTests
         }
     }
 
-    [Test]
-    public void CharacterAttributeLineTranslationPatch_KeepsAbbreviationInEnglish_WhenPatched()
+    [TestCase("Strength", "STR")]
+    [TestCase("Agility", "AGI")]
+    [TestCase("Toughness", "TOU")]
+    [TestCase("Intelligence", "INT")]
+    [TestCase("Willpower", "WIL")]
+    [TestCase("Ego", "EGO")]
+    [TestCase("MoveSpeed", "MS")]
+    [TestCase("Armor", "AV")]
+    [TestCase("Dodge", "DV")]
+    [TestCase("MentalArmor", "MA")]
+    public void CharacterAttributeLineTranslationPatch_KeepsAbbreviationInEnglish_WhenPatched(
+        string statName,
+        string shortDisplayName)
     {
         // Stat abbreviations (STR, AGI, MS, AV, DV, MA, etc.) are kept in English
         // to avoid layout shifts (see commit 63cc3ad).
@@ -68,12 +79,12 @@ public sealed class StatusScreenBindingOwnerPatchTests
             var target = new DummyCharacterAttributeLineTarget();
             target.setData(new DummyCharacterAttributeLineDataTarget
             {
-                stat = "Strength",
+                stat = statName,
                 go = new DummyStatusGameObject(),
                 data = new DummyStatusStatistic
                 {
-                    Name = "Strength",
-                    ShortDisplayName = "STR",
+                    Name = statName,
+                    ShortDisplayName = shortDisplayName,
                     Value = 18,
                     BaseValue = 18,
                     Modifier = 2,
@@ -82,7 +93,7 @@ public sealed class StatusScreenBindingOwnerPatchTests
 
             Assert.Multiple(() =>
             {
-                Assert.That(target.attributeText.Text, Is.EqualTo("STR"),
+                Assert.That(target.attributeText.Text, Is.EqualTo(shortDisplayName),
                     "Stat abbreviations must remain in English to avoid layout shifts");
                 Assert.That(target.valueText.Text, Is.Not.Null.And.Not.Empty,
                     "Value text should be populated by the prefix");

--- a/Mods/QudJP/Localization/Dictionaries/ui-attributes.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-attributes.ja.json
@@ -10,19 +10,9 @@
     },
     "entries": [
         {
-            "key": "STR",
-            "context": "Qud.UI.CharacterAttributeLine.AttributeLabel",
-            "text": "筋力"
-        },
-        {
             "key": "Strength",
             "context": "Qud.UI.CharacterAttributeLine.AttributeLabel",
             "text": "筋力"
-        },
-        {
-            "key": "AGI",
-            "context": "Qud.UI.CharacterAttributeLine.AttributeLabel",
-            "text": "敏捷"
         },
         {
             "key": "Agility",
@@ -30,19 +20,9 @@
             "text": "敏捷"
         },
         {
-            "key": "TOU",
-            "context": "Qud.UI.CharacterAttributeLine.AttributeLabel",
-            "text": "頑健"
-        },
-        {
             "key": "Toughness",
             "context": "Qud.UI.CharacterAttributeLine.AttributeLabel",
             "text": "頑健"
-        },
-        {
-            "key": "INT",
-            "context": "Qud.UI.CharacterAttributeLine.AttributeLabel",
-            "text": "知力"
         },
         {
             "key": "Intelligence",
@@ -50,19 +30,9 @@
             "text": "知力"
         },
         {
-            "key": "WIL",
-            "context": "Qud.UI.CharacterAttributeLine.AttributeLabel",
-            "text": "意志力"
-        },
-        {
             "key": "Willpower",
             "context": "Qud.UI.CharacterAttributeLine.AttributeLabel",
             "text": "意志力"
-        },
-        {
-            "key": "EGO",
-            "context": "Qud.UI.CharacterAttributeLine.AttributeLabel",
-            "text": "自我"
         },
         {
             "key": "Ego",
@@ -80,29 +50,9 @@
             "text": "俊敏"
         },
         {
-            "key": "MS",
-            "context": "Qud.UI.CharacterAttributeLine.AttributeLabel",
-            "text": "移動速度"
-        },
-        {
             "key": "MoveSpeed",
             "context": "Qud.UI.CharacterAttributeLine.AttributeLabel",
             "text": "移動速度"
-        },
-        {
-            "key": "AV",
-            "context": "Qud.UI.CharacterAttributeLine.AttributeLabel",
-            "text": "装甲値"
-        },
-        {
-            "key": "DV",
-            "context": "Qud.UI.CharacterAttributeLine.AttributeLabel",
-            "text": "回避値"
-        },
-        {
-            "key": "MA",
-            "context": "Qud.UI.CharacterAttributeLine.AttributeLabel",
-            "text": "精神装甲"
         },
         {
             "key": "CP",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -291,13 +291,15 @@ python scripts/translation_checker.py \
   --skip-sync \
   --screenshot-path artifacts/translation_checker/verified-inventory.png
 
-# 最終 L3 smoke: セーブ読込、各画面、ポップアップ、NPC会話、攻撃/ログを連続確認
+# 最終 L3 smoke: セーブ読込、インベントリ起点の各タブ/項目、アビリティ、
+# active effects、ポップアップ、NPC会話、攻撃/ログを連続確認
 python scripts/translation_checker.py \
   --skip-sync \
   --flow final-smoke \
   --flow-screenshot-dir /tmp/qudjp-l3-final-smoke
 
-# 死亡確認まで進める場合（検証セーブは自動バックアップ後に復元）
+# 死亡確認を明示的に調整する場合（既定は最大30回、検証セーブは自動バックアップ後に復元）
+# 低HPなどの戦闘警告は既定で space を送って閉じます。
 python scripts/translation_checker.py \
   --skip-sync \
   --flow final-smoke \
@@ -323,19 +325,38 @@ python scripts/translation_checker.py \
 - JSON 形式で `screenshot_path`、`player_log_path`、`load_ready_matches`、一致した inventory probe、ログ抜粋を標準出力に表示
 - スクリーンショット自体の破棄は、この JSON を読んだ呼び出し側が行う想定
 
-`--flow final-smoke` では `screenshot_dir` と `screenshot_paths` を出力します。標準ステージは次の通りです。
+`--flow final-smoke` では `screenshot_dir`、`screenshot_paths`、`verification_report_path` を出力します。
+`verification_report.json` には各スクリーンショット stage に対応する Player.log 範囲、翻訳済み runtime evidence、
+missing key、message pattern gap、SinkObserve の未翻訳候補、markup/color tag 差分候補、preserved-English 分類が含まれます。
+各 flow screenshot は、画面を開いた後に `--flow-screenshot-wait` 秒だけ待ってから撮影します。既定は 3 秒です。
+標準ステージは次の通りです。
 
 - セーブ読込直後
-- インベントリ、装備、キャラクター、技能/パワー、クエスト、ティンカリング、ジャーナル
+- インベントリ画面起点: 初期タブ、表示オプション、先頭アイテムの選択/アクションメニュー、複数アイテム行、Page Right で到達するタブ群
+- アビリティ画面、active effects 画面
 - システムメニュー、注目地点、Look 方向選択、ヘルプ、射撃武器なしポップアップ
 - NPC 会話
 - Classic 攻撃または攻撃確認ポップアップ
 - 攻撃後のメッセージログ
-- `--death-attack-count` 指定時の死亡/戦闘終了画面
+- 死亡/戦闘終了画面
+- 死亡/戦闘終了後のメッセージログ
+
+インベントリ起点の走査量は `--inventory-tab-page-rights`、`--inventory-item-scan-count`、
+`--inventory-item-action-row-offset`、`--inventory-item-pane-chord` で調整できます。既定では、
+インベントリ一覧ペインへ移動して先頭アイテムのアクションメニューを開き、8 件分のアイテム行と
+Page Right 8 回分のタブ遷移を撮影します。
+
+アビリティ画面と active effects 画面を開くキーは `--abilities-chord` と
+`--active-effects-chord` で調整できます。active effects は既定で `x,e` とし、
+キャラクター画面を開いてからキャラクターシート内の「状態効果を表示」を選びます。
 
 NPC 会話の移動先や方向はテストセーブに依存します。既定値は実測したテストセーブ向けに
 `--npc-poi-key d`、`--npc-talk-direction right`、攻撃は `--attack-chord backslash,right` です。
 合わない場合はこれらの引数を変えて同じ検証フローを再利用します。
+戦闘は既定で初回攻撃後に最大30回まで同じ攻撃入力を繰り返し、死亡または戦闘終了画面と
+その後のメッセージログを撮影します。低HPなどの戦闘警告は `--death-confirm-key space` で閉じます。
+死亡確認を省略する場合は `--death-attack-count 0`、警告確認キーを送らない場合は
+`--death-confirm-key ""` を使います。
 
 `--manual-load` は Computer Use 用の導線です。スクリプトは必ず `scripts/launch_rosetta.sh`
 経由で起動し、タイトル/ロード画面への入力は送らず、ロード完了 probe だけを待ちます。
@@ -367,7 +388,7 @@ pytest scripts/tests/test_diff_localization.py
 pytest scripts/tests/test_translation_checker.py
 ```
 
-現在のテスト数: **290 件**
+現在のテスト数: **325 件**
 
 ---
 

--- a/scripts/tests/test_preserved_english_policy.py
+++ b/scripts/tests/test_preserved_english_policy.py
@@ -1,0 +1,43 @@
+"""Tests for the preserved-English policy."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.triage.preserved_policy import load_preserved_english_policy
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DICTIONARY_DIR = REPO_ROOT / "Mods" / "QudJP" / "Localization" / "Dictionaries"
+
+
+def test_policy_loads_route_aware_rules() -> None:
+    """The preserved-English policy is machine readable and route-aware."""
+    policy = load_preserved_english_policy()
+    rule = next(rule for rule in policy.rules if rule.id == "character_attribute_line_short_labels")
+    assert policy.version == 1
+    assert rule.matches_route("CharacterAttributeLineTranslationPatch")
+    assert rule.matches_text("+1 STR")
+    assert not rule.matches_route("InventoryAndEquipmentStatusScreenTranslationPatch")
+
+
+def test_policy_protected_dictionary_entries_are_not_registered() -> None:
+    """Dictionary assets must not re-register tokens protected by policy contexts."""
+    policy = load_preserved_english_policy()
+    protected_entries = {
+        (context, text)
+        for rule in policy.rules
+        for context in rule.dictionary_contexts
+        for text in rule.texts
+    }
+    offenders: list[tuple[str, str, str]] = []
+
+    for dictionary_path in sorted(DICTIONARY_DIR.glob("*.ja.json")):
+        payload = json.loads(dictionary_path.read_text(encoding="utf-8"))
+        for entry in payload.get("entries", ()):
+            key = entry.get("key")
+            context = entry.get("context")
+            if (context, key) in protected_entries:
+                offenders.append((dictionary_path.name, str(context), str(key)))
+
+    assert offenders == []

--- a/scripts/tests/test_translation_checker.py
+++ b/scripts/tests/test_translation_checker.py
@@ -8,13 +8,16 @@ import pytest
 from scripts.translation_checker import (
     _attack_sequences,
     _build_activate_application_script,
+    _build_final_smoke_character_screen_stages,
     _build_final_smoke_popup_stages,
     _build_final_smoke_stage_names,
     _build_focus_script,
     _build_hammerspoon_focus_lua,
     _build_launch_game_command,
     _build_system_events_key_code_script,
+    _build_verification_report,
     _combat_evidence_matches,
+    _death_evidence_matches,
     _escape_osascript_string,
     _find_matching_patterns,
     _flow_requires_load_ready,
@@ -32,6 +35,7 @@ from scripts.translation_checker import (
     _read_log_delta,
     _should_send_title_load_inputs,
     _stabilize_game_focus,
+    _StageCapture,
     _title_navigation_delay,
 )
 
@@ -40,6 +44,10 @@ class TestInputMappings:
     def test_maps_special_key_codes(self) -> None:
         assert _key_code_for("return") == 36
         assert _key_code_for("up") == 126
+        assert _key_code_for("end") == 119
+        assert _key_code_for("home") == 115
+        assert _key_code_for("pagedown") == 121
+        assert _key_code_for("pageup") == 116
         assert _key_code_for("numpad6") == 88
         assert _key_code_for("backslash") == 42
         assert _key_code_for("oem102") == 42
@@ -130,11 +138,24 @@ class TestFinalSmokeFlowHelpers:
     def test_final_smoke_stage_names_cover_user_requested_runtime_checks(self) -> None:
         stage_names = _build_final_smoke_stage_names()
         assert "after-load" in stage_names
-        assert "inventory-inventory" in stage_names
+        assert "inventory-tab-00-initial" in stage_names
+        assert "inventory-display-options" in stage_names
+        assert "inventory-item-00-actions" in stage_names
+        assert "inventory-item-scan-08" in stage_names
+        assert "inventory-tab-page-right-08" in stage_names
+        assert "abilities-screen" in stage_names
+        assert "active-effects-screen" in stage_names
         assert "popup-system-menu" in stage_names
         assert "npc-conversation" in stage_names
         assert "attack-or-confirmation" in stage_names
         assert "message-log-after-attack" in stage_names
+
+    def test_final_smoke_stage_names_respect_inventory_drilldown_counts(self) -> None:
+        stage_names = _build_final_smoke_stage_names(tab_page_rights=2, item_scan_count=1)
+        assert "inventory-tab-page-right-02" in stage_names
+        assert "inventory-tab-page-right-03" not in stage_names
+        assert "inventory-item-scan-01" in stage_names
+        assert "inventory-item-scan-02" not in stage_names
 
     def test_final_smoke_help_toggle_closes_with_same_key(self) -> None:
         popup_stages = {
@@ -142,6 +163,15 @@ class TestFinalSmokeFlowHelpers:
             for label, open_chord, close_chord in _build_final_smoke_popup_stages()
         }
         assert popup_stages["popup-help"] == ("p", "p")
+
+    def test_final_smoke_character_screen_stages_use_configured_keys(self) -> None:
+        args = _parse_args(["--abilities-chord", "shift+a", "--active-effects-chord", "x,e"])
+        character_stages = {
+            label: (open_sequence, close_sequence)
+            for label, open_sequence, close_sequence in _build_final_smoke_character_screen_stages(args)
+        }
+        assert character_stages["abilities-screen"] == (("shift+a",), ("escape",))
+        assert character_stages["active-effects-screen"] == (("x", "e"), ("escape", "escape"))
 
 
 class TestHammerspoonHelpers:
@@ -260,6 +290,49 @@ class TestReadLogDelta:
         assert _read_log_delta(log_path, 999) == "new\n"
 
 
+class TestVerificationReport:
+    def test_builds_stage_aware_translation_report(self, tmp_path: Path) -> None:
+        first_stage = (
+            "[QudJP] DynamicTextProbe/v1: route='MessagePatternTranslator' family='combat'"
+            " hit=1 changed=true source='{{W|You hit snapjaw.}}'"
+            " translated='あなたはsnapjawに命中した。'. (context: MessageLogPatch)\n"
+            "[QudJP] Translator: missing key 'STR' (hit 1). (context: CharacterAttributeLineTranslationPatch)\n"
+            "[QudJP] Translator: missing key 'Inventory' (hit 1). (context: UITextSkinTranslationPatch)\n"
+            "[QudJP] MessagePatternTranslator: no pattern for 'Game saved!' (hit 1). (context: MessageLogPatch)\n"
+            "[QudJP] SinkObserve/v1: sink='MessageLog' route='EmitMessage'"
+            " detail='ObservationOnly' source='You catch fire' stripped='You catch fire'"
+        )
+        second_stage = "[QudJP] Translator: missing key 'Equipment' (hit 1). (context: UITextSkinTranslationPatch)"
+        log_text = f"{first_stage}\n{second_stage}\n"
+        first_end = len((first_stage + "\n").encode())
+        log_path = tmp_path / "Player.log"
+        log_path.write_text(log_text, encoding="utf-8")
+        first_screenshot = str(tmp_path / "01-message-log.png")
+        second_screenshot = str(tmp_path / "02-equipment.png")
+
+        report = _build_verification_report(
+            [
+                _StageCapture("message-log-after-attack", first_screenshot, 0, first_end),
+                _StageCapture("inventory-equipment", second_screenshot, first_end, len(log_text.encode())),
+            ],
+            log_path,
+        )
+
+        first = report["stages"][0]
+        assert first["stage"] == "message-log-after-attack"
+        assert first["screenshot_path"] == first_screenshot
+        assert [entry["text"] for entry in first["translated_events"]] == ["{{W|You hit snapjaw.}}"]
+        assert [entry["text"] for entry in first["preserved_english"]] == ["STR"]
+        assert [entry["text"] for entry in first["missing_key_candidates"]] == ["Inventory"]
+        assert [entry["text"] for entry in first["message_pattern_gaps"]] == ["Game saved!"]
+        assert [entry["text"] for entry in first["sink_observed_untranslated_candidates"]] == ["You catch fire"]
+        assert first["markup_color_tag_issue_candidates"][0]["source_markup"] == ["{{W|", "}}"]
+        assert report["summary"]["stage_count"] == 2
+        assert report["summary"]["missing_key_candidates"] == 2
+        assert report["summary"]["markup_color_tag_issue_candidates"] == 1
+        assert report["summary"]["preserved_english"] == 1
+
+
 class TestLoadReadyMatches:
     def test_detects_bottom_context_probe(self) -> None:
         text = "[QudJP] QudMenuBottomContextProbe/RefreshButtonsAfter/v1: buttons=2"
@@ -333,6 +406,15 @@ class TestCombatEvidenceMatches:
         assert _combat_evidence_matches(text) == []
 
 
+class TestDeathEvidenceMatches:
+    def test_detects_english_death_message(self) -> None:
+        assert _death_evidence_matches("You died!") == ["You died"]
+
+    def test_detects_translated_death_message(self) -> None:
+        text = "[QudJP] DynamicTextProbe/v1: translated='あなたは倒れた。'"
+        assert _death_evidence_matches(text)
+
+
 class TestParseArgs:
     def test_defaults_match_observed_title_menu_flow(self) -> None:
         args = _parse_args([])
@@ -352,10 +434,19 @@ class TestParseArgs:
         assert args.attack_chord == "backslash,right"
         assert args.attack_sequence is None
         assert args.attack_confirm_key == ""
+        assert args.death_attack_count == 30
+        assert args.death_confirm_key == "space"
         assert args.require_combat_evidence is False
         assert args.load_ready_timeout == 45.0
         assert args.title_ready_wait == 12.0
         assert args.title_ready_post_wait == 1.0
+        assert args.flow_screenshot_wait == 3.0
+        assert args.inventory_tab_page_rights == 8
+        assert args.inventory_item_scan_count == 8
+        assert args.inventory_item_action_row_offset == 1
+        assert args.inventory_item_pane_chord == "right"
+        assert args.abilities_chord == "a"
+        assert args.active_effects_chord == "x,e"
 
     def test_manual_load_flag_is_parsed(self) -> None:
         args = _parse_args(["--manual-load", "--load-ready-timeout", "300"])

--- a/scripts/tests/test_triage_classifier.py
+++ b/scripts/tests/test_triage_classifier.py
@@ -56,6 +56,38 @@ def test_classify_embedded_number() -> None:
     assert "12" in result.slot_evidence
 
 
+def test_classify_preserved_stat_abbreviation() -> None:
+    """Route-owned stat abbreviations are preserved English, not static leaves."""
+    result = classify(_mk("STR", route="CharacterAttributeLineTranslationPatch"))
+    assert result.classification == TriageClassification.PRESERVED_ENGLISH
+    assert result.slot_evidence == ["STR"]
+
+
+def test_classify_unexpected_translation_of_preserved_stat_abbreviation() -> None:
+    """Dynamic probes flag protected tokens that were translated unexpectedly."""
+    entry = LogEntry(
+        kind=LogEntryKind.DYNAMIC_TEXT_PROBE,
+        route="DescriptionLongDescriptionPatch",
+        text="+1 STR",
+        hits=1,
+        line_number=1,
+        family="Description.LongDescription",
+        translated_text="+1 筋力",
+        changed=True,
+    )
+    result = classify(entry)
+    assert result.classification == TriageClassification.UNEXPECTED_TRANSLATION_OF_PRESERVED_TOKEN
+    assert result.slot_evidence == ["STR"]
+
+
+def test_classify_route_specific_lbs_is_not_global() -> None:
+    """Compact lbs. labels are allowed only on routes that explicitly preserve them."""
+    trade_result = classify(_mk("{{W|$50}} | {{K|123/200 lbs.}}", route="TradeScreenUpdateTotalsTranslationPatch"))
+    inventory_result = classify(_mk("123/200 lbs.", route="InventoryAndEquipmentStatusScreenTranslationPatch"))
+    assert trade_result.classification == TriageClassification.PRESERVED_ENGLISH
+    assert inventory_result.classification == TriageClassification.LOGIC_REQUIRED
+
+
 def test_classify_numeric_stat_line() -> None:
     """Weight or HP readouts are dynamic."""
     result = classify(_mk("56/240#"))

--- a/scripts/tests/test_triage_integration.py
+++ b/scripts/tests/test_triage_integration.py
@@ -146,6 +146,8 @@ def test_cli_adds_structured_group_without_changing_actionable_categories(tmp_pa
         "static_leaf": 1,
         "route_patch": 0,
         "logic_required": 0,
+        "preserved_english": 0,
+        "unexpected_translation_of_preserved_token": 0,
         "unresolved": 0,
     }
     entry = data["by_classification"]["static_leaf"][0]
@@ -211,12 +213,16 @@ def test_module_cli_classify_treats_missing_runtime_dir_as_empty_report(tmp_path
             "static_leaf": 0,
             "route_patch": 0,
             "logic_required": 0,
+            "preserved_english": 0,
+            "unexpected_translation_of_preserved_token": 0,
             "unresolved": 0,
         },
         "by_classification": {
             "static_leaf": [],
             "route_patch": [],
             "logic_required": [],
+            "preserved_english": [],
+            "unexpected_translation_of_preserved_token": [],
             "unresolved": [],
         },
         "by_route": {},
@@ -272,8 +278,31 @@ def test_module_cli_classify_keeps_no_context_split_explicit(tmp_path: Path) -> 
         "static_leaf": 1,
         "route_patch": 0,
         "logic_required": 1,
+        "preserved_english": 0,
+        "unexpected_translation_of_preserved_token": 0,
         "unresolved": 1,
     }
+
+
+def test_cli_classifies_preserved_english_separately(tmp_path: Path) -> None:
+    """Preserved English appears in its own actionable report bucket."""
+    log = tmp_path / "Player.log"
+    out = tmp_path / "triage.json"
+    _write_log(
+        log,
+        [
+            "[QudJP] Translator: missing key 'STR' (hit 1). (context: CharacterAttributeLineTranslationPatch)",
+            "[QudJP] Translator: missing key '123/200 lbs.' (hit 1). (context: UnknownWeightRoute)",
+        ],
+    )
+
+    result = main(["--log", str(log), "--output", str(out)])
+    assert result == 0
+
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["summary"]["preserved_english"] == 1
+    assert data["summary"]["logic_required"] == 1
+    assert [entry["text"] for entry in data["by_classification"]["preserved_english"]] == ["STR"]
 
 
 def test_module_cli_classify_returns_error_when_output_parent_cannot_be_created(tmp_path: Path) -> None:

--- a/scripts/tests/test_triage_log_parser.py
+++ b/scripts/tests/test_triage_log_parser.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from scripts.triage.log_parser import parse_log
+from scripts.triage.log_parser import parse_log, parse_log_text
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -43,6 +43,14 @@ _SINK_OBSERVE_NEW = (
     " family=sink_observe; template_id=<missing>; payload_mode=full;"
     " payload_excerpt=You catch fire; payload_sha256=<missing>"
 )
+
+
+def test_parse_log_text_uses_same_parser_as_file_input() -> None:
+    """In-memory log slices can be parsed for stage-aware verification reports."""
+    entries = parse_log_text(_MISSING_KEY_OLD)
+    assert len(entries) == 1
+    assert entries[0].kind == LogEntryKind.MISSING_KEY
+    assert entries[0].text == "Put away"
 _MISSING_KEY_ESCAPED = (
     "[QudJP] Translator: missing key 'Put away; route=Spoofed; family=spoof=value'"
     " (hit 3). (context: ExactKey); route=ExactKey; family=missing_key;"

--- a/scripts/tests/test_triage_models.py
+++ b/scripts/tests/test_triage_models.py
@@ -61,6 +61,11 @@ def test_classification_values() -> None:
     assert TriageClassification.STATIC_LEAF.value == "static_leaf"
     assert TriageClassification.ROUTE_PATCH.value == "route_patch"
     assert TriageClassification.LOGIC_REQUIRED.value == "logic_required"
+    assert TriageClassification.PRESERVED_ENGLISH.value == "preserved_english"
+    assert (
+        TriageClassification.UNEXPECTED_TRANSLATION_OF_PRESERVED_TOKEN.value
+        == "unexpected_translation_of_preserved_token"
+    )
     assert TriageClassification.UNRESOLVED.value == "unresolved"
 
 

--- a/scripts/translation_checker.py
+++ b/scripts/translation_checker.py
@@ -17,6 +17,16 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+if __package__ in {None, ""}:
+    _PROJECT_ROOT = Path(__file__).resolve().parents[1]
+    _PROJECT_ROOT_STR = str(_PROJECT_ROOT)
+    if _PROJECT_ROOT_STR not in sys.path:
+        sys.path.insert(0, _PROJECT_ROOT_STR)
+
+from scripts.triage.classifier import classify
+from scripts.triage.log_parser import parse_log_text
+from scripts.triage.models import LogEntry, LogEntryKind, TriageClassification, TriageResult
+
 _PLAYER_LOG = Path.home() / "Library" / "Logs" / "Freehold Games" / "CavesOfQud" / "Player.log"
 _BUILD_MARKER = "[QudJP] Build marker:"
 _TITLE_READY_PROBE = "MainMenuLocalizationPatch"
@@ -45,17 +55,43 @@ _DEFAULT_INVENTORY_PATTERNS: tuple[str, ...] = (
     "[QudJP] InventoryLineReplacementStateNextFrame/v1:",
     "[QudJP] EquipmentLineProbe/v1:",
 )
+_MESSAGE_LOG_ROUTES = frozenset({"MessageLog", "MessageLogPatch", "EmitMessage"})
+_ASCII_WORD_PATTERN = re.compile(r"[A-Za-z]{2,}")
+_MARKUP_TOKEN_PATTERN = re.compile(
+    r"\{\{[A-Za-z0-9#]+\||\}\}|&&|\^\^|&[A-Za-z]|\^[A-Za-z]|</?color(?:=[^>]+)?>|=[A-Za-z0-9_.]+=",
+)
+_DEFAULT_INVENTORY_TAB_PAGE_RIGHTS = 8
+_DEFAULT_INVENTORY_ITEM_SCAN_COUNT = 8
+_DEFAULT_INVENTORY_ITEM_ACTION_ROW_OFFSET = 1
+_DEFAULT_INVENTORY_ITEM_PANE_CHORD = "right"
+_DEFAULT_ABILITIES_CHORD = "a"
+_DEFAULT_ACTIVE_EFFECTS_CHORD = "x,e"
+_DEFAULT_DEATH_ATTACK_COUNT = 30
+_DEFAULT_DEATH_CONFIRM_KEY = "space"
+_DEATH_EVIDENCE_PATTERNS: tuple[str, ...] = (
+    "You died",
+    "You are dead",
+    "You were killed",
+    "You have died",
+)
+_DEATH_EVIDENCE_REGEXES: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?:source|translated)='[^']*(?:あなた|君|プレイヤー).*(?:死|倒れ)"),
+)
 _SPECIAL_KEY_CODES = {
     "backspace": 51,
     "backslash": 42,
     "delete": 51,
     "down": 125,
+    "end": 119,
     "enter": 76,
     "escape": 53,
+    "home": 115,
     "iso_section": 10,
     "jis_yen": 93,
     "left": 123,
     "oem102": 42,
+    "pagedown": 121,
+    "pageup": 116,
     "return": 36,
     "right": 124,
     "space": 49,
@@ -163,6 +199,17 @@ def _read_log_delta(path: Path, offset: int) -> str:
         return handle.read().decode("utf-8", errors="replace")
 
 
+def _read_log_range(path: Path, start_offset: int, end_offset: int) -> str:
+    if not path.exists():
+        return ""
+    size = path.stat().st_size
+    start = 0 if start_offset > size else max(start_offset, 0)
+    end = min(max(end_offset, start), size)
+    with path.open("rb") as handle:
+        handle.seek(start)
+        return handle.read(end - start).decode("utf-8", errors="replace")
+
+
 def _current_log_offset(path: Path) -> int:
     if not path.exists():
         return 0
@@ -228,6 +275,14 @@ def _load_ready_failure_matches(text: str) -> list[str]:
 def _combat_evidence_matches(text: str) -> list[str]:
     matches = _find_matching_patterns(text, _COMBAT_EVIDENCE_PATTERNS)
     for pattern in _COMBAT_EVIDENCE_REGEXES:
+        if pattern.search(text):
+            matches.append(pattern.pattern)
+    return matches
+
+
+def _death_evidence_matches(text: str) -> list[str]:
+    matches = _find_matching_patterns(text, _DEATH_EVIDENCE_PATTERNS)
+    for pattern in _DEATH_EVIDENCE_REGEXES:
         if pattern.search(text):
             matches.append(pattern.pattern)
     return matches
@@ -670,16 +725,19 @@ def _capture_flow_screenshot(output_dir: Path, index: int, label: str) -> Path:
     return path
 
 
-def _build_final_smoke_inventory_stages() -> tuple[tuple[str, str], ...]:
-    return (
-        ("inventory-inventory", "shift+i"),
-        ("inventory-equipment", "shift+e"),
-        ("inventory-character", "shift+x"),
-        ("inventory-skills-powers", "shift+p"),
-        ("inventory-quests", "shift+q"),
-        ("inventory-tinkering", "shift+k"),
-        ("inventory-journal", "shift+j"),
-    )
+def _build_final_smoke_inventory_drilldown_stage_names(
+    *,
+    tab_page_rights: int = _DEFAULT_INVENTORY_TAB_PAGE_RIGHTS,
+    item_scan_count: int = _DEFAULT_INVENTORY_ITEM_SCAN_COUNT,
+) -> list[str]:
+    return [
+        "inventory-tab-00-initial",
+        "inventory-display-options",
+        "inventory-item-00-selected",
+        "inventory-item-00-actions",
+        *[f"inventory-item-scan-{index:02d}" for index in range(1, item_scan_count + 1)],
+        *[f"inventory-tab-page-right-{index:02d}" for index in range(1, tab_page_rights + 1)],
+    ]
 
 
 def _build_final_smoke_popup_stages() -> tuple[tuple[str, str, str], ...]:
@@ -692,15 +750,34 @@ def _build_final_smoke_popup_stages() -> tuple[tuple[str, str, str], ...]:
     )
 
 
-def _build_final_smoke_stage_names() -> list[str]:
+def _build_final_smoke_character_screen_stages(
+    args: argparse.Namespace,
+) -> tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...]:
+    return (
+        ("abilities-screen", _parse_key_sequence(args.abilities_chord), ("escape",)),
+        ("active-effects-screen", _parse_key_sequence(args.active_effects_chord), ("escape", "escape")),
+    )
+
+
+def _build_final_smoke_stage_names(
+    *,
+    tab_page_rights: int = _DEFAULT_INVENTORY_TAB_PAGE_RIGHTS,
+    item_scan_count: int = _DEFAULT_INVENTORY_ITEM_SCAN_COUNT,
+) -> list[str]:
     return [
         "after-load",
-        *[label for label, _ in _build_final_smoke_inventory_stages()],
+        *_build_final_smoke_inventory_drilldown_stage_names(
+            tab_page_rights=tab_page_rights,
+            item_scan_count=item_scan_count,
+        ),
+        "abilities-screen",
+        "active-effects-screen",
         *[label for label, _, _ in _build_final_smoke_popup_stages()],
         "npc-conversation",
         "attack-or-confirmation",
         "message-log-after-attack",
         "death-or-combat-end",
+        "message-log-after-death",
     ]
 
 
@@ -834,7 +911,7 @@ def _stop_game(
     process.wait(timeout=5.0)
 
 
-def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # noqa: PLR0915 -- CLI options stay together.
     parser = argparse.ArgumentParser(
         description=(
             "Deploy QudJP, launch Caves of Qud via Rosetta, and capture translation verification screenshots."
@@ -876,6 +953,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=float,
         default=1.0,
         help="Seconds to wait after each final-smoke key action.",
+    )
+    parser.add_argument(
+        "--flow-screenshot-wait",
+        type=float,
+        default=3.0,
+        help="Seconds to wait immediately before each flow screenshot so TMP text can settle into translations.",
     )
     parser.add_argument(
         "--input-backend",
@@ -956,8 +1039,19 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--death-attack-count",
         type=int,
-        default=0,
-        help="Repeat the attack chord this many times after the first attack to drive a death/combat-end screenshot.",
+        default=_DEFAULT_DEATH_ATTACK_COUNT,
+        help=(
+            "Maximum repeated attack count after the first attack. "
+            "Use 0 to skip death/combat-end message-log evidence."
+        ),
+    )
+    parser.add_argument(
+        "--death-confirm-key",
+        default=_DEFAULT_DEATH_CONFIRM_KEY,
+        help=(
+            "Key sent after each repeated death attack to dismiss combat warning popups, "
+            "such as low-health warnings. Empty string skips the extra confirmation."
+        ),
     )
     parser.add_argument(
         "--require-combat-evidence",
@@ -1081,6 +1175,42 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Seconds to wait for inventory-related probe lines after opening inventory.",
     )
     parser.add_argument(
+        "--inventory-tab-page-rights",
+        type=int,
+        default=_DEFAULT_INVENTORY_TAB_PAGE_RIGHTS,
+        help="How many Page Right steps to capture after opening inventory in final-smoke.",
+    )
+    parser.add_argument(
+        "--inventory-item-scan-count",
+        type=int,
+        default=_DEFAULT_INVENTORY_ITEM_SCAN_COUNT,
+        help="How many selected inventory rows to capture after opening the first item action menu.",
+    )
+    parser.add_argument(
+        "--inventory-item-action-row-offset",
+        type=int,
+        default=_DEFAULT_INVENTORY_ITEM_ACTION_ROW_OFFSET,
+        help="How many Down presses to reach the first inventory item before opening its action menu.",
+    )
+    parser.add_argument(
+        "--inventory-item-pane-chord",
+        default=_DEFAULT_INVENTORY_ITEM_PANE_CHORD,
+        help="Key chord used to move focus to the inventory item list before item drilldown.",
+    )
+    parser.add_argument(
+        "--abilities-chord",
+        default=_DEFAULT_ABILITIES_CHORD,
+        help="Key chord used to open the Manage Abilities screen during final-smoke.",
+    )
+    parser.add_argument(
+        "--active-effects-chord",
+        default=_DEFAULT_ACTIVE_EFFECTS_CHORD,
+        help=(
+            "Comma-separated key chord sequence used to open active effects during final-smoke. "
+            "Defaults to opening attributes, then the status effects action."
+        ),
+    )
+    parser.add_argument(
         "--inventory-pattern",
         action="append",
         help=(
@@ -1173,11 +1303,21 @@ def _continue_from_title(process: subprocess.Popen[bytes], args: argparse.Namesp
 
 
 @dataclass
+class _StageCapture:
+    label: str
+    screenshot_path: str
+    log_start_offset: int
+    log_end_offset: int
+
+
+@dataclass
 class _FlowCapture:
     pid: int
     output_dir: Path
     screenshot_paths: list[str]
+    stage_captures: list[_StageCapture]
     wait: float
+    screenshot_wait: float
     input_backend: str
     index: int = 1
 
@@ -1187,10 +1327,26 @@ class _FlowCapture:
         _send_key_chord(self.pid, chord, self.input_backend)
         time.sleep(self.wait if wait is None else wait)
 
-    def screenshot(self, label: str) -> None:
+    def send_sequence(self, sequence: tuple[str, ...]) -> None:
+        for chord in sequence:
+            self.send(chord)
+
+    def screenshot(self, label: str, log_start_offset: int | None = None) -> None:
+        start_offset = _current_log_offset(_PLAYER_LOG) if log_start_offset is None else log_start_offset
+        if self.screenshot_wait > 0:
+            time.sleep(self.screenshot_wait)
         _stabilize_game_focus(self.pid)
         path = _capture_flow_screenshot(self.output_dir, self.index, label)
+        end_offset = _current_log_offset(_PLAYER_LOG)
         self.screenshot_paths.append(str(path))
+        self.stage_captures.append(
+            _StageCapture(
+                label=label,
+                screenshot_path=str(path),
+                log_start_offset=start_offset,
+                log_end_offset=end_offset,
+            ),
+        )
         self.index += 1
 
     def close_popup(self) -> None:
@@ -1198,14 +1354,268 @@ class _FlowCapture:
         time.sleep(self.wait)
 
     def inventory_stage(self, label: str, chord: str) -> None:
+        stage_start_offset = _current_log_offset(_PLAYER_LOG)
         self.send(chord)
-        self.screenshot(label)
+        self.screenshot(label, stage_start_offset)
         self.close_popup()
 
     def popup_stage(self, label: str, chord: str, close_chord: str) -> None:
+        stage_start_offset = _current_log_offset(_PLAYER_LOG)
         self.send(chord)
-        self.screenshot(label)
+        self.screenshot(label, stage_start_offset)
         self.send(close_chord)
+
+    def screen_stage(self, label: str, open_sequence: tuple[str, ...], close_sequence: tuple[str, ...]) -> None:
+        stage_start_offset = _current_log_offset(_PLAYER_LOG)
+        self.send_sequence(open_sequence)
+        self.screenshot(label, stage_start_offset)
+        self.send_sequence(close_sequence)
+
+
+def _run_inventory_drilldown(capture: _FlowCapture, args: argparse.Namespace) -> None:
+    stage_start_offset = _current_log_offset(_PLAYER_LOG)
+    capture.send(args.inventory_key)
+    capture.screenshot("inventory-tab-00-initial", stage_start_offset)
+
+    _capture_inventory_display_options(capture)
+    _capture_inventory_first_item_actions(
+        capture,
+        args.inventory_item_action_row_offset,
+        args.inventory_item_pane_chord,
+    )
+    _capture_inventory_item_scan(capture, args.inventory_item_scan_count)
+    _capture_inventory_tabs_by_page_right(capture, args.inventory_tab_page_rights)
+
+    capture.send("escape")
+
+
+def _capture_inventory_display_options(capture: _FlowCapture) -> None:
+    stage_start_offset = _current_log_offset(_PLAYER_LOG)
+    capture.send("tab")
+    capture.screenshot("inventory-display-options", stage_start_offset)
+    capture.send("escape")
+
+
+def _capture_inventory_first_item_actions(capture: _FlowCapture, row_offset: int, item_pane_chord: str) -> None:
+    stage_start_offset = _current_log_offset(_PLAYER_LOG)
+    capture.send(item_pane_chord)
+    for _ in range(row_offset):
+        capture.send("down")
+    capture.screenshot("inventory-item-00-selected", stage_start_offset)
+
+    action_stage_start_offset = _current_log_offset(_PLAYER_LOG)
+    capture.send("enter")
+    capture.screenshot("inventory-item-00-actions", action_stage_start_offset)
+    capture.send("escape")
+
+
+def _capture_inventory_item_scan(capture: _FlowCapture, item_scan_count: int) -> None:
+    for index in range(1, item_scan_count + 1):
+        stage_start_offset = _current_log_offset(_PLAYER_LOG)
+        capture.send("down")
+        capture.screenshot(f"inventory-item-scan-{index:02d}", stage_start_offset)
+
+
+def _capture_inventory_tabs_by_page_right(capture: _FlowCapture, tab_page_rights: int) -> None:
+    for index in range(1, tab_page_rights + 1):
+        stage_start_offset = _current_log_offset(_PLAYER_LOG)
+        capture.send("end")
+        capture.screenshot(f"inventory-tab-page-right-{index:02d}", stage_start_offset)
+
+
+def _build_verification_report(stage_captures: list[_StageCapture], log_path: Path) -> dict[str, object]:
+    stages = [_build_stage_verification(stage, log_path) for stage in stage_captures]
+    return {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "player_log_path": str(log_path),
+        "summary": _build_verification_summary(stages),
+        "stages": stages,
+    }
+
+
+def _write_verification_report(report: dict[str, object], output_dir: Path) -> Path:
+    report_path = output_dir / "verification_report.json"
+    report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    return report_path
+
+
+def _build_stage_verification(stage: _StageCapture, log_path: Path) -> dict[str, object]:
+    log_text = _read_log_range(log_path, stage.log_start_offset, stage.log_end_offset)
+    entries = parse_log_text(log_text)
+    results = [classify(entry) for entry in entries]
+    markup_issues = _markup_issue_candidates(entries)
+    summary = _build_stage_summary(results)
+    summary["markup_color_tag_issue_candidates"] = len(markup_issues)
+    return {
+        "stage": stage.label,
+        "screenshot_path": stage.screenshot_path,
+        "log_start_offset": stage.log_start_offset,
+        "log_end_offset": stage.log_end_offset,
+        "summary": summary,
+        "translated_events": [_serialize_result(result) for result in _translated_results(results)],
+        "missing_key_candidates": [_serialize_result(result) for result in _missing_key_candidates(results)],
+        "message_pattern_gaps": [_serialize_result(result) for result in _message_pattern_gaps(results)],
+        "sink_observed_untranslated_candidates": [
+            _serialize_result(result) for result in _sink_observed_untranslated_candidates(results)
+        ],
+        "message_log_candidates": [_serialize_result(result) for result in _message_log_candidates(results)],
+        "markup_color_tag_issue_candidates": markup_issues,
+        "preserved_english": [_serialize_result(result) for result in _preserved_english_results(results)],
+    }
+
+
+def _build_stage_summary(results: list[TriageResult]) -> dict[str, object]:
+    counts = {
+        "translated_events": len(_translated_results(results)),
+        "missing_key_candidates": len(_missing_key_candidates(results)),
+        "message_pattern_gaps": len(_message_pattern_gaps(results)),
+        "sink_observed_untranslated_candidates": len(_sink_observed_untranslated_candidates(results)),
+        "message_log_candidates": len(_message_log_candidates(results)),
+        "preserved_english": len(_preserved_english_results(results)),
+    }
+    return {
+        **counts,
+        "by_route": _count_results_by_route(results),
+    }
+
+
+def _build_verification_summary(stages: list[dict[str, object]]) -> dict[str, object]:
+    totals: dict[str, int] = {
+        "stage_count": len(stages),
+        "translated_events": 0,
+        "missing_key_candidates": 0,
+        "message_pattern_gaps": 0,
+        "sink_observed_untranslated_candidates": 0,
+        "message_log_candidates": 0,
+        "markup_color_tag_issue_candidates": 0,
+        "preserved_english": 0,
+    }
+    by_stage: dict[str, dict[str, int]] = {}
+    by_route: dict[str, int] = {}
+    for stage in stages:
+        stage_name = str(stage["stage"])
+        stage_summary = stage["summary"]
+        if not isinstance(stage_summary, dict):
+            continue
+        by_stage[stage_name] = _int_counts(stage_summary)
+        for key in totals:
+            if key == "stage_count":
+                continue
+            totals[key] += int(stage_summary.get(key, 0))
+        stage_routes = stage_summary.get("by_route", {})
+        if isinstance(stage_routes, dict):
+            for route, count in stage_routes.items():
+                by_route[str(route)] = by_route.get(str(route), 0) + int(count)
+
+    return {**totals, "by_stage": by_stage, "by_route": dict(sorted(by_route.items()))}
+
+
+def _translated_results(results: list[TriageResult]) -> list[TriageResult]:
+    return [
+        result
+        for result in results
+        if result.entry.kind == LogEntryKind.DYNAMIC_TEXT_PROBE and result.entry.changed is True
+    ]
+
+
+def _missing_key_candidates(results: list[TriageResult]) -> list[TriageResult]:
+    return [
+        result
+        for result in results
+        if result.entry.kind == LogEntryKind.MISSING_KEY
+        and result.classification != TriageClassification.PRESERVED_ENGLISH
+    ]
+
+
+def _message_pattern_gaps(results: list[TriageResult]) -> list[TriageResult]:
+    return [result for result in results if result.entry.kind == LogEntryKind.NO_PATTERN]
+
+
+def _sink_observed_untranslated_candidates(results: list[TriageResult]) -> list[TriageResult]:
+    return [
+        result
+        for result in results
+        if result.entry.kind == LogEntryKind.SINK_OBSERVE
+        and result.classification != TriageClassification.PRESERVED_ENGLISH
+        and _has_ascii_word_candidate(result.entry.text)
+    ]
+
+
+def _message_log_candidates(results: list[TriageResult]) -> list[TriageResult]:
+    return [
+        result
+        for result in results
+        if result.entry.kind == LogEntryKind.NO_PATTERN or result.entry.route in _MESSAGE_LOG_ROUTES
+    ]
+
+
+def _preserved_english_results(results: list[TriageResult]) -> list[TriageResult]:
+    return [result for result in results if result.classification == TriageClassification.PRESERVED_ENGLISH]
+
+
+def _has_ascii_word_candidate(text: str) -> bool:
+    return _ASCII_WORD_PATTERN.search(text) is not None
+
+
+def _markup_issue_candidates(entries: list[LogEntry]) -> list[dict[str, object]]:
+    candidates: list[dict[str, object]] = []
+    for entry in entries:
+        if entry.kind != LogEntryKind.DYNAMIC_TEXT_PROBE or entry.translated_text is None:
+            continue
+        source_markup = _markup_signature(entry.text)
+        translated_markup = _markup_signature(entry.translated_text)
+        if source_markup == translated_markup:
+            continue
+        candidates.append(
+            {
+                "text": entry.text,
+                "translated_text": entry.translated_text,
+                "route": entry.route,
+                "kind": entry.kind.value,
+                "line_number": entry.line_number,
+                "source_markup": source_markup,
+                "translated_markup": translated_markup,
+            },
+        )
+    return candidates
+
+
+def _markup_signature(text: str) -> list[str]:
+    return _MARKUP_TOKEN_PATTERN.findall(text)
+
+
+def _count_results_by_route(results: list[TriageResult]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for result in results:
+        counts[result.entry.route] = counts.get(result.entry.route, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _int_counts(summary: dict[object, object]) -> dict[str, int]:
+    return {str(key): int(value) for key, value in summary.items() if isinstance(value, int)}
+
+
+def _serialize_result(result: TriageResult) -> dict[str, object]:
+    entry = result.entry
+    payload: dict[str, object] = {
+        "text": entry.text,
+        "route": entry.route,
+        "kind": entry.kind.value,
+        "line_number": entry.line_number,
+        "classification": result.classification.value,
+        "reason": result.reason,
+    }
+    if entry.hits is not None:
+        payload["hits"] = entry.hits
+    if entry.family is not None:
+        payload["family"] = entry.family
+    if entry.translated_text is not None:
+        payload["translated_text"] = entry.translated_text
+    if entry.changed is not None:
+        payload["changed"] = entry.changed
+    if result.slot_evidence:
+        payload["slot_evidence"] = result.slot_evidence
+    return payload
 
 
 def _confirm_attack_if_requested(capture: _FlowCapture, confirm_key: str) -> None:
@@ -1215,44 +1625,71 @@ def _confirm_attack_if_requested(capture: _FlowCapture, confirm_key: str) -> Non
     time.sleep(capture.wait)
 
 
-def _capture_message_log_after_attack(capture: _FlowCapture, message_log_chord: str) -> None:
+def _capture_message_log(capture: _FlowCapture, message_log_chord: str, label: str) -> None:
+    stage_start_offset = _current_log_offset(_PLAYER_LOG)
     if message_log_chord:
         capture.send(message_log_chord)
-    capture.screenshot("message-log-after-attack")
+    capture.screenshot(label, stage_start_offset)
     if message_log_chord:
         capture.close_popup()
 
 
-def _send_attack_sequence(capture: _FlowCapture, sequence: tuple[str, ...], attempt_index: int | None = None) -> None:
+def _capture_message_log_after_attack(capture: _FlowCapture, message_log_chord: str) -> None:
+    _capture_message_log(capture, message_log_chord, "message-log-after-attack")
+
+
+def _capture_message_log_after_death(capture: _FlowCapture, message_log_chord: str) -> None:
+    _capture_message_log(capture, message_log_chord, "message-log-after-death")
+
+
+def _send_attack_sequence(
+    capture: _FlowCapture,
+    sequence: tuple[str, ...],
+    attempt_index: int | None = None,
+    *,
+    capture_steps: bool = True,
+) -> None:
     for chord_index, chord in enumerate(sequence):
+        stage_start_offset = _current_log_offset(_PLAYER_LOG)
         capture.send(chord)
         is_last_chord = chord_index + 1 == len(sequence)
-        if not is_last_chord:
+        if capture_steps and not is_last_chord:
             if attempt_index is None:
                 label = f"attack-sequence-step-{chord_index + 1}"
             else:
                 label = f"attack-attempt-{attempt_index}-step-{chord_index + 1}"
-            capture.screenshot(label)
+            capture.screenshot(label, stage_start_offset)
 
 
 def _repeat_death_attacks(
     capture: _FlowCapture,
     attack_sequence: tuple[str, ...],
     confirm_key: str,
+    death_confirm_key: str,
     count: int,
-) -> None:
+) -> tuple[list[str], str]:
+    pre_death_offset = _current_log_offset(_PLAYER_LOG)
+    death_evidence_matches: list[str] = []
     for _ in range(count):
-        _send_attack_sequence(capture, attack_sequence)
+        _send_attack_sequence(capture, attack_sequence, capture_steps=False)
         _confirm_attack_if_requested(capture, confirm_key)
+        _confirm_attack_if_requested(capture, death_confirm_key)
+        death_log_delta = _read_log_delta(_PLAYER_LOG, pre_death_offset)
+        death_evidence_matches = _death_evidence_matches(death_log_delta)
+        if death_evidence_matches:
+            break
 
     if count:
-        capture.screenshot("death-or-combat-end")
+        capture.screenshot("death-or-combat-end", pre_death_offset)
+
+    death_log_delta = _read_log_delta(_PLAYER_LOG, pre_death_offset)
+    return _death_evidence_matches(death_log_delta), death_log_delta
 
 
 def _perform_final_smoke_attack_check(
     capture: _FlowCapture,
     args: argparse.Namespace,
-) -> tuple[list[str], str, tuple[str, ...]]:
+) -> tuple[list[str], str, tuple[str, ...], list[str], str]:
     pre_attack_offset = _current_log_offset(_PLAYER_LOG)
     attack_sequences = _attack_sequences(args)
     successful_sequence = attack_sequences[-1]
@@ -1260,11 +1697,12 @@ def _perform_final_smoke_attack_check(
 
     for attempt_index, attack_sequence in enumerate(attack_sequences, start=1):
         successful_sequence = attack_sequence
+        stage_start_offset = _current_log_offset(_PLAYER_LOG)
         _send_attack_sequence(capture, attack_sequence, attempt_index if len(attack_sequences) > 1 else None)
         label = "attack-or-confirmation"
         if len(attack_sequences) > 1:
             label = f"attack-attempt-{attempt_index}-result"
-        capture.screenshot(label)
+        capture.screenshot(label, stage_start_offset)
         _confirm_attack_if_requested(capture, args.attack_confirm_key)
 
         combat_log_delta = _read_log_delta(_PLAYER_LOG, pre_attack_offset)
@@ -1272,11 +1710,28 @@ def _perform_final_smoke_attack_check(
         if combat_evidence_matches:
             break
 
-    _capture_message_log_after_attack(capture, args.message_log_chord)
-    _repeat_death_attacks(capture, successful_sequence, args.attack_confirm_key, args.death_attack_count)
+    if args.death_attack_count:
+        death_evidence_matches, death_log_delta = _repeat_death_attacks(
+            capture,
+            successful_sequence,
+            args.attack_confirm_key,
+            args.death_confirm_key,
+            args.death_attack_count,
+        )
+        _capture_message_log_after_death(capture, args.message_log_chord)
+    else:
+        _capture_message_log_after_attack(capture, args.message_log_chord)
+        death_evidence_matches = []
+        death_log_delta = ""
 
     combat_log_delta = _read_log_delta(_PLAYER_LOG, pre_attack_offset)
-    return _combat_evidence_matches(combat_log_delta), combat_log_delta, successful_sequence
+    return (
+        _combat_evidence_matches(combat_log_delta),
+        combat_log_delta,
+        successful_sequence,
+        death_evidence_matches,
+        death_log_delta,
+    )
 
 
 def _run_combat_smoke_flow(
@@ -1287,7 +1742,16 @@ def _run_combat_smoke_flow(
     output_dir = args.flow_screenshot_dir
     output_dir.mkdir(parents=True, exist_ok=True)
     screenshot_paths: list[str] = []
-    capture = _FlowCapture(process.pid, output_dir, screenshot_paths, args.flow_step_wait, args.input_backend)
+    stage_captures: list[_StageCapture] = []
+    capture = _FlowCapture(
+        process.pid,
+        output_dir,
+        screenshot_paths,
+        stage_captures,
+        args.flow_step_wait,
+        args.flow_screenshot_wait,
+        args.input_backend,
+    )
 
     capture.screenshot("after-load")
     if args.npc_poi_key:
@@ -1295,13 +1759,21 @@ def _run_combat_smoke_flow(
         capture.send(args.npc_poi_key, args.poi_travel_wait)
     capture.screenshot("before-combat")
 
-    combat_evidence_matches, combat_log_delta, successful_attack_sequence = _perform_final_smoke_attack_check(
+    (
+        combat_evidence_matches,
+        combat_log_delta,
+        successful_attack_sequence,
+        death_evidence_matches,
+        death_log_delta,
+    ) = _perform_final_smoke_attack_check(
         capture,
         args,
     )
     if not combat_evidence_matches:
         _raise_missing_combat_evidence(output_dir)
 
+    verification_report = _build_verification_report(stage_captures, _PLAYER_LOG)
+    verification_report_path = _write_verification_report(verification_report, output_dir)
     return {
         "build_marker_found": True,
         "load_ready_found": bool(load_ready_matches),
@@ -1310,11 +1782,18 @@ def _run_combat_smoke_flow(
         "flow": "combat-smoke",
         "screenshot_dir": str(output_dir),
         "screenshot_paths": screenshot_paths,
+        "verification_report_path": str(verification_report_path),
+        "verification_report": verification_report,
         "combat_evidence_found": True,
         "combat_evidence_matches": combat_evidence_matches,
+        "death_attack_count": args.death_attack_count,
+        "death_confirm_key": args.death_confirm_key,
+        "death_evidence_found": bool(death_evidence_matches),
+        "death_evidence_matches": death_evidence_matches,
         "attack_sequences": [list(sequence) for sequence in _attack_sequences(args)],
         "successful_attack_sequence": list(successful_attack_sequence),
         "combat_log_excerpt": combat_log_delta.splitlines()[-40:],
+        "death_log_excerpt": death_log_delta.splitlines()[-40:],
     }
 
 
@@ -1326,12 +1805,23 @@ def _run_final_smoke_flow(
     output_dir = args.flow_screenshot_dir
     output_dir.mkdir(parents=True, exist_ok=True)
     screenshot_paths: list[str] = []
-    capture = _FlowCapture(process.pid, output_dir, screenshot_paths, args.flow_step_wait, args.input_backend)
+    stage_captures: list[_StageCapture] = []
+    capture = _FlowCapture(
+        process.pid,
+        output_dir,
+        screenshot_paths,
+        stage_captures,
+        args.flow_step_wait,
+        args.flow_screenshot_wait,
+        args.input_backend,
+    )
 
     capture.screenshot("after-load")
 
-    for label, chord in _build_final_smoke_inventory_stages():
-        capture.inventory_stage(label, chord)
+    _run_inventory_drilldown(capture, args)
+
+    for label, open_sequence, close_sequence in _build_final_smoke_character_screen_stages(args):
+        capture.screen_stage(label, open_sequence, close_sequence)
 
     for label, chord, close_chord in _build_final_smoke_popup_stages():
         capture.popup_stage(label, chord, close_chord)
@@ -1340,38 +1830,61 @@ def _run_final_smoke_flow(
         capture.send("backspace")
         capture.send(args.npc_poi_key, args.poi_travel_wait)
 
+    npc_stage_start_offset = _current_log_offset(_PLAYER_LOG)
     capture.send(args.npc_talk_key)
     capture.send(args.npc_talk_direction)
-    capture.screenshot("npc-conversation")
+    capture.screenshot("npc-conversation", npc_stage_start_offset)
     capture.close_popup()
 
-    combat_evidence_matches, combat_log_delta, successful_attack_sequence = _perform_final_smoke_attack_check(
+    (
+        combat_evidence_matches,
+        combat_log_delta,
+        successful_attack_sequence,
+        death_evidence_matches,
+        death_log_delta,
+    ) = _perform_final_smoke_attack_check(
         capture,
         args,
     )
     if args.require_combat_evidence and not combat_evidence_matches:
         _raise_missing_combat_evidence(output_dir)
 
+    verification_report = _build_verification_report(stage_captures, _PLAYER_LOG)
+    verification_report_path = _write_verification_report(verification_report, output_dir)
     return {
         "build_marker_found": True,
         "load_ready_found": bool(load_ready_matches),
         "load_ready_matches": load_ready_matches,
         "player_log_path": str(_PLAYER_LOG),
         "flow": "final-smoke",
-        "flow_stage_names": _build_final_smoke_stage_names(),
+        "flow_stage_names": _build_final_smoke_stage_names(
+            tab_page_rights=args.inventory_tab_page_rights,
+            item_scan_count=args.inventory_item_scan_count,
+        ),
         "screenshot_dir": str(output_dir),
         "screenshot_paths": screenshot_paths,
+        "verification_report_path": str(verification_report_path),
+        "verification_report": verification_report,
         "death_attack_count": args.death_attack_count,
+        "death_confirm_key": args.death_confirm_key,
         "combat_evidence_found": bool(combat_evidence_matches),
         "combat_evidence_matches": combat_evidence_matches,
+        "death_evidence_found": bool(death_evidence_matches),
+        "death_evidence_matches": death_evidence_matches,
         "attack_sequences": [list(sequence) for sequence in _attack_sequences(args)],
         "successful_attack_sequence": list(successful_attack_sequence),
         "combat_log_excerpt": combat_log_delta.splitlines()[-40:],
+        "death_log_excerpt": death_log_delta.splitlines()[-40:],
     }
 
 
 def _raise_invalid_death_attack_count() -> None:
     msg = "--death-attack-count must be 0 or greater."
+    raise ValueError(msg)
+
+
+def _raise_invalid_nonnegative_option(option: str) -> None:
+    msg = f"--{option} must be 0 or greater."
     raise ValueError(msg)
 
 
@@ -1387,6 +1900,18 @@ def _raise_missing_combat_evidence(output_dir: Path) -> None:
 def _validate_runtime_args(args: argparse.Namespace) -> None:
     if args.death_attack_count < 0:
         _raise_invalid_death_attack_count()
+    if args.inventory_tab_page_rights < 0:
+        _raise_invalid_nonnegative_option("inventory-tab-page-rights")
+    if args.inventory_item_scan_count < 0:
+        _raise_invalid_nonnegative_option("inventory-item-scan-count")
+    if args.inventory_item_action_row_offset < 0:
+        _raise_invalid_nonnegative_option("inventory-item-action-row-offset")
+    if args.inventory_item_pane_chord:
+        _parse_key_chord(args.inventory_item_pane_chord)
+    if args.abilities_chord:
+        _parse_key_sequence(args.abilities_chord)
+    if args.active_effects_chord:
+        _parse_key_sequence(args.active_effects_chord)
     _attack_sequences(args)
 
 

--- a/scripts/triage/classifier.py
+++ b/scripts/triage/classifier.py
@@ -6,6 +6,7 @@ import re
 from typing import TYPE_CHECKING
 
 from scripts.triage.models import LogEntry, LogEntryKind, TriageClassification, TriageResult
+from scripts.triage.preserved_policy import classify_preserved_english
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -49,6 +50,7 @@ _KNOWN_STATIC_LABELS = frozenset(
 def classify(entry: LogEntry) -> TriageResult:
     """Classify a single untranslated string observation."""
     classifiers: tuple[Callable[[LogEntry], TriageResult | None], ...] = (
+        classify_preserved_english,
         _classify_dynamic_probe,
         _classify_sink_observe,
         _classify_fragment,

--- a/scripts/triage/log_parser.py
+++ b/scripts/triage/log_parser.py
@@ -157,11 +157,20 @@ def parse_log(log_path: Path) -> list[LogEntry]:
     if not log_path.exists():
         return []
 
+    return parse_log_text(log_path.read_text(encoding="utf-8", errors="replace"))
+
+
+def parse_log_text(text: str) -> list[LogEntry]:
+    """Parse Player.log text into deduplicated ``LogEntry`` records.
+
+    Args:
+        text: Log text to parse.
+
+    Returns:
+        Deduplicated entries sorted by line number, route, and text.
+    """
     seen: dict[tuple[str, str, str, str, str, str], LogEntry] = {}
-    for line_number, line in enumerate(
-        log_path.read_text(encoding="utf-8", errors="replace").splitlines(),
-        start=1,
-    ):
+    for line_number, line in enumerate(text.splitlines(), start=1):
         entry = _try_parse_line(line, line_number)
         if entry is None:
             continue

--- a/scripts/triage/models.py
+++ b/scripts/triage/models.py
@@ -27,6 +27,8 @@ class TriageClassification(Enum):
     STATIC_LEAF = "static_leaf"
     ROUTE_PATCH = "route_patch"
     LOGIC_REQUIRED = "logic_required"
+    PRESERVED_ENGLISH = "preserved_english"
+    UNEXPECTED_TRANSLATION_OF_PRESERVED_TOKEN = "unexpected_translation_of_preserved_token"  # noqa: S105
     UNRESOLVED = "unresolved"
 
 

--- a/scripts/triage/preserved_english_policy.json
+++ b/scripts/triage/preserved_english_policy.json
@@ -1,0 +1,123 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "id": "character_attribute_line_short_labels",
+      "category": "must_remain_english",
+      "reason": "Character attribute short labels are kept in English to avoid layout shifts; route help text carries the Japanese expansion.",
+      "routes": [
+        "CharacterAttributeLineTranslationPatch",
+        "CharacterStatusScreenTranslationPatch",
+        "DescriptionLongDescriptionPatch",
+        "LookTooltipContentPatch",
+        "UITextSkinTranslationPatch"
+      ],
+      "texts": [
+        "STR",
+        "AGI",
+        "TOU",
+        "INT",
+        "WIL",
+        "EGO",
+        "MS",
+        "AV",
+        "DV",
+        "MA"
+      ],
+      "patterns": [
+        "^[+-]\\d+\\s+(?:STR|AGI|TOU|INT|WIL|EGO|MS|AV|DV|MA)$"
+      ],
+      "protected_tokens": [
+        "STR",
+        "AGI",
+        "TOU",
+        "INT",
+        "WIL",
+        "EGO",
+        "MS",
+        "AV",
+        "DV",
+        "MA"
+      ],
+      "dictionary_contexts": [
+        "Qud.UI.CharacterAttributeLine.AttributeLabel"
+      ]
+    },
+    {
+      "id": "key_labels_and_hotkeys",
+      "category": "allowed_english_token",
+      "reason": "Keyboard labels and hotkey-only segments are control tokens, not translation targets.",
+      "texts": [
+        "Tab",
+        "Esc",
+        "Enter",
+        "Space",
+        "Delete"
+      ],
+      "patterns": [
+        "^\\[(?:Tab|Esc|Enter|Space|Delete|[A-Z])\\]$"
+      ],
+      "protected_tokens": [
+        "Tab",
+        "Esc",
+        "Enter",
+        "Space",
+        "Delete"
+      ]
+    },
+    {
+      "id": "trade_totals_compact_weight_unit",
+      "category": "allowed_english_by_route",
+      "reason": "Trade total labels intentionally keep the compact lbs. unit while translating drams separately.",
+      "routes": [
+        "TradeScreenUpdateTotalsTranslationPatch"
+      ],
+      "patterns": [
+        "\\blbs\\.",
+        "\\blbs\\.\\}\\}"
+      ],
+      "protected_tokens": [
+        "lbs."
+      ]
+    },
+    {
+      "id": "numeric_or_glyph_only_text",
+      "category": "numeric_or_glyph_only_text",
+      "reason": "Numeric counters and glyph-only UI chrome do not carry translatable prose.",
+      "patterns": [
+        "^\\s*-?\\d+(?:[/:.]\\d+)*(?:#|%)?\\s*$",
+        "^[\\[\\]{}|<>\\-+*/:;.,!?$#%→←■□\\s]+$"
+      ]
+    },
+    {
+      "id": "product_and_mod_proper_nouns",
+      "category": "allowed_english_token",
+      "reason": "Product and mod-domain proper nouns are intentionally preserved in English.",
+      "texts": [
+        "Caves",
+        "Qud",
+        "of",
+        "Mod",
+        "Caves of Qud"
+      ],
+      "protected_tokens": [
+        "Caves",
+        "Qud",
+        "of",
+        "Mod"
+      ]
+    },
+    {
+      "id": "player_authored_free_text",
+      "category": "player_authored_text",
+      "reason": "Player-authored journal or note text should remain user-authored rather than machine translated.",
+      "routes": [
+        "PlayerAuthoredJournalText",
+        "JournalPlayerAuthoredText"
+      ],
+      "patterns": [
+        ".+"
+      ]
+    }
+  ]
+}

--- a/scripts/triage/preserved_policy.py
+++ b/scripts/triage/preserved_policy.py
@@ -1,0 +1,128 @@
+"""Classify intentionally preserved English text from a route-aware policy."""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from scripts.triage.models import LogEntry, LogEntryKind, TriageClassification, TriageResult
+
+_POLICY_PATH = Path(__file__).with_name("preserved_english_policy.json")
+
+
+@dataclass(frozen=True)
+class PreservedEnglishRule:
+    """One route-aware preserved-English policy rule."""
+
+    id: str
+    category: str
+    reason: str
+    routes: tuple[str, ...]
+    texts: frozenset[str]
+    patterns: tuple[str, ...]
+    protected_tokens: tuple[str, ...]
+    dictionary_contexts: tuple[str, ...]
+
+    @classmethod
+    def from_json(cls, payload: dict[str, Any]) -> PreservedEnglishRule:
+        """Create a rule from the machine-readable policy payload."""
+        return cls(
+            id=str(payload["id"]),
+            category=str(payload["category"]),
+            reason=str(payload["reason"]),
+            routes=tuple(str(route) for route in payload.get("routes", ())),
+            texts=frozenset(str(text) for text in payload.get("texts", ())),
+            patterns=tuple(str(pattern) for pattern in payload.get("patterns", ())),
+            protected_tokens=tuple(str(token) for token in payload.get("protected_tokens", ())),
+            dictionary_contexts=tuple(str(context) for context in payload.get("dictionary_contexts", ())),
+        )
+
+    def matches_route(self, route: str) -> bool:
+        """Return whether this rule applies to ``route``."""
+        return not self.routes or any(fnmatch.fnmatchcase(route, route_pattern) for route_pattern in self.routes)
+
+    def matches_text(self, text: str) -> bool:
+        """Return whether this rule applies to ``text``."""
+        return text in self.texts or any(re.search(pattern, text) for pattern in self.patterns)
+
+    def protected_tokens_in(self, text: str) -> list[str]:
+        """Return protected tokens from this rule that appear in ``text``."""
+        return [token for token in self.protected_tokens if _contains_token(text, token)]
+
+
+@dataclass(frozen=True)
+class PreservedEnglishPolicy:
+    """Machine-readable preserved-English policy."""
+
+    version: int
+    rules: tuple[PreservedEnglishRule, ...]
+
+    @classmethod
+    def from_json(cls, payload: dict[str, Any]) -> PreservedEnglishPolicy:
+        """Create a policy from a decoded JSON payload."""
+        return cls(
+            version=int(payload["version"]),
+            rules=tuple(PreservedEnglishRule.from_json(rule) for rule in payload.get("rules", ())),
+        )
+
+
+@lru_cache(maxsize=1)
+def load_preserved_english_policy() -> PreservedEnglishPolicy:
+    """Load the route-aware preserved-English policy."""
+    return PreservedEnglishPolicy.from_json(json.loads(_POLICY_PATH.read_text(encoding="utf-8")))
+
+
+def classify_preserved_english(entry: LogEntry) -> TriageResult | None:
+    """Classify a log entry using the preserved-English policy."""
+    for rule in load_preserved_english_policy().rules:
+        if rule.category == "numeric_or_glyph_only_text":
+            continue
+        if not rule.matches_route(entry.route) or not rule.matches_text(entry.text):
+            continue
+
+        unexpected_tokens = _unexpectedly_translated_tokens(entry, rule)
+        if unexpected_tokens:
+            return TriageResult(
+                entry=entry,
+                classification=TriageClassification.UNEXPECTED_TRANSLATION_OF_PRESERVED_TOKEN,
+                reason=_format_reason(rule, "Protected English token was translated unexpectedly"),
+                slot_evidence=unexpected_tokens,
+            )
+
+        return TriageResult(
+            entry=entry,
+            classification=TriageClassification.PRESERVED_ENGLISH,
+            reason=_format_reason(rule, "Allowed by preserved-English policy"),
+            slot_evidence=rule.protected_tokens_in(entry.text) or [rule.id],
+        )
+
+    return None
+
+
+def _unexpectedly_translated_tokens(entry: LogEntry, rule: PreservedEnglishRule) -> list[str]:
+    """Return protected tokens that disappeared from a translated runtime probe."""
+    if rule.category != "must_remain_english":
+        return []
+    if entry.kind != LogEntryKind.DYNAMIC_TEXT_PROBE or not entry.changed or entry.translated_text is None:
+        return []
+
+    source_tokens = rule.protected_tokens_in(entry.text)
+    if not source_tokens:
+        return []
+    return [token for token in source_tokens if not _contains_token(entry.translated_text or "", token)]
+
+
+def _format_reason(rule: PreservedEnglishRule, prefix: str) -> str:
+    """Build a stable human-readable reason."""
+    return f"{prefix}: {rule.id} ({rule.category}) - {rule.reason}"
+
+
+def _contains_token(text: str, token: str) -> bool:
+    """Return whether ``token`` appears as a standalone ASCII token in ``text``."""
+    escaped = re.escape(token)
+    return re.search(rf"(?<![A-Za-z0-9]){escaped}(?![A-Za-z0-9])", text) is not None


### PR DESCRIPTION
## Summary

- Adds a preserved-English policy file and classifier support so approved English tokens are separated from actionable missing-key triage.
- Removes stale preserved-English attribute/status abbreviations from the UI attribute dictionary.
- Extends the L3 translation checker to capture stage-aware verification reports, inventory drilldown tabs/items, abilities, active effects, delayed screenshots, combat-to-death evidence, and post-death message logs.

## Why

Issues 373 and 374 need runtime evidence that distinguishes intentional English from localization gaps, and the final smoke flow needs to cover the screens reachable from inventory plus combat messages through the player's death. The previous combat smoke could stop at low-health warning popups and miss the final message log.

## Validation

- `ruff check scripts/`
- `uv run --with pytest python -m pytest scripts/tests/ -q` (`325 passed`)
- `git diff --check`
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1` (`1104 passed`)
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2` (`698 passed`)
- Practical combat smoke: `python3.12 scripts/translation_checker.py --skip-sync --flow combat-smoke --input-backend osascript --flow-screenshot-dir /tmp/qudjp-l3-combat-smoke-death-confirm`, confirming `You died`, `You were killed by ...`, and `HP: 0 / 17` in the collected report/screenshots.