### PR TITLE
Fix AbilityBar HUD translation coverage

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyAbilityBarAfterRenderTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyAbilityBarAfterRenderTargets.cs
@@ -4,9 +4,13 @@ internal sealed class DummyAbilityBarAfterRenderTarget
 {
     private string effectText = string.Empty;
 
+    private bool effectTextDirty;
+
     private string targetText = string.Empty;
 
     private string targetHealthText = string.Empty;
+
+    public DummyUITextSkin EffectText { get; } = new DummyUITextSkin();
 
     public string NextEffectText { get; set; } = string.Empty;
 
@@ -19,8 +23,18 @@ internal sealed class DummyAbilityBarAfterRenderTarget
         _ = core;
         _ = sb;
         effectText = NextEffectText;
+        effectTextDirty = true;
         targetText = NextTargetText;
         targetHealthText = NextTargetHealthText;
+    }
+
+    public void Update()
+    {
+        if (effectTextDirty)
+        {
+            EffectText.SetText(effectText);
+            effectTextDirty = false;
+        }
     }
 
     public string GetEffectText()
@@ -36,5 +50,24 @@ internal sealed class DummyAbilityBarAfterRenderTarget
     public string GetTargetHealthText()
     {
         return targetHealthText;
+    }
+}
+
+internal sealed class DummyAbilityBarButtonTextTarget
+{
+    public List<object> AbilityButtons = new List<object>();
+
+    public void Update()
+    {
+    }
+}
+
+internal sealed class DummyAbilityBarButton
+{
+    public DummyUITextSkin Text = new DummyUITextSkin();
+
+    public DummyAbilityBarButton(string text)
+    {
+        Text.SetText(text);
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
@@ -109,6 +109,7 @@ internal static class ColorRouteCatalog
             ["Mods/QudJP/Assemblies/src/Patches/GetDisplayNamePatch.cs|GetDisplayNameRouteTranslator.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/GetDisplayNameProcessPatch.cs|GetDisplayNameRouteTranslator.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs|GetDisplayNameRouteTranslator.TranslatePreservingColors("] = 1,
+            ["Mods/QudJP/Assemblies/src/Patches/AbilityBarButtonTextTranslationPatch.cs|GetDisplayNameRouteTranslator.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/GameManagerUpdateSelectedAbilityPatch.cs|GetDisplayNameRouteTranslator.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/HelpRowTranslationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/HighScoresScreenTranslationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarAfterRenderTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarAfterRenderTranslationPatchTests.cs
@@ -159,6 +159,36 @@ public sealed class AbilityBarAfterRenderTranslationPatchTests
     }
 
     [Test]
+    public void Postfix_TranslatesLabelOnlyActiveEffectsAndFlushesToTextField()
+    {
+        WriteDictionary(("ACTIVE EFFECTS:", "発動中の効果:"));
+
+        RunWithPostfixPatch(() =>
+        {
+            var target = new DummyAbilityBarAfterRenderTarget
+            {
+                NextEffectText = "<color=#FFFFFFFF><color=#508d75>ACTIVE EFFECTS:</color></color><color=#B1C9C3FF> </color>",
+            };
+
+            target.AfterRender(core: null, sb: null);
+            target.Update();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    target.GetEffectText(),
+                    Is.EqualTo("<color=#FFFFFFFF><color=#508d75>発動中の効果:</color></color><color=#B1C9C3FF> </color>"));
+                Assert.That(target.EffectText.text, Is.EqualTo(target.GetEffectText()));
+                Assert.That(
+                    DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                        nameof(AbilityBarAfterRenderTranslationPatch),
+                        "AbilityBar.ActiveEffects"),
+                    Is.GreaterThan(0));
+            });
+        });
+    }
+
+    [Test]
     public void Postfix_PreservesMarkupWrappedEnglishModifierInTargetDisplayName()
     {
         WriteDictionary(

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarButtonTextTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarButtonTextTranslationPatchTests.cs
@@ -65,10 +65,16 @@ public sealed class AbilityBarButtonTextTranslationPatchTests
             var freezingRay = new DummyAbilityBarButton("&CFreezing Ray {{C|[5]}} {{K|[{{g|on}}]}}");
             var toggle = new DummyAbilityBarButton("&CToggle {{K|[{{r|off}}]}} {{K|[offhand]}}");
             var sense = new DummyAbilityBarButton("&CSense {{K|[condition]}} {{K|[{{g|on}}]}}");
+            var englishFallback = new DummyAbilityBarButton("UnregisteredText");
+            var empty = new DummyAbilityBarButton(string.Empty);
+            var marker = new DummyAbilityBarButton("\u0001SomeText");
             target.AbilityButtons.Add(sprint);
             target.AbilityButtons.Add(freezingRay);
             target.AbilityButtons.Add(toggle);
             target.AbilityButtons.Add(sense);
+            target.AbilityButtons.Add(englishFallback);
+            target.AbilityButtons.Add(empty);
+            target.AbilityButtons.Add(marker);
 
             target.Update();
 
@@ -78,6 +84,9 @@ public sealed class AbilityBarButtonTextTranslationPatchTests
                 Assert.That(freezingRay.Text.text, Is.EqualTo("&C凍結線 {{C|[5]}} {{K|[{{g|オン}}]}}"));
                 Assert.That(toggle.Text.text, Is.EqualTo("&C切替 {{K|[{{r|オフ}}]}} {{K|[offhand]}}"));
                 Assert.That(sense.Text.text, Is.EqualTo("&C感知 {{K|[condition]}} {{K|[{{g|オン}}]}}"));
+                Assert.That(englishFallback.Text.text, Is.EqualTo("UnregisteredText"));
+                Assert.That(empty.Text.text, Is.EqualTo(string.Empty));
+                Assert.That(marker.Text.text, Is.EqualTo("\u0001SomeText"));
                 Assert.That(
                     DynamicTextObservability.GetRouteFamilyHitCountForTests(
                         nameof(AbilityBarButtonTextTranslationPatch),

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarButtonTextTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarButtonTextTranslationPatchTests.cs
@@ -1,0 +1,144 @@
+using System.Reflection;
+using System.Text;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class AbilityBarButtonTextTranslationPatchTests
+{
+    private static readonly UTF8Encoding Utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    private string tempDirectory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempDirectory = Path.Combine(Path.GetTempPath(), "qudjp-abilitybar-button-text-l2", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+
+        Translator.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(tempDirectory);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+
+        if (Directory.Exists(tempDirectory))
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Postfix_TranslatesAbilityButtonTextAndRecordsOwnerRoute()
+    {
+        WriteDictionary(
+            ("Sprint", "ダッシュ"),
+            ("Freezing Ray", "凍結線"),
+            ("[disabled]", "[無効]"),
+            ("on", "オン"));
+
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyAbilityBarButtonTextTarget), nameof(DummyAbilityBarButtonTextTarget.Update)),
+                postfix: new HarmonyMethod(RequirePatchMethod("Postfix", typeof(object))));
+
+            var target = new DummyAbilityBarButtonTextTarget();
+            var sprint = new DummyAbilityBarButton("&CSprint {{K|[disabled]}} {{Y|<{{w|S}}>}}");
+            var freezingRay = new DummyAbilityBarButton("&CFreezing Ray {{C|[5]}} {{K|[{{g|on}}]}}");
+            target.AbilityButtons.Add(sprint);
+            target.AbilityButtons.Add(freezingRay);
+
+            target.Update();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sprint.Text.text, Is.EqualTo("&Cダッシュ {{K|[無効]}} {{Y|<{{w|S}}>}}"));
+                Assert.That(freezingRay.Text.text, Is.EqualTo("&C凍結線 {{C|[5]}} {{K|[{{g|オン}}]}}"));
+                Assert.That(
+                    DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                        nameof(AbilityBarButtonTextTranslationPatch),
+                        "AbilityBar.ButtonText"),
+                    Is.EqualTo(2));
+                Assert.That(
+                    SinkObservation.GetHitCountForTests(
+                        nameof(UITextSkinTranslationPatch),
+                        nameof(AbilityBarButtonTextTranslationPatch),
+                        SinkObservation.ObservationOnlyDetail,
+                        "&CSprint {{K|[disabled]}} {{Y|<{{w|S}}>}}",
+                        "&CSprint {{K|[disabled]}} {{Y|<{{w|S}}>}}"),
+                    Is.EqualTo(0));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName)
+    {
+        var method = AccessTools.Method(type, methodName);
+        Assert.That(method, Is.Not.Null, $"Method not found: {type.FullName}.{methodName}");
+        return method!;
+    }
+
+    private static MethodInfo RequirePatchMethod(string methodName, params Type[] parameterTypes)
+    {
+        var patchType = typeof(Translator).Assembly.GetType("QudJP.Patches.AbilityBarButtonTextTranslationPatch", throwOnError: false);
+        Assert.That(patchType, Is.Not.Null, "AbilityBarButtonTextTranslationPatch type not found.");
+
+        var method = patchType!.GetMethod(
+            methodName,
+            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: parameterTypes,
+            modifiers: null);
+        Assert.That(method, Is.Not.Null, $"Method not found: {patchType.FullName}.{methodName}");
+        return method!;
+    }
+
+    private void WriteDictionary(params (string key, string text)[] entries)
+    {
+        var path = Path.Combine(tempDirectory, "abilitybar-button-text-l2.ja.json");
+        using var writer = new StreamWriter(path, append: false, Utf8WithoutBom);
+        writer.Write("{\"entries\":[");
+
+        for (var index = 0; index < entries.Length; index++)
+        {
+            if (index > 0)
+            {
+                writer.Write(',');
+            }
+
+            writer.Write("{\"key\":\"");
+            writer.Write(EscapeJson(entries[index].key));
+            writer.Write("\",\"text\":\"");
+            writer.Write(EscapeJson(entries[index].text));
+            writer.Write("\"}");
+        }
+
+        writer.WriteLine("]}");
+    }
+
+    private static string EscapeJson(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarButtonTextTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarButtonTextTranslationPatchTests.cs
@@ -46,8 +46,11 @@ public sealed class AbilityBarButtonTextTranslationPatchTests
         WriteDictionary(
             ("Sprint", "ダッシュ"),
             ("Freezing Ray", "凍結線"),
+            ("Toggle", "切替"),
+            ("Sense", "感知"),
             ("[disabled]", "[無効]"),
-            ("on", "オン"));
+            ("on", "オン"),
+            ("off", "オフ"));
 
         var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
         var harmony = new Harmony(harmonyId);
@@ -60,8 +63,12 @@ public sealed class AbilityBarButtonTextTranslationPatchTests
             var target = new DummyAbilityBarButtonTextTarget();
             var sprint = new DummyAbilityBarButton("&CSprint {{K|[disabled]}} {{Y|<{{w|S}}>}}");
             var freezingRay = new DummyAbilityBarButton("&CFreezing Ray {{C|[5]}} {{K|[{{g|on}}]}}");
+            var toggle = new DummyAbilityBarButton("&CToggle {{K|[{{r|off}}]}} {{K|[offhand]}}");
+            var sense = new DummyAbilityBarButton("&CSense {{K|[condition]}} {{K|[{{g|on}}]}}");
             target.AbilityButtons.Add(sprint);
             target.AbilityButtons.Add(freezingRay);
+            target.AbilityButtons.Add(toggle);
+            target.AbilityButtons.Add(sense);
 
             target.Update();
 
@@ -69,11 +76,13 @@ public sealed class AbilityBarButtonTextTranslationPatchTests
             {
                 Assert.That(sprint.Text.text, Is.EqualTo("&Cダッシュ {{K|[無効]}} {{Y|<{{w|S}}>}}"));
                 Assert.That(freezingRay.Text.text, Is.EqualTo("&C凍結線 {{C|[5]}} {{K|[{{g|オン}}]}}"));
+                Assert.That(toggle.Text.text, Is.EqualTo("&C切替 {{K|[{{r|オフ}}]}} {{K|[offhand]}}"));
+                Assert.That(sense.Text.text, Is.EqualTo("&C感知 {{K|[condition]}} {{K|[{{g|オン}}]}}"));
                 Assert.That(
                     DynamicTextObservability.GetRouteFamilyHitCountForTests(
                         nameof(AbilityBarButtonTextTranslationPatch),
                         "AbilityBar.ButtonText"),
-                    Is.EqualTo(2));
+                    Is.EqualTo(4));
                 Assert.That(
                     SinkObservation.GetHitCountForTests(
                         nameof(UITextSkinTranslationPatch),

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -154,6 +154,7 @@ public sealed class TargetMethodResolutionTests
         "System.Collections.Generic.IReadOnlyList`1[[ConsoleLib.Console.IRenderable]]",
     })]
     [TestCase(typeof(AbilityBarUpdateAbilitiesTextPatch), "UpdateAbilitiesText", "Qud.UI.AbilityBar", "System.Void", new string[0])]
+    [TestCase(typeof(AbilityBarButtonTextTranslationPatch), "Update", "Qud.UI.AbilityBar", "System.Void", new string[0])]
     [TestCase(typeof(EffectDescriptionPatch), "GetDescription", "XRL.World.Effect", "System.String", new string[0])]
     [TestCase(typeof(EffectDetailsPatch), "GetDetails", "XRL.World.Effect", "System.String", new string[0])]
     [TestCase(typeof(CherubimSpawnerReplaceDescriptionPatch), "ReplaceDescription", "XRL.World.Parts.CherubimSpawner", "System.Void", new[] { "XRL.World.GameObject", "System.String", "System.String" })]

--- a/Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs
@@ -13,7 +13,7 @@ public static class AbilityBarAfterRenderTranslationPatch
     private const string Context = nameof(AbilityBarAfterRenderTranslationPatch);
 
     private static readonly Regex ActiveEffectsPattern =
-        new Regex("^(?<label>ACTIVE EFFECTS:)(?: (?<tail>.+))?$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+        new Regex("^(?<label>ACTIVE EFFECTS:)(?<separator>\\s*)(?<tail>.*)$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
     private static readonly Regex TargetTextPattern =
         new Regex("^(?<label>TARGET:)\\s+(?<name>.+)$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
@@ -107,10 +107,12 @@ public static class AbilityBarAfterRenderTranslationPatch
         }
 
         translated = ColorAwareTranslationComposer.RestoreCapture(translatedLabel, spans, match.Groups["label"]);
+        translated += ColorAwareTranslationComposer.RestoreCapture(match.Groups["separator"].Value, spans, match.Groups["separator"]);
+
         var tailGroup = match.Groups["tail"];
-        if (tailGroup.Success)
+        if (tailGroup.Success && tailGroup.Length > 0)
         {
-            translated += " " + TranslateActiveEffectTailParts(tailGroup.Value, spans, tailGroup.Index);
+            translated += TranslateActiveEffectTailParts(tailGroup.Value, spans, tailGroup.Index);
         }
 
         if (string.Equals(translated, source, StringComparison.Ordinal))

--- a/Mods/QudJP/Assemblies/src/Patches/AbilityBarButtonTextTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/AbilityBarButtonTextTranslationPatch.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -12,6 +13,13 @@ namespace QudJP.Patches;
 public static class AbilityBarButtonTextTranslationPatch
 {
     private const string Context = nameof(AbilityBarButtonTextTranslationPatch);
+    private static readonly object CacheLock = new object();
+    private static readonly Dictionary<Type, FieldInfo?> AbilityButtonsFields = new Dictionary<Type, FieldInfo?>();
+    private static readonly Dictionary<Type, FieldInfo?> TextFields = new Dictionary<Type, FieldInfo?>();
+    private static readonly Dictionary<Type, MethodInfo?> GetComponentByTypeMethods = new Dictionary<Type, MethodInfo?>();
+    private static readonly Dictionary<Type, MethodInfo?> GetComponentGenericMethods = new Dictionary<Type, MethodInfo?>();
+    private static bool abilityBarButtonComponentTypeResolved;
+    private static Type? abilityBarButtonComponentType;
 
     [HarmonyTargetMethod]
     private static MethodBase? TargetMethod()
@@ -46,7 +54,7 @@ public static class AbilityBarButtonTextTranslationPatch
 
     private static void TranslateAbilityButtons(object instance)
     {
-        var buttonsField = AccessTools.Field(instance.GetType(), "AbilityButtons");
+        var buttonsField = GetCachedField(AbilityButtonsFields, instance.GetType(), "AbilityButtons");
         if (buttonsField?.GetValue(instance) is not IEnumerable buttons)
         {
             return;
@@ -60,7 +68,7 @@ public static class AbilityBarButtonTextTranslationPatch
                 continue;
             }
 
-            var textObject = AccessTools.Field(component.GetType(), "Text")?.GetValue(component);
+            var textObject = GetCachedField(TextFields, component.GetType(), "Text")?.GetValue(component);
             var current = UITextSkinReflectionAccessor.GetCurrentText(textObject, Context);
             if (string.IsNullOrEmpty(current))
             {
@@ -88,30 +96,82 @@ public static class AbilityBarButtonTextTranslationPatch
             return null;
         }
 
-        if (AccessTools.Field(buttonObject.GetType(), "Text") is not null)
+        if (GetCachedField(TextFields, buttonObject.GetType(), "Text") is not null)
         {
             return buttonObject;
         }
 
-        var componentType = GameTypeResolver.FindType("Qud.UI.AbilityBarButton", "AbilityBarButton");
+        var componentType = GetAbilityBarButtonComponentType();
         if (componentType is null)
         {
             return null;
         }
 
-        var getComponentByType = AccessTools.Method(buttonObject.GetType(), "GetComponent", new[] { typeof(Type) });
+        var buttonType = buttonObject.GetType();
+        var getComponentByType = GetCachedMethod(GetComponentByTypeMethods, buttonType, static type =>
+            AccessTools.Method(type, "GetComponent", new[] { typeof(Type) }));
         if (getComponentByType is not null)
         {
             return getComponentByType.Invoke(buttonObject, new object[] { componentType });
         }
 
-        var getComponentGeneric = buttonObject.GetType()
-            .GetMethods(BindingFlags.Public | BindingFlags.Instance)
-            .FirstOrDefault(static method =>
+        var getComponentGeneric = GetCachedMethod(GetComponentGenericMethods, buttonType, type =>
+            type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(static method =>
                 string.Equals(method.Name, "GetComponent", StringComparison.Ordinal)
                 && method.IsGenericMethodDefinition
-                && method.GetParameters().Length == 0);
+                && method.GetParameters().Length == 0));
         return getComponentGeneric?.MakeGenericMethod(componentType).Invoke(buttonObject, Array.Empty<object>());
+    }
+
+    private static FieldInfo? GetCachedField(Dictionary<Type, FieldInfo?> cache, Type type, string fieldName)
+    {
+        lock (CacheLock)
+        {
+            if (!cache.TryGetValue(type, out var field))
+            {
+                field = AccessTools.Field(type, fieldName);
+                cache[type] = field;
+            }
+
+            return field;
+        }
+    }
+
+    private static MethodInfo? GetCachedMethod(
+        Dictionary<Type, MethodInfo?> cache,
+        Type type,
+        Func<Type, MethodInfo?> resolve)
+    {
+        lock (CacheLock)
+        {
+            if (!cache.TryGetValue(type, out var method))
+            {
+                method = resolve(type);
+                cache[type] = method;
+            }
+
+            return method;
+        }
+    }
+
+    private static Type? GetAbilityBarButtonComponentType()
+    {
+        if (abilityBarButtonComponentTypeResolved)
+        {
+            return abilityBarButtonComponentType;
+        }
+
+        lock (CacheLock)
+        {
+            if (!abilityBarButtonComponentTypeResolved)
+            {
+                abilityBarButtonComponentType = GameTypeResolver.FindType("Qud.UI.AbilityBarButton", "AbilityBarButton");
+                abilityBarButtonComponentTypeResolved = true;
+            }
+
+            return abilityBarButtonComponentType;
+        }
     }
 
     private static bool TryTranslateAbilityButtonText(string source, string route, out string translated)

--- a/Mods/QudJP/Assemblies/src/Patches/AbilityBarButtonTextTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/AbilityBarButtonTextTranslationPatch.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class AbilityBarButtonTextTranslationPatch
+{
+    private const string Context = nameof(AbilityBarButtonTextTranslationPatch);
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = GameTypeResolver.FindType("Qud.UI.AbilityBar", "AbilityBar");
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found.", Context);
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "Update", Type.EmptyTypes);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.Update not found.", Context);
+        }
+
+        return method;
+    }
+
+    public static void Postfix(object __instance)
+    {
+        try
+        {
+            TranslateAbilityButtons(__instance);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Postfix failed: {1}", Context, ex);
+        }
+    }
+
+    private static void TranslateAbilityButtons(object instance)
+    {
+        var buttonsField = AccessTools.Field(instance.GetType(), "AbilityButtons");
+        if (buttonsField?.GetValue(instance) is not IEnumerable buttons)
+        {
+            return;
+        }
+
+        foreach (var buttonObject in buttons.Cast<object?>())
+        {
+            var component = ResolveButtonComponent(buttonObject);
+            if (component is null)
+            {
+                continue;
+            }
+
+            var textObject = AccessTools.Field(component.GetType(), "Text")?.GetValue(component);
+            var current = UITextSkinReflectionAccessor.GetCurrentText(textObject, Context);
+            if (string.IsNullOrEmpty(current))
+            {
+                continue;
+            }
+
+            var route = ObservabilityHelpers.ComposeContext(Context, "field=AbilityButtons.Text");
+            if (!TryTranslateAbilityButtonText(current!, route, out var translated)
+                || string.Equals(current, translated, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (UITextSkinReflectionAccessor.SetCurrentText(textObject, translated, Context))
+            {
+                DynamicTextObservability.RecordTransform(route, "AbilityBar.ButtonText", current!, translated);
+            }
+        }
+    }
+
+    private static object? ResolveButtonComponent(object? buttonObject)
+    {
+        if (buttonObject is null)
+        {
+            return null;
+        }
+
+        if (AccessTools.Field(buttonObject.GetType(), "Text") is not null)
+        {
+            return buttonObject;
+        }
+
+        var componentType = GameTypeResolver.FindType("Qud.UI.AbilityBarButton", "AbilityBarButton");
+        if (componentType is null)
+        {
+            return null;
+        }
+
+        var getComponentByType = AccessTools.Method(buttonObject.GetType(), "GetComponent", new[] { typeof(Type) });
+        if (getComponentByType is not null)
+        {
+            return getComponentByType.Invoke(buttonObject, new object[] { componentType });
+        }
+
+        var getComponentGeneric = buttonObject.GetType()
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(static method =>
+                string.Equals(method.Name, "GetComponent", StringComparison.Ordinal)
+                && method.IsGenericMethodDefinition
+                && method.GetParameters().Length == 0);
+        return getComponentGeneric?.MakeGenericMethod(componentType).Invoke(buttonObject, Array.Empty<object>());
+    }
+
+    private static bool TryTranslateAbilityButtonText(string source, string route, out string translated)
+    {
+        var suffixIndex = source.IndexOf(" {{", StringComparison.Ordinal);
+        var nameSegment = suffixIndex >= 0 ? source.Substring(0, suffixIndex) : source;
+        var suffix = suffixIndex >= 0 ? source.Substring(suffixIndex) : string.Empty;
+
+        var changed = false;
+        var translatedName = TranslateNameSegment(nameSegment, route, out var nameChanged);
+        changed |= nameChanged;
+
+        var translatedSuffix = TranslateSuffix(suffix, out var suffixChanged);
+        changed |= suffixChanged;
+
+        translated = translatedName + translatedSuffix;
+        return changed;
+    }
+
+    private static string TranslateNameSegment(string source, string route, out bool changed)
+    {
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
+        var translated = StringHelpers.TranslateExactOrLowerAscii(stripped);
+        if (translated is null)
+        {
+            translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+                source,
+                ObservabilityHelpers.ComposeContext(route, "segment=name"));
+            changed = !string.Equals(translated, source, StringComparison.Ordinal);
+            return translated;
+        }
+
+        var restored = spans.Count == 0 ? translated : ColorAwareTranslationComposer.Restore(translated, spans);
+        changed = !string.Equals(restored, source, StringComparison.Ordinal);
+        return restored;
+    }
+
+    private static string TranslateSuffix(string source, out bool changed)
+    {
+        var translated = source;
+        translated = ReplaceExactToken(translated, "[disabled]");
+        translated = ReplaceExactToken(translated, "on");
+        translated = ReplaceExactToken(translated, "off");
+        changed = !string.Equals(translated, source, StringComparison.Ordinal);
+        return translated;
+    }
+
+    private static string ReplaceExactToken(string source, string token)
+    {
+        var translated = StringHelpers.TranslateExactOrLowerAscii(token);
+        return translated is null
+            ? source
+            : source.Replace(token, translated);
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/AbilityBarButtonTextTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/AbilityBarButtonTextTranslationPatch.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using HarmonyLib;
 
 namespace QudJP.Patches;
@@ -161,8 +162,21 @@ public static class AbilityBarButtonTextTranslationPatch
     private static string ReplaceExactToken(string source, string token)
     {
         var translated = StringHelpers.TranslateExactOrLowerAscii(token);
-        return translated is null
-            ? source
-            : source.Replace(token, translated);
+        if (translated is null)
+        {
+            return source;
+        }
+
+        var pattern = token.All(IsAsciiLetterOrDigit)
+            ? $@"(?<![A-Za-z0-9]){Regex.Escape(token)}(?![A-Za-z0-9])"
+            : Regex.Escape(token);
+        return Regex.Replace(source, pattern, translated, RegexOptions.CultureInvariant);
+    }
+
+    private static bool IsAsciiLetterOrDigit(char character)
+    {
+        return (character >= 'A' && character <= 'Z')
+            || (character >= 'a' && character <= 'z')
+            || (character >= '0' && character <= '9');
     }
 }

--- a/Mods/QudJP/Localization/Dictionaries/ui-skillsandpowers.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-skillsandpowers.ja.json
@@ -801,6 +801,21 @@
       "text": "スプリント"
     },
     {
+      "key": "Freezing Ray",
+      "context": "AbilityBar.ButtonText",
+      "text": "凍結線"
+    },
+    {
+      "key": "Butcher Corpses",
+      "context": "AbilityBar.ButtonText",
+      "text": "死体を解体"
+    },
+    {
+      "key": "Teleport",
+      "context": "AbilityBar.ButtonText",
+      "text": "テレポート"
+    },
+    {
       "key": "Harvest Plants",
       "context": "AbilityManager.Name",
       "text": "収穫"


### PR DESCRIPTION
## Summary

- handles label-only `ACTIVE EFFECTS:` text with trailing color-wrapped whitespace
- adds an AbilityBar button text owner route for direct TMP ability slot labels
- adds exact runtime ability names for `Freezing Ray`, `Butcher Corpses`, and `Teleport`

Fixes #391.

## Validation

- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~AbilityBarAfterRenderTranslationPatchTests|FullyQualifiedName~AbilityBarButtonTextTranslationPatchTests|FullyQualifiedName~SkillsAndAbilitiesOwnerPatchTests"`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~TargetMethodResolutionTests"`
- `python3.12 scripts/check_encoding.py Mods/QudJP/Localization/Dictionaries/ui-skillsandpowers.ja.json`
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 能力バーの「ACTIVE EFFECTS:」ラベルと後続テキスト間の空白処理を改善しました。

* **New Features**
  * 能力バーボタンの表示テキスト翻訳を追加し、更新時に翻訳結果を反映するようにしました。
  * 能力エフェクト表示の更新フローを改善し、表示反映の信頼性を向上しました。

* **Localization**
  * 日本語に「Freezing Ray」「Butcher Corpses」「Teleport」のエントリを追加しました。

* **Tests**
  * 翻訳動作と観測記録を検証する統合テストを追加しました。
  * 翻訳パッチのターゲット解決とベースライン期待値を更新するテストを追加／更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->