### PR TITLE
test(#426): edge-case fixture coverage for ReshephHistoryTranslationTests

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/Fixtures/annals-samples.json
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/Fixtures/annals-samples.json
@@ -41,11 +41,7 @@
       "candidate_id": "ReshephCleansesGyre#gospel",
       "event_property": "gospel",
       "input_source": "In 1234 AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks.",
-      "expected_japanese_exact": "1234年、レシェフは湿地帯よりジャイアの災厄を祓い、その肥沃なる道筋に沿ってワターヴァインを蒔く術をアブラムに授けた。",
-      "expected_japanese_contains": [
-        "レシェフ",
-        "年、レシェフは湿地帯より"
-      ]
+      "expected_japanese_exact": "1234年、レシェフは湿地帯よりジャイアの災厄を祓い、その肥沃なる道筋に沿ってワターヴァインを蒔く術をアブラムに授けた。"
     },
     {
       "candidate_id": "ReshephClosesTomb#gospel",

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/Fixtures/annals-samples.json
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/Fixtures/annals-samples.json
@@ -41,6 +41,7 @@
       "candidate_id": "ReshephCleansesGyre#gospel",
       "event_property": "gospel",
       "input_source": "In 1234 AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks.",
+      "expected_japanese_exact": "1234年、レシェフは湿地帯よりジャイアの災厄を祓い、その肥沃なる道筋に沿ってワターヴァインを蒔く術をアブラムに授けた。",
       "expected_japanese_contains": [
         "レシェフ",
         "年、レシェフは湿地帯より"
@@ -153,6 +154,30 @@
         "レシェフ",
         "年、レベカはグロットロッ"
       ]
+    },
+    {
+      "candidate_id": "edge_empty_gospel",
+      "event_property": "gospel",
+      "input_source": "",
+      "expected_unchanged": true
+    },
+    {
+      "candidate_id": "edge_color_tagged_year",
+      "event_property": "gospel",
+      "input_source": "In {{R|3}} AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks.",
+      "expected_japanese_exact": "{{R|3}}年、レシェフは湿地帯よりジャイアの災厄を祓い、その肥沃なる道筋に沿ってワターヴァインを蒔く術をアブラムに授けた。"
+    },
+    {
+      "candidate_id": "edge_x01_literal_prefix",
+      "event_property": "gospel",
+      "input_source": "\u0001In 1234 AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks.",
+      "expected_unchanged": true
+    },
+    {
+      "candidate_id": "edge_english_fallback",
+      "event_property": "gospel",
+      "input_source": "Resheph wrote 5 books in 99 AR but no entry exists for that.",
+      "expected_unchanged": true
     }
   ]
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
@@ -112,6 +112,11 @@ public sealed class ReshephHistoryTranslationTests
                 $"sample {sample.CandidateId}: 期待値が未設定です。expected_unchanged / expected_japanese_exact / expected_japanese_contains のいずれかを設定してください。");
             return;
         }
+        if (sample.ExpectedJapaneseContains.Exists(static needle => string.IsNullOrWhiteSpace(needle)))
+        {
+            Assert.Fail(
+                $"sample {sample.CandidateId}: expected_japanese_contains に空文字または空白要素は設定できません。");
+        }
         foreach (var needle in sample.ExpectedJapaneseContains)
         {
             Assert.That(actual, Does.Contain(needle),

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
@@ -17,11 +17,9 @@ public sealed class ReshephSampleEntry
     public string InputSource { get; set; } = "";
     [DataMember(Name = "expected_japanese_contains")]
     public List<string> ExpectedJapaneseContains { get; set; } = new();
-    // expected_japanese_exact locks down deterministic translator output in full.
-    [DataMember(Name = "expected_japanese_exact", IsRequired = false, EmitDefaultValue = false)]
+    [DataMember(Name = "expected_japanese_exact")]
     public string? ExpectedJapaneseExact { get; set; }
-    // expected_unchanged covers the English-fallback / passthrough contract.
-    [DataMember(Name = "expected_unchanged", IsRequired = false, EmitDefaultValue = false)]
+    [DataMember(Name = "expected_unchanged")]
     public bool ExpectedUnchanged { get; set; }
 }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
@@ -107,6 +107,10 @@ public sealed class ReshephHistoryTranslationTests
             Assert.That(actual, Is.EqualTo(sample.ExpectedJapaneseExact),
                 $"sample {sample.CandidateId}: exact match failed. actual='{actual}'");
         }
+        if (sample.ExpectedJapaneseContains is null)
+        {
+            return;
+        }
         foreach (var needle in sample.ExpectedJapaneseContains)
         {
             Assert.That(actual, Does.Contain(needle),

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
@@ -116,6 +116,7 @@ public sealed class ReshephHistoryTranslationTests
         {
             Assert.Fail(
                 $"sample {sample.CandidateId}: expected_japanese_contains に空文字または空白要素は設定できません。");
+            return;
         }
         foreach (var needle in sample.ExpectedJapaneseContains)
         {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
@@ -94,6 +94,21 @@ public sealed class ReshephHistoryTranslationTests
         HistoricNarrativeDictionaryWalker.TranslateEventPropertiesDict(dict);
 
         var actual = dict[sample.EventProperty];
+
+        var hasContains = sample.ExpectedJapaneseContains is { Count: > 0 };
+        if (sample.ExpectedUnchanged && (sample.ExpectedJapaneseExact is not null || hasContains))
+        {
+            Assert.Fail(
+                $"sample {sample.CandidateId}: expected_unchanged は expected_japanese_exact / expected_japanese_contains と同時に設定できません。");
+            return;
+        }
+        if (!sample.ExpectedUnchanged && sample.ExpectedJapaneseExact is not null && hasContains)
+        {
+            Assert.Fail(
+                $"sample {sample.CandidateId}: expected_japanese_exact と expected_japanese_contains の同時設定は不可です。どちらか一方を設定してください。");
+            return;
+        }
+
         if (sample.ExpectedUnchanged)
         {
             Assert.That(actual, Is.EqualTo(sample.InputSource),

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
@@ -17,6 +17,12 @@ public sealed class ReshephSampleEntry
     public string InputSource { get; set; } = "";
     [DataMember(Name = "expected_japanese_contains")]
     public List<string> ExpectedJapaneseContains { get; set; } = new();
+    // expected_japanese_exact locks down deterministic translator output in full.
+    [DataMember(Name = "expected_japanese_exact", IsRequired = false, EmitDefaultValue = false)]
+    public string? ExpectedJapaneseExact { get; set; }
+    // expected_unchanged covers the English-fallback / passthrough contract.
+    [DataMember(Name = "expected_unchanged", IsRequired = false, EmitDefaultValue = false)]
+    public bool ExpectedUnchanged { get; set; }
 }
 
 [DataContract]
@@ -90,6 +96,17 @@ public sealed class ReshephHistoryTranslationTests
         HistoricNarrativeDictionaryWalker.TranslateEventPropertiesDict(dict);
 
         var actual = dict[sample.EventProperty];
+        if (sample.ExpectedUnchanged)
+        {
+            Assert.That(actual, Is.EqualTo(sample.InputSource),
+                $"sample {sample.CandidateId}: expected unchanged passthrough but got '{actual}'");
+            return;
+        }
+        if (sample.ExpectedJapaneseExact is not null)
+        {
+            Assert.That(actual, Is.EqualTo(sample.ExpectedJapaneseExact),
+                $"sample {sample.CandidateId}: exact match failed. actual='{actual}'");
+        }
         foreach (var needle in sample.ExpectedJapaneseContains)
         {
             Assert.That(actual, Does.Contain(needle),

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
@@ -104,9 +104,12 @@ public sealed class ReshephHistoryTranslationTests
         {
             Assert.That(actual, Is.EqualTo(sample.ExpectedJapaneseExact),
                 $"sample {sample.CandidateId}: exact match failed. actual='{actual}'");
+            return;
         }
-        if (sample.ExpectedJapaneseContains is null)
+        if (sample.ExpectedJapaneseContains is null || sample.ExpectedJapaneseContains.Count == 0)
         {
+            Assert.Fail(
+                $"sample {sample.CandidateId}: 期待値が未設定です。expected_unchanged / expected_japanese_exact / expected_japanese_contains のいずれかを設定してください。");
             return;
         }
         foreach (var needle in sample.ExpectedJapaneseContains)


### PR DESCRIPTION
## Summary

Closes #426.

Addresses the CodeRabbit Critical from PR #425 (deferred): `ReshephHistoryTranslationTests` had only happy-path samples with substring-only `Does.Contain` assertions. This PR adds the missing coverage shapes and extends the fixture schema with two optional fields so each contract is asserted at the right granularity.

### Schema (test code)

`ReshephSampleEntry` gains two optional fields:
- `expected_japanese_exact` — locks down deterministic translator output by full-string equality.
- `expected_unchanged` — asserts input passes through unchanged (English-fallback / passthrough contract).

The test method picks the strongest applicable assertion: `expected_unchanged` short-circuits to `Is.EqualTo(InputSource)`; otherwise `expected_japanese_exact` triggers `Is.EqualTo(...)`; the existing `expected_japanese_contains` foreach runs as a sanity check on top.

### Fixture additions

| Sample | Mode | Behaviour locked in |
|---|---|---|
| `edge_empty_gospel` | `expected_unchanged: true` | empty input → empty output (defensive passthrough) |
| `edge_color_tagged_year` | `expected_japanese_exact` | `{{R\|3}}` color span survives translation at the same position (corroborates PR #413 color-span fix) |
| `edge_x01_literal_prefix` | `expected_unchanged: true` | `\x01`-prefixed input falls through unchanged because the regex anchor breaks |
| `edge_english_fallback` | `expected_unchanged: true` | unmatched English string returns verbatim |
| `ReshephCleansesGyre#gospel` (upgraded) | `expected_japanese_exact` | one happy-path sample upgraded to exact-match |

No translator changes — fixture-only PR. Each behaviour was probed empirically on the actual translator before locking the assertion in.

## Test plan

- [x] `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- [x] `ruff check scripts/`
- [x] `uv run pytest scripts/tests/ -x` — 614 passed (unchanged)
- [x] `dotnet test ... --filter TestCategory=L1` — 1355 passed (unchanged)
- [x] `dotnet test ... --filter TestCategory=L2` — 740 passed (was 736; +4 new edge cases as expected)
- [x] All 17 pre-existing Resheph samples still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * テスト仕様を拡張し、翻訳出力の検証ロジックを強化しました。
  * 厳密な文字列一致（expected_japanese_exact）と「変更なし」(expected_unchanged) モードを追加し、期待値の表現を明確化しました。
  * 空入力、制御文字プレフィックス、色タグ付き年、対応エントリ無しのフォールバックなど、複数のエッジケースを追加してカバレッジを拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->