### PR TITLE
Fix runtime translation markup and tutorial chargen

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -474,6 +474,27 @@ public sealed class MessagePatternTranslatorTests
     }
 
     [Test]
+    public void Translate_RepositoryDictionary_PreservesOuterWrapperForPlayerWeaponMiss_WhenRollIsOutsideWrapper()
+    {
+        UseRepositoryPatternDictionary();
+
+        var translated = MessagePatternTranslator.Translate("{{r|You miss with your {{w|青銅の短剣}}!}} [7 vs 12]");
+
+        Assert.That(translated, Is.EqualTo("{{r|{{w|青銅の短剣}}での攻撃は外れた。[7 vs 12]}}"));
+    }
+
+    [Test]
+    public void Translate_RepositoryDictionary_RemovesPossessivePronounFromIncomingArmorPenetrationWeapon()
+    {
+        UseRepositoryPatternDictionary();
+
+        var translated = MessagePatternTranslator.Translate(
+            "The ウォーターヴァイン農家 doesn't penetrate your armor with his 鉄の蔓刈り斧! [7]");
+
+        Assert.That(translated, Is.EqualTo("ウォーターヴァイン農家は鉄の蔓刈り斧であなたの防具を貫通できなかった！ [7]"));
+    }
+
+    [Test]
     public void Translate_RepositoryDictionary_TranslatesPlayerAcidDamageMessage()
     {
         UseRepositoryPatternDictionary();

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupTranslationPatchTests.cs
@@ -1493,6 +1493,34 @@ public sealed class PopupTranslationPatchTests
         Assert.That(result, Is.EqualTo("Already translated text"));
     }
 
+    [Test]
+    public void TranslatePopupTextForProducerRoute_ExactStrippedLookup_DoesNotProjectInlineSourceColors()
+    {
+        WriteDictionary((
+            "You need a dram of either blood or putrescence to desecrate a shrine.",
+            "祠を冒涜するには血液か腐敗液のどちらか1ドラムが必要だ。"));
+
+        var translated = PopupTranslationPatch.TranslatePopupTextForProducerRoute(
+            "You need a dram of either {{r|blood}} or {{putrid|putrescence}} to desecrate a shrine.",
+            nameof(PopupTranslationPatch));
+
+        Assert.That(translated, Is.EqualTo("祠を冒涜するには血液か腐敗液のどちらか1ドラムが必要だ。"));
+    }
+
+    [Test]
+    public void TranslatePopupTextForProducerRoute_ExactStrippedLookup_DoesNotLeaveEmptySourceWrapper()
+    {
+        WriteDictionary((
+            "You note this piece of information in the Sultan Histories > Resheph section of your journal.",
+            "この情報をジャーナルの「スルタン史 > レシェフ」欄に記録した。"));
+
+        var translated = PopupTranslationPatch.TranslatePopupTextForProducerRoute(
+            "You note this piece of information in the {{W|Sultan Histories > Resheph}} section of your journal.",
+            nameof(PopupTranslationPatch));
+
+        Assert.That(translated, Is.EqualTo("この情報をジャーナルの「スルタン史 > レシェフ」欄に記録した。"));
+    }
+
     private static string CreateHarmonyId()
     {
         return $"qudjp.tests.{Guid.NewGuid():N}";

--- a/Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs
@@ -337,6 +337,46 @@ public static class PopupTranslationPatch
         return translated.Replace("{{hotkey|}}", string.Empty);
     }
 
+    private static bool HasEmptyQudWrapper(string translated)
+    {
+        for (var index = 0; index < translated.Length; index++)
+        {
+            if (translated[index] != '{'
+                || index + 3 >= translated.Length
+                || translated[index + 1] != '{')
+            {
+                continue;
+            }
+
+            var pipeIndex = translated.IndexOf('|', index + 2);
+            if (pipeIndex < 0 || pipeIndex + 2 >= translated.Length)
+            {
+                continue;
+            }
+
+            if (translated[pipeIndex + 1] == '}'
+                && translated[pipeIndex + 2] == '}'
+                && !IsHotkeyWrapper(translated, index, pipeIndex))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsHotkeyWrapper(string translated, int openIndex, int pipeIndex)
+    {
+        return pipeIndex - openIndex == "{{hotkey".Length
+            && string.Compare(
+                translated,
+                openIndex,
+                "{{hotkey",
+                0,
+                "{{hotkey".Length,
+                StringComparison.Ordinal) == 0;
+    }
+
     private static bool TryTranslatePopupProducerText(string source, string route, string family, out string translated)
     {
         var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
@@ -406,6 +446,11 @@ public static class PopupTranslationPatch
             && !string.Equals(exact, stripped, StringComparison.Ordinal))
         {
             translated = spans.Count == 0 ? exact : ColorAwareTranslationComposer.Restore(exact, spans);
+            if (HasEmptyQudWrapper(translated))
+            {
+                translated = exact;
+            }
+
             DynamicTextObservability.RecordTransform(route, family + ".Exact", source, translated);
             return true;
         }

--- a/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
@@ -467,7 +467,7 @@ internal static class MessagePatternTranslator
             && HasInteriorBoundarySpans(spans, strippedSourceLength.Value)
             && TryApplySegmentedColorAwareTemplate(template, match, strippedSourceLength.Value, spans, out var segmented))
         {
-            return segmented;
+            return BalanceQudBoundaryMarkup(segmented);
         }
 
         var builder = new StringBuilder(template.Length);
@@ -588,7 +588,7 @@ internal static class MessagePatternTranslator
         if (HasInteriorBoundarySpans(spans, strippedSourceLength.Value)
             && TryRestoreWholeLineBoundaryWrappers(translated, spans, strippedSourceLength.Value, out var wholeLineRestored))
         {
-            return wholeLineRestored;
+            return BalanceQudBoundaryMarkup(wholeLineRestored);
         }
 
         if (translatedFirstCaptureStart < 0
@@ -596,17 +596,18 @@ internal static class MessagePatternTranslator
             || translatedFirstCaptureStart > translatedLastCaptureEnd)
         {
             var boundarySpans = ColorAwareTranslationComposer.SliceBoundarySpans(spans, match, strippedSourceLength.Value, translated.Length);
-            return ColorAwareTranslationComposer.Restore(translated, boundarySpans);
+            return BalanceQudBoundaryMarkup(ColorAwareTranslationComposer.Restore(translated, boundarySpans));
         }
 
-        return ColorAwareTranslationComposer.RestoreMatchBoundaries(
-            translated,
-            spans,
-            match,
-            strippedSourceLength.Value,
-            translatedFirstCaptureStart,
-            translatedLastCaptureEnd,
-            lastCaptureConsumesAdjacentClosingBoundary);
+        return BalanceQudBoundaryMarkup(
+            ColorAwareTranslationComposer.RestoreMatchBoundaries(
+                translated,
+                spans,
+                match,
+                strippedSourceLength.Value,
+                translatedFirstCaptureStart,
+                translatedLastCaptureEnd,
+                lastCaptureConsumesAdjacentClosingBoundary));
     }
 
     private static bool TryApplySegmentedColorAwareTemplate(
@@ -825,6 +826,71 @@ internal static class MessagePatternTranslator
                 && ColorCodePreserver.IsOpeningBoundaryToken(span.Token))
             {
                 return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string BalanceQudBoundaryMarkup(string source)
+    {
+        if (source.IndexOf("{{", StringComparison.Ordinal) < 0)
+        {
+            return source;
+        }
+
+        var openCount = 0;
+        for (var index = 0; index < source.Length - 1; index++)
+        {
+            if (source[index] == '{'
+                && source[index + 1] == '{'
+                && TryReadQudOpeningToken(source, index, out var nextIndex))
+            {
+                openCount++;
+                index = nextIndex - 1;
+                continue;
+            }
+
+            if (source[index] == '}' && source[index + 1] == '}')
+            {
+                if (openCount > 0)
+                {
+                    openCount--;
+                }
+
+                index++;
+            }
+        }
+
+        if (openCount <= 0)
+        {
+            return source;
+        }
+
+        var builder = new StringBuilder(source.Length + (openCount * 2));
+        builder.Append(source);
+        for (var index = 0; index < openCount; index++)
+        {
+            builder.Append("}}");
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool TryReadQudOpeningToken(string source, int startIndex, out int nextIndex)
+    {
+        nextIndex = startIndex;
+        for (var index = startIndex + 2; index < source.Length; index++)
+        {
+            if (source[index] == '|')
+            {
+                nextIndex = index + 1;
+                return true;
+            }
+
+            if (index < source.Length - 1 && source[index] == '}' && source[index + 1] == '}')
+            {
+                return false;
             }
         }
 

--- a/Mods/QudJP/Localization/Dictionaries/messages.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/messages.ja.json
@@ -1039,7 +1039,7 @@
       "route": "popup"
     },
     {
-      "pattern": "^(?:The |the |[Aa]n? )?(.+?) (?:doesn't|don't) penetrate your armor with (.+?)! \\[(.+?)\\]$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) (?:doesn't|don't) penetrate your armor with (?:(?:his|her|its|their) )?(.+?)! \\[(.+?)\\]$",
       "template": "{0}は{1}であなたの防具を貫通できなかった！ [{2}]",
       "route": "emit-message"
     },

--- a/Mods/QudJP/Localization/Dictionaries/ui-chargen.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-chargen.ja.json
@@ -25,6 +25,36 @@
       "text": "プレイ方式を選択"
     },
     {
+      "key": "Game Modes",
+      "context": "Chargen.WindowName.GameModes",
+      "text": "ゲームモード"
+    },
+    {
+      "key": "CharTypes",
+      "context": "Chargen.WindowName.CharTypes",
+      "text": "キャラクター種別"
+    },
+    {
+      "key": "Genotypes",
+      "context": "Chargen.WindowName.Genotypes",
+      "text": "ジェノタイプ"
+    },
+    {
+      "key": "Subtypes",
+      "context": "Chargen.WindowName.Subtypes",
+      "text": "サブタイプ"
+    },
+    {
+      "key": "Subtypes with Category",
+      "context": "Chargen.WindowName.SubtypesWithCategory",
+      "text": "カテゴリ別サブタイプ"
+    },
+    {
+      "key": "Starting Location",
+      "context": "Chargen.WindowName.StartingLocation",
+      "text": "開始場所"
+    },
+    {
       "key": "Tutorial",
       "context": "Chargen.Chartype.Option",
       "text": "チュートリアル"

--- a/Mods/QudJP/Localization/EmbarkModules.jp.xml
+++ b/Mods/QudJP/Localization/EmbarkModules.jp.xml
@@ -8,7 +8,7 @@
   <module Class="XRL.CharacterBuilds.Qud.QudGamemodeModule">
     <window ID="Chargen/Modes" Prefab="HorizScroll" Class="XRL.CharacterBuilds.Qud.UI.QudGamemodeModuleWindow">
       <title>：ゲームモードを選択：</title>
-      <name>ゲームモード</name>
+      <name>Game Modes</name>
     </window>
 
 		<modes>
@@ -63,7 +63,7 @@
 
   <module Class="XRL.CharacterBuilds.Qud.QudChartypeModule">
     <window ID="Chargen/CharType" Prefab="HorizScroll" Class="XRL.CharacterBuilds.Qud.UI.QudChartypeModuleWindow">
-      <name>キャラクター種別</name>
+      <name>CharTypes</name>
       <title>：プレイ方式を選択：</title>
     </window>
 
@@ -107,21 +107,21 @@
   
   <module Class="XRL.CharacterBuilds.Qud.QudBuildLibraryModule">
     <window ID="Chargen/BuildLibrary" Prefab="HorizScroll" Class="XRL.CharacterBuilds.Qud.UI.QudBuildLibraryModuleWindow">
-      <name>ビルドライブラリ</name>
+      <name>Build Library</name>
       <title>：ビルドライブラリ：</title>
     </window>
   </module>
   
   <module Class="XRL.CharacterBuilds.Qud.QudGenotypeModule">
     <window ID="Chargen/ChooseGenotypes" Prefab="HorizScroll" Class="XRL.CharacterBuilds.Qud.UI.QudGenotypeModuleWindow">
-      <name>ジェノタイプ</name>
+      <name>Genotypes</name>
       <title>：ジェノタイプを選択：</title>
     </window>
   </module>
   
   <module Class="XRL.CharacterBuilds.Qud.QudPregenModule">
     <window ID="Chargen/Pregens" Prefab="HorizScroll" Class="XRL.CharacterBuilds.Qud.UI.QudPregenModuleWindow">
-      <name>プリセット</name>
+      <name>Pregens</name>
       <title>：プリセットを選択：</title>
     </window>
 
@@ -221,18 +221,18 @@
 
   <module Class="XRL.CharacterBuilds.Qud.QudSubtypeModule">
     <window ID="Chargen/ChooseSubtypes" Prefab="HorizScroll" Class="XRL.CharacterBuilds.Qud.UI.QudSubtypeModuleWindow">
-      <name>サブタイプ</name>
+      <name>Subtypes</name>
       <title>：サブタイプを選択：</title>
     </window>
     <window ID="Chargen/ChooseSubtypesCategory" Prefab="SwitchingScroller" Class="XRL.CharacterBuilds.Qud.UI.QudSubtypeModuleCategoryWindow">
-      <name>カテゴリ別サブタイプ</name>
+      <name>Subtypes with Category</name>
       <title>：サブタイプを選択：</title>
     </window>
   </module>
 
   <module Class="XRL.CharacterBuilds.Qud.QudMutationsModule">
     <window ID="Chargen/Mutations" Prefab="CategoryMenus" Class="XRL.CharacterBuilds.Qud.UI.QudMutationsModuleWindow">
-      <name>変異</name>
+      <name>Mutations</name>
       <title>：変異を選択：</title>
     </window>
 
@@ -241,34 +241,34 @@
   <module Class="XRL.CharacterBuilds.Qud.QudAttributesModule">
     <window ID="Chargen/PickAttributes" Prefab="HorizScrollerScroller" Class="XRL.CharacterBuilds.Qud.UI.QudAttributesModuleWindow">
       <title>：能力値を選択：</title>
-      <name>能力値</name>
+      <name>Attributes</name>
     </window>
   </module>
 
   <module Class="XRL.CharacterBuilds.Qud.QudCyberneticsModule">
     <window ID="Chargen/Cybernetic" Prefab="CategoryMenus" Class="XRL.CharacterBuilds.Qud.UI.QudCyberneticsModuleWindow">
-      <name>サイバネ</name>
+      <name>Cybernetics</name>
       <title>：サイバネ移植を選択：</title>
     </window>
   </module>
 
   <module Class="XRL.CharacterBuilds.Qud.QudBuildSummaryModule">
     <window ID="Chargen/BuildSummary" Prefab="HorizScroll" Class="XRL.CharacterBuilds.Qud.UI.QudBuildSummaryModuleWindow">
-      <name>まとめ</name>
+      <name>Summary</name>
       <title>：ビルドまとめ：</title>
     </window>
   </module>
 
   <module Class="XRL.CharacterBuilds.Qud.QudCustomizeCharacterModule">
     <window ID="Chargen/Customize" Prefab="VertScroll" Class="XRL.CharacterBuilds.Qud.UI.QudCustomizeCharacterModuleWindow">
-      <name>カスタマイズ</name>
+      <name>Customize</name>
       <title>：キャラクターをカスタマイズ：</title>
     </window>
   </module>
 
   <module Class="XRL.CharacterBuilds.Qud.QudChooseStartingLocationModule">
     <window ID="Chargen/ChooseStartingLocation" Prefab="HorizScroll" Class="XRL.CharacterBuilds.Qud.UI.QudChooseStartingLocationModuleWindow">
-      <name>開始場所</name>
+      <name>Starting Location</name>
       <title>：開始場所を選択：</title>
     </window>
     
@@ -469,5 +469,4 @@
 
   </module>
 </embarkmodules>
-
 

--- a/scripts/tests/test_embark_modules_contracts.py
+++ b/scripts/tests/test_embark_modules_contracts.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOCALIZATION_ROOT = REPO_ROOT / "Mods" / "QudJP" / "Localization"
+
+
+def test_embark_module_window_names_preserve_runtime_keys() -> None:
+    """Window names are runtime panel keys used by tutorial chargen flow."""
+    expected_names = [
+        "Game Modes",
+        "CharTypes",
+        "Build Library",
+        "Genotypes",
+        "Pregens",
+        "Subtypes",
+        "Subtypes with Category",
+        "Mutations",
+        "Attributes",
+        "Cybernetics",
+        "Summary",
+        "Customize",
+        "Starting Location",
+    ]
+
+    tree = ET.parse(LOCALIZATION_ROOT / "EmbarkModules.jp.xml")  # noqa: S314
+    actual_names = [
+        name.text
+        for name in tree.findall("./module/window/name")
+    ]
+
+    assert actual_names == expected_names
+
+
+def test_embark_module_window_runtime_keys_have_display_translations() -> None:
+    """Runtime window keys still need dictionary entries for display text."""
+    dictionary_paths = [
+        LOCALIZATION_ROOT / "Dictionaries" / "ui-chargen.ja.json",
+        LOCALIZATION_ROOT / "Dictionaries" / "ui-default.ja.json",
+    ]
+    expected_keys = {
+        "Game Modes",
+        "CharTypes",
+        "Build Library",
+        "Genotypes",
+        "Pregens",
+        "Subtypes",
+        "Subtypes with Category",
+        "Mutations",
+        "Attributes",
+        "Cybernetics",
+        "Summary",
+        "Customize",
+        "Starting Location",
+    }
+
+    translated_keys: set[str] = set()
+    for dictionary_path in dictionary_paths:
+        payload = json.loads(dictionary_path.read_text(encoding="utf-8"))
+        translated_keys.update(
+            entry["key"]
+            for entry in payload["entries"]
+            if entry.get("text") and entry.get("key") in expected_keys
+        )
+
+    assert expected_keys <= translated_keys


### PR DESCRIPTION
## Summary
- Fix final-output markup restoration so exact stripped popup translations do not inherit source color spans or leave empty Qud wrappers
- Balance boundary Qud markup in message pattern translations and remove incoming armor-penetration possessive pronouns
- Restore Embark module window names to runtime keys and add Japanese display translations so Tutorial chargen can advance into world boot

## Root Cause
- `EmbarkModules.jp.xml` translated `<window><name>` runtime identifiers. Tutorial chargen checks the English panel names (`Game Modes`, `Genotypes`, `Pregens`, etc.) to decide editable panels, so localized names caused the flow to skip required data and crash during boot with `QudGenotypeModule.handleBootEvent` null data.

## Verification
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2`
- `ruff check scripts/`
- `uv run pytest scripts/tests/`
- `python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts`
- `python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json`
- `python3.12 scripts/sync_mod.py`
- Manual Rosetta game run: selected New Game -> Tutorial -> Mutated Human -> Marsh Taur -> starting location, generated the tutorial world, and confirmed the prior `ERROR - Booting game` / `NullReferenceException` signature did not recur in `Player.log`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 翻訳されたテキストの空のマークアップラッパーが適切に処理されるようになりました
  * 不一致のマークアップ境界が自動的にバランスされるようになりました
  * 装甲貫通メッセージの日本語翻訳精度が向上しました

* **新機能**
  * キャラクター生成UIに複数の日本語ラベル翻訳が追加されました（ゲームモード、キャラクタータイプ、ジェノタイプ、サブタイプ、開始地点）

* **テスト**
  * メッセージパターン翻訳の新規テストケースが追加されました
  * ポップアップテキスト翻訳のテストカバレッジが拡張されました
  * ローカライゼーション契約の検証テストが追加されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->