### PR TITLE
fix(localization): restore information-bearing =variable= tokens in templates.ja.json (#402)

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/BlueprintTemplateTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/BlueprintTemplateTranslationPatchTests.cs
@@ -86,9 +86,19 @@ public sealed class BlueprintTemplateTranslationPatchTests
     [TestCase("=subject.The==subject.name= =verb:recognize= your =object.name=.",
         "=subject.name=があなたの=object.name=を認識した。")]
     [TestCase("You touch =subject.t= and recall =pronouns.possessive= passcode. =pronouns.Subjective= =verb:beep:afterpronoun= warmly.",
-        "あなたは=subject.name=に触れ、パスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。")]
+        "あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。")]
     [TestCase("A loud buzz is emitted. The unauthorized glyph flashes on the display.",
         "大きなブザー音が鳴った。認証されていないグリフがディスプレイに点滅した。")]
+    [TestCase("{{g|You touch =subject.the==subject.name= and recall =pronouns.possessive= passcode. =pronouns.Subjective= =verb:beep:afterpronoun= warmly.}}",
+        "{{g|あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。}}")]
+    [TestCase("{{R|=subject.T= =verb:consume= =object.an==object.directionIfAny=!}}",
+        "{{R|=subject.name=が=object.name==object.directionIfAny=を消費した！}}")]
+    [TestCase("=object.T= =object.verb:react= strangely with =subject.t= and =object.verb:convert= =pronouns.objective= to =newLiquid=.",
+        "=object.name=が=subject.name=と奇妙な反応を起こし、=subject.name=を=newLiquid=に変換した。")]
+    [TestCase("=object.Does:are= much too old and rusted to enter.",
+        "=object.name=は古すぎて錆びついており、中に入ることはできない。")]
+    [TestCase("=subject.T= =verb:extrude= through the mirror of =pronouns.possessive= crystalline rind!",
+        "=subject.name=が=subject.name=の結晶の外殻の鏡面を通り抜けた！")]
     public void LoadTranslations_ContainsExpectedMapping(string englishKey, string expectedJapanese)
     {
         var translations = BlueprintTemplateTranslationPatch.LoadTranslations();
@@ -276,7 +286,7 @@ public sealed class BlueprintTemplateTranslationPatchTests
                 Is.EqualTo("=subject.name=があなたの=object.name=を認識した。"));
             Assert.That(
                 GetDummyPartSetter(part, "PsychometryAccessMessage").OriginalValue,
-                Is.EqualTo("あなたは=subject.name=に触れ、パスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。"));
+                Is.EqualTo("あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。"));
             Assert.That(
                 GetDummyPartSetter(part, "AccessFailureMessage").OriginalValue,
                 Is.EqualTo("大きなブザー音が鳴った。認証されていないグリフがディスプレイに点滅した。"));

--- a/Mods/QudJP/Localization/BlueprintTemplates/templates.ja.json
+++ b/Mods/QudJP/Localization/BlueprintTemplates/templates.ja.json
@@ -18,7 +18,7 @@
     },
     {
       "key": "{{g|You touch =subject.the==subject.name= and recall =pronouns.possessive= passcode. =pronouns.Subjective= =verb:beep:afterpronoun= warmly.}}",
-      "text": "{{g|あなたは=subject.name=に触れ、パスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。}}"
+      "text": "{{g|あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。}}"
     },
     {
       "key": "{{r|A loud buzz is emitted. The unauthorized glyph flashes on the display.}}",
@@ -26,7 +26,7 @@
     },
     {
       "key": "You touch =subject.t= and recall =pronouns.possessive= passcode. =pronouns.Subjective= =verb:beep:afterpronoun= warmly.",
-      "text": "あなたは=subject.name=に触れ、パスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。"
+      "text": "あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。"
     },
     {
       "key": "A loud buzz is emitted. The unauthorized glyph flashes on the display.",
@@ -34,7 +34,7 @@
     },
     {
       "key": "{{R|=subject.T= =verb:consume= =object.an==object.directionIfAny=!}}",
-      "text": "{{R|=subject.name=が=object.name=を消費した！}}"
+      "text": "{{R|=subject.name=が=object.name==object.directionIfAny=を消費した！}}"
     },
     {
       "key": "=subject.T= =verb:fizzle= for several seconds.",
@@ -46,7 +46,7 @@
     },
     {
       "key": "=object.T= =object.verb:react= strangely with =subject.t= and =object.verb:convert= =pronouns.objective= to =newLiquid=.",
-      "text": "=object.name=が=subject.name=と奇妙な反応を起こし、=newLiquid=に変換された。"
+      "text": "=object.name=が=subject.name=と奇妙な反応を起こし、=subject.name=を=newLiquid=に変換した。"
     },
     {
       "key": "=subject.T= =verb:float= off.",
@@ -86,7 +86,7 @@
     },
     {
       "key": "=object.Does:are= much too old and rusted to enter.",
-      "text": "古すぎて錆びついており、中に入ることはできない。"
+      "text": "=object.name=は古すぎて錆びついており、中に入ることはできない。"
     },
     {
       "key": "=subject.Name's= =object.name= =object.verb:burst= outward, destroying =objpronouns.reflexive= to prevent potentially lethal damage.",
@@ -102,7 +102,7 @@
     },
     {
       "key": "=subject.T= =verb:extrude= through the mirror of =pronouns.possessive= crystalline rind!",
-      "text": "=subject.name=が結晶の外殻の鏡面を通り抜けた！"
+      "text": "=subject.name=が=subject.name=の結晶の外殻の鏡面を通り抜けた！"
     },
     {
       "key": "=subject.T= =verb:stumble= into =object.t=!",

--- a/docs/superpowers/plans/2026-04-25-issue-402-templates-variable-replacement.md
+++ b/docs/superpowers/plans/2026-04-25-issue-402-templates-variable-replacement.md
@@ -1,0 +1,241 @@
+# Issue #402 — `templates.ja.json` `=variable=` token information loss plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore information-bearing `=variable=` tokens in 6 of 30 entries in `templates.ja.json` and lock the new Japanese strings behind the existing L1 parametrized TestCase.
+
+**Architecture:** Pure data fix in one JSON file plus parametrized TestCase additions in one C# test file. No production C# changes. No new test files.
+
+**Tech Stack:** NUnit3 (`[TestCase]` attributes), .NET, JSON.
+
+**Spec:** `docs/superpowers/specs/2026-04-25-issue-402-templates-variable-replacement-design.md`
+
+---
+
+## File map
+
+| Action | Path | Responsibility |
+| --- | --- | --- |
+| Modify | `Mods/QudJP/Assemblies/QudJP.Tests/L1/BlueprintTemplateTranslationPatchTests.cs:82-91` | Update entry-7 expected value; add 5 new TestCase lines for entries 5, 9, 12, 22, 26 |
+| Modify | `Mods/QudJP/Localization/BlueprintTemplates/templates.ja.json` | Edit 6 `text` fields |
+
+No new files. No production code changes.
+
+---
+
+### Task 1: Failing TestCase additions
+
+**Files:**
+- Modify: `Mods/QudJP/Assemblies/QudJP.Tests/L1/BlueprintTemplateTranslationPatchTests.cs`
+
+- [ ] **Step 1: Update the parametrized test**
+
+Find the block at lines 82-91:
+
+```csharp
+    [TestCase("Nothing happens.", "何も起こらなかった。")]
+    [TestCase("You hear inaudible mumbling.", "聞き取れないつぶやきが聞こえた。")]
+    [TestCase("=subject.The==subject.name= =verb:start= up with a hum.",
+        "=subject.name=がうなり声を上げて起動した。")]
+    [TestCase("=subject.The==subject.name= =verb:recognize= your =object.name=.",
+        "=subject.name=があなたの=object.name=を認識した。")]
+    [TestCase("You touch =subject.t= and recall =pronouns.possessive= passcode. =pronouns.Subjective= =verb:beep:afterpronoun= warmly.",
+        "あなたは=subject.name=に触れ、パスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。")]
+    [TestCase("A loud buzz is emitted. The unauthorized glyph flashes on the display.",
+        "大きなブザー音が鳴った。認証されていないグリフがディスプレイに点滅した。")]
+```
+
+Replace the entry-7 line (the `You touch =subject.t=...` TestCase, lines 88-89) so the expected Japanese carries `=subject.name=のパスコード` instead of bare `パスコード`. Also append 5 new TestCase attributes immediately after the existing block (still on the same `LoadTranslations_ContainsExpectedMapping` method). The full updated block looks like this:
+
+```csharp
+    [TestCase("Nothing happens.", "何も起こらなかった。")]
+    [TestCase("You hear inaudible mumbling.", "聞き取れないつぶやきが聞こえた。")]
+    [TestCase("=subject.The==subject.name= =verb:start= up with a hum.",
+        "=subject.name=がうなり声を上げて起動した。")]
+    [TestCase("=subject.The==subject.name= =verb:recognize= your =object.name=.",
+        "=subject.name=があなたの=object.name=を認識した。")]
+    [TestCase("You touch =subject.t= and recall =pronouns.possessive= passcode. =pronouns.Subjective= =verb:beep:afterpronoun= warmly.",
+        "あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。")]
+    [TestCase("A loud buzz is emitted. The unauthorized glyph flashes on the display.",
+        "大きなブザー音が鳴った。認証されていないグリフがディスプレイに点滅した。")]
+    [TestCase("{{g|You touch =subject.the==subject.name= and recall =pronouns.possessive= passcode. =pronouns.Subjective= =verb:beep:afterpronoun= warmly.}}",
+        "{{g|あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。}}")]
+    [TestCase("{{R|=subject.T= =verb:consume= =object.an==object.directionIfAny=!}}",
+        "{{R|=subject.name=が=object.name==object.directionIfAny=を消費した！}}")]
+    [TestCase("=object.T= =object.verb:react= strangely with =subject.t= and =object.verb:convert= =pronouns.objective= to =newLiquid=.",
+        "=object.name=が=subject.name=と奇妙な反応を起こし、=subject.name=を=newLiquid=に変換した。")]
+    [TestCase("=object.Does:are= much too old and rusted to enter.",
+        "=object.name=は古すぎて錆びついており、中に入ることはできない。")]
+    [TestCase("=subject.T= =verb:extrude= through the mirror of =pronouns.possessive= crystalline rind!",
+        "=subject.name=が=subject.name=の結晶の外殻の鏡面を通り抜けた！")]
+```
+
+Use a multi-replacement Edit: target the original 10-line block (lines 82-91) and replace it with the 22-line block above. Do not modify the method body or the surrounding tests.
+
+- [ ] **Step 2: Run the L1 BlueprintTemplate tests; expect failure**
+
+Run:
+
+```bash
+dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~BlueprintTemplate" --logger "console;verbosity=normal"
+```
+
+Expected: 6 cases of `LoadTranslations_ContainsExpectedMapping` FAIL — one for the modified entry-7 case (existing JSON does not match new expected) and 5 for the newly-added entries 5, 9, 12, 22, 26. The other tests (`LoadTranslations_LoadsDictionaryWithExpectedEntryCount`, `LoadTranslations_AllKeysAreNonEmptyAndDistinct`, `LoadTranslations_TranslatedTemplatesPreserveVariableReplaceSlots`, etc.) PASS.
+
+If a different test fails or the failure count is not exactly 6, stop and report.
+
+---
+
+### Task 2: Apply the 6 JSON `text` edits
+
+**Files:**
+- Modify: `Mods/QudJP/Localization/BlueprintTemplates/templates.ja.json` — six text-field edits
+
+- [ ] **Step 1: Entry 5 (the `{{g|...}}` variant)**
+
+Replace:
+
+```json
+      "text": "{{g|あなたは=subject.name=に触れ、パスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。}}"
+```
+
+with:
+
+```json
+      "text": "{{g|あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。}}"
+```
+
+- [ ] **Step 2: Entry 7 (the bare variant)**
+
+Replace:
+
+```json
+      "text": "あなたは=subject.name=に触れ、パスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。"
+```
+
+with:
+
+```json
+      "text": "あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。"
+```
+
+- [ ] **Step 3: Entry 9 (consume + direction)**
+
+Replace:
+
+```json
+      "text": "{{R|=subject.name=が=object.name=を消費した！}}"
+```
+
+with:
+
+```json
+      "text": "{{R|=subject.name=が=object.name==object.directionIfAny=を消費した！}}"
+```
+
+- [ ] **Step 4: Entry 12 (alchemy convert)**
+
+Replace:
+
+```json
+      "text": "=object.name=が=subject.name=と奇妙な反応を起こし、=newLiquid=に変換された。"
+```
+
+with:
+
+```json
+      "text": "=object.name=が=subject.name=と奇妙な反応を起こし、=subject.name=を=newLiquid=に変換した。"
+```
+
+- [ ] **Step 5: Entry 22 (Does:are subject)**
+
+Replace:
+
+```json
+      "text": "古すぎて錆びついており、中に入ることはできない。"
+```
+
+with:
+
+```json
+      "text": "=object.name=は古すぎて錆びついており、中に入ることはできない。"
+```
+
+- [ ] **Step 6: Entry 26 (extrude through rind)**
+
+Replace:
+
+```json
+      "text": "=subject.name=が結晶の外殻の鏡面を通り抜けた！"
+```
+
+with:
+
+```json
+      "text": "=subject.name=が=subject.name=の結晶の外殻の鏡面を通り抜けた！"
+```
+
+- [ ] **Step 7: Re-run the L1 BlueprintTemplate tests**
+
+Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~BlueprintTemplate"`
+
+Expected: ALL pass.
+
+---
+
+### Task 3: Full verification
+
+**Files:**
+- (none — verification only)
+
+- [ ] **Step 1: Run all repo checks**
+
+Run each in order; all must succeed:
+
+```bash
+dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1
+dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2
+uv run pytest scripts/tests/ -q
+python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
+python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts
+ruff check scripts/
+dotnet build Mods/QudJP/Assemblies/QudJP.csproj
+```
+
+Expected exit codes / outputs:
+- L1 dotnet: all green (1182 plus the 5 new TestCase invocations).
+- L2 dotnet: all green.
+- pytest: 405 passed.
+- validate_xml: exit 0, no new warnings.
+- check_encoding: 190 OK, 0 issues.
+- ruff: clean.
+- dotnet build: 0 warnings, 0 errors.
+
+If any fails, stop, report, do not widen scope.
+
+- [ ] **Step 2: Stop**
+
+Do not commit. The user reviews the diff and runs the `/codex` review → `/simplify` → PR flow.
+
+---
+
+## Verification summary
+
+After Task 3:
+
+| Check | Command | Expectation |
+| --- | --- | --- |
+| L1 BlueprintTemplate tests | `dotnet test ... --filter "FullyQualifiedName~BlueprintTemplate"` | all green, includes 11 ContainsExpectedMapping cases |
+| L1 / L2 dotnet | `dotnet test ... --filter TestCategory=L1`, `--filter TestCategory=L2` | all green |
+| Full pytest | `uv run pytest scripts/tests/ -q` | 405 pass |
+| Strict XML validation | `python3.12 scripts/validate_xml.py ... --strict ...` | exit 0 |
+| Encoding | `python3.12 scripts/check_encoding.py ...` | clean |
+| Ruff | `ruff check scripts/` | clean |
+| DLL build | `dotnet build ...` | 0 warnings, 0 errors |
+
+## Out-of-scope reminders
+
+- Do NOT modify the 24 entries that were classified GOOD in the spec.
+- Do NOT add a generic placeholder-parity validator. That is #409.
+- Do NOT touch `BlueprintTemplateTranslationPatch.cs` itself — only the test and the JSON.
+- Do NOT modify `LoadTranslations_TranslatedTemplatesPreserveVariableReplaceSlots`. The new TestCase additions are sufficient for #402.

--- a/docs/superpowers/specs/2026-04-25-issue-402-templates-variable-replacement-design.md
+++ b/docs/superpowers/specs/2026-04-25-issue-402-templates-variable-replacement-design.md
@@ -48,7 +48,7 @@ The existing `LoadTranslations_TranslatedTemplatesPreserveVariableReplaceSlots` 
 ## How
 
 1. Update `BlueprintTemplateTranslationPatchTests.cs`: change the existing entry-7 TestCase's expected value, then add 5 new TestCase lines for entries 5, 9, 12, 22, 26 with the new Japanese strings.
-2. Run the L1 test. Expect 5–6 failures (entry 7 because the existing TestCase now expects new text; entries 5/9/12/22/26 because their TestCases assert text that does not yet exist in JSON).
+2. Run the L1 test. Expect exactly 6 failures (entry 7 because the existing TestCase now expects new text; entries 5/9/12/22/26 because their TestCases assert text that does not yet exist in JSON).
 3. Apply the six text-field edits to `templates.ja.json`.
 4. Re-run the L1 test. Expect green.
 5. Run the standard repo verification suite.

--- a/docs/superpowers/specs/2026-04-25-issue-402-templates-variable-replacement-design.md
+++ b/docs/superpowers/specs/2026-04-25-issue-402-templates-variable-replacement-design.md
@@ -1,0 +1,81 @@
+# Issue #402 — `templates.ja.json` `=variable=` token information loss
+
+## Why
+
+`Mods/QudJP/Localization/BlueprintTemplates/templates.ja.json` shipped 30 entries. The issue body counted 22 of them as having a `=variable=` token-multiset mismatch and feared runtime crashes, but the deeper read of the resolver shows the picture is mixed:
+
+- The Caves of Qud resolver (`XRL.GameText.Process` / `XRL.World.Text.Delegates.VariableReplacers`, decompiled) treats `=subject.T=`, `=subject.t=`, `=subject.The=`, `=subject.name=` etc. all as valid registered keys. Substituting `=subject.name=` for `=subject.T=` does **not** crash and does **not** leave a raw token; it returns the bare display name. The article ("the ", capitalisation) information is simply discarded — which is appropriate for Japanese, where definite articles do not exist.
+- However, several tokens carry **information that Japanese still needs**: the possessive ("his/her/its passcode"), the direction marker (`=directionIfAny=`), and the subject of the sentence itself. When those are dropped, the player loses information that no Japanese surface form can recover.
+
+So the actual #402 work is narrower than the issue body suggested: **6 entries truly lose information; the remaining 24 are acceptable Japanese collapses** of article/verb-conjugation tokens that have no Japanese equivalent.
+
+A general placeholder-parity validator that flags every `=T=`-to-`=name=` collapse would produce noise. The right place for that automation is #409, with an allowlist that distinguishes article-class tokens (collapse OK) from information-bearing tokens (must survive). #402 stays data-scoped.
+
+## What
+
+Six entries in `Mods/QudJP/Localization/BlueprintTemplates/templates.ja.json` need their `text` field updated. Indices below are 1-based to match the issue body.
+
+| # | Source key (excerpt) | Current Japanese | New Japanese | Information restored |
+| ---: | --- | --- | --- | --- |
+| 5 | `{{g\|You touch =subject.the==subject.name= and recall =pronouns.possessive= passcode. =pronouns.Subjective= =verb:beep:afterpronoun= warmly.}}` | `{{g\|あなたは=subject.name=に触れ、パスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。}}` | `{{g\|あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。}}` | passcode owner |
+| 7 | `You touch =subject.t= and recall =pronouns.possessive= passcode. =pronouns.Subjective= =verb:beep:afterpronoun= warmly.` | `あなたは=subject.name=に触れ、パスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。` | `あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。` | passcode owner |
+| 9 | `{{R\|=subject.T= =verb:consume= =object.an==object.directionIfAny=!}}` | `{{R\|=subject.name=が=object.name=を消費した！}}` | `{{R\|=subject.name=が=object.name==object.directionIfAny=を消費した！}}` | direction marker |
+| 12 | `=object.T= =object.verb:react= strangely with =subject.t= and =object.verb:convert= =pronouns.objective= to =newLiquid=.` | `=object.name=が=subject.name=と奇妙な反応を起こし、=newLiquid=に変換された。` | `=object.name=が=subject.name=と奇妙な反応を起こし、=subject.name=を=newLiquid=に変換した。` | what is converted (subject), active voice |
+| 22 | `=object.Does:are= much too old and rusted to enter.` | `古すぎて錆びついており、中に入ることはできない。` | `=object.name=は古すぎて錆びついており、中に入ることはできない。` | sentence subject |
+| 26 | `=subject.T= =verb:extrude= through the mirror of =pronouns.possessive= crystalline rind!` | `=subject.name=が結晶の外殻の鏡面を通り抜けた！` | `=subject.name=が=subject.name=の結晶の外殻の鏡面を通り抜けた！` | rind owner |
+
+The remaining 24 entries are left as shipped. They collapse pure article-class or English-verb-conjugation tokens (`=subject.T=` / `=subject.t=` / `=subject.The=` / `=verb:start=` / `=verb:stare=` / `=Name's=` etc.) into bare Japanese forms that carry the same information. The resolver renders them correctly via `name` lookup (verified against decompiled `VariableReplacers.cs`).
+
+### Tradeoffs in the chosen Japanese forms
+
+- **Entries 5 & 7**: The original English uses `=pronouns.possessive=` ("his/her/its"). Japanese has no equivalent neuter possessive pronoun for inanimate objects, so the natural rendering reuses the subject's name with the genitive `の`: `=subject.name=のパスコード`. The token multiset gains an extra `=subject.name=` rather than introducing `=pronouns.possessive=` (which would render in Japanese as awkward English-style pronouns).
+- **Entry 9**: `=object.directionIfAny=` resolves to a direction marker like `↑` or `に北` (or empty). Inserting it after `=object.name=` matches the surface form the player expects when the action is directional.
+- **Entry 12**: The current passive `に変換された` is grammatically correct but loses the subject of the conversion. The new active form `=subject.name=を=newLiquid=に変換した` mirrors the English `convert =pronouns.objective= to =newLiquid=` exactly.
+- **Entry 22**: A bare `=object.name=は` opens the sentence, restoring the subject reference that `=object.Does:are=` carried in English.
+- **Entry 26**: The `=subject.name=の結晶の外殻` repetition is mildly redundant, but the alternative `自分の` would lose machine-readability for future translators auditing token coverage. Preferred mechanical preservation.
+
+### Test seam
+
+Update `Mods/QudJP/Assemblies/QudJP.Tests/L1/BlueprintTemplateTranslationPatchTests.cs` `LoadTranslations_ContainsExpectedMapping` parametrized test:
+
+- The existing `[TestCase("You touch =subject.t= ...", "あなたは=subject.name=に触れ、パスコードを思い出した。...")]` is the entry-7 case. Update the `expected` argument to the new Japanese.
+- Add five new `[TestCase(...)]` lines covering entries 5, 9, 12, 22, 26.
+
+Each TestCase exercises the dictionary load path end-to-end: it asserts the JSON entry exists with the expected key and renders the expected text. If the JSON edit forgets one fix, the test fails on that case.
+
+The existing `LoadTranslations_TranslatedTemplatesPreserveVariableReplaceSlots` test (line 59-80) only checks `=subject.name=` and `=object.name=` slot survival, which is too loose to catch this class of bug. We do not extend it here; #409 owns the broader contract.
+
+## How
+
+1. Update `BlueprintTemplateTranslationPatchTests.cs`: change the existing entry-7 TestCase's expected value, then add 5 new TestCase lines for entries 5, 9, 12, 22, 26 with the new Japanese strings.
+2. Run the L1 test. Expect 5–6 failures (entry 7 because the existing TestCase now expects new text; entries 5/9/12/22/26 because their TestCases assert text that does not yet exist in JSON).
+3. Apply the six text-field edits to `templates.ja.json`.
+4. Re-run the L1 test. Expect green.
+5. Run the standard repo verification suite.
+
+## Verification
+
+```bash
+dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~BlueprintTemplate"
+dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1
+dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2
+uv run pytest scripts/tests/ -q
+python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
+ruff check scripts/
+dotnet build Mods/QudJP/Assemblies/QudJP.csproj
+```
+
+All must pass.
+
+## Out of scope
+
+- Generic `=variable=` token-parity validator across all dictionaries. That belongs in #409 with an allowlist that classifies tokens as "article-collapsable" vs. "information-bearing".
+- Style polish on the 24 GOOD entries (e.g., `start up with a hum` → more natural Japanese verbs). Translation tone is not a Steam blocker for these entries; treat as polish, file separately if pursued.
+- `Pettable` part-translation pipeline question Codex raised about entry 16 — the entry is in the JSON but may not be reached at runtime because `Pettable` is not in the patch's `TranslatablePartFields` list. That is a separate runtime-evidence question and not the scope of #402's data fix.
+- XML override files (`*.jp.xml`) that may have similar `=variable=` issues — those have their own translation paths and belong to other issues.
+
+## Risks
+
+- **Resolver behaviour drift**: if a future game version changes how unrecognised `=variable=` keys are handled (e.g., from "log warning + leave raw" to "throw"), our liberal collapses become liabilities. The L1 TestCase locks current expectations.
+- **Translation tone**: the chosen Japanese for entries 5, 7, 26 reuses `=subject.name=` in possessive position. If a future glossary prefers `自分の` style, the test will still pass because it asserts exact text — change in one place.
+- **Entry 16 (Pettable) silent inapplicability**: out of scope here, called out for tracking.


### PR DESCRIPTION
## Summary

Closes #402.

Six of the 30 entries in `Mods/QudJP/Localization/BlueprintTemplates/templates.ja.json` dropped tokens whose information cannot be recovered by the resolver in Japanese rendering: possessive owner, sentence subject, direction marker, and the converted referent in alchemy reactions. This PR restores those tokens.

## Why only 6 of "22"

The issue body counted 22 of 30 entries as token-multiset mismatches and feared runtime crashes. The deeper read of the resolver shows the picture is mixed:

- The decompiled `XRL.GameText.Process` / `XRL.World.Text.Delegates.VariableReplacers` pipeline accepts `=subject.T=`, `=subject.t=`, `=subject.The=`, and `=subject.name=` as valid registered keys. Substituting `=subject.name=` for `=subject.T=` does **not** crash and does **not** leave a raw token; the resolver returns the bare display name. The article information ("the ", capitalisation) is simply discarded — appropriate for Japanese.
- However, several tokens carry information that **Japanese still needs**: `=pronouns.possessive=` (passcode owner), `=directionIfAny=` (direction marker), `=object.Does:are=` (sentence subject), and the convert-referent in entry 12. When those are dropped, the player loses information no Japanese surface form can recover.

So the actual fix is narrower than the issue body suggested: 6 entries truly lose information; the remaining 24 are acceptable Japanese collapses.

## Fixed entries

| # | Token restored | New Japanese (excerpt) |
| ---: | --- | --- |
| 5 | passcode owner | `あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。…` |
| 7 | same as 5 | same form, no `{{g\|...}}` wrapper |
| 9 | `=object.directionIfAny=` | `=subject.name=が=object.name==object.directionIfAny=を消費した！` |
| 12 | converted referent + active voice | `=object.name=が=subject.name=と奇妙な反応を起こし、=subject.name=を=newLiquid=に変換した。` |
| 22 | sentence subject | `=object.name=は古すぎて錆びついており、中に入ることはできない。` |
| 26 | rind owner | `=subject.name=が=subject.name=の結晶の外殻の鏡面を通り抜けた！` |

## Tests

Five new `[TestCase(...)]` rows are added to the existing L1 parametrized `LoadTranslations_ContainsExpectedMapping` test (entries 5, 9, 12, 22, 26). The pre-existing entry-7 TestCase has its expected value updated. One hardcoded `OriginalValue` assertion at line 289 (which aliased the same English source) was also updated to keep the two assertion sites in sync.

A generic `=variable=` parity validator is intentionally **deferred to #409** because the right contract requires an allowlist that distinguishes article-class tokens (collapse OK in Japanese) from information-bearing tokens (must survive). Adding such a validator inside #402 would require either over-broad rules (false positives on the 24 acceptable entries) or a hand-curated allowlist that is itself the validator's main maintenance burden.

## Verification

```
$ dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~BlueprintTemplate"
all green (11 ContainsExpectedMapping cases pass)

$ dotnet test --filter TestCategory=L1
1187 passed, 0 failed

$ dotnet test --filter TestCategory=L2
713 passed, 0 failed

$ uv run pytest scripts/tests/ -q
343 passed

$ python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
exit 0

$ python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts
Scanned 189 files: 189 OK, 0 issue(s)

$ ruff check scripts/
All checks passed!

$ dotnet build Mods/QudJP/Assemblies/QudJP.csproj
0 Warning(s), 0 Error(s)
```

## Out of scope

- Generic `=variable=` token-parity validator across all dictionaries — #409 with allowlist.
- Style polish on the 24 GOOD entries — translation tone work.
- `Pettable` part-translation pipeline (entry 16 questionable applicability) — separate runtime-evidence issue.
- XML overlay files (`*.jp.xml`) that may have similar `=variable=` issues — separate translation paths.

## Test plan

- [x] L1 BlueprintTemplate fixture all green
- [x] L1 / L2 dotnet test suites green (1187 / 713)
- [x] Full pytest green (343)
- [x] validate_xml --strict exit 0
- [x] Codex review approved
- [x] /simplify reviews (reuse / quality / efficiency) all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 日本語翻訳で主体・対象などの変数プレースホルダーの配置と語順を修正し、パスコード表現や消費・変換・反応系のメッセージ、年齢制限や鏡を通す表現の翻訳精度を向上しました。

* **テスト**
  * 上記の変数保持を検証するための単体テストが追加・拡充されました。

* **ドキュメント**
  * 修正方針と検証手順をまとめた計画・仕様書を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->