### PR TITLE
fix color restoration regressions and add initial PBT coverage

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorCodePreserverTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorCodePreserverTests.cs
@@ -170,6 +170,20 @@ public sealed class ColorCodePreserverTests
     }
 
     [Test]
+    public void RestoreCapture_PreservesEmptyWrapperAtCaptureEnd()
+    {
+        var input = "{{C|TARGET: タム、ドロマド商団 [座っている]{{B|}}}}";
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(input);
+        var match = Regex.Match(stripped, "^(?<label>TARGET:) (?<name>.+)$");
+
+        Assert.That(match.Success, Is.True);
+
+        var restored = ColorAwareTranslationComposer.RestoreCapture("タム、ドロマド商団 [座っている]", spans, match.Groups["name"]);
+
+        Assert.That(restored, Is.EqualTo("タム、ドロマド商団 [座っている]{{B|}}}}"));
+    }
+
+    [Test]
     public void TranslatePreservingColors_PreservesTerminalSingleCharacterWrapper()
     {
         var translated = ColorAwareTranslationComposer.TranslatePreservingColors(

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorCodePreserverTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorCodePreserverTests.cs
@@ -170,6 +170,24 @@ public sealed class ColorCodePreserverTests
     }
 
     [Test]
+    public void SliceSpans_DoesNotTreatAdjacentColorCodeOpenersAsCaptureClosers()
+    {
+        var input = "{{R|lead}}^rslug^k";
+        var (stripped, spans) = ColorCodePreserver.Strip(input);
+
+        var first = ColorCodePreserver.Restore("鉛", ColorCodePreserver.SliceSpans(spans, 0, 4));
+        var second = ColorCodePreserver.Restore("弾", ColorCodePreserver.SliceSpans(spans, 4, 4));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stripped, Is.EqualTo("leadslug"));
+            Assert.That(first, Is.EqualTo("{{R|鉛}}"));
+            Assert.That(second, Does.StartWith("^r"));
+            Assert.That(second, Does.Not.Contain("{{R|"));
+        });
+    }
+
+    [Test]
     public void RestoreCapture_PreservesEmptyWrapperAtCaptureEnd()
     {
         var input = "{{C|TARGET: タム、ドロマド商団 [座っている]{{B|}}}}";

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DeathWrapperFamilyTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DeathWrapperFamilyTranslatorTests.cs
@@ -116,6 +116,29 @@ public sealed class DeathWrapperFamilyTranslatorTests
     }
 
     [Test]
+    public void TryTranslateMessage_PreservesOuterKillerWrapper_WhenTranslationInjectsMarkup()
+    {
+        WriteDictionary(
+            CommonEntries().Concat(
+            [
+                ("dromad merchant", "ドロマド商人"),
+                ("bloody", "{{r|血まみれの}}"),
+                ("[sitting]", "[座っている]"),
+            ]));
+
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
+            "You were killed by {{C|{{r|bloody}} Tam, dromad merchant [sitting]}}.");
+
+        var translated = DeathWrapperFamilyTranslator.TryTranslateMessage(stripped, spans, out var messageTranslated);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(messageTranslated, Is.EqualTo("{{C|{{r|血まみれの}}Tam、ドロマド商人 [座っている]}}に殺された。"));
+        });
+    }
+
+    [Test]
     public void TryTranslatePopup_PreservesTerminalEmptyWrapperInLocalizedKillerName()
     {
         var (stripped, spans) = ColorAwareTranslationComposer.Strip(

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DeathWrapperFamilyTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DeathWrapperFamilyTranslatorTests.cs
@@ -92,6 +92,50 @@ public sealed class DeathWrapperFamilyTranslatorTests
         });
     }
 
+    [Test]
+    public void TryTranslateMessage_PreservesMarkupWrappedEnglishModifierInKillerName()
+    {
+        WriteDictionary(
+            CommonEntries().Concat(
+            [
+                ("dromad merchant", "ドロマド商人"),
+                ("bloody", "{{r|血まみれの}}"),
+                ("[sitting]", "[座っている]"),
+            ]));
+
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
+            "You were killed by {{r|bloody}} Tam, dromad merchant [sitting].");
+
+        var translated = DeathWrapperFamilyTranslator.TryTranslateMessage(stripped, spans, out var messageTranslated);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(messageTranslated, Is.EqualTo("{{r|血まみれの}}Tam、ドロマド商人 [座っている]に殺された。"));
+        });
+    }
+
+    [Test]
+    public void TryTranslatePopup_PreservesTerminalEmptyWrapperInLocalizedKillerName()
+    {
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
+            "You died.\n\nYou were killed by タム、ドロマド商団 [座っている]{{B|}}.");
+
+        var translated = DeathWrapperFamilyTranslator.TryTranslatePopup(
+            stripped,
+            spans,
+            nameof(PopupShowSpaceTranslationPatch),
+            out var popupTranslated);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(
+                popupTranslated,
+                Is.EqualTo("あなたは死んだ。\n\nタム、ドロマド商団 [座っている]{{B|}}に殺された。"));
+        });
+    }
+
     [TestCase("You were killed by a snapjaw.", "スナップジョーに殺された。")]
     [TestCase("You were killed by an amoeba.", "アメーバに殺された。")]
     [TestCase("You were killed by the snapjaw.", "スナップジョーに殺された。")]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DeathWrapperFamilyTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DeathWrapperFamilyTranslatorTests.cs
@@ -139,6 +139,29 @@ public sealed class DeathWrapperFamilyTranslatorTests
     }
 
     [Test]
+    public void TryTranslateMessage_PreservesAmpersandWholeKillerWrapper_WhenTranslationInjectsMarkup()
+    {
+        WriteDictionary(
+            CommonEntries().Concat(
+            [
+                ("dromad merchant", "ドロマド商人"),
+                ("bloody", "{{r|血まみれの}}"),
+                ("[sitting]", "[座っている]"),
+            ]));
+
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
+            "You were killed by &G{{r|bloody}} Tam, dromad merchant [sitting]&y.");
+
+        var translated = DeathWrapperFamilyTranslator.TryTranslateMessage(stripped, spans, out var messageTranslated);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(messageTranslated, Is.EqualTo("&G{{r|血まみれの}}Tam、ドロマド商人 [座っている]&yに殺された。"));
+        });
+    }
+
+    [Test]
     public void TryTranslatePopup_PreservesTerminalEmptyWrapperInLocalizedKillerName()
     {
         var (stripped, spans) = ColorAwareTranslationComposer.Strip(

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs
@@ -190,6 +190,22 @@ public sealed class GetDisplayNameRouteTranslatorTests
         Assert.That(translated, Is.EqualTo("{{r|血まみれの}}Naruur"));
     }
 
+    [Test]
+    public void TranslatePreservingColors_PreservesMarkupWrappedEnglishModifierWithoutNestedColorCorruption()
+    {
+        WriteDictionary(("dromad merchant", "ドロマド商人"));
+        WriteDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("bloody", "{{r|血まみれの}}"),
+            ("[sitting]", "[座っている]"));
+
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            "{{r|bloody}} Tam, dromad merchant [sitting]",
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(translated, Is.EqualTo("{{r|血まみれの}}Tam、ドロマド商人 [座っている]"));
+    }
+
     private void WriteDictionary(params (string key, string text)[] entries)
     {
         WriteDictionaryFile("ui-displayname-route.ja.json", entries);

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessageLogProducerTranslationHelpersTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessageLogProducerTranslationHelpersTests.cs
@@ -367,6 +367,28 @@ public sealed class MessageLogProducerTranslationHelpersTests
     }
 
     [Test]
+    public void TryPreparePatternMessage_StripsLeadingControlHeader_ForColorizedPlayerHitWithRoll()
+    {
+        UseRepositoryPatternDictionary();
+
+        var source = "\u0002hit\u001F7\u001F18\u001F\u0003{{g|You hit {{&w|(x1)}} for 1 damage with your {{w|青銅の短剣}}! [18]}}";
+
+        var translated = MessageLogProducerTranslationHelpers.TryPreparePatternMessage(
+            ref source,
+            nameof(GameObjectEmitMessageTranslationPatch),
+            "EmitMessage",
+            markJapaneseAsDirect: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(
+                source,
+                Is.EqualTo("\u0001{{g|{{w|青銅の短剣}}で1ダメージを与えた。({{&w|x1}}) [18]}}"));
+        });
+    }
+
+    [Test]
     public void PrepareZoneBannerMessage_MarksAlreadyLocalizedBanner()
     {
         var result = MessageLogProducerTranslationHelpers.PrepareZoneBannerMessage(
@@ -465,6 +487,13 @@ public sealed class MessageLogProducerTranslationHelpersTests
         builder.AppendLine();
 
         File.WriteAllText(patternFilePath, builder.ToString(), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private void UseRepositoryPatternDictionary()
+    {
+        var root = TestProjectPaths.GetRepositoryRoot();
+        var repositoryPatternFile = Path.Combine(root, "Mods", "QudJP", "Localization", "Dictionaries", "messages.ja.json");
+        File.Copy(repositoryPatternFile, patternFilePath, overwrite: true);
     }
 
     private static string EscapeJson(string value)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -144,6 +144,16 @@ public sealed class MessagePatternTranslatorTests
     }
 
     [Test]
+    public void Translate_PreservesAmpersandWholeLineColor_WhenInnerWrappersArePresent()
+    {
+        WritePatternDictionary(("^You hit (.+) for (\\d+) damage[.!]?$", "{0}に{1}ダメージを与えた"));
+
+        var translated = MessagePatternTranslator.Translate("&GYou hit {{R|snapjaw}} for 7 damage^k!");
+
+        Assert.That(translated, Is.EqualTo("&G{{R|snapjaw}}に7ダメージを与えた^k"));
+    }
+
+    [Test]
     public void Translate_PreservesCaptureLocalMarkupWhenReorderingPlaceholders()
     {
         WritePatternDictionary(("^You hit (.+) for (\\d+) damage[.!]?$", "{1}ダメージを{0}に与えた"));

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -440,6 +440,30 @@ public sealed class MessagePatternTranslatorTests
     }
 
     [Test]
+    public void Translate_RepositoryDictionary_PreservesNestedColorWrappersForPlayerHitWithRoll()
+    {
+        UseRepositoryPatternDictionary();
+
+        var translated = MessagePatternTranslator.Translate("{{g|You hit {{&w|(x1)}} for 1 damage with your {{fiery|燃え盛る}} {{w|青銅の短剣}}! [9]}}");
+
+        Assert.That(
+            translated,
+            Is.EqualTo("{{g|{{fiery|燃え盛る}} {{w|青銅の短剣}}で1ダメージを与えた。({{&w|x1}}) [9]}}"));
+    }
+
+    [Test]
+    public void Translate_RepositoryDictionary_PreservesOuterWrapperForPlayerWeaponMiss()
+    {
+        UseRepositoryPatternDictionary();
+
+        var translated = MessagePatternTranslator.Translate("{{r|You miss with your {{fiery|燃え盛る}} {{w|青銅の短剣}}! [0 vs 0]}}");
+
+        Assert.That(
+            translated,
+            Is.EqualTo("{{r|{{fiery|燃え盛る}} {{w|青銅の短剣}}での攻撃は外れた。[0 vs 0]}}"));
+    }
+
+    [Test]
     public void Translate_RepositoryDictionary_TranslatesPlayerAcidDamageMessage()
     {
         UseRepositoryPatternDictionary();

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ClonelingVehicleFragmentTranslatorArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ClonelingVehicleFragmentTranslatorArbitraries.cs
@@ -1,0 +1,67 @@
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace QudJP.Tests.L1.Pbt;
+
+public sealed record ClonelingVisibleFragment(string Source, string Expected);
+
+public sealed record ClonelingPopupCase(string Source, string ExpectedTranslated);
+
+public sealed record ClonelingQueuedCase(string Source, string ExpectedTranslated);
+
+public sealed record ClonelingPopupPassthroughCase(string Source);
+
+public sealed record ClonelingQueuedPassthroughCase(string Source);
+
+public static class ClonelingVehicleFragmentTranslatorArbitraries
+{
+    private static Gen<string> BaseText()
+    {
+        return Gen.Elements("sunslag", "cloning draught", "warm static", "熊油", "発光液");
+    }
+
+    private static Gen<ClonelingVisibleFragment> VisibleFragments()
+    {
+        var wrappers = Gen.Elements("{{C|", "{{G|", "{{Y|", "{{r|");
+
+        var plain = BaseText().Select(value => new ClonelingVisibleFragment(value, value));
+        var wrapped =
+            from value in BaseText()
+            from open in wrappers
+            select new ClonelingVisibleFragment(open + value + "}}", open + value + "}}");
+
+        return Gen.OneOf(plain, wrapped);
+    }
+
+    public static Arbitrary<ClonelingPopupCase> PopupCases()
+    {
+        return VisibleFragments()
+            .Select(liquid => new ClonelingPopupCase(
+                $"You do not have 1 dram of {liquid.Source}.",
+                $"{liquid.Expected}を1ドラム持っていない。"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<ClonelingQueuedCase> QueuedCases()
+    {
+        return VisibleFragments()
+            .Select(liquid => new ClonelingQueuedCase(
+                $"Your onboard systems are out of {liquid.Source}.",
+                $"搭載システムの{liquid.Expected}が切れている。"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<ClonelingPopupPassthroughCase> PopupPassthroughCases()
+    {
+        return PopupCases().Generator
+            .Select(sample => new ClonelingPopupPassthroughCase("\u0001" + sample.Source))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<ClonelingQueuedPassthroughCase> QueuedPassthroughCases()
+    {
+        return QueuedCases().Generator
+            .Select(sample => new ClonelingQueuedPassthroughCase("\u0001" + sample.Source))
+            .ToArbitrary();
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ClonelingVehicleFragmentTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ClonelingVehicleFragmentTranslatorPropertyTests.cs
@@ -1,0 +1,86 @@
+using FsCheck.Fluent;
+
+using FsCheckProperty = FsCheck.Property;
+
+using QudJP.Patches;
+
+namespace QudJP.Tests.L1.Pbt;
+
+[TestFixture]
+[Category("L1")]
+public sealed class ClonelingVehicleFragmentTranslatorPropertyTests
+{
+    private const string ReplaySeed = "642531987,97531";
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(ClonelingVehicleFragmentTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TryTranslatePopupMessage_PreservesLiquidWrappers(ClonelingPopupCase sample)
+    {
+        var translated = ClonelingVehicleFragmentTranslator.TryTranslatePopupMessage(
+            sample.Source,
+            nameof(ClonelingVehicleFragmentTranslatorPropertyTests),
+            "WorldParts.Popup",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(actual, Is.EqualTo(sample.ExpectedTranslated));
+        });
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(ClonelingVehicleFragmentTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TryTranslateQueuedMessage_PreservesLiquidWrappers(ClonelingQueuedCase sample)
+    {
+        var translated = ClonelingVehicleFragmentTranslator.TryTranslateQueuedMessage(
+            sample.Source,
+            nameof(ClonelingVehicleFragmentTranslatorPropertyTests),
+            "WorldParts.Queue",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(actual, Is.EqualTo(sample.ExpectedTranslated));
+        });
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(ClonelingVehicleFragmentTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TryTranslatePopupMessage_LeavesDirectMarkedTextUntouched(ClonelingPopupPassthroughCase sample)
+    {
+        var translated = ClonelingVehicleFragmentTranslator.TryTranslatePopupMessage(
+            sample.Source,
+            nameof(ClonelingVehicleFragmentTranslatorPropertyTests),
+            "WorldParts.Popup",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.False);
+            Assert.That(actual, Is.EqualTo(sample.Source));
+        });
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(ClonelingVehicleFragmentTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TryTranslateQueuedMessage_LeavesDirectMarkedTextUntouched(ClonelingQueuedPassthroughCase sample)
+    {
+        var translated = ClonelingVehicleFragmentTranslator.TryTranslateQueuedMessage(
+            sample.Source,
+            nameof(ClonelingVehicleFragmentTranslatorPropertyTests),
+            "WorldParts.Queue",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.False);
+            Assert.That(actual, Is.EqualTo(sample.Source));
+        });
+
+        return true.ToProperty();
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ClonelingVehicleFragmentTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ClonelingVehicleFragmentTranslatorPropertyTests.cs
@@ -83,4 +83,70 @@ public sealed class ClonelingVehicleFragmentTranslatorPropertyTests
 
         return true.ToProperty();
     }
+
+    [Test]
+    public void TryTranslatePopupMessage_LeavesEmptyInputUntouched()
+    {
+        var translated = ClonelingVehicleFragmentTranslator.TryTranslatePopupMessage(
+            string.Empty,
+            nameof(ClonelingVehicleFragmentTranslatorPropertyTests),
+            "WorldParts.Popup",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.False);
+            Assert.That(actual, Is.EqualTo(string.Empty));
+        });
+    }
+
+    [Test]
+    public void TryTranslatePopupMessage_LeavesNonMatchingEnglishUntouched()
+    {
+        const string source = "You do not have 1 dram of nothing in particular?";
+        var translated = ClonelingVehicleFragmentTranslator.TryTranslatePopupMessage(
+            source,
+            nameof(ClonelingVehicleFragmentTranslatorPropertyTests),
+            "WorldParts.Popup",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.False);
+            Assert.That(actual, Is.EqualTo(source));
+        });
+    }
+
+    [Test]
+    public void TryTranslateQueuedMessage_LeavesEmptyInputUntouched()
+    {
+        var translated = ClonelingVehicleFragmentTranslator.TryTranslateQueuedMessage(
+            string.Empty,
+            nameof(ClonelingVehicleFragmentTranslatorPropertyTests),
+            "WorldParts.Queue",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.False);
+            Assert.That(actual, Is.EqualTo(string.Empty));
+        });
+    }
+
+    [Test]
+    public void TryTranslateQueuedMessage_LeavesNonMatchingEnglishUntouched()
+    {
+        const string source = "Your onboard systems are out of nothing in particular?";
+        var translated = ClonelingVehicleFragmentTranslator.TryTranslateQueuedMessage(
+            source,
+            nameof(ClonelingVehicleFragmentTranslatorPropertyTests),
+            "WorldParts.Queue",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.False);
+            Assert.That(actual, Is.EqualTo(source));
+        });
+    }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ColorCodePreserverArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ColorCodePreserverArbitraries.cs
@@ -9,6 +9,8 @@ public sealed record ForegroundColorCodeCase(string Source, string VisibleText, 
 
 public sealed record BackgroundColorCodeCase(string Source, string VisibleText, string TranslatedVisibleText, string ExpectedRestored);
 
+public sealed record TmpColorTagCase(string Source, string VisibleText, string TranslatedVisibleText, string ExpectedRestored);
+
 public sealed record ColorWrapper(string Open, string Close);
 
 public static class ColorCodePreserverArbitraries
@@ -17,6 +19,14 @@ public static class ColorCodePreserverArbitraries
     {
         var characters = Gen.Elements('a', 'b', 'c', 'x', 'y', 'z', '刀', '緑', '危', '険', '光');
         return Gen.Choose(1, 8)
+            .SelectMany(length => Gen.ArrayOf(characters, length))
+            .Select(chars => new string(chars));
+    }
+
+    private static Gen<string> SafeTextIncludingEmpty()
+    {
+        var characters = Gen.Elements('a', 'b', 'c', 'x', 'y', 'z', '刀', '緑', '危', '険', '光');
+        return Gen.Choose(0, 8)
             .SelectMany(length => Gen.ArrayOf(characters, length))
             .Select(chars => new string(chars));
     }
@@ -59,6 +69,24 @@ public static class ColorCodePreserverArbitraries
                     rawVisible,
                     translated,
                     "^r" + translated + "^k"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<TmpColorTagCase> TmpColorTagCases()
+    {
+        var colors = Gen.OneOf(
+            Gen.Constant("red"),
+            Gen.Constant("cyan"),
+            Gen.Constant("#00ff00"));
+
+        return (from rawVisible in SafeTextIncludingEmpty()
+                from color in colors
+                let translated = new string('訳', rawVisible.Length)
+                select new TmpColorTagCase(
+                    $"<color={color}>{rawVisible}</color>",
+                    rawVisible,
+                    translated,
+                    $"<color={color}>{translated}</color>"))
             .ToArbitrary();
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ColorCodePreserverArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ColorCodePreserverArbitraries.cs
@@ -1,0 +1,64 @@
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace QudJP.Tests.L1.Pbt;
+
+public sealed record ColorizedCase(string Source, string VisibleText, string TranslatedVisibleText, string ExpectedRestored);
+
+public sealed record ForegroundColorCodeCase(string Source, string VisibleText, string TranslatedVisibleText, string ExpectedRestored);
+
+public sealed record BackgroundColorCodeCase(string Source, string VisibleText, string TranslatedVisibleText, string ExpectedRestored);
+
+public sealed record ColorWrapper(string Open, string Close);
+
+public static class ColorCodePreserverArbitraries
+{
+    private static Gen<string> SafeText()
+    {
+        var characters = Gen.Elements('a', 'b', 'c', 'x', 'y', 'z', '刀', '緑', '危', '険', '光');
+        return Gen.Choose(1, 8)
+            .SelectMany(length => Gen.ArrayOf(characters, length))
+            .Select(chars => new string(chars));
+    }
+
+    public static Arbitrary<ColorizedCase> ColorizedCases()
+    {
+        var wrappers = Gen.OneOf(
+            Gen.Constant(new ColorWrapper("{{W|", "}}")),
+            Gen.Constant(new ColorWrapper("{{r|", "}}")));
+
+        return (from rawVisible in SafeText()
+            from wrapper in wrappers
+            let translated = new string('訳', rawVisible.Length)
+            select new ColorizedCase(
+                wrapper.Open + rawVisible + wrapper.Close,
+                rawVisible,
+                translated,
+                wrapper.Open + translated + wrapper.Close))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<ForegroundColorCodeCase> ForegroundColorCodeCases()
+    {
+        return (from rawVisible in SafeText()
+                let translated = new string('訳', rawVisible.Length)
+                select new ForegroundColorCodeCase(
+                    "&G" + rawVisible + "&y",
+                    rawVisible,
+                    translated,
+                    "&G" + translated + "&y"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<BackgroundColorCodeCase> BackgroundColorCodeCases()
+    {
+        return (from rawVisible in SafeText()
+                let translated = new string('訳', rawVisible.Length)
+                select new BackgroundColorCodeCase(
+                    "^r" + rawVisible + "^k",
+                    rawVisible,
+                    translated,
+                    "^r" + translated + "^k"))
+            .ToArbitrary();
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ColorCodePreserverPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ColorCodePreserverPropertyTests.cs
@@ -67,4 +67,30 @@ public sealed class ColorCodePreserverPropertyTests
 
         return true.ToProperty();
     }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(ColorCodePreserverArbitraries) }, MaxTest = 200, Replay = ReplaySeed)]
+    public FsCheckProperty StripThenRestore_PreservesTmpColorTags(TmpColorTagCase sample)
+    {
+        var (stripped, spans) = ColorCodePreserver.Strip(sample.Source);
+        var restored = ColorCodePreserver.Restore(sample.TranslatedVisibleText, spans);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stripped, Is.EqualTo(sample.VisibleText));
+            Assert.That(restored, Is.EqualTo(sample.ExpectedRestored));
+        });
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(ColorCodePreserverArbitraries) }, MaxTest = 200, Replay = ReplaySeed)]
+    public FsCheckProperty StripThenRestore_DoesNotChangeVisibleText_ForTmpColorTags(TmpColorTagCase sample)
+    {
+        var (stripped, spans) = ColorCodePreserver.Strip(sample.Source);
+        var restored = ColorCodePreserver.Restore(stripped, spans);
+
+        Assert.That(restored, Is.EqualTo(sample.Source));
+
+        return true.ToProperty();
+    }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ColorCodePreserverPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ColorCodePreserverPropertyTests.cs
@@ -1,0 +1,70 @@
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.NUnit;
+
+using FsCheckProperty = FsCheck.Property;
+
+namespace QudJP.Tests.L1.Pbt;
+
+[TestFixture]
+[Category("L1")]
+public sealed class ColorCodePreserverPropertyTests
+{
+    private const string ReplaySeed = "123456789,97531";
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(ColorCodePreserverArbitraries) }, MaxTest = 200, Replay = ReplaySeed)]
+    public FsCheckProperty StripThenRestore_PreservesSupportedMarkup(ColorizedCase sample)
+    {
+        var (stripped, spans) = ColorCodePreserver.Strip(sample.Source);
+        var restored = ColorCodePreserver.Restore(sample.TranslatedVisibleText, spans);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stripped, Is.EqualTo(sample.VisibleText));
+            Assert.That(restored, Is.EqualTo(sample.ExpectedRestored));
+        });
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(ColorCodePreserverArbitraries) }, MaxTest = 200, Replay = ReplaySeed)]
+    public FsCheckProperty StripThenRestore_DoesNotChangeVisibleText(ColorizedCase sample)
+    {
+        var (stripped, spans) = ColorCodePreserver.Strip(sample.Source);
+        var restored = ColorCodePreserver.Restore(stripped, spans);
+
+        Assert.That(restored, Is.EqualTo(sample.Source));
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(ColorCodePreserverArbitraries) }, MaxTest = 200, Replay = ReplaySeed)]
+    public FsCheckProperty StripThenRestore_PreservesForegroundCodes(ForegroundColorCodeCase sample)
+    {
+        var (stripped, spans) = ColorCodePreserver.Strip(sample.Source);
+        var restored = ColorCodePreserver.Restore(sample.TranslatedVisibleText, spans);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stripped, Is.EqualTo(sample.VisibleText));
+            Assert.That(restored, Is.EqualTo(sample.ExpectedRestored));
+        });
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(ColorCodePreserverArbitraries) }, MaxTest = 200, Replay = ReplaySeed)]
+    public FsCheckProperty StripThenRestore_PreservesBackgroundCodes(BackgroundColorCodeCase sample)
+    {
+        var (stripped, spans) = ColorCodePreserver.Strip(sample.Source);
+        var restored = ColorCodePreserver.Restore(sample.TranslatedVisibleText, spans);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stripped, Is.EqualTo(sample.VisibleText));
+            Assert.That(restored, Is.EqualTo(sample.ExpectedRestored));
+        });
+
+        return true.ToProperty();
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/EnclosingFragmentTranslatorArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/EnclosingFragmentTranslatorArbitraries.cs
@@ -1,0 +1,63 @@
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace QudJP.Tests.L1.Pbt;
+
+public sealed record VisibleFragment(string Source, string Expected);
+
+public sealed record EnclosingExtricateCase(string Source, string ExpectedTranslated);
+
+public sealed record EnclosingPassthroughCase(string Source);
+
+public static class EnclosingFragmentTranslatorArbitraries
+{
+    private static Gen<string> BaseText()
+    {
+        return Gen.Elements("snapjaw", "golem", "stasis pod", "cryo chamber", "熊", "光る棺");
+    }
+
+    private static Gen<VisibleFragment> VisibleFragments()
+    {
+        var wrappers = Gen.Elements("{{r|", "{{C|", "{{G|", "{{Y|");
+
+        var plain = BaseText().Select(value => new VisibleFragment(value, value));
+        var wrapped =
+            from value in BaseText()
+            from open in wrappers
+            select new VisibleFragment(open + value + "}}", open + value + "}}");
+
+        return Gen.OneOf(plain, wrapped);
+    }
+
+    public static Arbitrary<EnclosingExtricateCase> ExtricateCases()
+    {
+        var yourselfCases =
+            from container in VisibleFragments()
+            select new EnclosingExtricateCase(
+                $"You extricate yourself from {container.Source}.",
+                $"{container.Expected}から抜け出した。");
+
+        var itselfCases =
+            from container in VisibleFragments()
+            select new EnclosingExtricateCase(
+                $"You extricate itself from {container.Source}.",
+                $"{container.Expected}からそれ自身を引き出した。");
+
+        var subjectCases =
+            from subject in VisibleFragments()
+            from container in VisibleFragments()
+            select new EnclosingExtricateCase(
+                $"You extricate {subject.Source} from {container.Source}.",
+                $"{container.Expected}から{subject.Expected}を引き出した。");
+
+        return Gen.OneOf(yourselfCases, itselfCases, subjectCases)
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<EnclosingPassthroughCase> PassthroughCases()
+    {
+        return ExtricateCases().Generator
+            .Select(sample => new EnclosingPassthroughCase("\u0001" + sample.Source))
+            .ToArbitrary();
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/EnclosingFragmentTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/EnclosingFragmentTranslatorPropertyTests.cs
@@ -1,0 +1,50 @@
+using FsCheck.Fluent;
+
+using FsCheckProperty = FsCheck.Property;
+
+using QudJP.Patches;
+
+namespace QudJP.Tests.L1.Pbt;
+
+[TestFixture]
+[Category("L1")]
+public sealed class EnclosingFragmentTranslatorPropertyTests
+{
+    private const string ReplaySeed = "531246879,97531";
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(EnclosingFragmentTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TryTranslatePopupMessage_PreservesExtricateTranslation(EnclosingExtricateCase sample)
+    {
+        var translated = EnclosingFragmentTranslator.TryTranslatePopupMessage(
+            sample.Source,
+            nameof(EnclosingFragmentTranslatorPropertyTests),
+            "Enclosing",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(actual, Is.EqualTo(sample.ExpectedTranslated));
+        });
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(EnclosingFragmentTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TryTranslatePopupMessage_LeavesDirectMarkedTextUntouched(EnclosingPassthroughCase sample)
+    {
+        var translated = EnclosingFragmentTranslator.TryTranslatePopupMessage(
+            sample.Source,
+            nameof(EnclosingFragmentTranslatorPropertyTests),
+            "Enclosing",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.False);
+            Assert.That(actual, Is.EqualTo(sample.Source));
+        });
+
+        return true.ToProperty();
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/LiquidVolumeFragmentTranslatorArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/LiquidVolumeFragmentTranslatorArbitraries.cs
@@ -1,0 +1,133 @@
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace QudJP.Tests.L1.Pbt;
+
+public sealed record LiquidFragment(string Source, string Expected);
+
+public sealed record LiquidStatusCase(string Source, string ExpectedTranslated);
+
+public sealed record LiquidOwnershipCase(string Source, string ExpectedTranslated);
+
+public sealed record LiquidTargetRuleCase(string Source, string ExpectedTranslated);
+
+public sealed record LiquidPourIntoCase(string Source, string ExpectedTranslated);
+
+public sealed record LiquidPassthroughCase(string Source);
+
+public static class LiquidVolumeFragmentTranslatorArbitraries
+{
+    private static Gen<string> TargetBaseText()
+    {
+        return Gen.Elements("canteen", "vial", "tank", "熊油瓶");
+    }
+
+    private static Gen<string> StatusBaseText()
+    {
+        return Gen.Elements("hydrated", "slimy", "glowing", "発光中");
+    }
+
+    private static Gen<LiquidFragment> PlainOrWrappedTargets()
+    {
+        var wrappers = Gen.Elements("{{Y|", "{{C|", "{{B|", "{{r|");
+
+        var plain = TargetBaseText().Select(value => new LiquidFragment(value, value));
+        var wrapped =
+            from value in TargetBaseText()
+            from open in wrappers
+            select new LiquidFragment(open + value + "}}", open + value + "}}");
+
+        return Gen.OneOf(plain, wrapped);
+    }
+
+    private static Gen<LiquidFragment> NormalizedContainerTargets()
+    {
+        var plain = PlainOrWrappedTargets();
+        var articleTargets = Gen.Elements(
+            new LiquidFragment("the canteen", "canteen"),
+            new LiquidFragment("The vial", "vial"));
+
+        return Gen.OneOf(plain, articleTargets);
+    }
+
+    private static Gen<LiquidFragment> PourTargets()
+    {
+        return Gen.Elements(
+            new LiquidFragment("yourself", "自分"),
+            new LiquidFragment("itself", "それ自身"),
+            new LiquidFragment("{{Y|yourself}}", "{{Y|自分}}"),
+            new LiquidFragment("{{Y|itself}}", "{{Y|それ自身}}"));
+    }
+
+    private static Gen<LiquidFragment> StatusFragments()
+    {
+        var wrappers = Gen.Elements("{{B|", "{{C|", "{{Y|");
+
+        var plain = StatusBaseText().Select(value => new LiquidFragment(value, value));
+        var wrapped =
+            from value in StatusBaseText()
+            from open in wrappers
+            select new LiquidFragment(open + value + "}}", open + value + "}}");
+
+        return Gen.OneOf(plain, wrapped);
+    }
+
+    public static Arbitrary<LiquidStatusCase> StatusCases()
+    {
+        return StatusFragments()
+            .Select(status => new LiquidStatusCase(
+                $"You are now {status.Source}.",
+                $"あなたは今、{status.Expected}。"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<LiquidOwnershipCase> OwnershipCases()
+    {
+        var templates = Gen.Elements(
+            (Source: "drink from it", Suffix: "そこから飲みますか？"),
+            (Source: "drain it", Suffix: "排出しますか？"),
+            (Source: "fill it", Suffix: "満たしますか？"));
+
+        return (from target in PlainOrWrappedTargets()
+                from template in templates
+                select new LiquidOwnershipCase(
+                    $"{target.Source} is not owned by you. Are you sure you want to {template.Source}?",
+                    $"{target.Expected}はあなたの所有物ではない。本当に{template.Suffix}"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<LiquidTargetRuleCase> TargetRuleCases()
+    {
+        var templates = Gen.Elements(
+            (SourcePrefix: "You cannot seem to interact with ", SourceSuffix: " in any way.", ExpectedSuffix: "にはどうやっても干渉できないようだ。"),
+            (SourcePrefix: string.Empty, SourceSuffix: " has no drain.", ExpectedSuffix: "には排出口がない。"),
+            (SourcePrefix: string.Empty, SourceSuffix: " is sealed.", ExpectedSuffix: "は密閉されている。"),
+            (SourcePrefix: "Do you want to empty ", SourceSuffix: " first?", ExpectedSuffix: "を先に空にしますか？"));
+
+        return (from target in NormalizedContainerTargets()
+                from template in templates
+                select new LiquidTargetRuleCase(
+                    template.SourcePrefix + target.Source + template.SourceSuffix,
+                    target.Expected + template.ExpectedSuffix))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<LiquidPourIntoCase> PourIntoCases()
+    {
+        return PourTargets()
+            .Select(target => new LiquidPourIntoCase(
+                $"You can't pour from a container into {target.Source}.",
+                $"{target.Expected}に容器から注ぐことはできない。"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<LiquidPassthroughCase> PassthroughCases()
+    {
+        return Gen.Elements(
+                new LiquidPassthroughCase(string.Empty),
+                new LiquidPassthroughCase("This is a random liquid message."),
+                new LiquidPassthroughCase("Are you sure you want to drink from canteen?"),
+                new LiquidPassthroughCase("\u0001You cannot seem to interact with canteen in any way."))
+            .ToArbitrary();
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/LiquidVolumeFragmentTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/LiquidVolumeFragmentTranslatorPropertyTests.cs
@@ -1,0 +1,104 @@
+using FsCheck.Fluent;
+
+using FsCheckProperty = FsCheck.Property;
+
+using QudJP.Patches;
+
+namespace QudJP.Tests.L1.Pbt;
+
+[TestFixture]
+[Category("L1")]
+public sealed class LiquidVolumeFragmentTranslatorPropertyTests
+{
+    private const string ReplaySeed = "753124689,97531";
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(LiquidVolumeFragmentTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TryTranslatePopupMessage_PreservesStatusWrappers(LiquidStatusCase sample)
+    {
+        var translated = LiquidVolumeFragmentTranslator.TryTranslatePopupMessage(
+            sample.Source,
+            nameof(LiquidVolumeFragmentTranslatorPropertyTests),
+            "LiquidVolume",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(actual, Is.EqualTo(sample.ExpectedTranslated));
+        });
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(LiquidVolumeFragmentTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TryTranslatePopupMessage_PreservesOwnershipTargetWrappers(LiquidOwnershipCase sample)
+    {
+        var translated = LiquidVolumeFragmentTranslator.TryTranslatePopupMessage(
+            sample.Source,
+            nameof(LiquidVolumeFragmentTranslatorPropertyTests),
+            "LiquidVolume",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(actual, Is.EqualTo(sample.ExpectedTranslated));
+        });
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(LiquidVolumeFragmentTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TryTranslatePopupMessage_TranslatesTargetRules(LiquidTargetRuleCase sample)
+    {
+        var translated = LiquidVolumeFragmentTranslator.TryTranslatePopupMessage(
+            sample.Source,
+            nameof(LiquidVolumeFragmentTranslatorPropertyTests),
+            "LiquidVolume",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(actual, Is.EqualTo(sample.ExpectedTranslated));
+        });
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(LiquidVolumeFragmentTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TryTranslatePopupMessage_TranslatesPourIntoTargets(LiquidPourIntoCase sample)
+    {
+        var translated = LiquidVolumeFragmentTranslator.TryTranslatePopupMessage(
+            sample.Source,
+            nameof(LiquidVolumeFragmentTranslatorPropertyTests),
+            "LiquidVolume",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(actual, Is.EqualTo(sample.ExpectedTranslated));
+        });
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(LiquidVolumeFragmentTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TryTranslatePopupMessage_LeavesDirectMarkedTextUntouched(LiquidPassthroughCase sample)
+    {
+        var translated = LiquidVolumeFragmentTranslator.TryTranslatePopupMessage(
+            sample.Source,
+            nameof(LiquidVolumeFragmentTranslatorPropertyTests),
+            "LiquidVolume",
+            out var actual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.False);
+            Assert.That(actual, Is.EqualTo(sample.Source));
+        });
+
+        return true.ToProperty();
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/LiquidVolumeFragmentTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/LiquidVolumeFragmentTranslatorPropertyTests.cs
@@ -85,7 +85,7 @@ public sealed class LiquidVolumeFragmentTranslatorPropertyTests
     }
 
     [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(LiquidVolumeFragmentTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
-    public FsCheckProperty TryTranslatePopupMessage_LeavesDirectMarkedTextUntouched(LiquidPassthroughCase sample)
+    public FsCheckProperty TryTranslatePopupMessage_LeavesUnmatchedTextUntouched(LiquidPassthroughCase sample)
     {
         var translated = LiquidVolumeFragmentTranslator.TryTranslatePopupMessage(
             sample.Source,

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessageFrameTranslatorArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessageFrameTranslatorArbitraries.cs
@@ -1,0 +1,19 @@
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace QudJP.Tests.L1.Pbt;
+
+public sealed record DirectMarkerText(string Value);
+
+public static class MessageFrameTranslatorArbitraries
+{
+    public static Arbitrary<DirectMarkerText> DirectMarkerTexts()
+    {
+        var characters = Gen.Elements('a', 'b', 'c', 'x', 'y', 'z', '熊', '防', 'ぐ', '刀', '光');
+
+        return Gen.Choose(1, 12)
+            .SelectMany(length => Gen.ArrayOf(characters, length))
+            .Select(chars => new DirectMarkerText(new string(chars)))
+            .ToArbitrary();
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessageFrameTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessageFrameTranslatorPropertyTests.cs
@@ -1,0 +1,48 @@
+using FsCheck.Fluent;
+
+using FsCheckProperty = FsCheck.Property;
+
+namespace QudJP.Tests.L1.Pbt;
+
+[TestFixture]
+[Category("L1")]
+public sealed class MessageFrameTranslatorPropertyTests
+{
+    private const string ReplaySeed = "864209753,13579";
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessageFrameTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty MarkDirectTranslation_IsIdempotentAndRoundTrips(DirectMarkerText sample)
+    {
+        var markedOnce = MessageFrameTranslator.MarkDirectTranslation(sample.Value);
+        var markedTwice = MessageFrameTranslator.MarkDirectTranslation(markedOnce);
+        var stripped = MessageFrameTranslator.TryStripDirectTranslationMarker(markedTwice, out var unmarked);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(markedOnce[0], Is.EqualTo(MessageFrameTranslator.DirectTranslationMarker));
+            Assert.That(markedTwice, Is.EqualTo(markedOnce));
+            Assert.That(stripped, Is.True);
+            Assert.That(unmarked, Is.EqualTo(sample.Value));
+        });
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessageFrameTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TryStripDirectTranslationMarker_LeavesUnmarkedTextUntouched(DirectMarkerText sample)
+    {
+        var stripped = MessageFrameTranslator.TryStripDirectTranslationMarker(sample.Value, out var unmarked);
+        var byRef = sample.Value;
+        var strippedByRef = MessageFrameTranslator.TryStripDirectTranslationMarker(ref byRef);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stripped, Is.False);
+            Assert.That(unmarked, Is.EqualTo(sample.Value));
+            Assert.That(strippedByRef, Is.False);
+            Assert.That(byRef, Is.EqualTo(sample.Value));
+        });
+
+        return true.ToProperty();
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessageFrameTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessageFrameTranslatorPropertyTests.cs
@@ -45,4 +45,31 @@ public sealed class MessageFrameTranslatorPropertyTests
 
         return true.ToProperty();
     }
+
+    [Test]
+    public void MarkDirectTranslation_EmptyInput_RoundTripsToEmpty()
+    {
+        var marked = MessageFrameTranslator.MarkDirectTranslation(string.Empty);
+        var stripped = MessageFrameTranslator.TryStripDirectTranslationMarker(marked, out var unmarked);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(marked, Is.EqualTo(MessageFrameTranslator.DirectTranslationMarker.ToString()));
+            Assert.That(stripped, Is.True);
+            Assert.That(unmarked, Is.EqualTo(string.Empty));
+        });
+    }
+
+    [Test]
+    public void TryStripDirectTranslationMarker_ByRef_MarkedInput_StripsAndMutates()
+    {
+        var message = $"{MessageFrameTranslator.DirectTranslationMarker}熊";
+        var stripped = MessageFrameTranslator.TryStripDirectTranslationMarker(ref message);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stripped, Is.True);
+            Assert.That(message, Is.EqualTo("熊"));
+        });
+    }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessageLogProducerTranslationHelpersArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessageLogProducerTranslationHelpersArbitraries.cs
@@ -1,0 +1,42 @@
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace QudJP.Tests.L1.Pbt;
+
+public sealed record CombatPatternCase(string Source, string ExpectedTranslated);
+
+public sealed record DirectMarkedCase(string Source);
+
+public static class MessageLogProducerTranslationHelpersArbitraries
+{
+    private static Gen<string> SafeWeaponText()
+    {
+        var characters = Gen.Elements('刀', '剣', '槍', '光', '炎', '鋼', '青', '銅');
+        return Gen.Choose(1, 6)
+            .SelectMany(length => Gen.ArrayOf(characters, length))
+            .Select(chars => new string(chars));
+    }
+
+    public static Arbitrary<CombatPatternCase> CombatPatternCases()
+    {
+        return (from weaponText in SafeWeaponText()
+                from multiplier in Gen.Choose(1, 4)
+                from damage in Gen.Choose(1, 12)
+                from roll in Gen.Choose(1, 30)
+                let multiplierText = $"x{multiplier}"
+                let weapon = $"{{{{w|{weaponText}}}}}"
+                let source = $"\u0002hit\u001F{damage}\u001F{roll}\u001F\u0003{{{{g|You hit {{{{&w|({multiplierText})}}}} for {damage} damage with your {weapon}! [{roll}]}}}}"
+                let expected = $"\u0001{{{{g|{weapon}で{damage}ダメージを与えた。({{{{&w|{multiplierText}}}}}) [{roll}]}}}}"
+                select new CombatPatternCase(source, expected))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<DirectMarkedCase> DirectMarkedCases()
+    {
+        return (from visible in SafeWeaponText()
+                from wrapper in Gen.OneOf(Gen.Constant("{{g|"), Gen.Constant("{{r|"))
+                let source = "\u0001" + wrapper + visible + "}}"
+                select new DirectMarkedCase(source))
+            .ToArbitrary();
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessageLogProducerTranslationHelpersPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessageLogProducerTranslationHelpersPropertyTests.cs
@@ -1,0 +1,88 @@
+using FsCheck.Fluent;
+using QudJP.Patches;
+
+using FsCheckProperty = FsCheck.Property;
+
+namespace QudJP.Tests.L1.Pbt;
+
+[TestFixture]
+[Category("L1")]
+public sealed class MessageLogProducerTranslationHelpersPropertyTests
+{
+    private const string ReplaySeed = "246813579,97531";
+
+    private string tempDirectory = null!;
+    private string dictionaryDirectory = null!;
+    private string patternFilePath = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempDirectory = Path.Combine(Path.GetTempPath(), "qudjp-message-log-producer-pbt", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        dictionaryDirectory = Path.Combine(tempDirectory, "dict");
+        Directory.CreateDirectory(dictionaryDirectory);
+        patternFilePath = Path.Combine(tempDirectory, "messages.ja.json");
+
+        Translator.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(dictionaryDirectory);
+        MessagePatternTranslator.ResetForTests();
+        MessagePatternTranslator.SetPatternFileForTests(patternFilePath);
+
+        var root = TestProjectPaths.GetRepositoryRoot();
+        var repositoryPatternFile = Path.Combine(root, "Mods", "QudJP", "Localization", "Dictionaries", "messages.ja.json");
+        File.Copy(repositoryPatternFile, patternFilePath, overwrite: true);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        MessagePatternTranslator.ResetForTests();
+
+        if (Directory.Exists(tempDirectory))
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessageLogProducerTranslationHelpersArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TryPreparePatternMessage_StripsControlHeaderAndPreservesNestedWrappers(CombatPatternCase sample)
+    {
+        var source = sample.Source;
+
+        var translated = MessageLogProducerTranslationHelpers.TryPreparePatternMessage(
+            ref source,
+            nameof(GameObjectEmitMessageTranslationPatch),
+            "EmitMessage",
+            markJapaneseAsDirect: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(source, Is.EqualTo(sample.ExpectedTranslated));
+        });
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessageLogProducerTranslationHelpersArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TryPreparePatternMessage_LeavesDirectMarkedMessagesUntouched(DirectMarkedCase sample)
+    {
+        var source = sample.Source;
+
+        var translated = MessageLogProducerTranslationHelpers.TryPreparePatternMessage(
+            ref source,
+            nameof(GameObjectEmitMessageTranslationPatch),
+            "EmitMessage",
+            markJapaneseAsDirect: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.False);
+            Assert.That(source, Is.EqualTo(sample.Source));
+        });
+
+        return true.ToProperty();
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessageLogProducerTranslationHelpersPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessageLogProducerTranslationHelpersPropertyTests.cs
@@ -31,6 +31,7 @@ public sealed class MessageLogProducerTranslationHelpersPropertyTests
 
         var root = TestProjectPaths.GetRepositoryRoot();
         var repositoryPatternFile = Path.Combine(root, "Mods", "QudJP", "Localization", "Dictionaries", "messages.ja.json");
+        Assert.That(File.Exists(repositoryPatternFile), Is.True, $"Repository pattern dictionary not found: {repositoryPatternFile}");
         File.Copy(repositoryPatternFile, patternFilePath, overwrite: true);
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorArbitraries.cs
@@ -1,0 +1,45 @@
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace QudJP.Tests.L1.Pbt;
+
+public sealed record HitWithRollPatternCase(string Source, string ExpectedTranslated);
+
+public sealed record WeaponMissPatternCase(string Source, string ExpectedTranslated);
+
+public static class MessagePatternTranslatorArbitraries
+{
+    private static Gen<string> SafeWeaponText()
+    {
+        var characters = Gen.Elements('刀', '剣', '槍', '光', '炎', '鋼', '青', '銅');
+        return Gen.Choose(1, 6)
+            .SelectMany(length => Gen.ArrayOf(characters, length))
+            .Select(chars => new string(chars));
+    }
+
+    public static Arbitrary<HitWithRollPatternCase> HitWithRollPatternCases()
+    {
+        return (from weaponText in SafeWeaponText()
+                from multiplier in Gen.Choose(1, 4)
+                from damage in Gen.Choose(1, 12)
+                from roll in Gen.Choose(1, 30)
+                let multiplierText = $"x{multiplier}"
+                let weapon = $"{{{{w|{weaponText}}}}}"
+                let source = $"{{{{g|You hit {{{{&w|({multiplierText})}}}} for {damage} damage with your {weapon}! [{roll}]}}}}"
+                let expected = $"{{{{g|{weapon}で{damage}ダメージを与えた。({{{{&w|{multiplierText}}}}}) [{roll}]}}}}"
+                select new HitWithRollPatternCase(source, expected))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<WeaponMissPatternCase> WeaponMissPatternCases()
+    {
+        return (from weaponText in SafeWeaponText()
+                from attacker in Gen.Choose(0, 20)
+                from defender in Gen.Choose(0, 20)
+                let weapon = $"{{{{w|{weaponText}}}}}"
+                let source = $"{{{{r|You miss with your {weapon}! [{attacker} vs {defender}]}}}}"
+                let expected = $"{{{{r|{weapon}での攻撃は外れた。[{attacker} vs {defender}]}}}}"
+                select new WeaponMissPatternCase(source, expected))
+            .ToArbitrary();
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorPropertyTests.cs
@@ -1,0 +1,52 @@
+using FsCheck.Fluent;
+
+using FsCheckProperty = FsCheck.Property;
+
+namespace QudJP.Tests.L1.Pbt;
+
+[TestFixture]
+[Category("L1")]
+public sealed class MessagePatternTranslatorPropertyTests
+{
+    private const string ReplaySeed = "975318642,24681";
+
+    [SetUp]
+    public void SetUp()
+    {
+        MessagePatternTranslator.ResetForTests();
+        UseRepositoryPatternDictionary();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        MessagePatternTranslator.ResetForTests();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty Translate_PreservesHitWithRollWrappers(HitWithRollPatternCase sample)
+    {
+        var translated = MessagePatternTranslator.Translate(sample.Source);
+
+        Assert.That(translated, Is.EqualTo(sample.ExpectedTranslated));
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty Translate_PreservesWeaponMissWrappers(WeaponMissPatternCase sample)
+    {
+        var translated = MessagePatternTranslator.Translate(sample.Source);
+
+        Assert.That(translated, Is.EqualTo(sample.ExpectedTranslated));
+
+        return true.ToProperty();
+    }
+
+    private static void UseRepositoryPatternDictionary()
+    {
+        var root = TestProjectPaths.GetRepositoryRoot();
+        var repositoryPatternFile = Path.Combine(root, "Mods", "QudJP", "Localization", "Dictionaries", "messages.ja.json");
+        MessagePatternTranslator.SetPatternFileForTests(repositoryPatternFile);
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarAfterRenderTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarAfterRenderTranslationPatchTests.cs
@@ -159,6 +159,52 @@ public sealed class AbilityBarAfterRenderTranslationPatchTests
     }
 
     [Test]
+    public void Postfix_PreservesMarkupWrappedEnglishModifierInTargetDisplayName()
+    {
+        WriteDictionary(
+            ("TARGET:", "ターゲット:"),
+            ("dromad merchant", "ドロマド商人"));
+        WriteDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("bloody", "{{r|血まみれの}}"),
+            ("[sitting]", "[座っている]"));
+
+        RunWithPostfixPatch(() =>
+        {
+            var target = new DummyAbilityBarAfterRenderTarget
+            {
+                NextTargetText = "{{C|TARGET: {{r|bloody}} Tam, dromad merchant [sitting]}}",
+            };
+
+            target.AfterRender(core: null, sb: null);
+
+            Assert.That(
+                target.GetTargetText(),
+                Is.EqualTo("{{C|ターゲット: {{r|血まみれの}}Tam、ドロマド商人 [座っている]}}"));
+        });
+    }
+
+    [Test]
+    public void Postfix_PreservesTerminalEmptyWrapperInTargetText()
+    {
+        WriteDictionary(("TARGET:", "ターゲット:"));
+
+        RunWithPostfixPatch(() =>
+        {
+            var target = new DummyAbilityBarAfterRenderTarget
+            {
+                NextTargetText = "{{C|<color=#3e83a5>TARGET:</color> タム、ドロマド商団 [座っている]{{B|}}}}",
+            };
+
+            target.AfterRender(core: null, sb: null);
+
+            Assert.That(
+                target.GetTargetText(),
+                Is.EqualTo("{{C|<color=#3e83a5>ターゲット:</color> タム、ドロマド商団 [座っている]{{B|}}}}"));
+        });
+    }
+
+    [Test]
     public void Postfix_RecordsOwnerRouteTransforms_WithoutUITextSkinSinkObservation()
     {
         WriteDictionary(

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarAfterRenderTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarAfterRenderTranslationPatchTests.cs
@@ -211,6 +211,58 @@ public sealed class AbilityBarAfterRenderTranslationPatchTests
     }
 
     [Test]
+    public void Postfix_PreservesAmpersandWholeLineColor_WhenDisplayNameTranslationOwnsMarkup()
+    {
+        WriteDictionary(
+            ("TARGET:", "ターゲット:"),
+            ("dromad merchant", "ドロマド商人"));
+        WriteDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("bloody", "{{r|血まみれの}}"),
+            ("[sitting]", "[座っている]"));
+
+        RunWithPostfixPatch(() =>
+        {
+            var target = new DummyAbilityBarAfterRenderTarget
+            {
+                NextTargetText = "&G<color=#3e83a5>TARGET:</color> {{r|bloody}} Tam, dromad merchant [sitting]&y",
+            };
+
+            target.AfterRender(core: null, sb: null);
+
+            Assert.That(
+                target.GetTargetText(),
+                Is.EqualTo("&G<color=#3e83a5>ターゲット:</color> {{r|血まみれの}}Tam、ドロマド商人 [座っている]&y"));
+        });
+    }
+
+    [Test]
+    public void Postfix_PreservesNestedSameTokenLabelWrapper_WhenDisplayNameTranslationOwnsMarkup()
+    {
+        WriteDictionary(
+            ("TARGET:", "ターゲット:"),
+            ("dromad merchant", "ドロマド商人"));
+        WriteDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("bloody", "{{r|血まみれの}}"),
+            ("[sitting]", "[座っている]"));
+
+        RunWithPostfixPatch(() =>
+        {
+            var target = new DummyAbilityBarAfterRenderTarget
+            {
+                NextTargetText = "{{C|{{C|TARGET:}} {{r|bloody}} Tam, dromad merchant [sitting]}}",
+            };
+
+            target.AfterRender(core: null, sb: null);
+
+            Assert.That(
+                target.GetTargetText(),
+                Is.EqualTo("{{C|{{C|ターゲット:}} {{r|血まみれの}}Tam、ドロマド商人 [座っている]}}"));
+        });
+    }
+
+    [Test]
     public void Postfix_PreservesTerminalEmptyWrapperInTargetText()
     {
         WriteDictionary(("TARGET:", "ターゲット:"));

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarAfterRenderTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarAfterRenderTranslationPatchTests.cs
@@ -185,6 +185,32 @@ public sealed class AbilityBarAfterRenderTranslationPatchTests
     }
 
     [Test]
+    public void Postfix_PreservesLabelMarkup_WhenDisplayNameTranslationOwnsMarkup()
+    {
+        WriteDictionary(
+            ("TARGET:", "ターゲット:"),
+            ("dromad merchant", "ドロマド商人"));
+        WriteDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("bloody", "{{r|血まみれの}}"),
+            ("[sitting]", "[座っている]"));
+
+        RunWithPostfixPatch(() =>
+        {
+            var target = new DummyAbilityBarAfterRenderTarget
+            {
+                NextTargetText = "{{C|<color=#3e83a5>TARGET:</color> {{r|bloody}} Tam, dromad merchant [sitting]}}",
+            };
+
+            target.AfterRender(core: null, sb: null);
+
+            Assert.That(
+                target.GetTargetText(),
+                Is.EqualTo("{{C|<color=#3e83a5>ターゲット:</color> {{r|血まみれの}}Tam、ドロマド商人 [座っている]}}"));
+        });
+    }
+
+    [Test]
     public void Postfix_PreservesTerminalEmptyWrapperInTargetText()
     {
         WriteDictionary(("TARGET:", "ターゲット:"));

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
@@ -679,6 +679,82 @@ public sealed class CombatAndLogMessageQueuePatchTests
     }
 
     [Test]
+    public void MessagingEmitMessage_PreservesNestedColorWrappersForPlayerHitWithRoll_WhenPatched()
+    {
+        UseRepositoryPatternDictionary();
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(
+                    typeof(DummyMessagingEmitMessageTarget),
+                    nameof(DummyMessagingEmitMessageTarget.EmitMessage),
+                    typeof(DummyGameObject),
+                    typeof(string),
+                    typeof(char),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(DummyGameObject),
+                    typeof(DummyGameObject)),
+                typeof(GameObjectEmitMessageTranslationPatch));
+
+            DummyMessagingEmitMessageTarget.MessageToSend = "{{g|You hit {{&w|(x1)}} for 1 damage with your {{fiery|燃え盛る}} {{w|青銅の短剣}}! [9]}}";
+            DummyMessagingEmitMessageTarget.EmitMessage(new DummyGameObject(), "unused", 'W', false, false, false);
+
+            Assert.That(
+                DummyMessageQueue.LastMessage,
+                Is.EqualTo("{{g|{{fiery|燃え盛る}} {{w|青銅の短剣}}で1ダメージを与えた。({{&w|x1}}) [9]}}"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void MessagingEmitMessage_PreservesNestedColorWrappersForPlayerHitWithRoll_WithControlHeader_WhenPatched()
+    {
+        UseRepositoryPatternDictionary();
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(
+                    typeof(DummyMessagingEmitMessageTarget),
+                    nameof(DummyMessagingEmitMessageTarget.EmitMessage),
+                    typeof(DummyGameObject),
+                    typeof(string),
+                    typeof(char),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(DummyGameObject),
+                    typeof(DummyGameObject)),
+                typeof(GameObjectEmitMessageTranslationPatch));
+
+            DummyMessagingEmitMessageTarget.MessageToSend = "\u0002hit\u001F7\u001F18\u001F\u0003{{g|You hit {{&w|(x1)}} for 1 damage with your {{w|青銅の短剣}}! [18]}}";
+            DummyMessagingEmitMessageTarget.EmitMessage(new DummyGameObject(), "unused", 'W', false, false, false);
+
+            Assert.That(
+                DummyMessageQueue.LastMessage,
+                Is.EqualTo("{{g|{{w|青銅の短剣}}で1ダメージを与えた。({{&w|x1}}) [18]}}"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
     public void MessagingEmitMessage_TranslatesThirdPersonAcidDamageMessage_WhenPatched()
     {
         UseRepositoryPatternDictionary();

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupShowSpaceTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupShowSpaceTranslationPatchTests.cs
@@ -152,6 +152,22 @@ public sealed class PopupShowSpaceTranslationPatchTests
         });
     }
 
+    [Test]
+    public void Prefix_TranslatesDeathPopupWithLocalizedKiller_AndPreservesLeadingColor()
+    {
+        WriteDictionary(
+            ("QudJP.DeathWrapper.Generic.Wrapped", "あなたは死んだ。\n\n{body}"),
+            ("QudJP.DeathWrapper.KilledBy.Bare", "{killer}に殺された。"));
+
+        using var patch = PatchShowSpace();
+
+        DummyPopupGenericTarget.ShowSpace("&yYou died.\n\nYou were killed by タム、ドロマド商団 [座っている].");
+
+        Assert.That(
+            DummyPopupGenericTarget.LastShowSpaceMessage,
+            Is.EqualTo("&yあなたは死んだ。\n\nタム、ドロマド商団 [座っている]に殺された。"));
+    }
+
     private static IDisposable PatchShowSpace()
     {
         var harmonyId = CreateHarmonyId();

--- a/Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj
@@ -21,6 +21,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FsCheck" Version="3.3.2" />
+    <PackageReference Include="FsCheck.NUnit" Version="3.3.2" />
     <PackageReference Include="Lib.Harmony" Version="2.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />

--- a/Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using HarmonyLib;
@@ -175,10 +176,20 @@ public static class AbilityBarAfterRenderTranslationPatch
                 ObservabilityHelpers.ComposeContext(Context, "field=targetText", "segment=name"));
         }
 
-        translated =
-            ColorAwareTranslationComposer.RestoreCapture(translatedLabel, spans, match.Groups["label"])
-            + " "
-            + ColorAwareTranslationComposer.RestoreCapture(translatedName, spans, match.Groups["name"]);
+        var displayNameOwnsMarkup = HasColorMarkup(translatedName);
+
+        if (displayNameOwnsMarkup)
+        {
+            translated = translatedLabel + " " + translatedName;
+            translated = RestoreWholeLineBoundaryWrappers(translated, spans, stripped.Length);
+        }
+        else
+        {
+            translated =
+                ColorAwareTranslationComposer.RestoreCapture(translatedLabel, spans, match.Groups["label"])
+                + " "
+                + ColorAwareTranslationComposer.RestoreCapture(translatedName, spans, match.Groups["name"]);
+        }
         if (string.Equals(translated, source, StringComparison.Ordinal))
         {
             return false;
@@ -216,6 +227,70 @@ public static class AbilityBarAfterRenderTranslationPatch
 
         DynamicTextObservability.RecordTransform(route, "AbilityBar.TargetHealth.Exact", source, translated);
         return true;
+    }
+
+    private static bool HasColorMarkup(string source)
+    {
+        var (stripped, _) = ColorAwareTranslationComposer.Strip(source);
+        return !string.Equals(stripped, source, StringComparison.Ordinal);
+    }
+
+    private static string RestoreWholeLineBoundaryWrappers(string translated, IReadOnlyList<ColorSpan>? spans, int sourceLength)
+    {
+        if (spans is null || spans.Count == 0)
+        {
+            return translated;
+        }
+
+        var wholeLineSpans = SliceWholeLineBoundarySpans(spans, sourceLength, translated.Length);
+        return wholeLineSpans.Count == 0
+            ? translated
+            : ColorAwareTranslationComposer.Restore(translated, wholeLineSpans);
+    }
+
+    private static List<ColorSpan> SliceWholeLineBoundarySpans(IReadOnlyList<ColorSpan> spans, int sourceLength, int translatedLength)
+    {
+        var wholeLinePairs = new List<(ColorSpan Opening, int OpeningOrder, ColorSpan Closing, int ClosingOrder)>();
+        var openingStack = new Stack<(ColorSpan Span, int Order)>();
+
+        for (var index = 0; index < spans.Count; index++)
+        {
+            var span = spans[index];
+            if (ColorCodePreserver.IsOpeningBoundaryToken(span.Token))
+            {
+                openingStack.Push((span, index));
+                continue;
+            }
+
+            if (!ColorCodePreserver.IsClosingBoundaryToken(span.Token) || openingStack.Count == 0)
+            {
+                continue;
+            }
+
+            var opening = openingStack.Pop();
+            if (opening.Span.Index == 0 && span.Index == sourceLength)
+            {
+                wholeLinePairs.Add((opening.Span, opening.Order, span, index));
+            }
+        }
+
+        if (wholeLinePairs.Count == 0)
+        {
+            return new List<ColorSpan>();
+        }
+
+        var result = new List<ColorSpan>(wholeLinePairs.Count * 2);
+        foreach (var pair in wholeLinePairs.OrderBy(static pair => pair.OpeningOrder))
+        {
+            result.Add(new ColorSpan(0, pair.Opening.Token));
+        }
+
+        foreach (var pair in wholeLinePairs.OrderBy(static pair => pair.ClosingOrder))
+        {
+            result.Add(new ColorSpan(translatedLength, pair.Closing.Token));
+        }
+
+        return result;
     }
 
     private delegate bool TryTranslateText(string source, string route, out string translated);

--- a/Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using HarmonyLib;
@@ -192,6 +191,7 @@ public static class AbilityBarAfterRenderTranslationPatch
                 + " "
                 + ColorAwareTranslationComposer.RestoreCapture(translatedName, spans, match.Groups["name"]);
         }
+
         if (string.Equals(translated, source, StringComparison.Ordinal))
         {
             return false;

--- a/Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs
@@ -180,7 +180,9 @@ public static class AbilityBarAfterRenderTranslationPatch
 
         if (displayNameOwnsMarkup)
         {
-            translated = translatedLabel + " " + translatedName;
+            translated = RestoreCaptureWithoutWholeLineOpenings(translatedLabel, spans, match.Groups["label"], stripped.Length)
+                + " "
+                + translatedName;
             translated = RestoreWholeLineBoundaryWrappers(translated, spans, stripped.Length);
         }
         else
@@ -248,8 +250,39 @@ public static class AbilityBarAfterRenderTranslationPatch
             : ColorAwareTranslationComposer.Restore(translated, wholeLineSpans);
     }
 
+    private static string RestoreCaptureWithoutWholeLineOpenings(
+        string translated,
+        IReadOnlyList<ColorSpan>? spans,
+        Group group,
+        int sourceLength)
+    {
+        if (spans is null || spans.Count == 0 || !group.Success)
+        {
+            return translated;
+        }
+
+        var captureSpans = ColorCodePreserver.SliceSpans(spans, group.Index, group.Length);
+        captureSpans.AddRange(ColorCodePreserver.SliceAdjacentCaptureBoundarySpans(spans, group.Index, group.Length));
+
+        if (group.Index == 0 && group.Length < sourceLength)
+        {
+            var wholeLineOpeningTokens = SliceWholeLineBoundarySpans(spans, sourceLength, sourceLength)
+                .Where(static span => span.Index == 0)
+                .Select(static span => span.Token)
+                .ToHashSet(StringComparer.Ordinal);
+
+            captureSpans.RemoveAll(span => span.Index == 0 && wholeLineOpeningTokens.Contains(span.Token));
+        }
+
+        return ColorAwareTranslationComposer.Restore(translated, captureSpans);
+    }
+
     private static List<ColorSpan> SliceWholeLineBoundarySpans(IReadOnlyList<ColorSpan> spans, int sourceLength, int translatedLength)
     {
+        // Keep this stack walk local to the absolute Restore(...) path.
+        // MessagePatternTranslator.SliceWholeLineBoundaryWrappers mirrors the same matching logic,
+        // but it must emit relative spans for RestoreRelative(...), so a shared helper would still
+        // need two span-construction contracts.
         var wholeLinePairs = new List<(ColorSpan Opening, int OpeningOrder, ColorSpan Closing, int ClosingOrder)>();
         var openingStack = new Stack<(ColorSpan Span, int Order)>();
 

--- a/Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs
@@ -244,7 +244,8 @@ public static class AbilityBarAfterRenderTranslationPatch
             return translated;
         }
 
-        var wholeLineSpans = SliceWholeLineBoundarySpans(spans, sourceLength, translated.Length);
+        var wholeLinePairs = ColorAwareTranslationComposer.SliceWholeBoundaryPairs(spans, sourceStart: 0, sourceLength);
+        var wholeLineSpans = ColorAwareTranslationComposer.ProjectWholeBoundaryPairsAbsolute(wholeLinePairs, translated.Length);
         return wholeLineSpans.Count == 0
             ? translated
             : ColorAwareTranslationComposer.Restore(translated, wholeLineSpans);
@@ -266,64 +267,11 @@ public static class AbilityBarAfterRenderTranslationPatch
 
         if (group.Index == 0 && group.Length < sourceLength)
         {
-            var wholeLineOpeningTokens = SliceWholeLineBoundarySpans(spans, sourceLength, sourceLength)
-                .Where(static span => span.Index == 0)
-                .Select(static span => span.Token)
-                .ToHashSet(StringComparer.Ordinal);
-
-            captureSpans.RemoveAll(span => span.Index == 0 && wholeLineOpeningTokens.Contains(span.Token));
+            var wholeLinePairs = ColorAwareTranslationComposer.SliceWholeBoundaryPairs(spans, sourceStart: 0, sourceLength);
+            ColorAwareTranslationComposer.RemoveWholeBoundaryOpenings(captureSpans, wholeLinePairs);
         }
 
         return ColorAwareTranslationComposer.Restore(translated, captureSpans);
-    }
-
-    private static List<ColorSpan> SliceWholeLineBoundarySpans(IReadOnlyList<ColorSpan> spans, int sourceLength, int translatedLength)
-    {
-        // Keep this stack walk local to the absolute Restore(...) path.
-        // MessagePatternTranslator.SliceWholeLineBoundaryWrappers mirrors the same matching logic,
-        // but it must emit relative spans for RestoreRelative(...), so a shared helper would still
-        // need two span-construction contracts.
-        var wholeLinePairs = new List<(ColorSpan Opening, int OpeningOrder, ColorSpan Closing, int ClosingOrder)>();
-        var openingStack = new Stack<(ColorSpan Span, int Order)>();
-
-        for (var index = 0; index < spans.Count; index++)
-        {
-            var span = spans[index];
-            if (ColorCodePreserver.IsOpeningBoundaryToken(span.Token))
-            {
-                openingStack.Push((span, index));
-                continue;
-            }
-
-            if (!ColorCodePreserver.IsClosingBoundaryToken(span.Token) || openingStack.Count == 0)
-            {
-                continue;
-            }
-
-            var opening = openingStack.Pop();
-            if (opening.Span.Index == 0 && span.Index == sourceLength)
-            {
-                wholeLinePairs.Add((opening.Span, opening.Order, span, index));
-            }
-        }
-
-        if (wholeLinePairs.Count == 0)
-        {
-            return new List<ColorSpan>();
-        }
-
-        var result = new List<ColorSpan>(wholeLinePairs.Count * 2);
-        foreach (var pair in wholeLinePairs.OrderBy(static pair => pair.OpeningOrder))
-        {
-            result.Add(new ColorSpan(0, pair.Opening.Token));
-        }
-
-        foreach (var pair in wholeLinePairs.OrderBy(static pair => pair.ClosingOrder))
-        {
-            result.Add(new ColorSpan(translatedLength, pair.Closing.Token));
-        }
-
-        return result;
     }
 
     private delegate bool TryTranslateText(string source, string route, out string translated);

--- a/Mods/QudJP/Assemblies/src/Patches/DeathWrapperFamilyTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/DeathWrapperFamilyTranslator.cs
@@ -320,7 +320,7 @@ internal static class DeathWrapperFamilyTranslator
         }
 
         var killer = TranslateEntityReference(match.Groups["killer"].Value, translationContext);
-        if (spans is not null && spans.Count > 0)
+        if (spans is not null && spans.Count > 0 && !HasColorMarkup(killer))
         {
             killer = ColorAwareTranslationComposer.RestoreCapture(killer, spans, match.Groups["killer"]);
         }
@@ -427,5 +427,11 @@ internal static class DeathWrapperFamilyTranslator
         return match.Groups["accidental"].Success
             ? "QudJP.DeathWrapper.AccidentalSuicide.Bare"
             : "QudJP.DeathWrapper.Suicide.Bare";
+    }
+
+    private static bool HasColorMarkup(string source)
+    {
+        var (stripped, _) = ColorAwareTranslationComposer.Strip(source);
+        return !string.Equals(stripped, source, StringComparison.Ordinal);
     }
 }

--- a/Mods/QudJP/Assemblies/src/Patches/DeathWrapperFamilyTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/DeathWrapperFamilyTranslator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace QudJP.Patches;
@@ -320,9 +321,11 @@ internal static class DeathWrapperFamilyTranslator
         }
 
         var killer = TranslateEntityReference(match.Groups["killer"].Value, translationContext);
-        if (spans is not null && spans.Count > 0 && !HasColorMarkup(killer))
+        if (spans is not null && spans.Count > 0)
         {
-            killer = ColorAwareTranslationComposer.RestoreCapture(killer, spans, match.Groups["killer"]);
+            killer = HasColorMarkup(killer)
+                ? RestoreKillerMarkupPreservingTranslatedOwnership(killer, spans, match.Groups["killer"])
+                : ColorAwareTranslationComposer.RestoreCapture(killer, spans, match.Groups["killer"]);
         }
 
         return TryComposeTranslation(
@@ -433,5 +436,75 @@ internal static class DeathWrapperFamilyTranslator
     {
         var (stripped, _) = ColorAwareTranslationComposer.Strip(source);
         return !string.Equals(stripped, source, StringComparison.Ordinal);
+    }
+
+    private static string RestoreKillerMarkupPreservingTranslatedOwnership(
+        string translatedKiller,
+        IReadOnlyList<ColorSpan> spans,
+        Group killerGroup)
+    {
+        var (visible, translatedOwnedSpans) = ColorAwareTranslationComposer.Strip(translatedKiller);
+        var preservedSourceWrappers = SliceWholeCaptureBoundarySpans(spans, killerGroup.Index, killerGroup.Length, visible.Length);
+
+        if (preservedSourceWrappers.Count == 0)
+        {
+            return translatedKiller;
+        }
+
+        var mergedSpans = new List<ColorSpan>(translatedOwnedSpans.Count + preservedSourceWrappers.Count);
+        mergedSpans.AddRange(preservedSourceWrappers.Where(static span => span.Index == 0));
+        mergedSpans.AddRange(translatedOwnedSpans);
+        mergedSpans.AddRange(preservedSourceWrappers.Where(span => span.Index == visible.Length));
+        return ColorAwareTranslationComposer.Restore(visible, mergedSpans);
+    }
+
+    private static List<ColorSpan> SliceWholeCaptureBoundarySpans(
+        IReadOnlyList<ColorSpan> spans,
+        int captureStart,
+        int captureLength,
+        int translatedLength)
+    {
+        var captureEnd = captureStart + captureLength;
+        var wholeCapturePairs = new List<(ColorSpan Opening, int OpeningOrder, ColorSpan Closing, int ClosingOrder)>();
+        var openingStack = new Stack<(ColorSpan Span, int Order)>();
+
+        for (var index = 0; index < spans.Count; index++)
+        {
+            var span = spans[index];
+            if (ColorCodePreserver.IsOpeningBoundaryToken(span.Token))
+            {
+                openingStack.Push((span, index));
+                continue;
+            }
+
+            if (!ColorCodePreserver.IsClosingBoundaryToken(span.Token) || openingStack.Count == 0)
+            {
+                continue;
+            }
+
+            var opening = openingStack.Pop();
+            if (opening.Span.Index == captureStart && span.Index == captureEnd)
+            {
+                wholeCapturePairs.Add((opening.Span, opening.Order, span, index));
+            }
+        }
+
+        if (wholeCapturePairs.Count == 0)
+        {
+            return new List<ColorSpan>();
+        }
+
+        var result = new List<ColorSpan>(wholeCapturePairs.Count * 2);
+        foreach (var pair in wholeCapturePairs.OrderBy(static pair => pair.OpeningOrder))
+        {
+            result.Add(new ColorSpan(0, pair.Opening.Token));
+        }
+
+        foreach (var pair in wholeCapturePairs.OrderBy(static pair => pair.ClosingOrder))
+        {
+            result.Add(new ColorSpan(translatedLength, pair.Closing.Token));
+        }
+
+        return result;
     }
 }

--- a/Mods/QudJP/Assemblies/src/Patches/DeathWrapperFamilyTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/DeathWrapperFamilyTranslator.cs
@@ -444,7 +444,8 @@ internal static class DeathWrapperFamilyTranslator
         Group killerGroup)
     {
         var (visible, translatedOwnedSpans) = ColorAwareTranslationComposer.Strip(translatedKiller);
-        var preservedSourceWrappers = SliceWholeCaptureBoundarySpans(spans, killerGroup.Index, killerGroup.Length, visible.Length);
+        var wholeCapturePairs = ColorAwareTranslationComposer.SliceWholeBoundaryPairs(spans, killerGroup.Index, killerGroup.Length);
+        var preservedSourceWrappers = ColorAwareTranslationComposer.ProjectWholeBoundaryPairsAbsolute(wholeCapturePairs, visible.Length);
 
         if (preservedSourceWrappers.Count == 0)
         {
@@ -456,55 +457,5 @@ internal static class DeathWrapperFamilyTranslator
         mergedSpans.AddRange(translatedOwnedSpans);
         mergedSpans.AddRange(preservedSourceWrappers.Where(span => span.Index == visible.Length));
         return ColorAwareTranslationComposer.Restore(visible, mergedSpans);
-    }
-
-    private static List<ColorSpan> SliceWholeCaptureBoundarySpans(
-        IReadOnlyList<ColorSpan> spans,
-        int captureStart,
-        int captureLength,
-        int translatedLength)
-    {
-        var captureEnd = captureStart + captureLength;
-        var wholeCapturePairs = new List<(ColorSpan Opening, int OpeningOrder, ColorSpan Closing, int ClosingOrder)>();
-        var openingStack = new Stack<(ColorSpan Span, int Order)>();
-
-        for (var index = 0; index < spans.Count; index++)
-        {
-            var span = spans[index];
-            if (ColorCodePreserver.IsOpeningBoundaryToken(span.Token))
-            {
-                openingStack.Push((span, index));
-                continue;
-            }
-
-            if (!ColorCodePreserver.IsClosingBoundaryToken(span.Token) || openingStack.Count == 0)
-            {
-                continue;
-            }
-
-            var opening = openingStack.Pop();
-            if (opening.Span.Index == captureStart && span.Index == captureEnd)
-            {
-                wholeCapturePairs.Add((opening.Span, opening.Order, span, index));
-            }
-        }
-
-        if (wholeCapturePairs.Count == 0)
-        {
-            return new List<ColorSpan>();
-        }
-
-        var result = new List<ColorSpan>(wholeCapturePairs.Count * 2);
-        foreach (var pair in wholeCapturePairs.OrderBy(static pair => pair.OpeningOrder))
-        {
-            result.Add(new ColorSpan(0, pair.Opening.Token));
-        }
-
-        foreach (var pair in wholeCapturePairs.OrderBy(static pair => pair.ClosingOrder))
-        {
-            result.Add(new ColorSpan(translatedLength, pair.Closing.Token));
-        }
-
-        return result;
     }
 }

--- a/Mods/QudJP/Assemblies/src/Patches/DescriptionTextTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/DescriptionTextTranslator.cs
@@ -303,59 +303,11 @@ internal static class DescriptionTextTranslator
             return translated;
         }
 
-        var wholeLineSpans = SliceWholeLineBoundarySpans(spans, sourceLength, translated.Length);
+        var wholeLinePairs = ColorAwareTranslationComposer.SliceWholeBoundaryPairs(spans, sourceStart: 0, sourceLength);
+        var wholeLineSpans = ColorAwareTranslationComposer.ProjectWholeBoundaryPairsAbsolute(wholeLinePairs, translated.Length);
         return wholeLineSpans.Count == 0
             ? translated
             : ColorAwareTranslationComposer.Restore(translated, wholeLineSpans);
-    }
-
-    private static List<ColorSpan> SliceWholeLineBoundarySpans(IReadOnlyList<ColorSpan> spans, int sourceLength, int translatedLength)
-    {
-        var wholeLinePairs = new List<(ColorSpan Opening, int OpeningOrder, ColorSpan Closing, int ClosingOrder)>();
-        var openingStack = new Stack<(ColorSpan Span, int Order)>();
-
-        for (var index = 0; index < spans.Count; index++)
-        {
-            var span = spans[index];
-            if (ColorCodePreserver.IsOpeningBoundaryToken(span.Token))
-            {
-                openingStack.Push((span, index));
-                continue;
-            }
-
-            if (!ColorCodePreserver.IsClosingBoundaryToken(span.Token) || openingStack.Count == 0)
-            {
-                continue;
-            }
-
-            var opening = openingStack.Pop();
-            if (opening.Span.Index == 0 && span.Index == sourceLength)
-            {
-                wholeLinePairs.Add((opening.Span, opening.Order, span, index));
-            }
-        }
-
-        if (wholeLinePairs.Count == 0)
-        {
-            return new List<ColorSpan>();
-        }
-
-        var result = new List<ColorSpan>(wholeLinePairs.Count * 2);
-        var openingOrderedPairs = wholeLinePairs.OrderBy(static pair => pair.OpeningOrder).ToArray();
-        for (var index = 0; index < openingOrderedPairs.Length; index++)
-        {
-            var pair = openingOrderedPairs[index];
-            result.Add(new ColorSpan(0, pair.Opening.Token));
-        }
-
-        var closingOrderedPairs = wholeLinePairs.OrderBy(static pair => pair.ClosingOrder).ToArray();
-        for (var index = 0; index < closingOrderedPairs.Length; index++)
-        {
-            var pair = closingOrderedPairs[index];
-            result.Add(new ColorSpan(translatedLength, pair.Closing.Token));
-        }
-
-        return result;
     }
 
     private static string TranslateDispositionReason(string source, string route)

--- a/Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs
@@ -320,8 +320,9 @@ internal static class GetDisplayNameRouteTranslator
             return false;
         }
 
-        var rest = TranslateDisplayNameFragment(match.Groups["rest"].Value, route);
-        translated = translatedModifier + " " + rest;
+        var restSource = match.Groups["rest"].Value;
+        var rest = TranslateDisplayNameFragment(restSource, route);
+        translated = translatedModifier + (ShouldElideModifierSpace(restSource) ? string.Empty : " ") + rest;
         DynamicTextObservability.RecordTransform(route, "DisplayName.MarkupLeadingModifier", source, translated);
         return true;
     }
@@ -535,6 +536,16 @@ internal static class GetDisplayNameRouteTranslator
         var direct = ScopedDictionaryLookup.TranslateExactOrLowerAscii(bracketed, DisplayNameDictionaryFiles);
         if (direct is null)
         {
+            using var _ = Translator.PushMissingKeyLoggingSuppression(true);
+            var global = Translator.Translate(bracketed);
+            if (!string.Equals(global, bracketed, StringComparison.Ordinal))
+            {
+                direct = global;
+            }
+        }
+
+        if (direct is null)
+        {
             translated = source;
             return false;
         }
@@ -714,6 +725,23 @@ internal static class GetDisplayNameRouteTranslator
         }
 
         return hasUppercase;
+    }
+
+    private static bool ShouldElideModifierSpace(string source)
+    {
+        if (LooksLikeGeneratedProperName(source))
+        {
+            return true;
+        }
+
+        var bracketedMatch = BracketedDisplayNameSuffixPattern.Match(source);
+        if (bracketedMatch.Success && LooksLikeGeneratedProperName(bracketedMatch.Groups["base"].Value))
+        {
+            return true;
+        }
+
+        var parenthesizedMatch = ParenthesizedDisplayNameSuffixPattern.Match(source);
+        return parenthesizedMatch.Success && LooksLikeGeneratedProperName(parenthesizedMatch.Groups["base"].Value);
     }
 
     private static string? TranslateAsciiTokenWithCaseFallback(string source)

--- a/Mods/QudJP/Assemblies/src/Translation/ColorAwareTranslationComposer.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/ColorAwareTranslationComposer.cs
@@ -6,6 +6,25 @@ namespace QudJP;
 
 internal static class ColorAwareTranslationComposer
 {
+    internal sealed class WholeBoundaryPair
+    {
+        internal WholeBoundaryPair(ColorSpan opening, int openingOrder, ColorSpan closing, int closingOrder)
+        {
+            Opening = opening;
+            OpeningOrder = openingOrder;
+            Closing = closing;
+            ClosingOrder = closingOrder;
+        }
+
+        internal ColorSpan Opening { get; }
+
+        internal int OpeningOrder { get; }
+
+        internal ColorSpan Closing { get; }
+
+        internal int ClosingOrder { get; }
+    }
+
     internal static (string stripped, List<ColorSpan> spans) Strip(string? source)
     {
         return ColorCodePreserver.Strip(source);
@@ -73,6 +92,103 @@ internal static class ColorAwareTranslationComposer
         var captureSpans = ColorCodePreserver.SliceSpans(spans, group.Index, group.Length);
         captureSpans.AddRange(ColorCodePreserver.SliceAdjacentCaptureBoundarySpans(spans, group.Index, group.Length));
         return Restore(value, captureSpans);
+    }
+
+    internal static List<WholeBoundaryPair> SliceWholeBoundaryPairs(
+        IReadOnlyList<ColorSpan>? spans,
+        int sourceStart,
+        int sourceLength)
+    {
+        var pairs = new List<WholeBoundaryPair>();
+        if (spans is null || spans.Count == 0)
+        {
+            return pairs;
+        }
+
+        var sourceEnd = sourceStart + sourceLength;
+        var openingCandidates = new List<(ColorSpan Span, int Order)>();
+        var closingCandidates = new List<(ColorSpan Span, int Order)>();
+
+        for (var index = 0; index < spans.Count; index++)
+        {
+            var span = spans[index];
+            if (span.Index == sourceStart && ColorCodePreserver.IsOpeningBoundaryToken(span.Token))
+            {
+                openingCandidates.Add((span, index));
+            }
+
+            if (span.Index == sourceEnd && ColorCodePreserver.IsClosingBoundaryToken(span.Token))
+            {
+                closingCandidates.Add((span, index));
+            }
+        }
+
+        var pairCount = Math.Min(openingCandidates.Count, closingCandidates.Count);
+        for (var index = 0; index < pairCount; index++)
+        {
+            pairs.Add(new WholeBoundaryPair(
+                openingCandidates[index].Span,
+                openingCandidates[index].Order,
+                closingCandidates[index].Span,
+                closingCandidates[index].Order));
+        }
+
+        return pairs;
+    }
+
+    internal static List<ColorSpan> ProjectWholeBoundaryPairsAbsolute(
+        IReadOnlyList<WholeBoundaryPair> pairs,
+        int translatedLength)
+    {
+        var projected = new List<ColorSpan>(pairs.Count * 2);
+        for (var index = 0; index < pairs.Count; index++)
+        {
+            projected.Add(new ColorSpan(0, pairs[index].Opening.Token));
+        }
+
+        for (var index = 0; index < pairs.Count; index++)
+        {
+            projected.Add(new ColorSpan(translatedLength, pairs[index].Closing.Token));
+        }
+
+        return projected;
+    }
+
+    internal static List<ColorSpan> ProjectWholeBoundaryPairsRelative(
+        IReadOnlyList<WholeBoundaryPair> pairs,
+        int sourceLength)
+    {
+        var projected = new List<ColorSpan>(pairs.Count * 2);
+        for (var index = 0; index < pairs.Count; index++)
+        {
+            projected.Add(new ColorSpan(0, pairs[index].Opening.Token, sourceLength, usesRelativeIndex: true));
+        }
+
+        for (var index = 0; index < pairs.Count; index++)
+        {
+            projected.Add(new ColorSpan(sourceLength, pairs[index].Closing.Token, sourceLength, usesRelativeIndex: true));
+        }
+
+        return projected;
+    }
+
+    internal static void RemoveWholeBoundaryOpenings(
+        List<ColorSpan> captureSpans,
+        IReadOnlyList<WholeBoundaryPair> pairs)
+    {
+        for (var pairIndex = 0; pairIndex < pairs.Count; pairIndex++)
+        {
+            var openingToken = pairs[pairIndex].Opening.Token;
+            for (var spanIndex = 0; spanIndex < captureSpans.Count; spanIndex++)
+            {
+                var span = captureSpans[spanIndex];
+                if (span.Index == 0 && string.Equals(span.Token, openingToken, StringComparison.Ordinal))
+                {
+                    captureSpans.RemoveAt(spanIndex);
+                    break;
+                }
+            }
+        }
     }
 
     internal static string RestoreSlice(string value, IReadOnlyList<ColorSpan>? spans, int startIndex, int length)

--- a/Mods/QudJP/Assemblies/src/Translation/ColorCodePreserver.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/ColorCodePreserver.cs
@@ -187,7 +187,7 @@ public static class ColorCodePreserver
                 continue;
             }
 
-            if (IsClosingBoundaryToken(span.Token))
+            if (IsCaptureClosingToken(span.Token))
             {
                 return true;
             }

--- a/Mods/QudJP/Assemblies/src/Translation/ColorCodePreserver.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/ColorCodePreserver.cs
@@ -101,7 +101,9 @@ public static class ColorCodePreserver
                 continue;
             }
 
-            if (span.Index == endIndex && !IsCaptureClosingToken(span.Token))
+            if (span.Index == endIndex
+                && !IsCaptureClosingToken(span.Token)
+                && !HasClosingBoundaryTokenAtSameIndex(spans, index + 1, endIndex))
             {
                 continue;
             }
@@ -168,6 +170,30 @@ public static class ColorCodePreserver
         }
 
         return hasOpening && hasClosing;
+    }
+
+    private static bool HasClosingBoundaryTokenAtSameIndex(IReadOnlyList<ColorSpan> spans, int startSearchIndex, int targetIndex)
+    {
+        for (var index = startSearchIndex; index < spans.Count; index++)
+        {
+            var span = spans[index];
+            if (span.Index != targetIndex)
+            {
+                if (span.Index > targetIndex)
+                {
+                    break;
+                }
+
+                continue;
+            }
+
+            if (IsClosingBoundaryToken(span.Token))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static int ResolveIndex(ColorSpan span, int textLength)

--- a/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
@@ -712,6 +712,10 @@ internal static class MessagePatternTranslator
 
     private static List<ColorSpan> SliceWholeLineBoundaryWrappers(IReadOnlyList<ColorSpan> spans, int sourceLength)
     {
+        // Keep this stack walk local to the relative RestoreRelative(...) path.
+        // AbilityBarAfterRenderTranslationPatch uses the same boundary matching, but it emits
+        // absolute spans at translatedLength for Restore(...), so the duplication here is in the
+        // span anchoring contract rather than the wrapper matching itself.
         var wholeLinePairs = new List<(ColorSpan Opening, int OpeningOrder, ColorSpan Closing, int ClosingOrder)>();
         var openingStack = new Stack<(ColorSpan Span, int Order)>();
 

--- a/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
 using System.Text;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using QudJP.Patches;
@@ -585,6 +586,12 @@ internal static class MessagePatternTranslator
             return translated;
         }
 
+        if (HasInteriorBoundarySpans(spans, strippedSourceLength.Value)
+            && TryRestoreWholeLineBoundaryWrappers(translated, spans, strippedSourceLength.Value, out var wholeLineRestored))
+        {
+            return wholeLineRestored;
+        }
+
         if (translatedFirstCaptureStart < 0
             || translatedLastCaptureEnd < 0
             || translatedFirstCaptureStart > translatedLastCaptureEnd)
@@ -684,6 +691,68 @@ internal static class MessagePatternTranslator
 
         translated = builder.ToString();
         return true;
+    }
+
+    private static bool TryRestoreWholeLineBoundaryWrappers(
+        string translated,
+        IReadOnlyList<ColorSpan> spans,
+        int strippedSourceLength,
+        out string restored)
+    {
+        var wholeLineSpans = SliceWholeLineBoundaryWrappers(spans, strippedSourceLength);
+        if (wholeLineSpans.Count == 0)
+        {
+            restored = string.Empty;
+            return false;
+        }
+
+        restored = ColorAwareTranslationComposer.RestoreRelative(translated, wholeLineSpans, strippedSourceLength);
+        return true;
+    }
+
+    private static List<ColorSpan> SliceWholeLineBoundaryWrappers(IReadOnlyList<ColorSpan> spans, int sourceLength)
+    {
+        var wholeLinePairs = new List<(ColorSpan Opening, int OpeningOrder, ColorSpan Closing, int ClosingOrder)>();
+        var openingStack = new Stack<(ColorSpan Span, int Order)>();
+
+        for (var index = 0; index < spans.Count; index++)
+        {
+            var span = spans[index];
+            if (ColorCodePreserver.IsOpeningBoundaryToken(span.Token))
+            {
+                openingStack.Push((span, index));
+                continue;
+            }
+
+            if (!ColorCodePreserver.IsClosingBoundaryToken(span.Token) || openingStack.Count == 0)
+            {
+                continue;
+            }
+
+            var opening = openingStack.Pop();
+            if (opening.Span.Index == 0 && span.Index == sourceLength)
+            {
+                wholeLinePairs.Add((opening.Span, opening.Order, span, index));
+            }
+        }
+
+        if (wholeLinePairs.Count == 0)
+        {
+            return new List<ColorSpan>();
+        }
+
+        var restored = new List<ColorSpan>(wholeLinePairs.Count * 2);
+        foreach (var pair in wholeLinePairs.OrderBy(static pair => pair.OpeningOrder))
+        {
+            restored.Add(new ColorSpan(0, pair.Opening.Token, sourceLength, usesRelativeIndex: true));
+        }
+
+        foreach (var pair in wholeLinePairs.OrderBy(static pair => pair.ClosingOrder))
+        {
+            restored.Add(new ColorSpan(sourceLength, pair.Closing.Token, sourceLength, usesRelativeIndex: true));
+        }
+
+        return restored;
     }
 
     private static string RestoreLiteralSegment(

--- a/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
 using System.Text;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using QudJP.Patches;

--- a/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
@@ -699,7 +699,8 @@ internal static class MessagePatternTranslator
         int strippedSourceLength,
         out string restored)
     {
-        var wholeLineSpans = SliceWholeLineBoundaryWrappers(spans, strippedSourceLength);
+        var wholeLinePairs = ColorAwareTranslationComposer.SliceWholeBoundaryPairs(spans, sourceStart: 0, strippedSourceLength);
+        var wholeLineSpans = ColorAwareTranslationComposer.ProjectWholeBoundaryPairsRelative(wholeLinePairs, strippedSourceLength);
         if (wholeLineSpans.Count == 0)
         {
             restored = string.Empty;
@@ -708,55 +709,6 @@ internal static class MessagePatternTranslator
 
         restored = ColorAwareTranslationComposer.RestoreRelative(translated, wholeLineSpans, strippedSourceLength);
         return true;
-    }
-
-    private static List<ColorSpan> SliceWholeLineBoundaryWrappers(IReadOnlyList<ColorSpan> spans, int sourceLength)
-    {
-        // Keep this stack walk local to the relative RestoreRelative(...) path.
-        // AbilityBarAfterRenderTranslationPatch uses the same boundary matching, but it emits
-        // absolute spans at translatedLength for Restore(...), so the duplication here is in the
-        // span anchoring contract rather than the wrapper matching itself.
-        var wholeLinePairs = new List<(ColorSpan Opening, int OpeningOrder, ColorSpan Closing, int ClosingOrder)>();
-        var openingStack = new Stack<(ColorSpan Span, int Order)>();
-
-        for (var index = 0; index < spans.Count; index++)
-        {
-            var span = spans[index];
-            if (ColorCodePreserver.IsOpeningBoundaryToken(span.Token))
-            {
-                openingStack.Push((span, index));
-                continue;
-            }
-
-            if (!ColorCodePreserver.IsClosingBoundaryToken(span.Token) || openingStack.Count == 0)
-            {
-                continue;
-            }
-
-            var opening = openingStack.Pop();
-            if (opening.Span.Index == 0 && span.Index == sourceLength)
-            {
-                wholeLinePairs.Add((opening.Span, opening.Order, span, index));
-            }
-        }
-
-        if (wholeLinePairs.Count == 0)
-        {
-            return new List<ColorSpan>();
-        }
-
-        var restored = new List<ColorSpan>(wholeLinePairs.Count * 2);
-        foreach (var pair in wholeLinePairs.OrderBy(static pair => pair.OpeningOrder))
-        {
-            restored.Add(new ColorSpan(0, pair.Opening.Token, sourceLength, usesRelativeIndex: true));
-        }
-
-        foreach (var pair in wholeLinePairs.OrderBy(static pair => pair.ClosingOrder))
-        {
-            restored.Add(new ColorSpan(sourceLength, pair.Closing.Token, sourceLength, usesRelativeIndex: true));
-        }
-
-        return restored;
     }
 
     private static string RestoreLiteralSegment(

--- a/docs/superpowers/plans/2026-04-19-pbt-phase1-color-invariants.md
+++ b/docs/superpowers/plans/2026-04-19-pbt-phase1-color-invariants.md
@@ -203,4 +203,6 @@ Do not add Python/Hypothesis work in this first execution slice.
 - `MessagePatternTranslator` was then added as the next deterministic slice for hit-with-roll and weapon-miss wrapper-preservation invariants using the repository pattern dictionary directly.
 - `MessageFrameTranslator` was then added as a small deterministic helper slice for direct-marker idempotence and strip round-trips, keeping the scope outside combat grammar expansion.
 - `EnclosingFragmentTranslator` was added next as a constrained route-owner slice for `You extricate X from Y.` so subject/container color wrappers stay preserved while direct-marked inputs still pass through unchanged.
-- The next follow-up after this PR should prefer `ClonelingVehicleFragmentTranslator` before `LiquidVolumeFragmentTranslator`, because it has a smaller grammar surface while still exercising wrapper-preservation on world-part fragment routes.
+- `ClonelingVehicleFragmentTranslator` was then added as the next world-part fragment slice, covering both popup and queued routes while preserving liquid wrappers and leaving direct-marked text untouched.
+- `LiquidVolumeFragmentTranslator` followed with a deliberately narrow generator surface that covers status wrappers, ownership questions, normalized targets, pour-into targets, and known passthrough inputs without over-generalizing the fragment grammar.
+- The next follow-up after this PR should likely move back to a smaller helper seam again before widening route grammar further.

--- a/docs/superpowers/plans/2026-04-19-pbt-phase1-color-invariants.md
+++ b/docs/superpowers/plans/2026-04-19-pbt-phase1-color-invariants.md
@@ -201,4 +201,6 @@ Do not add Python/Hypothesis work in this first execution slice.
 - Phase 1b was therefore implemented as separate property groups for foreground/background color codes instead of widening the existing wrapper generator.
 - The next non-trivial candidate, `MessageLogProducerTranslationHelpers`, was added in the same PR as a deterministic PBT slice for the `control header -> direct marker -> nested wrapper` invariant.
 - `MessagePatternTranslator` was then added as the next deterministic slice for hit-with-roll and weapon-miss wrapper-preservation invariants using the repository pattern dictionary directly.
-- The next follow-up after this PR should move beyond combat message families and target another pure helper or constrained route owner with a stable generator surface.
+- `MessageFrameTranslator` was then added as a small deterministic helper slice for direct-marker idempotence and strip round-trips, keeping the scope outside combat grammar expansion.
+- `EnclosingFragmentTranslator` was added next as a constrained route-owner slice for `You extricate X from Y.` so subject/container color wrappers stay preserved while direct-marked inputs still pass through unchanged.
+- The next follow-up after this PR should prefer `ClonelingVehicleFragmentTranslator` before `LiquidVolumeFragmentTranslator`, because it has a smaller grammar surface while still exercising wrapper-preservation on world-part fragment routes.

--- a/docs/superpowers/plans/2026-04-19-pbt-phase1-color-invariants.md
+++ b/docs/superpowers/plans/2026-04-19-pbt-phase1-color-invariants.md
@@ -1,0 +1,203 @@
+# PBT Phase 1 Color Invariants Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the first safe property-based tests to the C# L1 suite so issue-376 color/restore invariants are enforced by generated inputs without replacing existing regression tests.
+
+**Architecture:** Keep the first slice inside pure C# L1 helper logic. Introduce FsCheck + FsCheck.NUnit only in `QudJP.Tests`, add a small generator focused on supported color markup shapes, and use it to prove preservation properties for `ColorCodePreserver` before expanding to translator-level helpers.
+
+**Tech Stack:** .NET 10, NUnit 4, FsCheck, FsCheck.NUnit, existing `QudJP.Tests` project
+
+---
+
+## File Map
+
+- Modify: `Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj`
+  - Add the minimal NuGet packages needed for C# property tests.
+- Create: `Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ColorCodePreserverPropertyTests.cs`
+  - First PBT file, limited to color-preservation invariants already established by issue-376 regressions.
+- Create: `Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ColorCodePreserverArbitraries.cs`
+  - Narrow generators for supported wrapper/code shapes so failures stay readable and deterministic.
+- Keep: `Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorCodePreserverTests.cs`
+  - Existing example-based regressions remain unchanged and continue to prove exact broken shapes.
+
+### Task 1: Add the minimal FsCheck integration
+
+**Files:**
+- Modify: `Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj`
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj`
+
+- [ ] **Step 1: Write the failing package integration step**
+
+Add these package references under the existing test dependencies:
+
+```xml
+<PackageReference Include="FsCheck" Version="3.3.2" />
+<PackageReference Include="FsCheck.NUnit" Version="3.3.2" />
+```
+
+- [ ] **Step 2: Run restore/build to verify the project accepts the new references**
+
+Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~ColorCodePreserverTests`
+
+Expected: existing `ColorCodePreserverTests` still pass; no package-resolution or adapter errors.
+
+### Task 2: Add narrow generators for supported color shapes
+
+**Files:**
+- Create: `Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ColorCodePreserverArbitraries.cs`
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ColorCodePreserverPropertyTests.cs`
+
+- [ ] **Step 1: Write the failing property test scaffold that references a custom arbitrary**
+
+Create the property test file with this skeleton:
+
+```csharp
+using FsCheck;
+using FsCheck.NUnit;
+
+namespace QudJP.Tests.L1.Pbt;
+
+[TestFixture]
+[Category("L1")]
+public sealed class ColorCodePreserverPropertyTests
+{
+    [Property(Arbitrary = new[] { typeof(ColorCodePreserverArbitraries) }, MaxTest = 200)]
+    public Property StripThenRestore_PreservesSupportedMarkup(ColorizedCase sample)
+    {
+        var (stripped, spans) = ColorCodePreserver.Strip(sample.Source);
+        var restored = ColorCodePreserver.Restore(sample.TranslatedVisibleText, spans);
+
+        return (stripped == sample.VisibleText && restored == sample.ExpectedRestored)
+            .ToProperty();
+    }
+}
+```
+
+Expected: compile fails until `ColorizedCase` and `ColorCodePreserverArbitraries` exist.
+
+- [ ] **Step 2: Implement the narrow generator types**
+
+Create `ColorCodePreserverArbitraries.cs` with small, readable generators:
+
+```csharp
+using FsCheck;
+
+namespace QudJP.Tests.L1.Pbt;
+
+public sealed record ColorizedCase(string Source, string VisibleText, string TranslatedVisibleText, string ExpectedRestored);
+
+public static class ColorCodePreserverArbitraries
+{
+    public static Arbitrary<ColorizedCase> ColorizedCases()
+    {
+        var visible = Arb.Generate<NonEmptyString>()
+            .Select(static text => text.Get.Replace("{", string.Empty, StringComparison.Ordinal).Replace("}", string.Empty, StringComparison.Ordinal));
+
+        var translated = Arb.Generate<NonEmptyString>()
+            .Select(static text => "訳" + text.Get.Replace("{", string.Empty, StringComparison.Ordinal).Replace("}", string.Empty, StringComparison.Ordinal));
+
+        var wrappers = Gen.Elements(
+            (Open: "{{W|", Close: "}}"),
+            (Open: "{{r|", Close: "}}"),
+            (Open: "&G", Close: "&y"),
+            (Open: "^r", Close: "^k"));
+
+        return (from rawVisible in visible
+                from rawTranslated in translated
+                where !string.IsNullOrWhiteSpace(rawVisible)
+                from wrapper in wrappers
+                select new ColorizedCase(
+                    wrapper.Open + rawVisible + wrapper.Close,
+                    rawVisible,
+                    rawTranslated,
+                    wrapper.Open + rawTranslated + wrapper.Close))
+            .ToArbitrary();
+    }
+}
+```
+
+- [ ] **Step 3: Run the new property test and make sure it passes deterministically**
+
+Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~ColorCodePreserverPropertyTests`
+
+Expected: PASS with a stable run count; no shrinking into unsupported brace/code syntax.
+
+### Task 3: Add a second invariant that protects issue-376’s restore seam
+
+**Files:**
+- Modify: `Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ColorCodePreserverPropertyTests.cs`
+
+- [ ] **Step 1: Write the second failing property**
+
+Add a property that proves non-target text is not damaged by the strip/restore cycle:
+
+```csharp
+[Property(Arbitrary = new[] { typeof(ColorCodePreserverArbitraries) }, MaxTest = 200)]
+public Property StripThenRestore_DoesNotChangeVisibleText(ColorizedCase sample)
+{
+    var (stripped, spans) = ColorCodePreserver.Strip(sample.Source);
+    var restored = ColorCodePreserver.Restore(stripped, spans);
+
+    return (restored == sample.Source).ToProperty();
+}
+```
+
+- [ ] **Step 2: Run just the new property and verify it passes**
+
+Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~StripThenRestore_DoesNotChangeVisibleText`
+
+Expected: PASS
+
+### Task 4: Re-run the L1 baseline and preserve existing exact regressions
+
+**Files:**
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorCodePreserverTests.cs`
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/ColorCodePreserverPropertyTests.cs`
+
+- [ ] **Step 1: Run the helper-focused subset**
+
+Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~ColorCodePreserver`
+
+Expected: existing example-based tests and new property tests both pass.
+
+- [ ] **Step 2: Run the full L1 suite**
+
+Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1`
+
+Expected: PASS
+
+### Task 5: Document the next PBT expansion seam
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-04-19-pbt-phase1-color-invariants.md`
+
+- [ ] **Step 1: Record the next candidate after ColorCodePreserver**
+
+Append a short execution note after successful verification:
+
+```md
+## Follow-up after Phase 1
+
+- Next candidate: `MessageLogProducerTranslationHelpers`
+- First invariant: control-header stripping plus direct-marker normalization must preserve nested wrappers
+- Keep `MessagePatternTranslator` for Phase 1b or Phase 2, because its template grammar increases generator complexity
+```
+
+- [ ] **Step 2: Keep the scope boundary explicit**
+
+Do not add Python/Hypothesis work in this first execution slice.
+
+## Self-review
+
+- Spec coverage: The plan covers issue-378’s first staged C# slice and uses issue-376’s color/restore invariants as the source of properties.
+- Placeholder scan: No `TODO`/`TBD`; every task names exact files, code, and commands.
+- Type consistency: `ColorizedCase` and `ColorCodePreserverArbitraries` are defined before their use in the property tests.
+
+## Execution note after first slice
+
+- Phase 1 was implemented with deterministic FsCheck + NUnit properties for `ColorCodePreserver` using only Qud wrapper shapes (`{{W|...}}`, `{{r|...}}`).
+- The first generated failures showed that `&` / `^` color codes do not share the same restore invariant as Qud wrappers when mixed into one property family.
+- Phase 1b was therefore implemented as separate property groups for foreground/background color codes instead of widening the existing wrapper generator.
+- The next non-trivial candidate, `MessageLogProducerTranslationHelpers`, was added in the same PR as a deterministic PBT slice for the `control header -> direct marker -> nested wrapper` invariant.
+- The next follow-up after this PR should target `MessagePatternTranslator` directly, because it owns the reordered placeholder behavior that the producer helper now exercises only through a fixed route family.

--- a/docs/superpowers/plans/2026-04-19-pbt-phase1-color-invariants.md
+++ b/docs/superpowers/plans/2026-04-19-pbt-phase1-color-invariants.md
@@ -91,11 +91,12 @@ public static class ColorCodePreserverArbitraries
 {
     public static Arbitrary<ColorizedCase> ColorizedCases()
     {
-        var visible = Arb.Generate<NonEmptyString>()
-            .Select(static text => text.Get.Replace("{", string.Empty, StringComparison.Ordinal).Replace("}", string.Empty, StringComparison.Ordinal));
+        var characters = Gen.Elements('a', 'b', 'c', 'x', 'y', 'z', '刀', '緑', '危', '険', '光');
+        var visible = Gen.Choose(1, 8)
+            .SelectMany(length => Gen.ArrayOf(characters, length))
+            .Select(chars => new string(chars));
 
-        var translated = Arb.Generate<NonEmptyString>()
-            .Select(static text => "訳" + text.Get.Replace("{", string.Empty, StringComparison.Ordinal).Replace("}", string.Empty, StringComparison.Ordinal));
+        var translated = visible.Select(rawVisible => new string('訳', rawVisible.Length));
 
         var wrappers = Gen.Elements(
             (Open: "{{W|", Close: "}}"),

--- a/docs/superpowers/plans/2026-04-19-pbt-phase1-color-invariants.md
+++ b/docs/superpowers/plans/2026-04-19-pbt-phase1-color-invariants.md
@@ -200,4 +200,5 @@ Do not add Python/Hypothesis work in this first execution slice.
 - The first generated failures showed that `&` / `^` color codes do not share the same restore invariant as Qud wrappers when mixed into one property family.
 - Phase 1b was therefore implemented as separate property groups for foreground/background color codes instead of widening the existing wrapper generator.
 - The next non-trivial candidate, `MessageLogProducerTranslationHelpers`, was added in the same PR as a deterministic PBT slice for the `control header -> direct marker -> nested wrapper` invariant.
-- The next follow-up after this PR should target `MessagePatternTranslator` directly, because it owns the reordered placeholder behavior that the producer helper now exercises only through a fixed route family.
+- `MessagePatternTranslator` was then added as the next deterministic slice for hit-with-roll and weapon-miss wrapper-preservation invariants using the repository pattern dictionary directly.
+- The next follow-up after this PR should move beyond combat message families and target another pure helper or constrained route owner with a stable generator surface.

--- a/docs/superpowers/plans/2026-04-19-pbt-phase1-color-invariants.md
+++ b/docs/superpowers/plans/2026-04-19-pbt-phase1-color-invariants.md
@@ -62,7 +62,7 @@ namespace QudJP.Tests.L1.Pbt;
 [Category("L1")]
 public sealed class ColorCodePreserverPropertyTests
 {
-    [Property(Arbitrary = new[] { typeof(ColorCodePreserverArbitraries) }, MaxTest = 200)]
+    [Property(Arbitrary = new[] { typeof(ColorCodePreserverArbitraries) }, MaxTest = 200, Replay = "123456789,97531")]
     public Property StripThenRestore_PreservesSupportedMarkup(ColorizedCase sample)
     {
         var (stripped, spans) = ColorCodePreserver.Strip(sample.Source);
@@ -99,9 +99,7 @@ public static class ColorCodePreserverArbitraries
 
         var wrappers = Gen.Elements(
             (Open: "{{W|", Close: "}}"),
-            (Open: "{{r|", Close: "}}"),
-            (Open: "&G", Close: "&y"),
-            (Open: "^r", Close: "^k"));
+            (Open: "{{r|", Close: "}}"));
 
         return (from rawVisible in visible
                 from rawTranslated in translated
@@ -117,11 +115,13 @@ public static class ColorCodePreserverArbitraries
 }
 ```
 
+Add separate `ForegroundColorCodeCases()` and `BackgroundColorCodeCases()` generators for `&...` / `^...` shapes, because those color-code families do not share the same restore invariant as Qud wrappers and should not be mixed into one property-family generator.
+
 - [ ] **Step 3: Run the new property test and make sure it passes deterministically**
 
 Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~ColorCodePreserverPropertyTests`
 
-Expected: PASS with a stable run count; no shrinking into unsupported brace/code syntax.
+Expected: PASS with a stable run count using Replay `123456789,97531`; no shrinking into unsupported brace/code syntax.
 
 ### Task 3: Add a second invariant that protects issue-376’s restore seam
 
@@ -133,7 +133,7 @@ Expected: PASS with a stable run count; no shrinking into unsupported brace/code
 Add a property that proves non-target text is not damaged by the strip/restore cycle:
 
 ```csharp
-[Property(Arbitrary = new[] { typeof(ColorCodePreserverArbitraries) }, MaxTest = 200)]
+[Property(Arbitrary = new[] { typeof(ColorCodePreserverArbitraries) }, MaxTest = 200, Replay = "123456789,97531")]
 public Property StripThenRestore_DoesNotChangeVisibleText(ColorizedCase sample)
 {
     var (stripped, spans) = ColorCodePreserver.Strip(sample.Source);
@@ -201,8 +201,8 @@ Do not add Python/Hypothesis work in this first execution slice.
 - Phase 1b was therefore implemented as separate property groups for foreground/background color codes instead of widening the existing wrapper generator.
 - The next non-trivial candidate, `MessageLogProducerTranslationHelpers`, was added in the same PR as a deterministic PBT slice for the `control header -> direct marker -> nested wrapper` invariant.
 - `MessagePatternTranslator` was then added as the next deterministic slice for hit-with-roll and weapon-miss wrapper-preservation invariants using the repository pattern dictionary directly.
-- `MessageFrameTranslator` was then added as a small deterministic helper slice for direct-marker idempotence and strip round-trips, keeping the scope outside combat grammar expansion.
-- `EnclosingFragmentTranslator` was added next as a constrained route-owner slice for `You extricate X from Y.` so subject/container color wrappers stay preserved while direct-marked inputs still pass through unchanged.
-- `ClonelingVehicleFragmentTranslator` was then added as the next world-part fragment slice, covering both popup and queued routes while preserving liquid wrappers and leaving direct-marked text untouched.
+- `MessageFrameTranslator` then became a small deterministic helper slice for direct-marker idempotence and strip round-trips, keeping the scope outside combat grammar expansion.
+- Next, `EnclosingFragmentTranslator` served as a constrained route-owner slice for `You extricate X from Y.` so subject/container color wrappers stay preserved while direct-marked inputs still pass through unchanged.
+- Following that, `ClonelingVehicleFragmentTranslator` covered both popup and queued world-part routes while preserving liquid wrappers and leaving direct-marked text untouched.
 - `LiquidVolumeFragmentTranslator` followed with a deliberately narrow generator surface that covers status wrappers, ownership questions, normalized targets, pour-into targets, and known passthrough inputs without over-generalizing the fragment grammar.
 - The next follow-up after this PR should likely move back to a smaller helper seam again before widening route grammar further.


### PR DESCRIPTION
## Summary
- fix the display-name, death wrapper, ability bar, combat, and shared color-preservation regressions found while working issue-376
- add deterministic FsCheck/NUnit property coverage for `ColorCodePreserver` wrappers/color codes and `MessageLogProducerTranslationHelpers` control-header/direct-marker invariants as the first issue-378 slice
- record the PBT phase plan and the next follow-up slice in `docs/superpowers/plans/2026-04-19-pbt-phase1-color-invariants.md`

## Testing
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~ColorCodePreserverPropertyTests
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~ColorCodePreserver
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~MessageLogProducerTranslationHelpersPropertyTests
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~MessageLogProducerTranslationHelpers
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1

## Issues
- refs #376
- refs #378

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 大量の単体テストとFsCheckベースのプロパティテスト／Arbitraryジェネレータ群を追加し、カラー／ラッパーの保持性を網羅

* **Bug Fixes**
  * 切り取り→復元処理を強化し、入れ子・末尾の空ラッパー・全行境界ラッパーを正しく保持
  * 表示名、ターゲット表示、戦闘ログ、ポップアップで色付きマークアップの破壊を回避
  * 修飾語と本体の間の空白処理を改善

* **Chores**
  * テストプロジェクトにFsCheck依存を追加

* **Documentation**
  * PBT導入と検証手順の計画ドキュメントを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->