### PR TITLE
Fix PlayerStatusBar translated output refresh

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyPlayerStatusBarTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyPlayerStatusBarTargets.cs
@@ -104,3 +104,24 @@ internal sealed class DummyPlayerStatusBarTarget
         }
     }
 }
+
+internal sealed class DummyPlayerStatusBarTargetWithoutDirtyFlag
+{
+    private enum DummyStringDataType
+    {
+        Zone
+    }
+
+    private readonly Dictionary<DummyStringDataType, string> playerStringData = new Dictionary<DummyStringDataType, string>
+    {
+        { DummyStringDataType.Zone, "World Map" },
+    };
+
+    public string? GetStringData(string name)
+    {
+        return Enum.TryParse<DummyStringDataType>(name, ignoreCase: false, out var key)
+            && playerStringData.TryGetValue(key, out var value)
+            ? value
+            : null;
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyPlayerStatusBarTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyPlayerStatusBarTargets.cs
@@ -36,6 +36,8 @@ internal sealed class DummyPlayerStatusBarTarget
         { DummyStringDataType.FoodWater, string.Empty },
     };
 
+    private bool playerStringsDirty;
+
     public DummyPlayerStatusBarProgressBar XPBar = new DummyPlayerStatusBarProgressBar();
 
     public string? NextFoodWater { get; set; }
@@ -59,6 +61,13 @@ internal sealed class DummyPlayerStatusBarTarget
     public int Experience { get; set; }
 
     public int NextLevelExperience { get; set; } = 220;
+
+    public bool PlayerStringsDirtyForTests => playerStringsDirty;
+
+    public void MarkPlayerStringsFlushedForTests()
+    {
+        playerStringsDirty = false;
+    }
 
     public void BeginEndTurn(object? core)
     {
@@ -91,6 +100,7 @@ internal sealed class DummyPlayerStatusBarTarget
         if (value is not null)
         {
             playerStringData[type] = value;
+            playerStringsDirty = true;
         }
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
@@ -124,7 +124,7 @@ internal static class ColorRouteCatalog
             ["Mods/QudJP/Assemblies/src/Patches/LookTooltipContentPatch.cs|DescriptionTextTranslator.TranslateLongDescription("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/MainMenuLocalizationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/MainMenuRowTranslationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
-            ["Mods/QudJP/Assemblies/src/Patches/PlayerStatusBarProducerTranslationHelpers.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
+            ["Mods/QudJP/Assemblies/src/Patches/PlayerStatusBarProducerTranslationHelpers.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 2,
             ["Mods/QudJP/Assemblies/src/Patches/MessageLogProducerTranslationHelpers.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 5,
             ["Mods/QudJP/Assemblies/src/Patches/MessageLogProducerTranslationHelpers.cs|MessagePatternTranslator.Translate("] = 4,
             ["Mods/QudJP/Assemblies/src/Patches/OptionsLocalizationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PlayerStatusBarProducerTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PlayerStatusBarProducerTranslationPatchTests.cs
@@ -88,7 +88,7 @@ public sealed class PlayerStatusBarProducerTranslationPatchTests
     }
 
     [Test]
-    public void Postfix_MarksPlayerStringsDirty_WhenTranslatedAfterUiFlush()
+    public void TranslatePlayerStringData_MarksPlayerStringsDirty_WhenTranslatedAfterUiFlush()
     {
         WriteDictionary(
             ("Sated", "満腹"),

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PlayerStatusBarProducerTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PlayerStatusBarProducerTranslationPatchTests.cs
@@ -105,6 +105,10 @@ public sealed class PlayerStatusBarProducerTranslationPatchTests
 
         instance.BeginEndTurn(core: null);
         instance.MarkPlayerStringsFlushedForTests();
+        Assert.That(
+            instance.PlayerStringsDirtyForTests,
+            Is.False,
+            "Precondition: UI flush marker should clear playerStringsDirty before translation.");
 
         translateMethod.Invoke(null, new object?[] { instance });
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PlayerStatusBarProducerTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PlayerStatusBarProducerTranslationPatchTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Diagnostics;
 using System.Text;
 using HarmonyLib;
 using QudJP.Patches;
@@ -116,6 +117,45 @@ public sealed class PlayerStatusBarProducerTranslationPatchTests
                 Is.True,
                 "Translated playerStringData must force PlayerStatusBar.Update to flush the new Japanese values.");
         });
+    }
+
+    [Test]
+    public void TranslatePlayerStringData_WarnsOnce_WhenDirtyFlagFieldIsMissing()
+    {
+        WriteDictionary(("World Map", "ワールドマップ"));
+        ResetPatchField("playerStringDataField");
+        ResetPatchField("playerStringsDirtyField");
+        ResetPatchField("playerStringsDirtyMissingWarningLogged");
+
+        var listener = new CapturingTraceListener();
+        Trace.Listeners.Add(listener);
+
+        try
+        {
+            var translateMethod = RequirePatchMethod("TranslatePlayerStringData", typeof(object));
+            var instance = new DummyPlayerStatusBarTargetWithoutDirtyFlag();
+
+            translateMethod.Invoke(null, new object?[] { instance });
+            translateMethod.Invoke(null, new object?[] { instance });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(instance.GetStringData("Zone"), Is.EqualTo("ワールドマップ"));
+                Assert.That(
+                    listener.WarningMessages.Count(message =>
+                        message.Contains("playerStringsDirty", StringComparison.Ordinal)
+                        && message.Contains(nameof(DummyPlayerStatusBarTargetWithoutDirtyFlag), StringComparison.Ordinal)),
+                    Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            Trace.Listeners.Remove(listener);
+            listener.Dispose();
+            ResetPatchField("playerStringDataField");
+            ResetPatchField("playerStringsDirtyField");
+            ResetPatchField("playerStringsDirtyMissingWarningLogged");
+        }
     }
 
     [Test]
@@ -430,6 +470,16 @@ public sealed class PlayerStatusBarProducerTranslationPatchTests
         return method!;
     }
 
+    private static void ResetPatchField(string fieldName)
+    {
+        var patchType = typeof(Translator).Assembly.GetType("QudJP.Patches.PlayerStatusBarProducerTranslationPatch", throwOnError: false);
+        Assert.That(patchType, Is.Not.Null, "PlayerStatusBarProducerTranslationPatch type not found.");
+
+        var field = patchType!.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.That(field, Is.Not.Null, $"Field not found: {patchType.FullName}.{fieldName}");
+        field!.SetValue(null, field.FieldType == typeof(bool) ? false : null);
+    }
+
     private static MethodInfo RequireMethod(Type type, string methodName)
     {
         var method = AccessTools.Method(type, methodName);
@@ -465,5 +515,31 @@ public sealed class PlayerStatusBarProducerTranslationPatchTests
         return value
             .Replace("\\", "\\\\", StringComparison.Ordinal)
             .Replace("\"", "\\\"", StringComparison.Ordinal);
+    }
+
+    private sealed class CapturingTraceListener : TraceListener
+    {
+        internal readonly List<string> WarningMessages = new List<string>();
+
+        public override void Write(string? message)
+        {
+        }
+
+        public override void WriteLine(string? message)
+        {
+        }
+
+        public override void TraceEvent(
+            TraceEventCache? eventCache,
+            string source,
+            TraceEventType eventType,
+            int id,
+            string? message)
+        {
+            if (eventType == TraceEventType.Warning && message is not null)
+            {
+                WarningMessages.Add(message);
+            }
+        }
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PlayerStatusBarProducerTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PlayerStatusBarProducerTranslationPatchTests.cs
@@ -87,6 +87,38 @@ public sealed class PlayerStatusBarProducerTranslationPatchTests
     }
 
     [Test]
+    public void Postfix_MarksPlayerStringsDirty_WhenTranslatedAfterUiFlush()
+    {
+        WriteDictionary(
+            ("Sated", "満腹"),
+            ("Wet", "濡れ"),
+            ("Harvest Dawn", "ハーヴェスト・ドーン"),
+            ("Tuum Ut", "トゥーム・ウト"));
+
+        var translateMethod = RequirePatchMethod("TranslatePlayerStringData", typeof(object));
+        var instance = new DummyPlayerStatusBarTarget
+        {
+            NextFoodWater = "{{g|Sated}} {{b|Wet}}",
+            NextTime = "Harvest Dawn 30th of Tuum Ut",
+        };
+
+        instance.BeginEndTurn(core: null);
+        instance.MarkPlayerStringsFlushedForTests();
+
+        translateMethod.Invoke(null, new object?[] { instance });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(instance.GetStringData("FoodWater"), Is.EqualTo("{{g|満腹}} {{b|濡れ}}"));
+            Assert.That(instance.GetStringData("Time"), Is.EqualTo("ハーヴェスト・ドーン トゥーム・ウト30日"));
+            Assert.That(
+                instance.PlayerStringsDirtyForTests,
+                Is.True,
+                "Translated playerStringData must force PlayerStatusBar.Update to flush the new Japanese values.");
+        });
+    }
+
+    [Test]
     public void Postfix_UsesLowerAsciiFallbackWithoutMissingKeyNoise_ForProducerStringData()
     {
         WriteDictionary(

--- a/Mods/QudJP/Assemblies/src/Patches/PlayerStatusBarProducerTranslationHelpers.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PlayerStatusBarProducerTranslationHelpers.cs
@@ -45,13 +45,56 @@ internal static class PlayerStatusBarProducerTranslationHelpers
 
     private static string TranslateFoodWater(string source, string route)
     {
-        return StatusLineTranslationHelpers.TryTranslateCompareStatusSequence(
+        if (StatusLineTranslationHelpers.TryTranslateCompareStatusSequence(
             source,
             route,
             "PlayerStatusBar.FoodWater",
-            out var translated)
-            ? translated
-            : source;
+            out var translated))
+        {
+            return translated;
+        }
+
+        var parts = source.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 2)
+        {
+            return source;
+        }
+
+        var translatedParts = new string[parts.Length];
+        for (var index = 0; index < parts.Length; index++)
+        {
+            if (!TryTranslateFoodWaterPart(parts[index], out translatedParts[index]))
+            {
+                return source;
+            }
+        }
+
+        translated = string.Join(" ", translatedParts);
+        if (!string.Equals(translated, source, StringComparison.Ordinal))
+        {
+            DynamicTextObservability.RecordTransform(route, "PlayerStatusBar.FoodWater", source, translated);
+            return translated;
+        }
+
+        return source;
+    }
+
+    private static bool TryTranslateFoodWaterPart(string source, out string translated)
+    {
+        var (stripped, _) = ColorAwareTranslationComposer.Strip(source);
+        var visibleTranslation = StringHelpers.TranslateExactOrLowerAscii(stripped);
+        if (visibleTranslation is null)
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = ColorAwareTranslationComposer.TranslatePreservingColors(
+            source,
+            visible => string.Equals(visible, stripped, StringComparison.Ordinal)
+                ? visibleTranslation
+                : visible);
+        return true;
     }
 
     private static string TranslateHpBar(string source, string route)

--- a/Mods/QudJP/Assemblies/src/Patches/PlayerStatusBarProducerTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PlayerStatusBarProducerTranslationPatch.cs
@@ -16,6 +16,7 @@ public static class PlayerStatusBarProducerTranslationPatch
     private static FieldInfo? playerStringsDirtyField;
     private static FieldInfo? xpBarField;
     private static FieldInfo? xpBarTextField;
+    private static bool playerStringsDirtyMissingWarningLogged;
 
     [HarmonyTargetMethods]
     private static IEnumerable<MethodBase> TargetMethods()
@@ -134,7 +135,32 @@ public static class PlayerStatusBarProducerTranslationPatch
             playerStringsDirtyField = field;
         }
 
-        field?.SetValue(instance, true);
+        if (field is null)
+        {
+            if (!playerStringsDirtyMissingWarningLogged)
+            {
+                playerStringsDirtyMissingWarningLogged = true;
+                WriteWarning(
+                    "QudJP: {0} could not find playerStringsDirty on {1}. Translated playerStringData may not refresh immediately.",
+                    Context,
+                    instance.GetType().FullName);
+            }
+
+            return;
+        }
+
+        field.SetValue(instance, true);
+    }
+
+    private static void WriteWarning(string format, params object?[] args)
+    {
+        var message = string.Format(System.Globalization.CultureInfo.InvariantCulture, format, args);
+        foreach (TraceListener listener in Trace.Listeners)
+        {
+            listener.TraceEvent(null, "QudJP", TraceEventType.Warning, 0, message);
+        }
+
+        Trace.Flush();
     }
 
     private static void TranslateXpBar(object instance)

--- a/Mods/QudJP/Assemblies/src/Patches/PlayerStatusBarProducerTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PlayerStatusBarProducerTranslationPatch.cs
@@ -13,6 +13,7 @@ public static class PlayerStatusBarProducerTranslationPatch
 {
     private const string Context = nameof(PlayerStatusBarProducerTranslationPatch);
     private static FieldInfo? playerStringDataField;
+    private static FieldInfo? playerStringsDirtyField;
     private static FieldInfo? xpBarField;
     private static FieldInfo? xpBarTextField;
 
@@ -92,6 +93,7 @@ public static class PlayerStatusBarProducerTranslationPatch
             keys.Add(key);
         }
 
+        var changed = false;
         for (var index = 0; index < keys.Count; index++)
         {
             var key = keys[index];
@@ -113,8 +115,26 @@ public static class PlayerStatusBarProducerTranslationPatch
             if (!string.Equals(translated, source, StringComparison.Ordinal))
             {
                 dictionary[key] = translated;
+                changed = true;
             }
         }
+
+        if (changed)
+        {
+            MarkPlayerStringsDirty(instance);
+        }
+    }
+
+    private static void MarkPlayerStringsDirty(object instance)
+    {
+        var field = playerStringsDirtyField;
+        if (field is null || field.DeclaringType != instance.GetType())
+        {
+            field = AccessTools.Field(instance.GetType(), "playerStringsDirty");
+            playerStringsDirtyField = field;
+        }
+
+        field?.SetValue(instance, true);
     }
 
     private static void TranslateXpBar(object instance)


### PR DESCRIPTION
## Summary

- fixes PlayerStatusBar producer translations so changed `playerStringData` forces a UI refresh
- translates color-wrapped food/water status parts such as `{{g|Sated}} {{b|Wet}}` without collapsing color spans
- adds a dirty-flag regression test and updates the color route catalog

Fixes #390.

## Validation

- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~PlayerStatusBarProducerTranslationPatchTests"`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~ColorRouteCatalogTests"`
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリース ノート

* **テスト**
  * UI更新後の翻訳動作を検証する新しいユニットテストを追加
  * ダーティフラグ欠落時に警告が一度だけ出ることを確認するテストを追加

* **バグ修正 / 改善**
  * 食料/水表示の翻訳にトークン単位のフォールバックを導入し翻訳精度を向上
  * 実際に翻訳が変化した場合に変更を記録しUI更新が確実にトリガーされるよう改善

* **その他**
  * テスト用にダーティ状態の参照・クリア機能を追加し、フラグ非搭載の代替実装を用意
<!-- end of auto-generated comment: release notes by coderabbit.ai -->