### PR TITLE
fix(localization): restore {N} placeholder parity in shipped JSON dictionaries (#403)

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupTranslationPatchTests.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using System.Text;
-using System.Collections.Generic;
 using HarmonyLib;
 using QudJP.Patches;
 using QudJP.Tests.DummyTargets;
@@ -689,15 +688,16 @@ public sealed class PopupTranslationPatchTests
         Assert.That(translated, Is.EqualTo(expected));
     }
 
-    [Test]
-    public void TranslatePopupTextForProducerRoute_TranslatesCampfireCurePoisonPattern()
+    [TestCase("poisons")]
+    [TestCase("poison")]
+    public void TranslatePopupTextForProducerRoute_TranslatesCampfireCurePoisonPattern(string poisonToken)
     {
         WriteDictionary((
             "You cure the {0} coursing through {1} with a balm made from {2}.",
-            "{2}で作った塗り薬で{1}を蝕む毒を治した。"));
+            "{2}で作った塗り薬で{1}を蝕む{0}を治した。"));
 
-        const string source =
-            "You cure the poisons coursing through {{G|snapjaw scavenger}} with a balm made from {{Y|witchwood bark}}.";
+        var source =
+            $"You cure the {poisonToken} coursing through {{{{G|snapjaw scavenger}}}} with a balm made from {{{{Y|witchwood bark}}}}.";
 
         var translated = PopupTranslationPatch.TranslatePopupTextForProducerRoute(source, nameof(PopupTranslationPatch));
 

--- a/Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs
@@ -958,7 +958,7 @@ public static class PopupTranslationPatch
             return false;
         }
 
-        var poison = match.Groups["poison"].Value;
+        var poison = TranslateCampfirePoisonToken(match.Groups["poison"].Value);
         var target = match.Groups["target"].Value;
         var ingredient = match.Groups["ingredient"].Value;
         if (spans.Count > 0)
@@ -1183,5 +1183,14 @@ public static class PopupTranslationPatch
             field.SetValue(item, translated);
             list[index] = item;
         }
+    }
+
+    private static string TranslateCampfirePoisonToken(string capture)
+    {
+        return capture switch
+        {
+            "poison" or "poisons" => "毒",
+            _ => capture,
+        };
     }
 }

--- a/Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json
@@ -2580,7 +2580,7 @@
         },
         {
             "key": "You cure the {0} coursing through {1} with a balm made from {2}.",
-            "text": "{2}で作った塗り薬で{1}を蝕む毒を治した。"
+            "text": "{2}で作った塗り薬で{1}を蝕む{0}を治した。"
         },
         {
             "key": "You create a new recipe for {{|{0}}}!",

--- a/Mods/QudJP/Localization/Dictionaries/ui-trade.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-trade.ja.json
@@ -56,17 +56,17 @@
     {
       "key": "{0} will not trade with you until you pay {1} the {2} you owe {3}.",
       "context": "TradeUiPopupTranslationPatch",
-      "text": "{0}は、あなたが{1}に借りている{2}を支払うまで取引してくれない。"
+      "text": "{0}は、あなたが{3}に借りている{2}を{1}に支払うまで取引してくれない。"
     },
     {
       "key": "{0} will not trade with you until you pay {1} the {2} you owe {3}. Do you want to give {4} your {5} now?",
       "context": "TradeUiPopupTranslationPatch",
-      "text": "{0}は、あなたが{1}に借りている{2}を支払うまで取引してくれない。今すぐあなたの{5}を{4}に渡しますか？"
+      "text": "{0}は、あなたが{3}に借りている{2}を{1}に支払うまで取引してくれない。今すぐあなたの{5}を{4}に渡しますか？"
     },
     {
       "key": "{0} will not trade with you until you pay {1} the {2} you owe {3}. Do you want to give it to {4} now?",
       "context": "TradeUiPopupTranslationPatch",
-      "text": "{0}は、あなたが{1}に借りている{2}を支払うまで取引してくれない。今すぐそれを{4}に渡しますか？"
+      "text": "{0}は、あなたが{3}に借りている{2}を{1}に支払うまで取引してくれない。今すぐそれを{4}に渡しますか？"
     },
     {
       "key": "You can't understand {0} explanation.",

--- a/docs/superpowers/plans/2026-04-25-issue-403-json-placeholder-parity.md
+++ b/docs/superpowers/plans/2026-04-25-issue-403-json-placeholder-parity.md
@@ -1,0 +1,246 @@
+# Issue #403 — JSON dictionary `{N}` placeholder parity plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore `{N}` numeric-placeholder parity in four shipped dictionary entries (one in `ui-popup.ja.json`, three in `ui-trade.ja.json`) and lock the invariant dict-wide via a new pytest contract.
+
+**Architecture:** Pure data fix in JSON dictionaries plus a single pytest scanner that owns the dict-wide multiset-equality contract. No production C# / Python changes.
+
+**Tech Stack:** Python 3.12 + pytest, `re` for the placeholder regex, `json` for parsing.
+
+**Spec:** `docs/superpowers/specs/2026-04-25-issue-403-json-placeholder-parity-design.md`
+
+---
+
+## File map
+
+| Action | Path | Responsibility |
+| --- | --- | --- |
+| Create | `scripts/tests/test_json_placeholder_parity.py` | Dict-wide pytest: every `*.ja.json` entry whose `key` contains `{N}` must have a matching `{N}` multiset in `text` |
+| Modify | `Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json:2583` | Translate `text` to include `{0}` |
+| Modify | `Mods/QudJP/Localization/Dictionaries/ui-trade.ja.json:59,64,69` | Translate `text` on three entries to include `{3}` and reorder `{1}` |
+
+No new module files outside the test. No fixtures shared with other test modules (the test itself is small enough that a session-scoped fixture is unnecessary; one pass over ~64 small JSON files is sub-second).
+
+---
+
+### Task 1: Failing pytest
+
+**Files:**
+- Create: `scripts/tests/test_json_placeholder_parity.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Issue #403 — every JSON dictionary entry must preserve `{N}` numeric placeholders."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DICTIONARIES_ROOT = REPO_ROOT / "Mods" / "QudJP" / "Localization" / "Dictionaries"
+
+# Index-aware: matches `{0}`, `{12}`, `{0:+#;-#}`, etc. Captures the index only.
+PLACEHOLDER = re.compile(r"\{([0-9]+)(?::[^{}]*)?\}")
+
+
+def _placeholder_multiset(value: str) -> Counter[str]:
+    return Counter(match.group(1) for match in PLACEHOLDER.finditer(value))
+
+
+def _all_dictionary_files() -> list[Path]:
+    return sorted(DICTIONARIES_ROOT.rglob("*.json"))
+
+
+def _entries_with_placeholder_keys(path: Path) -> list[tuple[str, str]]:
+    """Return [(key, text), ...] for entries whose key contains a `{N}` placeholder."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    raw_entries = data.get("entries", []) if isinstance(data, dict) else data
+    if not isinstance(raw_entries, list):
+        return []
+    pairs: list[tuple[str, str]] = []
+    for entry in raw_entries:
+        if not isinstance(entry, dict):
+            continue
+        key = entry.get("key", "")
+        text = entry.get("text", "")
+        if not isinstance(key, str) or not isinstance(text, str):
+            continue
+        if PLACEHOLDER.search(key):
+            pairs.append((key, text))
+    return pairs
+
+
+@pytest.mark.parametrize("path", _all_dictionary_files(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix())
+def test_json_dictionary_numeric_placeholders_match(path: Path) -> None:
+    """Every dictionary entry must preserve the multiset of `{N}` placeholders from key to text."""
+    mismatches: list[str] = []
+    for key, text in _entries_with_placeholder_keys(path):
+        key_slots = _placeholder_multiset(key)
+        text_slots = _placeholder_multiset(text)
+        if key_slots != text_slots:
+            mismatches.append(
+                f"  key={key!r}\n    key_slots={dict(key_slots)} text_slots={dict(text_slots)}\n    text={text!r}"
+            )
+    assert not mismatches, (
+        f"Placeholder multiset mismatch in {path.relative_to(REPO_ROOT)}:\n"
+        + "\n".join(mismatches)
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails on exactly the expected entries**
+
+Run: `uv run pytest scripts/tests/test_json_placeholder_parity.py -v`
+
+Expected:
+- Most parametrized cases (~62 of them, one per JSON file) PASS.
+- `test_json_dictionary_numeric_placeholders_match[Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json]` FAILS with mismatch on the `You cure the {0}...` key (missing `{0}` in text).
+- `test_json_dictionary_numeric_placeholders_match[Mods/QudJP/Localization/Dictionaries/ui-trade.ja.json]` FAILS, listing all three trade-debt entries (each missing `{3}`).
+
+If any other JSON file fails, stop. The spec says exactly four entries mismatch; if a fifth surfaces, that is a new finding and must be triaged separately, not silently absorbed.
+
+---
+
+### Task 2: Fix `ui-popup.ja.json:2583`
+
+**Files:**
+- Modify: `Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json:2583`
+
+- [ ] **Step 1: Edit line 2583**
+
+Replace this exact text-field value:
+
+```json
+            "text": "{2}で作った塗り薬で{1}を蝕む毒を治した。"
+```
+
+with:
+
+```json
+            "text": "{2}で作った塗り薬で{1}を蝕む{0}を治した。"
+```
+
+The surrounding entry (key, context, etc.) is unchanged. Only the `text` field is updated.
+
+- [ ] **Step 2: Re-run the test**
+
+Run: `uv run pytest scripts/tests/test_json_placeholder_parity.py -v`
+
+Expected: `ui-popup.ja.json` case PASSES; `ui-trade.ja.json` case still FAILS.
+
+---
+
+### Task 3: Fix `ui-trade.ja.json:59` (the no-suffix variant)
+
+**Files:**
+- Modify: `Mods/QudJP/Localization/Dictionaries/ui-trade.ja.json:59`
+
+- [ ] **Step 1: Edit line 59**
+
+Replace this exact text-field value:
+
+```json
+      "text": "{0}は、あなたが{1}に借りている{2}を支払うまで取引してくれない。"
+```
+
+with:
+
+```json
+      "text": "{0}は、あなたが{3}に借りている{2}を{1}に支払うまで取引してくれない。"
+```
+
+- [ ] **Step 2: Confirm exactly the next two entries are still red**
+
+Don't run the test yet — Task 4 fixes the other two and runs the test once.
+
+---
+
+### Task 4: Fix `ui-trade.ja.json:64` and `:69` and verify
+
+**Files:**
+- Modify: `Mods/QudJP/Localization/Dictionaries/ui-trade.ja.json:64,69`
+
+- [ ] **Step 1: Edit line 64 (the "give your N drams now" variant)**
+
+Replace this exact text-field value:
+
+```json
+      "text": "{0}は、あなたが{1}に借りている{2}を支払うまで取引してくれない。今すぐあなたの{5}を{4}に渡しますか？"
+```
+
+with:
+
+```json
+      "text": "{0}は、あなたが{3}に借りている{2}を{1}に支払うまで取引してくれない。今すぐあなたの{5}を{4}に渡しますか？"
+```
+
+- [ ] **Step 2: Edit line 69 (the "give it to N now" variant)**
+
+Replace this exact text-field value:
+
+```json
+      "text": "{0}は、あなたが{1}に借りている{2}を支払うまで取引してくれない。今すぐそれを{4}に渡しますか？"
+```
+
+with:
+
+```json
+      "text": "{0}は、あなたが{3}に借りている{2}を{1}に支払うまで取引してくれない。今すぐそれを{4}に渡しますか？"
+```
+
+- [ ] **Step 3: Run the placeholder-parity test**
+
+Run: `uv run pytest scripts/tests/test_json_placeholder_parity.py -v`
+
+Expected: every parametrized case PASSES.
+
+- [ ] **Step 4: Run full pytest suite**
+
+Run: `uv run pytest scripts/tests/ -q`
+
+Expected: all green, no pre-existing tests newly fail.
+
+- [ ] **Step 5: Run remaining repo checks**
+
+Run each of the following from the repo root; all must succeed:
+
+```bash
+python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
+python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts
+ruff check scripts/
+dotnet build Mods/QudJP/Assemblies/QudJP.csproj
+```
+
+Expected: each command exits 0 with no new warnings or errors.
+
+- [ ] **Step 6: Stop**
+
+Do not commit. The user reviews the diff and runs the `/codex` review → `/simplify` → PR flow.
+
+---
+
+## Verification summary
+
+After Task 4:
+
+| Check | Command | Expectation |
+| --- | --- | --- |
+| Placeholder parity | `uv run pytest scripts/tests/test_json_placeholder_parity.py -v` | every parametrized case green |
+| Full pytest suite | `uv run pytest scripts/tests/ -q` | all green |
+| Strict XML validation | `python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json` | exit 0 |
+| Encoding | `python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts` | clean |
+| Ruff | `ruff check scripts/` | clean |
+| DLL build | `dotnet build Mods/QudJP/Assemblies/QudJP.csproj` | succeeds |
+
+## Out-of-scope reminders
+
+- Do not touch markup tokens (`{{Y|...}}`, `&X`, `^X`, `=var=`).
+- Do not modify dictionaries other than the four entries listed.
+- Do not alter the test scope to include XML files or other markup classes — that is for #401 and #409.
+- Do not allowlist any benign mismatch; the spec asserts there is none.

--- a/docs/superpowers/plans/2026-04-25-issue-403-json-placeholder-parity.md
+++ b/docs/superpowers/plans/2026-04-25-issue-403-json-placeholder-parity.md
@@ -55,7 +55,7 @@ def _placeholder_multiset(value: str) -> Counter[str]:
 
 
 def _all_dictionary_files() -> list[Path]:
-    return sorted(DICTIONARIES_ROOT.rglob("*.json"))
+    return sorted(DICTIONARIES_ROOT.rglob("*.ja.json"))
 
 
 def _entries_with_placeholder_keys(path: Path) -> list[tuple[str, str]]:

--- a/docs/superpowers/plans/2026-04-25-issue-403-json-placeholder-parity.md
+++ b/docs/superpowers/plans/2026-04-25-issue-403-json-placeholder-parity.md
@@ -4,7 +4,7 @@
 
 **Goal:** Restore `{N}` numeric-placeholder parity in four shipped dictionary entries (one in `ui-popup.ja.json`, three in `ui-trade.ja.json`) and lock the invariant dict-wide via a new pytest contract.
 
-**Architecture:** Pure data fix in JSON dictionaries plus a single pytest scanner that owns the dict-wide multiset-equality contract. No production C# / Python changes.
+**Architecture:** JSON dictionary fixes plus a pytest scanner enforcing dict-wide multiset-equality plus a minimal production C# correction in `PopupTranslationPatch.cs` (added `TranslateCampfirePoisonToken`). No production Python changes.
 
 **Tech Stack:** Python 3.12 + pytest, `re` for the placeholder regex, `json` for parsing.
 

--- a/docs/superpowers/specs/2026-04-25-issue-403-json-placeholder-parity-design.md
+++ b/docs/superpowers/specs/2026-04-25-issue-403-json-placeholder-parity-design.md
@@ -1,0 +1,74 @@
+# Issue #403 — JSON dictionary `{N}` placeholder parity
+
+## Why
+
+Four entries across `Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json` and `ui-trade.ja.json` carry `String.Format`-style `{N}` numeric placeholders in the English key but drop one of them in the Japanese `text`. At runtime the renderer calls `String.Format` with the full positional argument list; a missing slot in the format string silently loses player-facing information (poison name, debtor pronoun) while a stray slot would throw. The current shipped translations therefore render with semantic content missing.
+
+`docs/RULES.md` requires that markup and placeholders be preserved exactly. This spec restores that invariant for `{N}` and locks it behind a dict-wide pytest contract so any future regression is caught at validation time, not at runtime.
+
+## What
+
+### Data fixes
+
+Four entries change. Source key stays as-is; only the `text` field is updated.
+
+| File | Line | Source key (excerpt) | Current Japanese | New Japanese |
+| --- | ---: | --- | --- | --- |
+| `ui-popup.ja.json` | 2582 | `You cure the {0} coursing through {1} with a balm made from {2}.` | `{2}で作った塗り薬で{1}を蝕む毒を治した。` | `{2}で作った塗り薬で{1}を蝕む{0}を治した。` |
+| `ui-trade.ja.json` | 57 | `{0} will not trade with you until you pay {1} the {2} you owe {3}.` | `{0}は、あなたが{1}に借りている{2}を支払うまで取引してくれない。` | `{0}は、あなたが{3}に借りている{2}を{1}に支払うまで取引してくれない。` |
+| `ui-trade.ja.json` | 62 | `... pay {1} the {2} you owe {3}. Do you want to give {4} your {5} now?` | `{0}は、あなたが{1}に借りている{2}を支払うまで取引してくれない。今すぐあなたの{5}を{4}に渡しますか？` | `{0}は、あなたが{3}に借りている{2}を{1}に支払うまで取引してくれない。今すぐあなたの{5}を{4}に渡しますか？` |
+| `ui-trade.ja.json` | 67 | `... pay {1} the {2} you owe {3}. Do you want to give it to {4} now?` | `{0}は、あなたが{1}に借りている{2}を支払うまで取引してくれない。今すぐそれを{4}に渡しますか？` | `{0}は、あなたが{3}に借りている{2}を{1}に支払うまで取引してくれない。今すぐそれを{4}に渡しますか？` |
+
+Independent grep (`scripts/tests/.../check`) confirms these are the only four `{N}` mismatches across `Mods/QudJP/Localization/Dictionaries/` and `Dictionaries/Scoped/`. There is no fifth case.
+
+### Translation rationale
+
+- **Poison cure (`ui-popup.ja.json:2582`)**: `{0}` is the poison display name (per `Campfire.cs`). Inserting `{0}` in place of the generic word `毒` restores the specificity ("cured the venom"/"cured the snakeoil") instead of an abstract "poison".
+- **Trade-debt lines (`ui-trade.ja.json:57, 62, 67`)**: `TradeUI.cs:387,393,402` builds these via string concatenation. Both `{1}` and `{3}` are the same value `_Trader.them` (a pronoun); they appear twice because the English sentence references the trader pronoun in two grammatical positions (as the recipient of payment, and as the entity you owe). The new Japanese cleanly maps `{3}` to the creditor role (`{3}に借りている`) and `{1}` to the payee role (`{1}に支払う`), preserving English order. The two slots resolve to the same string at runtime, so no visible text changes — only the `String.Format` argument multiset becomes consistent.
+
+### New test contract
+
+Add `scripts/tests/test_json_placeholder_parity.py`. It scans every `*.ja.json` under `Mods/QudJP/Localization/Dictionaries/` (recursively, so the `Scoped/` subdirectory is included) and asserts, for each entry whose `key` contains a `{N}` numeric placeholder, that the multiset of placeholder indices in `key` matches the multiset in `text`.
+
+The placeholder regex must be index-aware to handle format-spec variants like `{0:+#;-#}` (used in `world-mods.ja.json` for stat modifiers): `\{([0-9]+)(?::[^{}]*)?\}`.
+
+No allowlist is needed; only the four entries above currently mismatch, and they will be green after the data fix.
+
+The test goes red on today's data (4 cases) and green after the fixes. It runs as part of the standard pytest suite.
+
+## How
+
+1. Write the failing pytest first.
+2. Run it; confirm exactly 4 mismatches surface, identical to the table above.
+3. Apply the four `text` field edits.
+4. Re-run the pytest; expect green.
+5. Run the full repo verification suite (`validate_xml`, `check_encoding`, `ruff`, full `pytest`, `dotnet build`).
+
+Step-by-step task layout lives in the implementation plan.
+
+## Verification
+
+```bash
+uv run pytest scripts/tests/test_json_placeholder_parity.py -v
+python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
+python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts
+ruff check scripts/
+uv run pytest scripts/tests/
+dotnet build Mods/QudJP/Assemblies/QudJP.csproj
+```
+
+All must pass.
+
+## Out of scope
+
+- Color/markup tokens (`{{Y|...}}`, `&X`, `^X`) — that is #401's territory.
+- `=variable=` runtime slots — that is #402's territory.
+- CI gate plumbing for the new test (#409 lands the workflow yaml later).
+- Any other dictionary entries flagged by the test going forward — they should be filed as follow-ups, not bundled here.
+- Translation tone changes unrelated to placeholder parity in the four entries.
+
+## Risks
+
+- **Trader pronoun grammar.** `_Trader.them` is the trader's third-person pronoun, which Caves of Qud determines per-creature. The translation reuses the same `{1}`/`{3}` pronoun in both grammatical roles; if the runtime renders mid-clitic Japanese particles incorrectly because `_Trader.them` lacks a Japanese form, the symptom will already exist in the current text on the unaffected portions. We are not changing pronoun rendering, only restoring the missing slot.
+- **Future placeholder regressions.** The dict-wide test catches them mechanically, but only for `{N}` numeric format slots. Other markup classes are still uncovered until #401, #402, #409 land.
+- **Test runtime.** Scanning all dictionaries on every test run reads ~64 JSON files; each is small and the parse is fast, so this is well below 1 second total. No fixture optimization needed.

--- a/scripts/tests/test_json_placeholder_parity.py
+++ b/scripts/tests/test_json_placeholder_parity.py
@@ -1,0 +1,57 @@
+"""Issue #403 — every JSON dictionary entry must preserve `{N}` numeric placeholders."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DICTIONARIES_ROOT = REPO_ROOT / "Mods" / "QudJP" / "Localization" / "Dictionaries"
+
+# Index-aware: matches `{0}`, `{12}`, `{0:+#;-#}`, etc. Captures the index only.
+PLACEHOLDER = re.compile(r"\{([0-9]+)(?::[^{}]*)?\}")
+
+
+def _placeholder_multiset(value: str) -> Counter[str]:
+    return Counter(match.group(1) for match in PLACEHOLDER.finditer(value))
+
+
+def _all_dictionary_files() -> list[Path]:
+    return sorted(DICTIONARIES_ROOT.rglob("*.json"))
+
+
+def _entries_with_placeholder_keys(path: Path) -> list[tuple[str, str]]:
+    """Return [(key, text), ...] for entries whose key contains a `{N}` placeholder."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    raw_entries = data.get("entries", []) if isinstance(data, dict) else data
+    if not isinstance(raw_entries, list):
+        return []
+    pairs: list[tuple[str, str]] = []
+    for entry in raw_entries:
+        if not isinstance(entry, dict):
+            continue
+        key = entry.get("key", "")
+        text = entry.get("text", "")
+        if not isinstance(key, str) or not isinstance(text, str):
+            continue
+        if PLACEHOLDER.search(key):
+            pairs.append((key, text))
+    return pairs
+
+
+@pytest.mark.parametrize("path", _all_dictionary_files(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix())
+def test_json_dictionary_numeric_placeholders_match(path: Path) -> None:
+    """Every dictionary entry must preserve the multiset of `{N}` placeholders from key to text."""
+    mismatches: list[str] = []
+    for key, text in _entries_with_placeholder_keys(path):
+        key_slots = _placeholder_multiset(key)
+        text_slots = _placeholder_multiset(text)
+        if key_slots != text_slots:
+            mismatches.append(
+                f"  key={key!r}\n    key_slots={dict(key_slots)} text_slots={dict(text_slots)}\n    text={text!r}"
+            )
+    assert not mismatches, f"Placeholder multiset mismatch in {path.relative_to(REPO_ROOT)}:\n" + "\n".join(mismatches)

--- a/scripts/tests/test_json_placeholder_parity.py
+++ b/scripts/tests/test_json_placeholder_parity.py
@@ -29,7 +29,11 @@ def _entries_with_placeholder_keys(path: Path) -> list[tuple[str, str]]:
     data = json.loads(path.read_text(encoding="utf-8"))
     raw_entries = data.get("entries", []) if isinstance(data, dict) else data
     if not isinstance(raw_entries, list):
-        return []
+        msg = (
+            f"Malformed dictionary structure in {path}: expected 'entries' to be a list, "
+            f"got {type(raw_entries).__name__}. data={data!r}, raw_entries={raw_entries!r}"
+        )
+        raise TypeError(msg)
     pairs: list[tuple[str, str]] = []
     for entry in raw_entries:
         if not isinstance(entry, dict):

--- a/scripts/tests/test_json_placeholder_parity.py
+++ b/scripts/tests/test_json_placeholder_parity.py
@@ -21,7 +21,7 @@ def _placeholder_multiset(value: str) -> Counter[str]:
 
 
 def _all_dictionary_files() -> list[Path]:
-    return sorted(DICTIONARIES_ROOT.rglob("*.json"))
+    return sorted(DICTIONARIES_ROOT.rglob("*.ja.json"))
 
 
 def _entries_with_placeholder_keys(path: Path) -> list[tuple[str, str]]:


### PR DESCRIPTION
## Summary

Closes #403.

Four shipped translation entries dropped a `{N}` numeric placeholder. At runtime that breaks `String.Format`'s positional contract — either a value is silently lost or (depending on the renderer) the format string fails. Both symptoms are player-facing.

| File | Line | Missing slot | Fix |
| --- | ---: | --- | --- |
| `ui-popup.ja.json` | 2583 | `{0}` (poison name) | Insert `{0}` in place of hardcoded 毒 |
| `ui-trade.ja.json` | 59, 64, 69 | `{3}` (creditor pronoun) | Insert `{3}` and reposition `{1}` to match English clause order |

## Corollary fix in `PopupTranslationPatch.cs`

Inserting `{0}` in the popup template alone would have **regressed** the runtime: `CampfireCurePoisonPattern` (line 74) captures the literal English `poison`/`poisons` and `TryTranslateCampfireCurePoison` substitutes it raw, so output would have read `…を蝕むpoisonsを治した。`. Codex review caught this on the first pass.

This PR adds a small `TranslateCampfirePoisonToken` helper that maps both English forms to 毒 before substitution. The captured value is provably one of two literals — `~/dev/coq-decompiled_stable/XRL.World.Parts/Campfire.cs:1707` builds the source as `"You cure the " + ((num == 1) ? "poison" : "poisons") + ...` — so the switch expression is exhaustive.

## New tests

- `scripts/tests/test_json_placeholder_parity.py` — dict-wide pytest contract: every entry whose key contains a `{N}` placeholder must have a matching multiset in `text`. The regex is index-aware (`\{([0-9]+)(?::[^{}]*)?\}`) so format-spec variants like `{0:+#;-#}` in `world-mods.ja.json` are not false-flagged. Passes 62/62 cases after the fix.
- `Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupTranslationPatchTests.cs:692-707` — the existing L2 test is now `[TestCase("poison")][TestCase("poisons")]`, exercising both the singular and plural runtime paths through the new helper.

## Why these `{N}` exist twice in `ui-trade`

`TradeUI.cs:387,393,402` builds the source via string concatenation; both `{1}` and `{3}` resolve to `_Trader.them` (the trader's third-person pronoun). They appear twice because the English sentence references the pronoun in two grammatical roles ("pay {1}" / "you owe {3}"). The new Japanese cleanly maps `{3}` to the creditor role (`{3}に借りている`) and `{1}` to the payee role (`{1}に支払う`). At runtime both render the same word; the change exists to satisfy the format-string slot multiset.

## Verification

```
$ uv run pytest scripts/tests/test_json_placeholder_parity.py -v
62 passed in 0.04s

$ dotnet test --filter "FullyQualifiedName~CampfireCurePoison"
2 passed (poison + poisons)

$ dotnet test --filter TestCategory=L1
1182 passed

$ dotnet test --filter TestCategory=L2
714 passed

$ uv run pytest scripts/tests/ -q
405 passed

$ python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
exit 0

$ python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts
Scanned 190 files: 190 OK, 0 issue(s)

$ ruff check scripts/
All checks passed!

$ dotnet build Mods/QudJP/Assemblies/QudJP.csproj
0 Warning(s), 0 Error(s)
```

## Out of scope

- Color/markup tokens (`{{Y|...}}`, `&X`, `^X`) — that is #401's territory.
- `=variable=` runtime slots — #402's territory.
- CI plumbing for the new pytest file — #409.

## Test plan

- [x] All 62 placeholder-parity cases green
- [x] L1 / L2 dotnet tests green (1182 / 714)
- [x] Full pytest suite green (405)
- [x] Codex review approved (no actionable correctness issues)
- [x] /simplify reviews (reuse / quality / efficiency) all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * キャンプファイア治療と取引の日本語翻訳を修正し、英語表示のプレースホルダー順序と可変語（単数・複数）に対応しました。

* **テスト**
  * 辞書JSONの数値プレースホルダー整合性を検出する自動テストを追加しました。
  * ポップアップ翻訳の既存テストを複数ケースで検証するよう強化しました。

* **ドキュメント**
  * プレースホルダー整合性の仕様と実行手順を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->