### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ node_modules/
 
 # Claude session handoff files (contain local paths and session IDs)
 .claude/handoff.md
+
+# Claude scheduled-task runtime lock
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
- Add `.claude/scheduled_tasks.lock` to `.gitignore`. It's a runtime lock file from Claude Code's scheduled-tasks feature that appears under untracked files after each session and is local-only.

## Test plan
- [x] `git status` no longer lists `.claude/scheduled_tasks.lock` as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 内部設定ファイルを更新し、ビルド環境の構成を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->