### PR TITLE
feat(#424): translate Resheph shrine description wrapper + quality rating

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
@@ -141,6 +141,7 @@ internal static class ColorRouteCatalog
             ["Mods/QudJP/Assemblies/src/Patches/QudMenuBottomContextTranslationPatch.cs|PopupTranslationPatch.TranslatePopupMenuItemTextForProducerRoute("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/TradeUiPopupTranslationPatch.cs|MessagePatternTranslator.Translate("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/TradeUiPopupTranslationPatch.cs|PopupTranslationPatch.TranslatePopupTextForProducerRoute("] = 1,
+            ["Mods/QudJP/Assemblies/src/Patches/SultanShrineWrapperTranslator.cs|JournalPatternTranslator.Translate("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/SkillsAndPowersLineTranslationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/SkillsAndPowersStatusScreenTranslationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 3,
             ["Mods/QudJP/Assemblies/src/Patches/DeathReasonTranslationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs
@@ -215,12 +215,12 @@ public sealed class SultanShrineWrapperTranslatorTests
     }
 
     [Test]
-    public void Translate_DoesNotMatch_WhenDirectTranslationMarkerSitsInsideColoredQuality()
+    public void Translate_PassesThroughUnknownQuality_WhenDirectTranslationMarkerSitsInsideColoredQuality()
     {
-        // Defensive: marker inside the quality color wrapper still must not trigger the
-        // shrine translator. The regex is anchored at ^ so anything that breaks the canonical
-        // prefix fails to match. This pins the behavior so a future regex relaxation cannot
-        // silently start consuming marker-bearing inputs.
+        // The quality token \x01Perfect is not in QualityKeys, so the wrapper translates
+        // sultan + gospel + prefix as usual but the quality segment falls through unchanged.
+        // This pins the asymmetric behavior: outer wrapper still matches, only quality is
+        // passthrough, no empty {{Y|}} pair leaks.
         var source = "The shrine depicts a significant event from the life of the ancient sultan Resheph:"
             + "\n\nIn 3 AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks."
             + "\n\n{{Y|\x01Perfect}}";

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs
@@ -61,7 +61,11 @@ public sealed class SultanShrineWrapperTranslatorTests
     [TestCase("Lightly Damaged", "軽微な損傷")]
     [TestCase("Damaged", "損傷")]
     [TestCase("Badly Damaged", "重度の損傷")]
-    public void Translate_TranslatesAllNonOrganicQualityRatings(string qualityEn, string qualityJa)
+    [TestCase("Undamaged", "無傷")]
+    [TestCase("Badly Wounded", "重傷")]
+    [TestCase("Wounded", "負傷")]
+    [TestCase("Injured", "軽傷")]
+    public void Translate_TranslatesAllShippedQualityRatings(string qualityEn, string qualityJa)
     {
         var source =
             "The shrine depicts a significant event from the life of the ancient sultan Resheph:"
@@ -85,7 +89,7 @@ public sealed class SultanShrineWrapperTranslatorTests
     }
 
     [Test]
-    public void Translate_TranslatesArbitrarySultanName_ViaTranslatorLeaf()
+    public void Translate_TranslatesResheph_ViaTranslatorLeaf()
     {
         const string source =
             "The shrine depicts a significant event from the life of the ancient sultan Resheph:"
@@ -150,5 +154,91 @@ public sealed class SultanShrineWrapperTranslatorTests
         var translated = MessagePatternTranslator.Translate(source, nameof(DescriptionLongDescriptionPatch));
 
         Assert.That(translated, Is.EqualTo(source), "unrelated two-paragraph inputs must fall through unchanged");
+    }
+
+    [Test]
+    public void TranslateLongDescription_KeepsQualityWrapperAroundJapaneseQuality_ForProductionColorFlow()
+    {
+        // Production color flow: Description.GetLongDescription -> DescriptionLongDescription-
+        // Patch.Postfix -> DescriptionTextTranslator.TranslateLongDescription -> Color-
+        // AwareTranslationComposer.TranslatePreservingColors strips colors BEFORE the inner
+        // visible-segment lambda calls MessagePatternTranslator. If shrine wrapper composes
+        // its color restoration only against the inner spans (which are empty on this path),
+        // the outer Restore re-applies absolute span positions from the long English source
+        // onto the much shorter Japanese output, producing "...完璧{{Y|}}" instead of
+        // "...{{Y|完璧}}". This test guards that path.
+        const string source =
+            "The shrine depicts a significant event from the life of the ancient sultan Resheph:"
+            + "\n\nIn 3 AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks."
+            + "\n\n{{Y|Perfect}}";
+
+        var translated = DescriptionTextTranslator.TranslateLongDescription(
+            source,
+            nameof(DescriptionLongDescriptionPatch));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Does.EndWith("{{Y|完璧}}"),
+                "color wrapper must enclose the translated quality word, not appear as an empty trailing pair");
+            Assert.That(translated, Does.Not.Contain("{{Y|}}"),
+                "empty color wrapper indicates spans were re-applied with stale source-length positions");
+            Assert.That(translated, Does.Contain("3年、レシェフは"),
+                "annals gospel must be translated");
+            Assert.That(translated, Does.Not.Contain("The shrine depicts"),
+                "wrapper prefix must be Japanese");
+        });
+    }
+
+    [Test]
+    public void Translate_ReturnsEmpty_WhenInputIsEmpty()
+    {
+        var translated = MessagePatternTranslator.Translate(string.Empty, nameof(DescriptionLongDescriptionPatch));
+
+        Assert.That(translated, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void Translate_DoesNotMatch_WhenDirectTranslationMarkerIsPresent()
+    {
+        // \x01-prefixed text is the direct-translation marker: producers signal "already
+        // translated, do not retranslate" by prepending it. The shrine wrapper must not
+        // claim such input, so it falls through MessagePatternTranslator unchanged (the
+        // outer patch is responsible for stripping the marker on its way to the sink).
+        var source = "\x01The shrine depicts a significant event from the life of the ancient sultan Resheph:"
+            + "\n\nIn 3 AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks."
+            + "\n\n{{Y|Perfect}}";
+
+        var translated = MessagePatternTranslator.Translate(source, nameof(DescriptionLongDescriptionPatch));
+
+        Assert.That(translated, Is.EqualTo(source),
+            "direct-marker-prefixed input must not be claimed by the shrine wrapper translator");
+    }
+
+    [Test]
+    public void Translate_DoesNotMatch_WhenDirectTranslationMarkerSitsInsideColoredQuality()
+    {
+        // Defensive: marker inside the quality color wrapper still must not trigger the
+        // shrine translator. The regex is anchored at ^ so anything that breaks the canonical
+        // prefix fails to match. This pins the behavior so a future regex relaxation cannot
+        // silently start consuming marker-bearing inputs.
+        var source = "The shrine depicts a significant event from the life of the ancient sultan Resheph:"
+            + "\n\nIn 3 AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks."
+            + "\n\n{{Y|\x01Perfect}}";
+
+        var translated = MessagePatternTranslator.Translate(source, nameof(DescriptionLongDescriptionPatch));
+
+        // The quality token "\x01Perfect" is not in the QualityKeys map, so quality
+        // translation falls through to the original. The wrapper still translates because
+        // sultan name + gospel + prefix all match — but the quality stays as the source
+        // marker-prefixed token, which is correct passthrough behavior for unknown qualities.
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Does.StartWith("この祠は古のスルタン"),
+                "wrapper prefix should still translate around the unknown marker-prefixed quality");
+            Assert.That(translated, Does.Contain("\x01Perfect"),
+                "marker-bearing quality token must pass through unchanged when not in QualityKeys");
+            Assert.That(translated, Does.Not.Contain("{{Y|}}"),
+                "no empty color wrapper should be left behind");
+        });
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs
@@ -114,4 +114,41 @@ public sealed class SultanShrineWrapperTranslatorTests
             Assert.That(translated, Does.EndWith("{{Y|完璧}}"));
         });
     }
+
+    [Test]
+    public void Translate_TranslatesTwoParagraphShape_WhenQualitySuffixAbsent()
+    {
+        // Shape produced directly by SultanShrine.ShrineInitialize (Description.Short).
+        // Quality rating is appended only on the tooltip / popup path, so routes that show
+        // the long description without the wound suffix must still translate the wrapper.
+        const string source =
+            "The shrine depicts a significant event from the life of the ancient sultan Resheph:"
+            + "\n\nIn 3 AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks.";
+
+        var translated = MessagePatternTranslator.Translate(source, nameof(DescriptionLongDescriptionPatch));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Does.StartWith("この祠は古のスルタン"), "wrapper prefix should be Japanese");
+            Assert.That(translated, Does.Contain("レシェフ"), "sultan name should be translated");
+            Assert.That(translated, Does.Contain("3年、レシェフは"), "annals gospel should be translated");
+            Assert.That(translated, Does.Not.Contain("The shrine depicts"), "no English wrapper should remain");
+            Assert.That(translated, Does.Not.Contain("Resheph"), "no English sultan name should remain");
+            Assert.That(translated, Does.Not.Contain("{quality}"), "quality placeholder should not leak");
+            Assert.That(translated, Does.Not.EndWith("\n\n"), "no dangling separator should remain when quality is absent");
+        });
+    }
+
+    [Test]
+    public void Translate_DoesNotOverMatchUnrelatedTwoParagraphTextStartingWithTheShrine()
+    {
+        // Plausible-but-unrelated two-paragraph text that begins with "The shrine" must not
+        // be claimed by the wrapper translator. Without the canonical "depicts a significant
+        // event from the life of the ancient sultan ...:" prefix the regex must miss.
+        const string source = "The shrine looks weathered.\n\nMoss has overgrown its base.";
+
+        var translated = MessagePatternTranslator.Translate(source, nameof(DescriptionLongDescriptionPatch));
+
+        Assert.That(translated, Is.EqualTo(source), "unrelated two-paragraph inputs must fall through unchanged");
+    }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs
@@ -1,0 +1,117 @@
+using System.IO;
+using QudJP.Patches;
+using QudJP.Tests.L1;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class SultanShrineWrapperTranslatorTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        var localizationRoot = Path.Combine(TestProjectPaths.GetRepositoryRoot(), "Mods", "QudJP", "Localization");
+        var dictionaryDir = Path.Combine(localizationRoot, "Dictionaries");
+
+        Translator.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(dictionaryDir);
+        LocalizationAssetResolver.SetLocalizationRootForTests(localizationRoot);
+        JournalPatternTranslator.ResetForTests();
+        JournalPatternTranslator.SetPatternFilesForTests(null);
+        MessagePatternTranslator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        JournalPatternTranslator.ResetForTests();
+        MessagePatternTranslator.ResetForTests();
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
+        DynamicTextObservability.ResetForTests();
+    }
+
+    [Test]
+    public void Translate_TranslatesPrefixGospelAndQuality_ForReshephAnnalsComposite()
+    {
+        const string source =
+            "The shrine depicts a significant event from the life of the ancient sultan Resheph:"
+            + "\n\nIn 3 AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks."
+            + "\n\n{{Y|Perfect}}";
+
+        var translated = MessagePatternTranslator.Translate(source, nameof(DescriptionLongDescriptionPatch));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Does.StartWith("この祠は古のスルタン"), "wrapper prefix should be Japanese");
+            Assert.That(translated, Does.Contain("レシェフ"), "sultan name should be translated");
+            Assert.That(translated, Does.Contain("3年、レシェフは"), "annals gospel should be translated via JournalPatternTranslator");
+            Assert.That(translated, Does.EndWith("{{Y|完璧}}"), "quality rating should be Japanese inside its color wrapper");
+            Assert.That(translated, Does.Not.Contain("Resheph"), "no English sultan name should remain");
+            Assert.That(translated, Does.Not.Contain("Perfect"), "no English quality word should remain");
+            Assert.That(translated, Does.Not.Contain("The shrine depicts"), "no English wrapper should remain");
+        });
+    }
+
+    [TestCase("Perfect", "完璧")]
+    [TestCase("Fine", "良好")]
+    [TestCase("Lightly Damaged", "軽微な損傷")]
+    [TestCase("Damaged", "損傷")]
+    [TestCase("Badly Damaged", "重度の損傷")]
+    public void Translate_TranslatesAllNonOrganicQualityRatings(string qualityEn, string qualityJa)
+    {
+        var source =
+            "The shrine depicts a significant event from the life of the ancient sultan Resheph:"
+            + "\n\nIn 3 AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks."
+            + "\n\n{{Y|" + qualityEn + "}}";
+
+        var translated = MessagePatternTranslator.Translate(source, nameof(DescriptionLongDescriptionPatch));
+
+        Assert.That(translated, Does.EndWith("{{Y|" + qualityJa + "}}"));
+        Assert.That(translated, Does.Not.Contain(qualityEn));
+    }
+
+    [Test]
+    public void Translate_DoesNotMatchUnrelatedComposite_LeavesPassthroughBehavior()
+    {
+        const string source = "The shrine depicts something completely different.";
+
+        var translated = MessagePatternTranslator.Translate(source, nameof(DescriptionLongDescriptionPatch));
+
+        Assert.That(translated, Is.EqualTo(source), "non-shrine-wrapper inputs must not be touched by this translator");
+    }
+
+    [Test]
+    public void Translate_TranslatesArbitrarySultanName_ViaTranslatorLeaf()
+    {
+        const string source =
+            "The shrine depicts a significant event from the life of the ancient sultan Resheph:"
+            + "\n\nIn 3 AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks."
+            + "\n\n{{Y|Perfect}}";
+
+        var translated = MessagePatternTranslator.Translate(source, nameof(DescriptionLongDescriptionPatch));
+
+        Assert.That(translated, Does.Contain("レシェフ"));
+    }
+
+    [Test]
+    public void Translate_PreservesUnknownGospel_WhenAnnalsPatternMissing()
+    {
+        const string source =
+            "The shrine depicts a significant event from the life of the ancient sultan Resheph:"
+            + "\n\nUnknown gospel that does not match any annals pattern."
+            + "\n\n{{Y|Perfect}}";
+
+        var translated = MessagePatternTranslator.Translate(source, nameof(DescriptionLongDescriptionPatch));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Does.StartWith("この祠は古のスルタン"));
+            Assert.That(translated, Does.Contain("Unknown gospel that does not match any annals pattern."));
+            Assert.That(translated, Does.EndWith("{{Y|完璧}}"));
+        });
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs
@@ -56,6 +56,28 @@ public sealed class SultanShrineWrapperTranslatorTests
         });
     }
 
+    [Test]
+    public void Translate_TranslatesPrefixGospelAndQuality_ForPopupRoute()
+    {
+        // Tooltip/popup route: SultanShrine surfaces the full composite (with quality suffix)
+        // through the popup path, so MessagePatternTranslator must translate it identically
+        // regardless of which Patch route called it. Locking this here pins popup regressions.
+        const string source =
+            "The shrine depicts a significant event from the life of the ancient sultan Resheph:"
+            + "\n\nIn 3 AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks."
+            + "\n\n{{Y|Perfect}}";
+
+        var translated = MessagePatternTranslator.Translate(source, nameof(PopupMessageTranslationPatch));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Does.StartWith("この祠は古のスルタン"), "wrapper prefix should be Japanese on popup route");
+            Assert.That(translated, Does.Contain("3年、レシェフは"), "annals gospel should be translated on popup route");
+            Assert.That(translated, Does.EndWith("{{Y|完璧}}"), "quality rating should be Japanese inside its color wrapper on popup route");
+            Assert.That(translated, Does.Not.Contain("The shrine depicts"), "no English wrapper should remain on popup route");
+        });
+    }
+
     [TestCase("Perfect", "完璧")]
     [TestCase("Fine", "良好")]
     [TestCase("Lightly Damaged", "軽微な損傷")]
@@ -89,7 +111,7 @@ public sealed class SultanShrineWrapperTranslatorTests
     }
 
     [Test]
-    public void Translate_TranslatesResheph_ViaTranslatorLeaf()
+    public void Translate_TranslatesReshephNameInsideShrineWrapper()
     {
         const string source =
             "The shrine depicts a significant event from the life of the ancient sultan Resheph:"
@@ -235,6 +257,8 @@ public sealed class SultanShrineWrapperTranslatorTests
         {
             Assert.That(translated, Does.StartWith("この祠は古のスルタン"),
                 "wrapper prefix should still translate around the unknown marker-prefixed quality");
+            Assert.That(translated, Does.Contain("{{Y|\x01Perfect}}"),
+                "marker-bearing quality token must remain wrapped in its original color tag");
             Assert.That(translated, Does.Contain("\x01Perfect"),
                 "marker-bearing quality token must pass through unchanged when not in QualityKeys");
             Assert.That(translated, Does.Not.Contain("{{Y|}}"),

--- a/Mods/QudJP/Assemblies/src/Patches/DescriptionTextTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/DescriptionTextTranslator.cs
@@ -79,12 +79,29 @@ internal static class DescriptionTextTranslator
             return true;
         }
 
+        if (TryTranslateSultanShrineWrapperPreservingColors(source, route, out translated))
+        {
+            return true;
+        }
+
         translated = ColorAwareTranslationComposer.TranslatePreservingColors(
             source,
             visible => TryTranslateVisibleSegment(visible, route, out var candidate)
                 ? candidate
                 : visible);
         return !string.Equals(translated, source, StringComparison.Ordinal);
+    }
+
+    private static bool TryTranslateSultanShrineWrapperPreservingColors(string source, string route, out string translated)
+    {
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
+        if (SultanShrineWrapperTranslator.TryTranslateMessage(stripped, spans, route, out translated))
+        {
+            return true;
+        }
+
+        translated = source;
+        return false;
     }
 
     private static bool TryTranslateVisibleSegment(string source, string route, out string translated)

--- a/Mods/QudJP/Assemblies/src/Patches/SultanShrineWrapperTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/SultanShrineWrapperTranslator.cs
@@ -6,12 +6,18 @@ namespace QudJP.Patches;
 
 internal static class SultanShrineWrapperTranslator
 {
-    private const string TemplateKey = "QudJP.ShrineWrapper.AncientSultan";
-    private const string FamilyTag = "ShrineWrapper.AncientSultan";
+    private const string TemplateKeyWithQuality = "QudJP.ShrineWrapper.AncientSultan";
+    private const string TemplateKeyWithoutQuality = "QudJP.ShrineWrapper.AncientSultan.NoQuality";
+    private const string FamilyTagWithQuality = "ShrineWrapper.AncientSultan";
+    private const string FamilyTagWithoutQuality = "ShrineWrapper.AncientSultan.NoQuality";
 
+    // The trailing "\n\n{quality}" segment is appended only on the tooltip / popup path. Routes
+    // that surface the bare Description.Short (set by SultanShrine.ShrineInitialize) see only
+    // the prefix + gospel, so the quality block must be optional or those routes pass through
+    // English.
     private static readonly Regex CompositePattern =
         new Regex(
-            "^The shrine depicts a significant event from the life of the ancient sultan (?<sultan>.+?):\\n\\n(?<gospel>.+?)\\n\\n(?<quality>.+?)$",
+            "^The shrine depicts a significant event from the life of the ancient sultan (?<sultan>.+?):\\n\\n(?<gospel>.+?)(?:\\n\\n(?<quality>.+?))?$",
             RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
 
     // Quality strings come from XRL.Rules.Strings.WoundLevel. The set is finite and shipped in
@@ -43,34 +49,52 @@ internal static class SultanShrineWrapperTranslator
             return false;
         }
 
-        if (!Translator.TryGetTranslation(TemplateKey, out var template))
+        var qualityGroup = match.Groups["quality"];
+        var hasQuality = qualityGroup.Success;
+        var templateKey = hasQuality ? TemplateKeyWithQuality : TemplateKeyWithoutQuality;
+        if (!Translator.TryGetTranslation(templateKey, out var template))
         {
             translated = source;
             return false;
         }
 
-        var sultanRaw = match.Groups["sultan"].Value;
-        var gospelRaw = match.Groups["gospel"].Value;
-        var qualityRaw = match.Groups["quality"].Value;
+        var sultan = TranslateSultanName(match.Groups["sultan"].Value);
+        var gospel = TranslateGospel(match.Groups["gospel"].Value, route);
 
-        var sultan = TranslateSultanName(sultanRaw);
-        var gospel = TranslateGospel(gospelRaw, route);
-        var quality = TranslateQuality(qualityRaw);
-
-        if (!TryComposeWithKnownQualityOffset(template, sultan, gospel, quality, out var composed, out var qualityStart))
+        string composed;
+        int qualityStart;
+        int qualityLength;
+        if (hasQuality)
         {
-            translated = source;
-            return false;
+            var quality = TranslateQuality(qualityGroup.Value);
+            if (!TryComposeWithQuality(template, sultan, gospel, quality, out composed, out qualityStart))
+            {
+                translated = source;
+                return false;
+            }
+
+            qualityLength = quality.Length;
+        }
+        else
+        {
+            if (!TryComposeWithoutQuality(template, sultan, gospel, out composed))
+            {
+                translated = source;
+                return false;
+            }
+
+            qualityStart = -1;
+            qualityLength = 0;
         }
 
-        if (spans is not null && spans.Count > 0 && qualityStart >= 0)
+        if (hasQuality && spans is not null && spans.Count > 0 && qualityStart >= 0)
         {
-            composed = WrapTranslatedQualityWithSourceColors(composed, qualityStart, quality.Length, spans, match.Groups["quality"]);
+            composed = WrapTranslatedQualityWithSourceColors(composed, qualityStart, qualityLength, spans, qualityGroup);
         }
 
         DynamicTextObservability.RecordTransform(
             nameof(MessagePatternTranslator),
-            FamilyTag,
+            hasQuality ? FamilyTagWithQuality : FamilyTagWithoutQuality,
             source,
             composed);
 
@@ -123,7 +147,7 @@ internal static class SultanShrineWrapperTranslator
     // Computes the substituted output AND the absolute index where {quality} ends up after
     // {sultan} and {gospel} have been replaced. Defensive: requires the template to contain
     // each placeholder exactly once and {quality} to follow {sultan}/{gospel} in template order.
-    private static bool TryComposeWithKnownQualityOffset(
+    private static bool TryComposeWithQuality(
         string template,
         string sultan,
         string gospel,
@@ -154,6 +178,29 @@ internal static class SultanShrineWrapperTranslator
         var sultanDelta = sultan.Length - sultanPlaceholder.Length;
         var gospelDelta = gospel.Length - gospelPlaceholder.Length;
         qualityStart = qualityIndex + sultanDelta + gospelDelta;
+        return true;
+    }
+
+    private static bool TryComposeWithoutQuality(
+        string template,
+        string sultan,
+        string gospel,
+        out string composed)
+    {
+        const string sultanPlaceholder = "{sultan}";
+        const string gospelPlaceholder = "{gospel}";
+
+        var sultanIndex = template.IndexOf(sultanPlaceholder, StringComparison.Ordinal);
+        var gospelIndex = template.IndexOf(gospelPlaceholder, StringComparison.Ordinal);
+        if (sultanIndex < 0 || gospelIndex < 0 || sultanIndex >= gospelIndex)
+        {
+            composed = string.Empty;
+            return false;
+        }
+
+        composed = template
+            .Replace(sultanPlaceholder, sultan)
+            .Replace(gospelPlaceholder, gospel);
         return true;
     }
 

--- a/Mods/QudJP/Assemblies/src/Patches/SultanShrineWrapperTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/SultanShrineWrapperTranslator.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace QudJP.Patches;
+
+internal static class SultanShrineWrapperTranslator
+{
+    private const string TemplateKey = "QudJP.ShrineWrapper.AncientSultan";
+    private const string FamilyTag = "ShrineWrapper.AncientSultan";
+
+    private static readonly Regex CompositePattern =
+        new Regex(
+            "^The shrine depicts a significant event from the life of the ancient sultan (?<sultan>.+?):\\n\\n(?<gospel>.+?)\\n\\n(?<quality>.+?)$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
+
+    // Quality strings come from XRL.Rules.Strings.WoundLevel. The set is finite and shipped in
+    // the world-shrine.ja.json dictionary; entries missing from the dictionary fall through to
+    // the original English so a future game-side addition does not silently break the wrapper.
+    private static readonly Dictionary<string, string> QualityKeys = new(StringComparer.Ordinal)
+    {
+        ["Perfect"] = "QudJP.ShrineWrapper.Quality.Perfect",
+        ["Fine"] = "QudJP.ShrineWrapper.Quality.Fine",
+        ["Lightly Damaged"] = "QudJP.ShrineWrapper.Quality.LightlyDamaged",
+        ["Damaged"] = "QudJP.ShrineWrapper.Quality.Damaged",
+        ["Badly Damaged"] = "QudJP.ShrineWrapper.Quality.BadlyDamaged",
+        ["Undamaged"] = "QudJP.ShrineWrapper.Quality.Undamaged",
+        ["Badly Wounded"] = "QudJP.ShrineWrapper.Quality.BadlyWounded",
+        ["Wounded"] = "QudJP.ShrineWrapper.Quality.Wounded",
+        ["Injured"] = "QudJP.ShrineWrapper.Quality.Injured",
+    };
+
+    internal static bool TryTranslateMessage(
+        string source,
+        IReadOnlyList<ColorSpan>? spans,
+        string route,
+        out string translated)
+    {
+        var match = CompositePattern.Match(source);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        if (!Translator.TryGetTranslation(TemplateKey, out var template))
+        {
+            translated = source;
+            return false;
+        }
+
+        var sultanRaw = match.Groups["sultan"].Value;
+        var gospelRaw = match.Groups["gospel"].Value;
+        var qualityRaw = match.Groups["quality"].Value;
+
+        var sultan = TranslateSultanName(sultanRaw);
+        var gospel = TranslateGospel(gospelRaw, route);
+        var quality = TranslateQuality(qualityRaw);
+
+        if (!TryComposeWithKnownQualityOffset(template, sultan, gospel, quality, out var composed, out var qualityStart))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (spans is not null && spans.Count > 0 && qualityStart >= 0)
+        {
+            composed = WrapTranslatedQualityWithSourceColors(composed, qualityStart, quality.Length, spans, match.Groups["quality"]);
+        }
+
+        DynamicTextObservability.RecordTransform(
+            nameof(MessagePatternTranslator),
+            FamilyTag,
+            source,
+            composed);
+
+        translated = composed;
+        return true;
+    }
+
+    private static string TranslateSultanName(string source)
+    {
+        if (string.IsNullOrEmpty(source))
+        {
+            return source;
+        }
+
+        using var _ = Translator.PushMissingKeyLoggingSuppression(true);
+        var direct = Translator.Translate(source);
+        return string.Equals(direct, source, StringComparison.Ordinal) ? source : direct;
+    }
+
+    private static string TranslateGospel(string source, string route)
+    {
+        if (string.IsNullOrEmpty(source))
+        {
+            return source;
+        }
+
+        return JournalPatternTranslator.Translate(source, route);
+    }
+
+    private static string TranslateQuality(string source)
+    {
+        if (string.IsNullOrEmpty(source))
+        {
+            return source;
+        }
+
+        if (!QualityKeys.TryGetValue(source, out var key))
+        {
+            return source;
+        }
+
+        if (!Translator.TryGetTranslation(key, out var translation))
+        {
+            return source;
+        }
+
+        return translation;
+    }
+
+    // Computes the substituted output AND the absolute index where {quality} ends up after
+    // {sultan} and {gospel} have been replaced. Defensive: requires the template to contain
+    // each placeholder exactly once and {quality} to follow {sultan}/{gospel} in template order.
+    private static bool TryComposeWithKnownQualityOffset(
+        string template,
+        string sultan,
+        string gospel,
+        string quality,
+        out string composed,
+        out int qualityStart)
+    {
+        const string sultanPlaceholder = "{sultan}";
+        const string gospelPlaceholder = "{gospel}";
+        const string qualityPlaceholder = "{quality}";
+
+        var sultanIndex = template.IndexOf(sultanPlaceholder, StringComparison.Ordinal);
+        var gospelIndex = template.IndexOf(gospelPlaceholder, StringComparison.Ordinal);
+        var qualityIndex = template.IndexOf(qualityPlaceholder, StringComparison.Ordinal);
+        if (sultanIndex < 0 || gospelIndex < 0 || qualityIndex < 0
+            || sultanIndex >= gospelIndex || gospelIndex >= qualityIndex)
+        {
+            composed = string.Empty;
+            qualityStart = -1;
+            return false;
+        }
+
+        composed = template
+            .Replace(sultanPlaceholder, sultan)
+            .Replace(gospelPlaceholder, gospel)
+            .Replace(qualityPlaceholder, quality);
+
+        var sultanDelta = sultan.Length - sultanPlaceholder.Length;
+        var gospelDelta = gospel.Length - gospelPlaceholder.Length;
+        qualityStart = qualityIndex + sultanDelta + gospelDelta;
+        return true;
+    }
+
+    private static string WrapTranslatedQualityWithSourceColors(
+        string composed,
+        int qualityStart,
+        int qualityLength,
+        IReadOnlyList<ColorSpan> spans,
+        Group qualityGroup)
+    {
+        var qualityCaptureSpans = ColorCodePreserver.SliceSpans(spans, qualityGroup.Index, qualityGroup.Length);
+        qualityCaptureSpans.AddRange(ColorCodePreserver.SliceAdjacentCaptureBoundarySpans(spans, qualityGroup.Index, qualityGroup.Length));
+        if (qualityCaptureSpans.Count == 0)
+        {
+            return composed;
+        }
+
+        var prefix = composed.Substring(0, qualityStart);
+        var middle = composed.Substring(qualityStart, qualityLength);
+        var suffix = composed.Substring(qualityStart + qualityLength);
+        var restoredMiddle = ColorAwareTranslationComposer.Restore(middle, qualityCaptureSpans);
+        return prefix + restoredMiddle + suffix;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/SultanShrineWrapperTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/SultanShrineWrapperTranslator.cs
@@ -60,36 +60,22 @@ internal static class SultanShrineWrapperTranslator
 
         var sultan = TranslateSultanName(match.Groups["sultan"].Value);
         var gospel = TranslateGospel(match.Groups["gospel"].Value, route);
+        var quality = hasQuality ? TranslateQuality(qualityGroup.Value) : null;
 
-        string composed;
-        int qualityStart;
-        int qualityLength;
-        if (hasQuality)
+        if (!TryCompose(template, sultan, gospel, quality, out var composed, out var qualityStart))
         {
-            var quality = TranslateQuality(qualityGroup.Value);
-            if (!TryComposeWithQuality(template, sultan, gospel, quality, out composed, out qualityStart))
-            {
-                translated = source;
-                return false;
-            }
-
-            qualityLength = quality.Length;
-        }
-        else
-        {
-            if (!TryComposeWithoutQuality(template, sultan, gospel, out composed))
-            {
-                translated = source;
-                return false;
-            }
-
-            qualityStart = -1;
-            qualityLength = 0;
+            translated = source;
+            return false;
         }
 
-        if (hasQuality && spans is not null && spans.Count > 0 && qualityStart >= 0)
+        if (hasQuality && quality is not null && spans is not null && spans.Count > 0 && qualityStart >= 0)
         {
-            composed = WrapTranslatedQualityWithSourceColors(composed, qualityStart, qualityLength, spans, qualityGroup);
+            var prefix = composed.Substring(0, qualityStart);
+            var middle = composed.Substring(qualityStart, quality.Length);
+            var suffix = composed.Substring(qualityStart + quality.Length);
+            composed = prefix
+                + ColorAwareTranslationComposer.RestoreCapture(middle, spans, qualityGroup)
+                + suffix;
         }
 
         DynamicTextObservability.RecordTransform(
@@ -144,14 +130,11 @@ internal static class SultanShrineWrapperTranslator
         return translation;
     }
 
-    // Computes the substituted output AND the absolute index where {quality} ends up after
-    // {sultan} and {gospel} have been replaced. Defensive: requires the template to contain
-    // each placeholder exactly once and {quality} to follow {sultan}/{gospel} in template order.
-    private static bool TryComposeWithQuality(
+    private static bool TryCompose(
         string template,
         string sultan,
         string gospel,
-        string quality,
+        string? quality,
         out string composed,
         out int qualityStart)
     {
@@ -161,9 +144,24 @@ internal static class SultanShrineWrapperTranslator
 
         var sultanIndex = template.IndexOf(sultanPlaceholder, StringComparison.Ordinal);
         var gospelIndex = template.IndexOf(gospelPlaceholder, StringComparison.Ordinal);
+        if (sultanIndex < 0 || gospelIndex < 0 || sultanIndex >= gospelIndex)
+        {
+            composed = string.Empty;
+            qualityStart = -1;
+            return false;
+        }
+
+        if (quality is null)
+        {
+            composed = template
+                .Replace(sultanPlaceholder, sultan)
+                .Replace(gospelPlaceholder, gospel);
+            qualityStart = -1;
+            return true;
+        }
+
         var qualityIndex = template.IndexOf(qualityPlaceholder, StringComparison.Ordinal);
-        if (sultanIndex < 0 || gospelIndex < 0 || qualityIndex < 0
-            || sultanIndex >= gospelIndex || gospelIndex >= qualityIndex)
+        if (qualityIndex < 0 || gospelIndex >= qualityIndex)
         {
             composed = string.Empty;
             qualityStart = -1;
@@ -179,49 +177,5 @@ internal static class SultanShrineWrapperTranslator
         var gospelDelta = gospel.Length - gospelPlaceholder.Length;
         qualityStart = qualityIndex + sultanDelta + gospelDelta;
         return true;
-    }
-
-    private static bool TryComposeWithoutQuality(
-        string template,
-        string sultan,
-        string gospel,
-        out string composed)
-    {
-        const string sultanPlaceholder = "{sultan}";
-        const string gospelPlaceholder = "{gospel}";
-
-        var sultanIndex = template.IndexOf(sultanPlaceholder, StringComparison.Ordinal);
-        var gospelIndex = template.IndexOf(gospelPlaceholder, StringComparison.Ordinal);
-        if (sultanIndex < 0 || gospelIndex < 0 || sultanIndex >= gospelIndex)
-        {
-            composed = string.Empty;
-            return false;
-        }
-
-        composed = template
-            .Replace(sultanPlaceholder, sultan)
-            .Replace(gospelPlaceholder, gospel);
-        return true;
-    }
-
-    private static string WrapTranslatedQualityWithSourceColors(
-        string composed,
-        int qualityStart,
-        int qualityLength,
-        IReadOnlyList<ColorSpan> spans,
-        Group qualityGroup)
-    {
-        var qualityCaptureSpans = ColorCodePreserver.SliceSpans(spans, qualityGroup.Index, qualityGroup.Length);
-        qualityCaptureSpans.AddRange(ColorCodePreserver.SliceAdjacentCaptureBoundarySpans(spans, qualityGroup.Index, qualityGroup.Length));
-        if (qualityCaptureSpans.Count == 0)
-        {
-            return composed;
-        }
-
-        var prefix = composed.Substring(0, qualityStart);
-        var middle = composed.Substring(qualityStart, qualityLength);
-        var suffix = composed.Substring(qualityStart + qualityLength);
-        var restoredMiddle = ColorAwareTranslationComposer.Restore(middle, qualityCaptureSpans);
-        return prefix + restoredMiddle + suffix;
     }
 }

--- a/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
@@ -184,6 +184,10 @@ internal static class MessagePatternTranslator
             return deathTranslated;
         }
 
+        // Backstop for callers that pass un-stripped colored input straight to
+        // MessagePatternTranslator (e.g. unit tests, MessageLogProducer paths). The primary
+        // production interception lives in DescriptionTextTranslator, which strips colors
+        // BEFORE MessagePatternTranslator is reached for shrine descriptions.
         var currentLogContext = Translator.GetCurrentLogContext();
         var shrineRoute = string.IsNullOrEmpty(currentLogContext)
             ? nameof(MessagePatternTranslator)

--- a/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
@@ -184,6 +184,16 @@ internal static class MessagePatternTranslator
             return deathTranslated;
         }
 
+        var currentLogContext = Translator.GetCurrentLogContext();
+        var shrineRoute = string.IsNullOrEmpty(currentLogContext)
+            ? nameof(MessagePatternTranslator)
+            : currentLogContext!;
+
+        if (SultanShrineWrapperTranslator.TryTranslateMessage(source, spans, shrineRoute, out var shrineTranslated))
+        {
+            return shrineTranslated;
+        }
+
         if (TryGetLeafTranslation(source, out var exactTranslation))
         {
             DynamicTextObservability.RecordTransform(

--- a/Mods/QudJP/Localization/Dictionaries/world-shrine.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/world-shrine.ja.json
@@ -1,0 +1,44 @@
+{
+    "entries": [
+        {
+            "key": "QudJP.ShrineWrapper.AncientSultan",
+            "text": "この祠は古のスルタン{sultan}の生涯における重要な出来事を描いている：\n\n{gospel}\n\n{quality}"
+        },
+        {
+            "key": "QudJP.ShrineWrapper.Quality.Perfect",
+            "text": "完璧"
+        },
+        {
+            "key": "QudJP.ShrineWrapper.Quality.Fine",
+            "text": "良好"
+        },
+        {
+            "key": "QudJP.ShrineWrapper.Quality.LightlyDamaged",
+            "text": "軽微な損傷"
+        },
+        {
+            "key": "QudJP.ShrineWrapper.Quality.Damaged",
+            "text": "損傷"
+        },
+        {
+            "key": "QudJP.ShrineWrapper.Quality.BadlyDamaged",
+            "text": "重度の損傷"
+        },
+        {
+            "key": "QudJP.ShrineWrapper.Quality.Undamaged",
+            "text": "無傷"
+        },
+        {
+            "key": "QudJP.ShrineWrapper.Quality.BadlyWounded",
+            "text": "重傷"
+        },
+        {
+            "key": "QudJP.ShrineWrapper.Quality.Wounded",
+            "text": "負傷"
+        },
+        {
+            "key": "QudJP.ShrineWrapper.Quality.Injured",
+            "text": "軽傷"
+        }
+    ]
+}

--- a/Mods/QudJP/Localization/Dictionaries/world-shrine.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/world-shrine.ja.json
@@ -5,6 +5,10 @@
             "text": "この祠は古のスルタン{sultan}の生涯における重要な出来事を描いている：\n\n{gospel}\n\n{quality}"
         },
         {
+            "key": "QudJP.ShrineWrapper.AncientSultan.NoQuality",
+            "text": "この祠は古のスルタン{sultan}の生涯における重要な出来事を描いている：\n\n{gospel}"
+        },
+        {
             "key": "QudJP.ShrineWrapper.Quality.Perfect",
             "text": "完璧"
         },


### PR DESCRIPTION
## Summary

Closes #424.

When a Resheph-history shrine is examined in-game, the description is composed by `XRL.World.Parts.SultanShrine` as `"The shrine depicts a significant event from the life of the ancient sultan {name}:\n\n{gospel}"` (and on tooltip/popup paths, with a trailing `\n\n{{Y|Perfect}}` quality suffix). The whole composite hits `MessagePatternTranslator` via `DescriptionLongDescriptionPatch` — annals patterns can't recurse into the captured group, so the wrapper sentence and quality rating stayed English even when the inner gospel translated correctly.

### Architecture: per-segment recursion

A new `SultanShrineWrapperTranslator` (mirroring `DeathWrapperFamilyTranslator`) is wired into `MessagePatternTranslator.TranslateStripped` ahead of leaf/pattern lookup. It splits the composite via a single regex with an optional quality group, dispatches each segment to its appropriate translator (`Translator.Translate` for sultan-name + quality, `JournalPatternTranslator.Translate` for the inner gospel), then recomposes via a Japanese template loaded from `world-shrine.ja.json`. Color spans around the quality token are preserved via `ColorAwareTranslationComposer.RestoreCapture`.

The "atomic dictionary entry" approach suggested in the issue body was rejected after empirically confirming `MessagePatternTranslator` doesn't recurse into captured groups — that approach would have left the gospel English.

### Quality rating list (data-driven)

9 quality ratings sourced from decompiled `XRL.Rules.Strings.WoundLevel` (`Perfect`, `Fine`, `Lightly Damaged`, `Damaged`, `Badly Damaged`, `Undamaged`, plus the 3 organic-creature variants for defense). Adding a future quality rating is a dictionary-only change.

### Routes covered

- Tooltip / popup composite (`...:\n\n<gospel>\n\n{{Y|Perfect}}`)
- Long description / direct (`...:\n\n<gospel>` — codex P2 surfaced this during review; both shapes now match)

## Test plan

- [x] `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- [x] `dotnet test ... --filter TestCategory=L1` — 1355 passed (unchanged)
- [x] `dotnet test ... --filter TestCategory=L2` — **751 passed** (+11 new for `SultanShrineWrapperTranslatorTests`: canonical composite, all 5 non-organic quality ratings, two-paragraph shape, sultan-name leaf, unknown-gospel passthrough, unrelated composite, over-match safety)
- [x] `dotnet test ... --filter TestCategory=L2G` — 190 passed
- [x] `ruff check scripts/`
- [x] `uv run pytest scripts/tests/` — 617 passed
- [x] `python3.12 scripts/validate_xml.py ... --strict` — exit 0

## Out of scope (explicitly deferred)

- Tomb inscription murals (`SultanMuralController` / `PlayerMuralController`) — different code path, not in #424.
- Non-Resheph sultans — wrapper translates any `{sultan}` segment via `Translator.Translate`, so future sultans light up by adding a `world-factions.ja.json` (or similar) entry. Only Resheph ships in this PR per the issue's AC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 古代スルタン聖殿の英語ラッパー表現を検出して日本語へ自動翻訳。品質語の対応と元の色付けを保持して出力します。

* **Tests**
  * 新しいL2テストスイートを追加し多様なラッパーケース、品質トークン、色スパン保持、直接翻訳マーカー挙動を検証。既存カタログテストも期待結果を更新。

* **Localization**
  * 聖殿用日本語辞書を追加。テンプレートと複数の品質キーを収録。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->