### PR TITLE
Add span-aware final output markup evidence

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/FinalOutputObservabilityTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/FinalOutputObservabilityTests.cs
@@ -39,6 +39,8 @@ public sealed class FinalOutputObservabilityTests
     [Test]
     public void Record_UsesExpectedFormatAndFinalTextPayloadIdentity()
     {
+        var expectedVisibleHash = ComputeSha256Hex("Unknown text");
+
         var output = TestTraceHelper.CaptureTrace(() =>
             FinalOutputObservability.Record(
                 CreateObservation(
@@ -51,6 +53,9 @@ public sealed class FinalOutputObservabilityTests
             output,
             Does.Contain(
                 "[QudJP] FinalOutputProbe/v1: sink='UITextSkinTranslationPatch' route='PopupTranslationPatch' detail='ObservationOnly' phase='before_sink' translation_status='sink_unclaimed' markup_status='not_evaluated' direct_marker_status='not_evaluated' hit=1 source='{{R|Unknown text}}' stripped='Unknown text' translated='' final='{{R|Unknown text}}'; route=PopupTranslationPatch; family=final_output; template_id=<missing>; payload_mode=full; payload_excerpt={{R|Unknown text}}; payload_sha256=<missing>; sink=UITextSkinTranslationPatch; detail=ObservationOnly; phase=before_sink; translation_status=sink_unclaimed; markup_status=not_evaluated; direct_marker_status=not_evaluated; source_text_sample={{R|Unknown text}}; stripped_text_sample=Unknown text; translated_text_sample=; final_text_sample={{R|Unknown text}}"));
+        Assert.That(output, Does.Contain("; source_markup_spans=qud:R@0-12; final_markup_spans=qud:R@0-12; markup_span_status=matched;"));
+        Assert.That(output, Does.Contain("; source_visible_sha256=" + expectedVisibleHash));
+        Assert.That(output, Does.Contain("; final_visible_sha256=" + expectedVisibleHash));
     }
 
     [Test]
@@ -159,6 +164,55 @@ public sealed class FinalOutputObservabilityTests
         Assert.That(output, Does.Contain("direct_marker_status='present'"));
         Assert.That(output, Does.Contain("markup_status='matched'"));
         Assert.That(output, Does.Contain("translated='{{G|あなたは命中した。}}' final='{{G|あなたは命中した。}}'"));
+    }
+
+    [Test]
+    public void ComputeMarkupSpanStatusForTests_DetectsBoundaryDriftWithMatchingTokenSequence()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                FinalOutputObservability.ComputeMarkupStatusForTests(
+                    "{{phase-harmonic|血まみれの}}タム",
+                    "{{phase-harmonic|血ま}}みれのタム"),
+                Is.EqualTo("matched"));
+            Assert.That(
+                FinalOutputObservability.ComputeMarkupSpanStatusForTests(
+                    "{{phase-harmonic|血まみれの}}タム",
+                    "{{phase-harmonic|血ま}}みれのタム"),
+                Is.EqualTo("span_mismatch"));
+            Assert.That(
+                FinalOutputObservability.BuildMarkupSpanSignatureForTests("{{phase-harmonic|血まみれの}}タム"),
+                Is.EqualTo("qud:phase-harmonic@0-5"));
+            Assert.That(
+                FinalOutputObservability.BuildMarkupSpanSignatureForTests("{{phase-harmonic|血ま}}みれのタム"),
+                Is.EqualTo("qud:phase-harmonic@0-2"));
+        });
+    }
+
+    [Test]
+    public void ComputeMarkupSpanStatusForTests_ClassifiesTokenMismatchBeforeSpanComparison()
+    {
+        Assert.That(
+            FinalOutputObservability.ComputeMarkupSpanStatusForTests("{{R|source}}", "{{G|source}}"),
+            Is.EqualTo("token_mismatch"));
+    }
+
+    [Test]
+    public void BuildMarkupSpanSignatureForTests_RecordsTmpColorRangesAndInlineTokenPositions()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                FinalOutputObservability.BuildMarkupSpanSignatureForTests("<color=#AA0000>HP</color> &Gready"),
+                Is.EqualTo("tmp:#AA0000@0-2|fg:G@3"));
+            Assert.That(
+                FinalOutputObservability.BuildMarkupSpanSignatureForTests("{{R|a&&b^^c}}"),
+                Is.EqualTo("escape:&@1|escape:^@3|qud:R@0-5"));
+            Assert.That(
+                FinalOutputObservability.BuildMarkupSpanSignatureForTests("{{w-W-Y sequence|Paingouin}}"),
+                Is.EqualTo("qud:w-W-Y sequence@0-9"));
+        });
     }
 
     [TestCase("plain", "plain", "no_markup")]

--- a/Mods/QudJP/Assemblies/src/Observability/FinalOutputObservability.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/FinalOutputObservability.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text;
@@ -19,6 +20,8 @@ internal static class FinalOutputObservability
     internal const string MarkupStatusMismatch = "mismatch";
     internal const string MarkupStatusNoMarkup = "no_markup";
     internal const string MarkupStatusSourceOnly = "source_only";
+    internal const string MarkupSpanStatusSpanMismatch = "span_mismatch";
+    internal const string MarkupSpanStatusTokenMismatch = "token_mismatch";
     internal const string NotEvaluatedStatus = "not_evaluated";
     internal const string PhaseBeforeSink = "before_sink";
     internal const string TranslationStatusAlreadyLocalized = "already_localized";
@@ -36,7 +39,7 @@ internal static class FinalOutputObservability
 
     private static readonly object HitCountsSync = new object();
     private static readonly Regex MarkupTokenPattern =
-        new Regex(@"\{\{[A-Za-z0-9#]+\||\}\}|&&|\^\^|&[A-Za-z]|\^[A-Za-z]|</?color(?:=[^>]+)?>|=[A-Za-z0-9_.]+=", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+        new Regex(@"\{\{[^|}]+\||\}\}|&&|\^\^|&[A-Za-z]|\^[A-Za-z]|<color=[^>]+>|</color>|=[A-Za-z0-9_.]+=", RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
     internal static void ResetForTests()
     {
@@ -58,6 +61,16 @@ internal static class FinalOutputObservability
     internal static string ComputeMarkupStatusForTests(string? sourceText, string? finalText)
     {
         return ComputeMarkupStatus(sourceText, finalText);
+    }
+
+    internal static string ComputeMarkupSpanStatusForTests(string? sourceText, string? finalText)
+    {
+        return ComputeMarkupSpanStatus(sourceText, finalText);
+    }
+
+    internal static string BuildMarkupSpanSignatureForTests(string? text)
+    {
+        return BuildMarkupSpanSignature(text);
     }
 
     internal static void RecordSinkUnclaimed(
@@ -148,6 +161,16 @@ internal static class FinalOutputObservability
             return;
         }
 
+        var sourceMarkupSpans = BuildMarkupSpanSignature(normalized.SourceText);
+        var finalMarkupSpans = BuildMarkupSpanSignature(normalized.FinalText);
+        var markupSpanStatus = ComputeMarkupSpanStatus(
+            normalized.SourceText,
+            normalized.FinalText,
+            sourceMarkupSpans,
+            finalMarkupSpans);
+        var sourceVisibleSha256 = ObservabilityHelpers.ComputeSha256Hex(BuildVisibleText(normalized.SourceText));
+        var finalVisibleSha256 = ObservabilityHelpers.ComputeSha256Hex(BuildVisibleText(normalized.FinalText));
+
         QudJPMod.LogToUnity(
             "[QudJP] FinalOutputProbe/" + ProbeVersion +
             ": sink='" + SanitizeQuotedValue(normalized.Sink) +
@@ -173,7 +196,12 @@ internal static class FinalOutputObservability
                 normalized.SourceText,
                 normalized.StrippedText,
                 normalized.TranslatedText,
-                normalized.FinalText));
+                normalized.FinalText,
+                sourceMarkupSpans,
+                finalMarkupSpans,
+                markupSpanStatus,
+                sourceVisibleSha256,
+                finalVisibleSha256));
     }
 
     private static string SanitizeQuotedValue(string value)
@@ -238,6 +266,340 @@ internal static class FinalOutputObservability
         }
 
         return MarkupStatusMatched;
+    }
+
+    private static string ComputeMarkupSpanStatus(string? sourceText, string? finalText)
+    {
+        return ComputeMarkupSpanStatus(
+            sourceText,
+            finalText,
+            BuildMarkupSpanSignature(sourceText),
+            BuildMarkupSpanSignature(finalText));
+    }
+
+    private static string ComputeMarkupSpanStatus(
+        string? sourceText,
+        string? finalText,
+        string sourceMarkupSpans,
+        string finalMarkupSpans)
+    {
+        var tokenStatus = ComputeMarkupStatus(sourceText, finalText);
+        if (string.Equals(tokenStatus, MarkupStatusNoMarkup, StringComparison.Ordinal)
+            || string.Equals(tokenStatus, MarkupStatusSourceOnly, StringComparison.Ordinal)
+            || string.Equals(tokenStatus, MarkupStatusFinalOnly, StringComparison.Ordinal))
+        {
+            return tokenStatus;
+        }
+
+        if (!string.Equals(tokenStatus, MarkupStatusMatched, StringComparison.Ordinal))
+        {
+            return MarkupSpanStatusTokenMismatch;
+        }
+
+        return string.Equals(sourceMarkupSpans, finalMarkupSpans, StringComparison.Ordinal)
+            ? MarkupStatusMatched
+            : MarkupSpanStatusSpanMismatch;
+    }
+
+    private static string BuildMarkupSpanSignature(string? text)
+    {
+        var value = text ?? string.Empty;
+        if (value.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var spans = new List<string>();
+        var stack = new Stack<MarkupScope>();
+        var visibleIndex = 0;
+        var index = 0;
+        while (index < value.Length)
+        {
+            if (TryReadQudOpen(value, index, out var qudShader, out var qudLength))
+            {
+                stack.Push(new MarkupScope("qud", qudShader, visibleIndex));
+                index += qudLength;
+                continue;
+            }
+
+            if (StartsWithOrdinal(value, index, "}}"))
+            {
+                if (TryPopScope(stack, "qud", out var scope))
+                {
+                    spans.Add(FormatSpan(scope, visibleIndex));
+                }
+                else
+                {
+                    spans.Add("qud-close@" + visibleIndex.ToString(CultureInfo.InvariantCulture));
+                }
+
+                index += 2;
+                continue;
+            }
+
+            if (TryReadTmpColorOpen(value, index, out var tmpColor, out var tmpOpenLength))
+            {
+                stack.Push(new MarkupScope("tmp", tmpColor, visibleIndex));
+                index += tmpOpenLength;
+                continue;
+            }
+
+            if (StartsWithOrdinal(value, index, "</color>"))
+            {
+                if (TryPopScope(stack, "tmp", out var scope))
+                {
+                    spans.Add(FormatSpan(scope, visibleIndex));
+                }
+                else
+                {
+                    spans.Add("tmp-close@" + visibleIndex.ToString(CultureInfo.InvariantCulture));
+                }
+
+                index += "</color>".Length;
+                continue;
+            }
+
+            if (StartsWithOrdinal(value, index, "&&"))
+            {
+                spans.Add("escape:&@" + visibleIndex.ToString(CultureInfo.InvariantCulture));
+                visibleIndex++;
+                index += 2;
+                continue;
+            }
+
+            if (StartsWithOrdinal(value, index, "^^"))
+            {
+                spans.Add("escape:^@" + visibleIndex.ToString(CultureInfo.InvariantCulture));
+                visibleIndex++;
+                index += 2;
+                continue;
+            }
+
+            if ((value[index] == '&' || value[index] == '^') && index + 1 < value.Length && IsAsciiLetter(value[index + 1]))
+            {
+                spans.Add((value[index] == '&' ? "fg:" : "bg:")
+                    + value[index + 1]
+                    + "@"
+                    + visibleIndex.ToString(CultureInfo.InvariantCulture));
+                index += 2;
+                continue;
+            }
+
+            if (TryReadPlaceholder(value, index, out var placeholder, out var placeholderLength))
+            {
+                spans.Add("placeholder:" + placeholder + "@" + visibleIndex.ToString(CultureInfo.InvariantCulture));
+                index += placeholderLength;
+                continue;
+            }
+
+            visibleIndex++;
+            index++;
+        }
+
+        while (stack.Count > 0)
+        {
+            var scope = stack.Pop();
+            spans.Add(FormatSpan(scope, visibleIndex));
+        }
+
+        return string.Join("|", spans);
+    }
+
+    private static string BuildVisibleText(string text)
+    {
+        var builder = new StringBuilder(text.Length);
+        var index = 0;
+        while (index < text.Length)
+        {
+            if (TryReadQudOpen(text, index, out _, out var qudLength))
+            {
+                index += qudLength;
+                continue;
+            }
+
+            if (StartsWithOrdinal(text, index, "}}"))
+            {
+                index += 2;
+                continue;
+            }
+
+            if (TryReadTmpColorOpen(text, index, out _, out var tmpOpenLength))
+            {
+                index += tmpOpenLength;
+                continue;
+            }
+
+            if (StartsWithOrdinal(text, index, "</color>"))
+            {
+                index += "</color>".Length;
+                continue;
+            }
+
+            if (StartsWithOrdinal(text, index, "&&"))
+            {
+                builder.Append('&');
+                index += 2;
+                continue;
+            }
+
+            if (StartsWithOrdinal(text, index, "^^"))
+            {
+                builder.Append('^');
+                index += 2;
+                continue;
+            }
+
+            if ((text[index] == '&' || text[index] == '^') && index + 1 < text.Length && IsAsciiLetter(text[index + 1]))
+            {
+                index += 2;
+                continue;
+            }
+
+            if (TryReadPlaceholder(text, index, out _, out var placeholderLength))
+            {
+                index += placeholderLength;
+                continue;
+            }
+
+            builder.Append(text[index]);
+            index++;
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool TryReadQudOpen(string value, int index, out string shader, out int length)
+    {
+        shader = string.Empty;
+        length = 0;
+        if (!StartsWithOrdinal(value, index, "{{"))
+        {
+            return false;
+        }
+
+        var separatorIndex = -1;
+        for (var scanIndex = index + 2; scanIndex < value.Length; scanIndex++)
+        {
+            if (scanIndex + 1 < value.Length && value[scanIndex] == '}' && value[scanIndex + 1] == '}')
+            {
+                return false;
+            }
+
+            if (value[scanIndex] == '|')
+            {
+                separatorIndex = scanIndex;
+                break;
+            }
+        }
+
+        if (separatorIndex < 0)
+        {
+            return false;
+        }
+
+        var candidate = value.Substring(index + 2, separatorIndex - index - 2);
+        if (candidate.Length == 0)
+        {
+            return false;
+        }
+
+        shader = candidate;
+        length = separatorIndex - index + 1;
+        return true;
+    }
+
+    private static bool TryReadTmpColorOpen(string value, int index, out string color, out int length)
+    {
+        color = string.Empty;
+        length = 0;
+        if (!StartsWithOrdinal(value, index, "<color="))
+        {
+            return false;
+        }
+
+        var endIndex = value.IndexOf('>', index + "<color=".Length);
+        if (endIndex < 0)
+        {
+            return false;
+        }
+
+        color = value.Substring(index + "<color=".Length, endIndex - index - "<color=".Length);
+        length = endIndex - index + 1;
+        return true;
+    }
+
+    private static bool TryReadPlaceholder(string value, int index, out string placeholder, out int length)
+    {
+        placeholder = string.Empty;
+        length = 0;
+        if (value[index] != '=')
+        {
+            return false;
+        }
+
+        var endIndex = value.IndexOf('=', index + 1);
+        if (endIndex < 0)
+        {
+            return false;
+        }
+
+        var candidate = value.Substring(index + 1, endIndex - index - 1);
+        if (candidate.Length == 0)
+        {
+            return false;
+        }
+
+        for (var candidateIndex = 0; candidateIndex < candidate.Length; candidateIndex++)
+        {
+            var character = candidate[candidateIndex];
+            if (!IsAsciiLetterOrDigit(character) && character != '_' && character != '.')
+            {
+                return false;
+            }
+        }
+
+        placeholder = candidate;
+        length = endIndex - index + 1;
+        return true;
+    }
+
+    private static bool TryPopScope(Stack<MarkupScope> stack, string kind, out MarkupScope scope)
+    {
+        if (stack.Count > 0 && string.Equals(stack.Peek().Kind, kind, StringComparison.Ordinal))
+        {
+            scope = stack.Pop();
+            return true;
+        }
+
+        scope = default;
+        return false;
+    }
+
+    private static string FormatSpan(MarkupScope scope, int endVisibleIndex)
+    {
+        return scope.Kind
+            + ":"
+            + scope.Value
+            + "@"
+            + scope.StartVisibleIndex.ToString(CultureInfo.InvariantCulture)
+            + "-"
+            + endVisibleIndex.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static bool StartsWithOrdinal(string value, int index, string prefix)
+    {
+        return index <= value.Length - prefix.Length
+            && string.CompareOrdinal(value, index, prefix, 0, prefix.Length) == 0;
+    }
+
+    private static bool IsAsciiLetter(char character)
+    {
+        return (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z');
+    }
+
+    private static bool IsAsciiLetterOrDigit(char character)
+    {
+        return IsAsciiLetter(character) || (character >= '0' && character <= '9');
     }
 
     private static NormalizedObservation Normalize(FinalOutputObservation observation)
@@ -342,5 +704,21 @@ internal static class FinalOutputObservability
         internal string TranslatedText { get; }
 
         internal string FinalText { get; }
+    }
+
+    private readonly struct MarkupScope
+    {
+        internal MarkupScope(string kind, string value, int startVisibleIndex)
+        {
+            Kind = kind;
+            Value = value;
+            StartVisibleIndex = startVisibleIndex;
+        }
+
+        internal string Kind { get; }
+
+        internal string Value { get; }
+
+        internal int StartVisibleIndex { get; }
     }
 }

--- a/Mods/QudJP/Assemblies/src/Observability/ObservabilityHelpers.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/ObservabilityHelpers.cs
@@ -186,7 +186,12 @@ internal static class ObservabilityHelpers
         string sourceText,
         string strippedText,
         string translatedText,
-        string finalText)
+        string finalText,
+        string sourceMarkupSpans,
+        string finalMarkupSpans,
+        string markupSpanStatus,
+        string sourceVisibleSha256,
+        string finalVisibleSha256)
     {
         return BuildHelperStructuredSuffix(route, FinalOutputObservability.Family, finalText)
             + "; sink=" + EscapeStructuredValue(sink)
@@ -198,7 +203,12 @@ internal static class ObservabilityHelpers
             + "; source_text_sample=" + EscapeStructuredSample(sourceText)
             + "; stripped_text_sample=" + EscapeStructuredSample(strippedText)
             + "; translated_text_sample=" + EscapeStructuredSample(translatedText)
-            + "; final_text_sample=" + EscapeStructuredSample(finalText);
+            + "; final_text_sample=" + EscapeStructuredSample(finalText)
+            + "; source_markup_spans=" + EscapeStructuredValue(sourceMarkupSpans)
+            + "; final_markup_spans=" + EscapeStructuredValue(finalMarkupSpans)
+            + "; markup_span_status=" + EscapeStructuredValue(markupSpanStatus)
+            + "; source_visible_sha256=" + EscapeStructuredValue(sourceVisibleSha256)
+            + "; final_visible_sha256=" + EscapeStructuredValue(finalVisibleSha256);
     }
 
     internal static string EscapeStructuredValue(string value)
@@ -255,7 +265,7 @@ internal static class ObservabilityHelpers
         return builder.ToString();
     }
 
-    private static string ComputeSha256Hex(string value)
+    internal static string ComputeSha256Hex(string value)
     {
         var bytes = Encoding.UTF8.GetBytes(value);
 #if NET48

--- a/scripts/tests/test_translation_checker.py
+++ b/scripts/tests/test_translation_checker.py
@@ -310,7 +310,8 @@ class TestVerificationReport:
             " payload_sha256=<missing>; sink=MessageLog; detail=ObservationOnly; phase=before_sink;"
             " translation_status=sink_unclaimed; markup_status=matched;"
             " direct_marker_status=not_evaluated; source_text_sample=You catch fire;"
-            " stripped_text_sample=You catch fire; translated_text_sample=; final_text_sample=You catch fire"
+            " stripped_text_sample=You catch fire; translated_text_sample=; final_text_sample=You catch fire;"
+            " source_visible_sha256=source-hash-catch-fire; final_visible_sha256=final-hash-catch-fire"
             "\n[QudJP] FinalOutputProbe/v1: sink='MessageLog' route='EmitMessage' detail='DirectMarker'"
             " phase='before_sink' translation_status='direct_marker' markup_status='source_only'"
             " direct_marker_status='present' hit=1 source='{{R|You hit snapjaw.}}'"
@@ -322,7 +323,23 @@ class TestVerificationReport:
             " translation_status=direct_marker; markup_status=source_only;"
             " direct_marker_status=present; source_text_sample={{R|You hit snapjaw.}};"
             " stripped_text_sample=You hit snapjaw.; translated_text_sample=あなたはsnapjawに命中した。;"
-            " final_text_sample=あなたはsnapjawに命中した。"
+            " final_text_sample=あなたはsnapjawに命中した。;"
+            " source_visible_sha256=source-hash-hit; final_visible_sha256=final-hash-hit"
+            "\n[QudJP] FinalOutputProbe/v1: sink='MessageLog' route='EmitMessage' detail='DirectMarker'"
+            " phase='before_sink' translation_status='direct_marker' markup_status='matched'"
+            " direct_marker_status='present' hit=1 source='{{phase-harmonic|snapjaw brute}}'"
+            " stripped='snapjaw brute' translated='{{phase-harmonic|snapjaw}} brute'"
+            " final='{{phase-harmonic|snapjaw}} brute'; route=EmitMessage;"
+            " family=final_output; template_id=<missing>; payload_mode=full;"
+            " payload_excerpt={{phase-harmonic|snapjaw}} brute; payload_sha256=<missing>;"
+            " sink=MessageLog; detail=DirectMarker; phase=before_sink;"
+            " translation_status=direct_marker; markup_status=matched;"
+            " direct_marker_status=present; source_text_sample={{phase-harmonic|snapjaw brute}};"
+            " stripped_text_sample=snapjaw brute; translated_text_sample={{phase-harmonic|snapjaw}} brute;"
+            " final_text_sample={{phase-harmonic|snapjaw}} brute;"
+            " source_markup_spans=qud:phase-harmonic@0-13;"
+            " final_markup_spans=qud:phase-harmonic@0-7; markup_span_status=span_mismatch;"
+            " source_visible_sha256=source-visible-hash; final_visible_sha256=final-visible-hash"
         )
         second_stage = "[QudJP] Translator: missing key 'Equipment' (hit 1). (context: UITextSkinTranslationPatch)"
         log_text = f"{first_stage}\n{second_stage}\n"
@@ -355,19 +372,34 @@ class TestVerificationReport:
         assert [entry["text"] for entry in final_output_observations] == [
             "You catch fire",
             "{{R|You hit snapjaw.}}",
+            "{{phase-harmonic|snapjaw brute}}",
         ]
         assert final_output_observations[0]["sink"] == "MessageLog"
         assert final_output_observations[0]["phase"] == "before_sink"
         assert final_output_observations[0]["translation_status"] == "sink_unclaimed"
         assert final_output_observations[0]["final_text_sample"] == "You catch fire"
-        assert first_summary["final_output_observations"] == 2
+        assert final_output_observations[0]["source_visible_sha256"] == "source-hash-catch-fire"
+        assert final_output_observations[0]["final_visible_sha256"] == "final-hash-catch-fire"
+        assert final_output_observations[1]["source_visible_sha256"] == "source-hash-hit"
+        assert final_output_observations[1]["final_visible_sha256"] == "final-hash-hit"
+        assert final_output_observations[2]["source_visible_sha256"] == "source-visible-hash"
+        assert final_output_observations[2]["final_visible_sha256"] == "final-visible-hash"
+        assert all("source_visible_sha256" in entry for entry in final_output_observations)
+        assert all("final_visible_sha256" in entry for entry in final_output_observations)
+        assert first_summary["final_output_observations"] == 3
+        assert final_output_observations[2]["markup_span_status"] == "span_mismatch"
+        assert final_output_observations[2]["source_markup_spans"] == "qud:phase-harmonic@0-13"
+        assert final_output_observations[2]["final_markup_spans"] == "qud:phase-harmonic@0-7"
         assert first["markup_color_tag_issue_candidates"][0]["source_markup"] == ["{{W|", "}}"]
         assert first["markup_color_tag_issue_candidates"][1]["kind"] == "final_output_probe"
         assert first["markup_color_tag_issue_candidates"][1]["markup_status"] == "source_only"
+        assert first["markup_color_tag_issue_candidates"][2]["markup_span_status"] == "span_mismatch"
+        assert first["markup_color_tag_issue_candidates"][2]["source_markup_spans"] == "qud:phase-harmonic@0-13"
+        assert first["markup_color_tag_issue_candidates"][2]["final_markup_spans"] == "qud:phase-harmonic@0-7"
         assert report_summary["stage_count"] == 2
         assert report_summary["missing_key_candidates"] == 2
-        assert report_summary["final_output_observations"] == 2
-        assert report_summary["markup_color_tag_issue_candidates"] == 2
+        assert report_summary["final_output_observations"] == 3
+        assert report_summary["markup_color_tag_issue_candidates"] == 3
         assert report_summary["preserved_english"] == 1
 
 

--- a/scripts/tests/test_triage_log_parser.py
+++ b/scripts/tests/test_triage_log_parser.py
@@ -60,6 +60,11 @@ def _final_output_probe_line(**overrides: str | int) -> str:
         "stripped": "You catch fire",
         "translated": "",
         "final": "You catch fire",
+        "source_markup_spans": "",
+        "final_markup_spans": "",
+        "markup_span_status": "no_markup",
+        "source_visible_sha256": "source-hash",
+        "final_visible_sha256": "final-hash",
     }
     unknown = set(overrides) - set(fields)
     if unknown:
@@ -84,7 +89,12 @@ def _final_output_probe_line(**overrides: str | int) -> str:
         f" direct_marker_status={structured['direct_marker_status']};"
         f" source_text_sample={structured['source']};"
         f" stripped_text_sample={structured['stripped']}; translated_text_sample={structured['translated']};"
-        f" final_text_sample={structured['final']}"
+        f" final_text_sample={structured['final']};"
+        f" source_markup_spans={structured['source_markup_spans']};"
+        f" final_markup_spans={structured['final_markup_spans']};"
+        f" markup_span_status={structured['markup_span_status']};"
+        f" source_visible_sha256={structured['source_visible_sha256']};"
+        f" final_visible_sha256={structured['final_visible_sha256']}"
     )
 
 
@@ -548,6 +558,11 @@ def test_parse_final_output_probe(tmp_path: Path) -> None:
     assert entry.stripped_text_sample == "You catch fire"
     assert entry.translated_text_sample == ""
     assert entry.final_text_sample == "You catch fire"
+    assert entry.source_markup_spans == ""
+    assert entry.final_markup_spans == ""
+    assert entry.markup_span_status == "no_markup"
+    assert entry.source_visible_sha256 == "source-hash"
+    assert entry.final_visible_sha256 == "final-hash"
 
 
 def test_parse_final_output_probe_keeps_phase_and_sink_distinct(tmp_path: Path) -> None:

--- a/scripts/translation_checker.py
+++ b/scripts/translation_checker.py
@@ -58,7 +58,7 @@ _DEFAULT_INVENTORY_PATTERNS: tuple[str, ...] = (
 _MESSAGE_LOG_ROUTES = frozenset({"MessageLog", "MessageLogPatch", "EmitMessage"})
 _ASCII_WORD_PATTERN = re.compile(r"[A-Za-z]{2,}")
 _MARKUP_TOKEN_PATTERN = re.compile(
-    r"\{\{[A-Za-z0-9#]+\||\}\}|&&|\^\^|&[A-Za-z]|\^[A-Za-z]|</?color(?:=[^>]+)?>|=[A-Za-z0-9_.]+=",
+    r"\{\{[^|}]+\||\}\}|&&|\^\^|&[A-Za-z]|\^[A-Za-z]|<color=[^>]+>|</color>|=[A-Za-z0-9_.]+=",
 )
 _FINAL_OUTPUT_OBSERVATION_FIELDS = (
     "sink",
@@ -71,10 +71,16 @@ _FINAL_OUTPUT_OBSERVATION_FIELDS = (
     "stripped_text_sample",
     "translated_text_sample",
     "final_text_sample",
+    "source_markup_spans",
+    "final_markup_spans",
+    "markup_span_status",
+    "source_visible_sha256",
+    "final_visible_sha256",
     "payload_mode",
     "payload_excerpt",
     "payload_sha256",
 )
+_NON_ISSUE_MARKUP_SPAN_STATUSES = frozenset({None, "matched", "no_markup"})
 _DEFAULT_INVENTORY_TAB_PAGE_RIGHTS = 8
 _DEFAULT_INVENTORY_ITEM_SCAN_COUNT = 8
 _DEFAULT_INVENTORY_ITEM_ACTION_ROW_OFFSET = 1
@@ -1604,7 +1610,9 @@ def _markup_issue_candidates(entries: list[LogEntry]) -> list[dict[str, object]]
             final_text = entry.final_text_sample or ""
             source_markup = _markup_signature(source_text)
             final_markup = _markup_signature(final_text)
-            if source_markup == final_markup:
+            token_signatures_match = source_markup == final_markup
+            span_status_is_issue = entry.markup_span_status not in _NON_ISSUE_MARKUP_SPAN_STATUSES
+            if token_signatures_match and not span_status_is_issue:
                 continue
             candidates.append(
                 {
@@ -1615,9 +1623,12 @@ def _markup_issue_candidates(entries: list[LogEntry]) -> list[dict[str, object]]
                     "line_number": entry.line_number,
                     "translation_status": entry.translation_status,
                     "markup_status": entry.markup_status,
+                    "markup_span_status": entry.markup_span_status,
                     "direct_marker_status": entry.direct_marker_status,
                     "source_markup": source_markup,
                     "final_markup": final_markup,
+                    "source_markup_spans": entry.source_markup_spans,
+                    "final_markup_spans": entry.final_markup_spans,
                 },
             )
     return candidates

--- a/scripts/triage/log_parser.py
+++ b/scripts/triage/log_parser.py
@@ -76,6 +76,11 @@ def _dedupe_key(entry: LogEntry) -> tuple[str, ...]:
             entry.stripped_text_sample or "",
             entry.translated_text_sample or "",
             entry.final_text_sample or "",
+            entry.source_markup_spans or "",
+            entry.final_markup_spans or "",
+            entry.markup_span_status or "",
+            entry.source_visible_sha256 or "",
+            entry.final_visible_sha256 or "",
             entry.translation_status or "",
             entry.markup_status or "",
             entry.direct_marker_status or "",
@@ -182,6 +187,11 @@ def _entry_with_structured_fields(
         stripped_text_sample=structured("stripped_text_sample", entry.stripped_text_sample),
         translated_text_sample=structured("translated_text_sample", entry.translated_text_sample),
         final_text_sample=structured("final_text_sample", entry.final_text_sample),
+        source_markup_spans=structured("source_markup_spans", entry.source_markup_spans),
+        final_markup_spans=structured("final_markup_spans", entry.final_markup_spans),
+        markup_span_status=structured("markup_span_status", entry.markup_span_status),
+        source_visible_sha256=structured("source_visible_sha256", entry.source_visible_sha256),
+        final_visible_sha256=structured("final_visible_sha256", entry.final_visible_sha256),
         structured_fields=present_fields,
     )
 

--- a/scripts/triage/models.py
+++ b/scripts/triage/models.py
@@ -60,6 +60,11 @@ class LogEntry:
     stripped_text_sample: str | None = None
     translated_text_sample: str | None = None
     final_text_sample: str | None = None
+    source_markup_spans: str | None = None
+    final_markup_spans: str | None = None
+    markup_span_status: str | None = None
+    source_visible_sha256: str | None = None
+    final_visible_sha256: str | None = None
     structured_fields: frozenset[str] = field(default_factory=frozenset)
 
     def has_structured_field(self, field_name: str) -> bool:


### PR DESCRIPTION
## Summary

- extend `FinalOutputProbe/v1` structured suffixes with visible-text markup span signatures, span status, and visible-text hashes
- keep existing token-sequence `markup_status` while adding boundary-aware `markup_span_status` for drift such as same tags covering different visible ranges
- parse and surface the new fields in triage/report tooling, and flag span mismatches in `verification_report.json`

Closes #386

## Verification

- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2`
- `uv run pytest scripts/tests/ -q`
- `ruff check scripts/`
- `uv run basedpyright scripts/triage/log_parser.py scripts/triage/models.py scripts/translation_checker.py scripts/tests/test_triage_log_parser.py scripts/tests/test_translation_checker.py --level error`
- `npx secretlint .`
- `git diff --check`
- Real game inventory run via `python3.12 scripts/sync_mod.py && python3.12 scripts/translation_checker.py --skip-sync --flow inventory --input-backend osascript --launch-timeout 90 --title-ready-timeout 30 --load-ready-timeout 45 --inventory-timeout 30`

## Runtime evidence

The real-game inventory run produced parseable `FinalOutputProbe/v1` entries with:

- `final_count`: 172
- `markup_span_status`: `no_markup=136`, `matched=36`
- `with_source_spans`: 36
- `with_visible_hashes`: 172

Sample parsed span evidence:

```text
source: 1.0.4\n{{K|build 2.0.210.24}}
final:  1.0.4\n{{K|build 2.0.210.24}}
spans:  qud:K@6-22 / qud:K@6-22 / matched
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * マークアップスパンの署名とスパンステータス判定、可視コンテンツのハッシュを観測データに追加。スパンとトークンの不一致を区別。

* **Tests**
  * マークアップスパン挙動と可視ハッシュを検証する単体テストを追加・拡張し、複数の不一致ケースを網羅。

* **Bug Fixes / Improvements**
  * ログ解析・集約と重複判定を拡張し、新しい構造化フィールドを正しく扱うよう改善。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->