### PR TITLE
test(pbt): expand GetDisplayNameRouteTranslator route coverage

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorArbitraries.cs
@@ -1,0 +1,49 @@
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace QudJP.Tests.L1.Pbt;
+
+public sealed record DisplayNameExactCase(string Source, string Expected);
+
+public sealed record DisplayNameTrimmedExactCase(string Source, string Expected);
+
+public sealed record DisplayNameScopedConflictCase(string Source, string Expected);
+
+public sealed record DisplayNameBracketedStateCase(string Source, string Expected);
+
+public static class GetDisplayNameRouteTranslatorArbitraries
+{
+    public static Arbitrary<DisplayNameExactCase> ExactCases()
+    {
+        return Gen.Elements(
+                new DisplayNameExactCase("worn bronze sword", "使い込まれた青銅の剣"),
+                new DisplayNameExactCase("Water Containers", "水容器"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<DisplayNameTrimmedExactCase> TrimmedExactCases()
+    {
+        return Gen.Elements(
+                new DisplayNameTrimmedExactCase("  worn bronze sword  ", "  使い込まれた青銅の剣  "),
+                new DisplayNameTrimmedExactCase("Water Containers  ", "水容器  "),
+                new DisplayNameTrimmedExactCase("  Water Containers", "  水容器"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<DisplayNameScopedConflictCase> ScopedConflictCases()
+    {
+        return Gen.Elements(
+                new DisplayNameScopedConflictCase("water", "{{B|水の}}"),
+                new DisplayNameScopedConflictCase("bloody Naruur", "{{r|血まみれの}}Naruur"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<DisplayNameBracketedStateCase> BracketedStateCases()
+    {
+        return Gen.Elements(
+                new DisplayNameBracketedStateCase("water flask [empty]", "水袋 [空]"),
+                new DisplayNameBracketedStateCase("water flask [empty, sealed]", "水袋 [空／密封]"),
+                new DisplayNameBracketedStateCase("water flask [auto-collecting]", "水袋 [自動採取中]"))
+            .ToArbitrary();
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorArbitraries.cs
@@ -15,6 +15,12 @@ public sealed record DisplayNameQuantityCase(string Source, string Expected);
 
 public sealed record DisplayNameParenthesizedStateCase(string Source, string Expected);
 
+public sealed record DisplayNameLeadingMarkupCase(string Source, string Expected);
+
+public sealed record DisplayNameMkTierCase(string Source, string Expected);
+
+public sealed record DisplayNameAngleCodeCase(string Source, string Expected);
+
 public static class GetDisplayNameRouteTranslatorArbitraries
 {
     public static Arbitrary<DisplayNameExactCase> ExactCases()
@@ -66,6 +72,30 @@ public static class GetDisplayNameRouteTranslatorArbitraries
                 new DisplayNameParenthesizedStateCase("lead slug (Frozen)", "鉛の弾 (凍結)"),
                 new DisplayNameParenthesizedStateCase("lead slug (FROZEN)", "鉛の弾 (凍結)"),
                 new DisplayNameParenthesizedStateCase("lead slug (frozen)", "鉛の弾 (凍結)"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<DisplayNameLeadingMarkupCase> LeadingMarkupCases()
+    {
+        return Gen.Elements(
+                new DisplayNameLeadingMarkupCase("{{r|bloody}} dromad merchant", "{{r|血まみれの}} ドロマド商人"),
+                new DisplayNameLeadingMarkupCase("[{{r|bloody}}] dromad merchant", "[{{r|血まみれの}}] ドロマド商人"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<DisplayNameMkTierCase> MkTierCases()
+    {
+        return Gen.Elements(
+                new DisplayNameMkTierCase("rusted grenade mk I <AA1>", "錆びたグレネード mk I <AA1>"),
+                new DisplayNameMkTierCase("rusted grenade mk X", "錆びたグレネード mk X"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<DisplayNameAngleCodeCase> AngleCodeCases()
+    {
+        return Gen.Elements(
+                new DisplayNameAngleCodeCase("worn bronze sword <BD1>", "使い込まれた青銅の剣 <BD1>"),
+                new DisplayNameAngleCodeCase("worn bronze sword <Z9>", "使い込まれた青銅の剣 <Z9>"))
             .ToArbitrary();
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorArbitraries.cs
@@ -21,6 +21,10 @@ public sealed record DisplayNameMkTierCase(string Source, string Expected);
 
 public sealed record DisplayNameAngleCodeCase(string Source, string Expected);
 
+public sealed record DisplayNameEmptyStringCase(string Source, string Expected);
+
+public sealed record DisplayNameControlCharacterCase(string Source, string Expected);
+
 public static class GetDisplayNameRouteTranslatorArbitraries
 {
     public static Arbitrary<DisplayNameExactCase> ExactCases()
@@ -96,6 +100,19 @@ public static class GetDisplayNameRouteTranslatorArbitraries
         return Gen.Elements(
                 new DisplayNameAngleCodeCase("worn bronze sword <BD1>", "使い込まれた青銅の剣 <BD1>"),
                 new DisplayNameAngleCodeCase("worn bronze sword <Z9>", "使い込まれた青銅の剣 <Z9>"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<DisplayNameEmptyStringCase> EmptyStringCases()
+    {
+        return Gen.Constant(new DisplayNameEmptyStringCase(string.Empty, string.Empty))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<DisplayNameControlCharacterCase> ControlCharacterCases()
+    {
+        return Gen.Elements(
+                new DisplayNameControlCharacterCase("item \u0001 name", "制御マーカー付き品名"))
             .ToArbitrary();
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorArbitraries.cs
@@ -11,6 +11,10 @@ public sealed record DisplayNameScopedConflictCase(string Source, string Expecte
 
 public sealed record DisplayNameBracketedStateCase(string Source, string Expected);
 
+public sealed record DisplayNameQuantityCase(string Source, string Expected);
+
+public sealed record DisplayNameParenthesizedStateCase(string Source, string Expected);
+
 public static class GetDisplayNameRouteTranslatorArbitraries
 {
     public static Arbitrary<DisplayNameExactCase> ExactCases()
@@ -44,6 +48,24 @@ public static class GetDisplayNameRouteTranslatorArbitraries
                 new DisplayNameBracketedStateCase("water flask [empty]", "水袋 [空]"),
                 new DisplayNameBracketedStateCase("water flask [empty, sealed]", "水袋 [空／密封]"),
                 new DisplayNameBracketedStateCase("water flask [auto-collecting]", "水袋 [自動採取中]"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<DisplayNameQuantityCase> QuantityCases()
+    {
+        return Gen.Elements(
+                new DisplayNameQuantityCase("water flask x2", "水袋 x2"),
+                new DisplayNameQuantityCase("water flask x12", "水袋 x12"),
+                new DisplayNameQuantityCase("worn bronze sword x3", "使い込まれた青銅の剣 x3"))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<DisplayNameParenthesizedStateCase> ParenthesizedStateCases()
+    {
+        return Gen.Elements(
+                new DisplayNameParenthesizedStateCase("lead slug (Frozen)", "鉛の弾 (凍結)"),
+                new DisplayNameParenthesizedStateCase("lead slug (FROZEN)", "鉛の弾 (凍結)"),
+                new DisplayNameParenthesizedStateCase("lead slug (frozen)", "鉛の弾 (凍結)"))
             .ToArbitrary();
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorPropertyTests.cs
@@ -1,0 +1,156 @@
+using System.Text;
+
+using FsCheck.Fluent;
+
+using FsCheckProperty = FsCheck.Property;
+
+using QudJP.Patches;
+
+namespace QudJP.Tests.L1.Pbt;
+
+[TestFixture]
+[Category("L1")]
+[NonParallelizable]
+public sealed class GetDisplayNameRouteTranslatorPropertyTests
+{
+    private static readonly UTF8Encoding Utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+    private const string ReplaySeed = "159357246,97531";
+
+    private string tempDirectory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempDirectory = Path.Combine(Path.GetTempPath(), "qudjp-displayname-route-pbt", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+
+        Translator.ResetForTests();
+        ScopedDictionaryLookup.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(tempDirectory);
+
+        WriteCommonDictionaries();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        ScopedDictionaryLookup.ResetForTests();
+
+        if (Directory.Exists(tempDirectory))
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(GetDisplayNameRouteTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TranslatePreservingColors_UsesExactWholeNameLookup(DisplayNameExactCase sample)
+    {
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            sample.Source,
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(translated, Is.EqualTo(sample.Expected));
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(GetDisplayNameRouteTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TranslatePreservingColors_UsesTrimmedExactWholeNameLookup(DisplayNameTrimmedExactCase sample)
+    {
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            sample.Source,
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(translated, Is.EqualTo(sample.Expected));
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(GetDisplayNameRouteTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TranslatePreservingColors_PrefersDisplayNameScopedConflicts(DisplayNameScopedConflictCase sample)
+    {
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            sample.Source,
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(translated, Is.EqualTo(sample.Expected));
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(GetDisplayNameRouteTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TranslatePreservingColors_UsesDisplayNameScopedBracketedStates(DisplayNameBracketedStateCase sample)
+    {
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            sample.Source,
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(translated, Is.EqualTo(sample.Expected));
+
+        return true.ToProperty();
+    }
+
+    private void WriteCommonDictionaries()
+    {
+        WriteDictionaryFile(
+            "ui-displayname-route.ja.json",
+            ("worn bronze sword", "使い込まれた青銅の剣"),
+            ("Water Containers", "水容器"),
+            ("water flask", "水袋"));
+
+        WriteDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("water", "{{B|水の}}"),
+            ("bloody", "{{r|血まみれの}}"),
+            ("[empty]", "[空]"),
+            ("[empty, sealed]", "[空／密封]"),
+            ("[auto-collecting]", "[自動採取中]"));
+
+        WriteDictionaryFile(
+            "ui-liquids.ja.json",
+            ("water", "水"));
+
+        WriteDictionaryFile(
+            "ui-liquid-adjectives.ja.json",
+            ("bloody", "血混じりの"));
+    }
+
+    private void WriteDictionaryFile(string fileName, params (string key, string text)[] entries)
+    {
+        var builder = new StringBuilder();
+        builder.Append('{');
+        builder.Append("\"entries\":[");
+
+        for (var index = 0; index < entries.Length; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append("{\"key\":\"");
+            builder.Append(EscapeJson(entries[index].key));
+            builder.Append("\",\"text\":\"");
+            builder.Append(EscapeJson(entries[index].text));
+            builder.Append("\"}");
+        }
+
+        builder.Append("]}");
+        builder.AppendLine();
+
+        File.WriteAllText(
+            Path.Combine(tempDirectory, fileName),
+            builder.ToString(),
+            Utf8WithoutBom);
+    }
+
+    private static string EscapeJson(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorPropertyTests.cs
@@ -115,6 +115,42 @@ public sealed class GetDisplayNameRouteTranslatorPropertyTests
         return true.ToProperty();
     }
 
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(GetDisplayNameRouteTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TranslatePreservingColors_PreservesLeadingMarkupModifier(DisplayNameLeadingMarkupCase sample)
+    {
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            sample.Source,
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(translated, Is.EqualTo(sample.Expected));
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(GetDisplayNameRouteTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TranslatePreservingColors_UsesMkTierSuffixLookup(DisplayNameMkTierCase sample)
+    {
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            sample.Source,
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(translated, Is.EqualTo(sample.Expected));
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(GetDisplayNameRouteTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TranslatePreservingColors_UsesAngleCodeSuffixLookup(DisplayNameAngleCodeCase sample)
+    {
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            sample.Source,
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(translated, Is.EqualTo(sample.Expected));
+
+        return true.ToProperty();
+    }
+
     private void WriteCommonDictionaries()
     {
         WriteDictionaryFile(
@@ -123,7 +159,9 @@ public sealed class GetDisplayNameRouteTranslatorPropertyTests
             ("Water Containers", "水容器"),
             ("water flask", "水袋"),
             ("lead slug", "鉛の弾"),
-            ("frozen", "凍結"));
+            ("frozen", "凍結"),
+            ("dromad merchant", "ドロマド商人"),
+            ("rusted grenade", "錆びたグレネード"));
 
         WriteDictionaryFile(
             "ui-displayname-adjectives.ja.json",

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorPropertyTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 
 using FsCheck.Fluent;
@@ -151,6 +152,30 @@ public sealed class GetDisplayNameRouteTranslatorPropertyTests
         return true.ToProperty();
     }
 
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(GetDisplayNameRouteTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TranslatePreservingColors_LeavesEmptyStringUntouched(DisplayNameEmptyStringCase sample)
+    {
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            sample.Source,
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(translated, Is.EqualTo(sample.Expected));
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(GetDisplayNameRouteTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TranslatePreservingColors_UsesExactLookupForControlCharacterInput(DisplayNameControlCharacterCase sample)
+    {
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            sample.Source,
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(translated, Is.EqualTo(sample.Expected));
+
+        return true.ToProperty();
+    }
+
     private void WriteCommonDictionaries()
     {
         WriteDictionaryFile(
@@ -161,7 +186,8 @@ public sealed class GetDisplayNameRouteTranslatorPropertyTests
             ("lead slug", "鉛の弾"),
             ("frozen", "凍結"),
             ("dromad merchant", "ドロマド商人"),
-            ("rusted grenade", "錆びたグレネード"));
+            ("rusted grenade", "錆びたグレネード"),
+            ("item \u0001 name", "制御マーカー付き品名"));
 
         WriteDictionaryFile(
             "ui-displayname-adjectives.ja.json",
@@ -211,10 +237,47 @@ public sealed class GetDisplayNameRouteTranslatorPropertyTests
 
     private static string EscapeJson(string value)
     {
-        return value
-            .Replace("\\", "\\\\", StringComparison.Ordinal)
-            .Replace("\r", "\\r", StringComparison.Ordinal)
-            .Replace("\n", "\\n", StringComparison.Ordinal)
-            .Replace("\"", "\\\"", StringComparison.Ordinal);
+        var builder = new StringBuilder(value.Length + 8);
+        foreach (var ch in value)
+        {
+            switch (ch)
+            {
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+                case '"':
+                    builder.Append("\\\"");
+                    break;
+                case '\b':
+                    builder.Append("\\b");
+                    break;
+                case '\f':
+                    builder.Append("\\f");
+                    break;
+                case '\n':
+                    builder.Append("\\n");
+                    break;
+                case '\r':
+                    builder.Append("\\r");
+                    break;
+                case '\t':
+                    builder.Append("\\t");
+                    break;
+                default:
+                    if (ch < 0x20)
+                    {
+                        builder.Append("\\u");
+                        builder.Append(((int)ch).ToString("x4", CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        builder.Append(ch);
+                    }
+
+                    break;
+            }
+        }
+
+        return builder.ToString();
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/GetDisplayNameRouteTranslatorPropertyTests.cs
@@ -91,13 +91,39 @@ public sealed class GetDisplayNameRouteTranslatorPropertyTests
         return true.ToProperty();
     }
 
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(GetDisplayNameRouteTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TranslatePreservingColors_UsesQuantitySuffixLookup(DisplayNameQuantityCase sample)
+    {
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            sample.Source,
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(translated, Is.EqualTo(sample.Expected));
+
+        return true.ToProperty();
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(GetDisplayNameRouteTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty TranslatePreservingColors_UsesParenthesizedStateFallback(DisplayNameParenthesizedStateCase sample)
+    {
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            sample.Source,
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(translated, Is.EqualTo(sample.Expected));
+
+        return true.ToProperty();
+    }
+
     private void WriteCommonDictionaries()
     {
         WriteDictionaryFile(
             "ui-displayname-route.ja.json",
             ("worn bronze sword", "使い込まれた青銅の剣"),
             ("Water Containers", "水容器"),
-            ("water flask", "水袋"));
+            ("water flask", "水袋"),
+            ("lead slug", "鉛の弾"),
+            ("frozen", "凍結"));
 
         WriteDictionaryFile(
             "ui-displayname-adjectives.ja.json",


### PR DESCRIPTION
## Summary
- extract the highest-value portion of PR 380 into a clean branch by keeping only `GetDisplayNameRouteTranslator` property-based tests
- add deterministic FsCheck coverage for exact lookup, scoped conflicts, suffix parsing, and markup-preserving route branches
- avoid reintroducing the already-merged PR 379 changes so the review surface stays focused on the remaining high-value route heuristics

## Verification
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter \"FullyQualifiedName~GetDisplayNameRouteTranslatorPropertyTests|FullyQualifiedName~GetDisplayNameRouteTranslatorTests\"`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * 表示名翻訳のプロパティベーステストを追加。固定シードで再現可能な実行と最大試行数制限を備え、完全一致・トリム・スコープ競合・括弧表記・数量接尾辞・括弧内状態のフォールバック・先頭マークアップ保持・mk/角コード接尾辞・空文字・制御文字など多様なケースを網羅。テストごとに一時辞書を生成・使用し実行後にクリーンアップします。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->