### PR TITLE
Extend final output provenance logging

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/FinalOutputObservabilityTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/FinalOutputObservabilityTests.cs
@@ -128,6 +128,52 @@ public sealed class FinalOutputObservabilityTests
         });
     }
 
+    [Test]
+    public void RecordSinkUnclaimed_ComputesMatchedMarkupStatus()
+    {
+        var output = TestTraceHelper.CaptureTrace(() =>
+            FinalOutputObservability.RecordSinkUnclaimed(
+                "UITextSkinTranslationPatch",
+                "PopupTranslationPatch",
+                "ObservationOnly",
+                "{{R|Unknown text}}",
+                "Unknown text"));
+
+        Assert.That(output, Does.Contain("translation_status='sink_unclaimed'"));
+        Assert.That(output, Does.Contain("markup_status='matched'"));
+        Assert.That(output, Does.Contain("direct_marker_status='absent'"));
+    }
+
+    [Test]
+    public void RecordDirectMarker_RecordsTranslatedFinalOutputProvenance()
+    {
+        var output = TestTraceHelper.CaptureTrace(() =>
+            FinalOutputObservability.RecordDirectMarker(
+                "MessageLogPatch",
+                "MessageLogPatch",
+                "DirectMarker",
+                "\u0001{{G|あなたは命中した。}}",
+                "{{G|あなたは命中した。}}"));
+
+        Assert.That(output, Does.Contain("translation_status='direct_marker'"));
+        Assert.That(output, Does.Contain("direct_marker_status='present'"));
+        Assert.That(output, Does.Contain("markup_status='matched'"));
+        Assert.That(output, Does.Contain("translated='{{G|あなたは命中した。}}' final='{{G|あなたは命中した。}}'"));
+    }
+
+    [TestCase("plain", "plain", "no_markup")]
+    [TestCase("{{R|source}}", "{{R|source}}", "matched")]
+    [TestCase("{{R|source}}", "source", "source_only")]
+    [TestCase("source", "{{R|source}}", "final_only")]
+    [TestCase("{{R|source}}", "{{G|source}}", "mismatch")]
+    public void ComputeMarkupStatusForTests_ClassifiesSourceFinalSignatures(
+        string source,
+        string final,
+        string expectedStatus)
+    {
+        Assert.That(FinalOutputObservability.ComputeMarkupStatusForTests(source, final), Is.EqualTo(expectedStatus));
+    }
+
     private static FinalOutputObservation CreateObservation(
         string sourceText = "Unknown text",
         string strippedText = "Unknown text",

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/UITextSkinTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/UITextSkinTranslationPatchTests.cs
@@ -74,9 +74,11 @@ public sealed class UITextSkinTranslationPatchTests
     {
         var text = "\u0001{{W|熊は防いだ。}}";
 
-        UITextSkinTranslationPatch.Prefix(ref text);
+        var output = TestTraceHelper.CaptureTrace(() => UITextSkinTranslationPatch.Prefix(ref text));
 
         Assert.That(text, Is.EqualTo("{{W|熊は防いだ。}}"));
+        Assert.That(output, Does.Contain("translation_status='direct_marker'"));
+        Assert.That(output, Does.Contain("direct_marker_status='present'"));
     }
 
     [TestCaseSource(typeof(QudJP.Tests.L1.ColorRouteInvariantCases), nameof(QudJP.Tests.L1.ColorRouteInvariantCases.UiTextSkinCases))]
@@ -101,12 +103,13 @@ public sealed class UITextSkinTranslationPatchTests
         WriteDictionary(("quit", "終了"), ("[Esc]", "[Esc-JP]"));
 
         var original = text;
-        UITextSkinTranslationPatch.Prefix(ref text);
+        var output = TestTraceHelper.CaptureTrace(() => UITextSkinTranslationPatch.Prefix(ref text));
 
         Assert.Multiple(() =>
         {
             Assert.That(text, Is.EqualTo(original));
             Assert.That(Translator.GetMissingKeyHitCountForTests(original), Is.EqualTo(0));
+            Assert.That(output, Does.Contain("translation_status='skipped'"));
         });
     }
 
@@ -119,13 +122,29 @@ public sealed class UITextSkinTranslationPatchTests
     {
         WriteDictionary(("クラシック", "CLASSIC-JP"));
 
-        var translated = UITextSkinTranslationPatch.TranslatePreservingColors(text, nameof(UITextSkinTranslationPatch));
+        var output = TestTraceHelper.CaptureTrace(() =>
+            Assert.That(
+                UITextSkinTranslationPatch.TranslatePreservingColors(text, nameof(UITextSkinTranslationPatch)),
+                Is.EqualTo(text)));
 
         Assert.Multiple(() =>
         {
-            Assert.That(translated, Is.EqualTo(text));
             Assert.That(Translator.GetMissingKeyHitCountForTests(text), Is.EqualTo(0));
+            Assert.That(output, Does.Contain("translation_status='skipped'"));
         });
+    }
+
+    [Test]
+    public void TranslatePreservingColors_RecordsAlreadyLocalizedDirectRouteText()
+    {
+        var text = "新しいゲーム";
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+            Assert.That(
+                UITextSkinTranslationPatch.TranslatePreservingColors(text, nameof(MainMenuLocalizationPatch)),
+                Is.EqualTo(text)));
+
+        Assert.That(output, Does.Contain("translation_status='already_localized'"));
     }
 
     [Test]

--- a/Mods/QudJP/Assemblies/src/Observability/FinalOutputObservability.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/FinalOutputObservability.cs
@@ -2,14 +2,28 @@ using System;
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace QudJP;
 
 internal static class FinalOutputObservability
 {
     internal const string Family = "final_output";
+    internal const string DetailAlreadyLocalized = "AlreadyLocalized";
+    internal const string DetailDirectMarker = "DirectMarker";
+    internal const string DetailSkipped = "Skipped";
+    internal const string DirectMarkerStatusAbsent = "absent";
+    internal const string DirectMarkerStatusPresent = "present";
+    internal const string MarkupStatusFinalOnly = "final_only";
+    internal const string MarkupStatusMatched = "matched";
+    internal const string MarkupStatusMismatch = "mismatch";
+    internal const string MarkupStatusNoMarkup = "no_markup";
+    internal const string MarkupStatusSourceOnly = "source_only";
     internal const string NotEvaluatedStatus = "not_evaluated";
     internal const string PhaseBeforeSink = "before_sink";
+    internal const string TranslationStatusAlreadyLocalized = "already_localized";
+    internal const string TranslationStatusDirectMarker = "direct_marker";
+    internal const string TranslationStatusSkipped = "skipped";
     internal const string TranslationStatusSinkUnclaimed = "sink_unclaimed";
 
     private const string ProbeVersion = "v1";
@@ -21,6 +35,8 @@ internal static class FinalOutputObservability
         new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
 
     private static readonly object HitCountsSync = new object();
+    private static readonly Regex MarkupTokenPattern =
+        new Regex(@"\{\{[A-Za-z0-9#]+\||\}\}|&&|\^\^|&[A-Za-z]|\^[A-Za-z]|</?color(?:=[^>]+)?>|=[A-Za-z0-9_.]+=", RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
     internal static void ResetForTests()
     {
@@ -37,6 +53,90 @@ internal static class FinalOutputObservability
         {
             return ObservabilityHelpers.GetCounterValue(HitCounts, BuildCounterKey(normalized));
         }
+    }
+
+    internal static string ComputeMarkupStatusForTests(string? sourceText, string? finalText)
+    {
+        return ComputeMarkupStatus(sourceText, finalText);
+    }
+
+    internal static void RecordSinkUnclaimed(
+        string sink,
+        string route,
+        string detail,
+        string? sourceText,
+        string? strippedText)
+    {
+        var sourceValue = sourceText ?? string.Empty;
+        Record(
+            new FinalOutputObservation(
+                sink,
+                route,
+                detail,
+                PhaseBeforeSink,
+                TranslationStatusSinkUnclaimed,
+                ComputeMarkupStatus(sourceValue, sourceValue),
+                DirectMarkerStatusAbsent,
+                sourceValue,
+                strippedText,
+                string.Empty,
+                sourceValue));
+    }
+
+    internal static void RecordDirectMarker(
+        string sink,
+        string route,
+        string detail,
+        string? sourceText,
+        string finalText)
+    {
+        var finalValue = finalText ?? string.Empty;
+        _ = MessageFrameTranslator.TryStripDirectTranslationMarker(sourceText, out var sourceValue);
+        var (stripped, _) = ColorAwareTranslationComposer.Strip(finalValue);
+        Record(
+            new FinalOutputObservation(
+                sink,
+                route,
+                detail,
+                PhaseBeforeSink,
+                TranslationStatusDirectMarker,
+                ComputeMarkupStatus(sourceValue, finalValue),
+                DirectMarkerStatusPresent,
+                sourceValue,
+                stripped,
+                finalValue,
+                finalValue));
+    }
+
+    internal static void RecordAlreadyLocalized(
+        string sink,
+        string route,
+        string? sourceText,
+        string? strippedText)
+    {
+        RecordPassthroughDecision(
+            sink,
+            route,
+            DetailAlreadyLocalized,
+            TranslationStatusAlreadyLocalized,
+            sourceText,
+            strippedText);
+    }
+
+    internal static void RecordSkipped(
+        string sink,
+        string route,
+        string detail,
+        string? sourceText,
+        string? strippedText)
+    {
+        RecordPassthroughDecision(
+            sink,
+            route,
+            detail,
+            TranslationStatusSkipped,
+            sourceText,
+            strippedText);
     }
 
     internal static void Record(FinalOutputObservation observation)
@@ -79,6 +179,65 @@ internal static class FinalOutputObservability
     private static string SanitizeQuotedValue(string value)
     {
         return ObservabilityHelpers.SanitizeForLog(value, MaxValueLength).Replace("'", "\\'");
+    }
+
+    private static void RecordPassthroughDecision(
+        string sink,
+        string route,
+        string detail,
+        string translationStatus,
+        string? sourceText,
+        string? strippedText)
+    {
+        var sourceValue = sourceText ?? string.Empty;
+        Record(
+            new FinalOutputObservation(
+                sink,
+                route,
+                detail,
+                PhaseBeforeSink,
+                translationStatus,
+                ComputeMarkupStatus(sourceValue, sourceValue),
+                DirectMarkerStatusAbsent,
+                sourceValue,
+                strippedText,
+                string.Empty,
+                sourceValue));
+    }
+
+    private static string ComputeMarkupStatus(string? sourceText, string? finalText)
+    {
+        var sourceMatches = MarkupTokenPattern.Matches(sourceText ?? string.Empty);
+        var finalMatches = MarkupTokenPattern.Matches(finalText ?? string.Empty);
+        if (sourceMatches.Count == 0 && finalMatches.Count == 0)
+        {
+            return MarkupStatusNoMarkup;
+        }
+
+        if (sourceMatches.Count == 0)
+        {
+            return MarkupStatusFinalOnly;
+        }
+
+        if (finalMatches.Count == 0)
+        {
+            return MarkupStatusSourceOnly;
+        }
+
+        if (sourceMatches.Count != finalMatches.Count)
+        {
+            return MarkupStatusMismatch;
+        }
+
+        for (var index = 0; index < sourceMatches.Count; index++)
+        {
+            if (!string.Equals(sourceMatches[index].Value, finalMatches[index].Value, StringComparison.Ordinal))
+            {
+                return MarkupStatusMismatch;
+            }
+        }
+
+        return MarkupStatusMatched;
     }
 
     private static NormalizedObservation Normalize(FinalOutputObservation observation)

--- a/Mods/QudJP/Assemblies/src/Observability/SinkObservation.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/SinkObservation.cs
@@ -70,19 +70,12 @@ internal static class SinkObservation
         var sourceValue = source ?? string.Empty;
         var strippedValue = stripped ?? string.Empty;
 
-        FinalOutputObservability.Record(
-            new FinalOutputObservation(
-                normalizedSink,
-                normalizedRoute,
-                normalizedDetail,
-                FinalOutputObservability.PhaseBeforeSink,
-                FinalOutputObservability.TranslationStatusSinkUnclaimed,
-                FinalOutputObservability.NotEvaluatedStatus,
-                FinalOutputObservability.NotEvaluatedStatus,
-                sourceValue,
-                strippedValue,
-                string.Empty,
-                sourceValue));
+        FinalOutputObservability.RecordSinkUnclaimed(
+            normalizedSink,
+            normalizedRoute,
+            normalizedDetail,
+            sourceValue,
+            strippedValue);
 
         var hitCount = AddOrUpdateCapped(
             HitCounts,

--- a/Mods/QudJP/Assemblies/src/Patches/MessageLogPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/MessageLogPatch.cs
@@ -29,8 +29,15 @@ public static class MessageLogPatch
             _ = Color;
             _ = Capitalize;
 
-            if (MessageFrameTranslator.TryStripDirectTranslationMarker(ref Message))
+            if (MessageFrameTranslator.TryStripDirectTranslationMarker(Message, out var markedText))
             {
+                FinalOutputObservability.RecordDirectMarker(
+                    nameof(MessageLogPatch),
+                    nameof(MessageLogPatch),
+                    FinalOutputObservability.DetailDirectMarker,
+                    Message,
+                    markedText);
+                Message = markedText;
                 return true;
             }
 

--- a/Mods/QudJP/Assemblies/src/Patches/UITextSkinTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/UITextSkinTranslationPatch.cs
@@ -88,6 +88,12 @@ public static class UITextSkinTranslationPatch
 
         if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
         {
+            FinalOutputObservability.RecordDirectMarker(
+                nameof(UITextSkinTranslationPatch),
+                context ?? string.Empty,
+                FinalOutputObservability.DetailDirectMarker,
+                source,
+                markedText);
             return markedText;
         }
 
@@ -101,11 +107,35 @@ public static class UITextSkinTranslationPatch
 
         if (IsIgnoredDirectRouteToken(stripped, effectiveContext))
         {
+            FinalOutputObservability.RecordSkipped(
+                nameof(UITextSkinTranslationPatch),
+                effectiveContext ?? string.Empty,
+                "IgnoredDirectRouteToken",
+                source!,
+                stripped);
             return source!;
         }
 
-        if (!IsAlreadyLocalizedDirectRouteText(stripped, effectiveContext)
-            && !ShouldSkipTranslation(stripped, effectiveContext))
+        var alreadyLocalized = IsAlreadyLocalizedDirectRouteText(stripped, effectiveContext);
+        var shouldSkipTranslation = ShouldSkipTranslation(stripped, effectiveContext);
+        if (alreadyLocalized)
+        {
+            FinalOutputObservability.RecordAlreadyLocalized(
+                nameof(UITextSkinTranslationPatch),
+                effectiveContext ?? string.Empty,
+                source!,
+                stripped);
+        }
+        else if (shouldSkipTranslation)
+        {
+            FinalOutputObservability.RecordSkipped(
+                nameof(UITextSkinTranslationPatch),
+                effectiveContext ?? string.Empty,
+                FinalOutputObservability.DetailSkipped,
+                source!,
+                stripped);
+        }
+        else
         {
             SinkObservation.LogUnclaimed(
                 nameof(UITextSkinTranslationPatch),

--- a/scripts/tests/test_translation_checker.py
+++ b/scripts/tests/test_translation_checker.py
@@ -303,14 +303,26 @@ class TestVerificationReport:
             "[QudJP] SinkObserve/v1: sink='MessageLog' route='EmitMessage'"
             " detail='ObservationOnly' source='You catch fire' stripped='You catch fire'\n"
             "[QudJP] FinalOutputProbe/v1: sink='MessageLog' route='EmitMessage' detail='ObservationOnly'"
-            " phase='before_sink' translation_status='sink_unclaimed' markup_status='not_evaluated'"
+            " phase='before_sink' translation_status='sink_unclaimed' markup_status='matched'"
             " direct_marker_status='not_evaluated' hit=1 source='You catch fire'"
             " stripped='You catch fire' translated='' final='You catch fire'; route=EmitMessage;"
             " family=final_output; template_id=<missing>; payload_mode=full; payload_excerpt=You catch fire;"
             " payload_sha256=<missing>; sink=MessageLog; detail=ObservationOnly; phase=before_sink;"
-            " translation_status=sink_unclaimed; markup_status=not_evaluated;"
+            " translation_status=sink_unclaimed; markup_status=matched;"
             " direct_marker_status=not_evaluated; source_text_sample=You catch fire;"
             " stripped_text_sample=You catch fire; translated_text_sample=; final_text_sample=You catch fire"
+            "\n[QudJP] FinalOutputProbe/v1: sink='MessageLog' route='EmitMessage' detail='DirectMarker'"
+            " phase='before_sink' translation_status='direct_marker' markup_status='source_only'"
+            " direct_marker_status='present' hit=1 source='{{R|You hit snapjaw.}}'"
+            " stripped='You hit snapjaw.' translated='あなたはsnapjawに命中した。'"
+            " final='あなたはsnapjawに命中した。'; route=EmitMessage;"
+            " family=final_output; template_id=<missing>; payload_mode=full;"
+            " payload_excerpt=あなたはsnapjawに命中した。; payload_sha256=<missing>;"
+            " sink=MessageLog; detail=DirectMarker; phase=before_sink;"
+            " translation_status=direct_marker; markup_status=source_only;"
+            " direct_marker_status=present; source_text_sample={{R|You hit snapjaw.}};"
+            " stripped_text_sample=You hit snapjaw.; translated_text_sample=あなたはsnapjawに命中した。;"
+            " final_text_sample=あなたはsnapjawに命中した。"
         )
         second_stage = "[QudJP] Translator: missing key 'Equipment' (hit 1). (context: UITextSkinTranslationPatch)"
         log_text = f"{first_stage}\n{second_stage}\n"
@@ -340,17 +352,22 @@ class TestVerificationReport:
         assert [entry["text"] for entry in first["missing_key_candidates"]] == ["Inventory"]
         assert [entry["text"] for entry in first["message_pattern_gaps"]] == ["Game saved!"]
         assert [entry["text"] for entry in first["sink_observed_untranslated_candidates"]] == ["You catch fire"]
-        assert [entry["text"] for entry in final_output_observations] == ["You catch fire"]
+        assert [entry["text"] for entry in final_output_observations] == [
+            "You catch fire",
+            "{{R|You hit snapjaw.}}",
+        ]
         assert final_output_observations[0]["sink"] == "MessageLog"
         assert final_output_observations[0]["phase"] == "before_sink"
         assert final_output_observations[0]["translation_status"] == "sink_unclaimed"
         assert final_output_observations[0]["final_text_sample"] == "You catch fire"
-        assert first_summary["final_output_observations"] == 1
+        assert first_summary["final_output_observations"] == 2
         assert first["markup_color_tag_issue_candidates"][0]["source_markup"] == ["{{W|", "}}"]
+        assert first["markup_color_tag_issue_candidates"][1]["kind"] == "final_output_probe"
+        assert first["markup_color_tag_issue_candidates"][1]["markup_status"] == "source_only"
         assert report_summary["stage_count"] == 2
         assert report_summary["missing_key_candidates"] == 2
-        assert report_summary["final_output_observations"] == 1
-        assert report_summary["markup_color_tag_issue_candidates"] == 1
+        assert report_summary["final_output_observations"] == 2
+        assert report_summary["markup_color_tag_issue_candidates"] == 2
         assert report_summary["preserved_english"] == 1
 
 

--- a/scripts/translation_checker.py
+++ b/scripts/translation_checker.py
@@ -1583,23 +1583,43 @@ def _has_ascii_word_candidate(text: str) -> bool:
 def _markup_issue_candidates(entries: list[LogEntry]) -> list[dict[str, object]]:
     candidates: list[dict[str, object]] = []
     for entry in entries:
-        if entry.kind != LogEntryKind.DYNAMIC_TEXT_PROBE or entry.translated_text is None:
-            continue
-        source_markup = _markup_signature(entry.text)
-        translated_markup = _markup_signature(entry.translated_text)
-        if source_markup == translated_markup:
-            continue
-        candidates.append(
-            {
-                "text": entry.text,
-                "translated_text": entry.translated_text,
-                "route": entry.route,
-                "kind": entry.kind.value,
-                "line_number": entry.line_number,
-                "source_markup": source_markup,
-                "translated_markup": translated_markup,
-            },
-        )
+        if entry.kind == LogEntryKind.DYNAMIC_TEXT_PROBE and entry.translated_text is not None:
+            source_markup = _markup_signature(entry.text)
+            translated_markup = _markup_signature(entry.translated_text)
+            if source_markup == translated_markup:
+                continue
+            candidates.append(
+                {
+                    "text": entry.text,
+                    "translated_text": entry.translated_text,
+                    "route": entry.route,
+                    "kind": entry.kind.value,
+                    "line_number": entry.line_number,
+                    "source_markup": source_markup,
+                    "translated_markup": translated_markup,
+                },
+            )
+        elif entry.kind == LogEntryKind.FINAL_OUTPUT_PROBE:
+            source_text = entry.source_text_sample or entry.text
+            final_text = entry.final_text_sample or ""
+            source_markup = _markup_signature(source_text)
+            final_markup = _markup_signature(final_text)
+            if source_markup == final_markup:
+                continue
+            candidates.append(
+                {
+                    "text": entry.text,
+                    "final_text": final_text,
+                    "route": entry.route,
+                    "kind": entry.kind.value,
+                    "line_number": entry.line_number,
+                    "translation_status": entry.translation_status,
+                    "markup_status": entry.markup_status,
+                    "direct_marker_status": entry.direct_marker_status,
+                    "source_markup": source_markup,
+                    "final_markup": final_markup,
+                },
+            )
     return candidates
 
 


### PR DESCRIPTION
## Summary

- extend `FinalOutputProbe/v1` beyond sink-unclaimed observations to include direct-marker, already-localized, and skipped UITextSkin/MessageLog paths
- compute meaningful `markup_status` values from source/final markup signatures and set `direct_marker_status` to present/absent
- include FinalOutputProbe-derived markup/color mismatches in verification reports

Closes #384

## Verification

- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2`
- `uv run pytest scripts/tests/ -q`
- `ruff check scripts/`
- `uv run basedpyright scripts/tests/test_translation_checker.py scripts/translation_checker.py scripts/triage/log_parser.py --level error`
- `npx secretlint .`
- real game inventory flow via `python3.12 scripts/translation_checker.py --skip-sync --flow inventory --input-backend osascript --launch-timeout 90 --title-ready-timeout 30 --load-ready-timeout 45 --inventory-timeout 30`

## Runtime evidence

The real-game inventory run produced `FinalOutputProbe/v1` observations with:

- `sink_unclaimed`: 78
- `skipped`: 68
- `direct_marker`: 27
- `markup_status=matched`: 37
- `markup_status=no_markup`: 136

The run also confirmed direct-marker observations include translated/final samples.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 翻訳出力の検証と分類に関する新規テストを追加しました
  * より多くのシナリオと条件下での翻訳処理を検証します

* **Chores**
  * 翻訳処理の内部トレース機構を拡張し、より詳細なログを記録するようにしました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->