### PR TITLE
feat(#430): AnnalsPatternExtractor extension — HistoryKit / string.Format / branch enumeration

### DIFF
--- a/scripts/tests/fixtures/annals/append_after_setter.cs
+++ b/scripts/tests/fixtures/annals/append_after_setter.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class AppendAfterSetterFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string text = "base";
+        SetEventProperty("gospel", text);
+        text += " after";
+    }
+}

--- a/scripts/tests/fixtures/annals/append_invalidated_by_reassignment.cs
+++ b/scripts/tests/fixtures/annals/append_invalidated_by_reassignment.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class AppendInvalidatedByReassignmentFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string text = "base";
+        text += " middle";
+        text = "override";
+        SetEventProperty("gospel", text);
+    }
+}

--- a/scripts/tests/fixtures/annals/branch_assign_after_setter.cs
+++ b/scripts/tests/fixtures/annals/branch_assign_after_setter.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class BranchAssignAfterSetterFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string value = "base";
+        if (Random(0, 1) == 0)
+        {
+            SetEventProperty("gospel", value);
+            value = "after";
+        }
+    }
+}

--- a/scripts/tests/fixtures/annals/branch_fanout_with_setter_outside_if.cs
+++ b/scripts/tests/fixtures/annals/branch_fanout_with_setter_outside_if.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace XRL.Annals;
+
+// Branch fanout when only ONE branch reassigns the local. The unassigned else-branch keeps
+// the local's declared initializer ("default"); the then-branch overrides it with "alt".
+// Runtime can produce EITHER value, so the extractor emits TWO candidates with `#if:then`
+// / `#if:else` ids — runtime-faithful per the BuildSetterScopedLocals design.
+[Serializable]
+public class BranchFanoutWithSetterOutsideIfFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string text = "default";
+        if (Random(0, 1) == 0)
+        {
+            text = "alt";
+        }
+        SetEventProperty("gospel", text);
+    }
+}

--- a/scripts/tests/fixtures/annals/duplicate_event_property_dedupe.cs
+++ b/scripts/tests/fixtures/annals/duplicate_event_property_dedupe.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class DuplicateEventPropertyDedupeFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        if (Random(0, 1) == 0)
+        {
+            SetEventProperty("gospel", "Resheph triumphed.");
+        }
+        else
+        {
+            SetEventProperty("gospel", "Resheph triumphed.");
+        }
+    }
+}

--- a/scripts/tests/fixtures/annals/elseif_chain_two_branches.cs
+++ b/scripts/tests/fixtures/annals/elseif_chain_two_branches.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class ElseifChainTwoBranchesFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        if (Random(0, 1) == 0)
+        {
+            SetEventProperty("gospel", "alpha");
+        }
+        else if (Random(0, 1) == 0)
+        {
+            SetEventProperty("gospel", "beta");
+        }
+    }
+}

--- a/scripts/tests/fixtures/annals/escaped_braces_in_format.cs
+++ b/scripts/tests/fixtures/annals/escaped_braces_in_format.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class EscapedBracesInFormatFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string name = "Hero";
+        SetEventProperty("gospel", string.Format("{{0}} struck {0}.", name));
+    }
+}

--- a/scripts/tests/fixtures/annals/expected_append_after_setter.json
+++ b/scripts/tests/fixtures/annals/expected_append_after_setter.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "append_after_setter#gospel",
+      "source_file": "append_after_setter.cs",
+      "annal_class": "append_after_setter",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "base",
+      "extracted_pattern": "^base$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:2824ba410734b560aa064cc2128072c51621625bc6bb25d53188fc3e1f7291d5"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_append_invalidated_by_reassignment.json
+++ b/scripts/tests/fixtures/annals/expected_append_invalidated_by_reassignment.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "append_invalidated_by_reassignment#gospel",
+      "source_file": "append_invalidated_by_reassignment.cs",
+      "annal_class": "append_invalidated_by_reassignment",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "override",
+      "extracted_pattern": "^override$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:b51f01d7aba645251e6de6a248c39d6c5ea582eb8e7db2931ef76f3530c5b2b7"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_branch_assign_after_setter.json
+++ b/scripts/tests/fixtures/annals/expected_branch_assign_after_setter.json
@@ -7,22 +7,15 @@
       "annal_class": "branch_assign_after_setter",
       "switch_case": "default",
       "event_property": "gospel",
-      "sample_source": "{0}",
-      "extracted_pattern": "^(.+?)$",
-      "slots": [
-        {
-          "index": 0,
-          "type": "unresolved-local",
-          "raw": "value",
-          "default": "{t0}"
-        }
-      ],
+      "sample_source": "base",
+      "extracted_pattern": "^base$",
+      "slots": [],
       "status": "pending",
       "reason": "",
       "ja_template": "",
       "review_notes": "",
       "route": "annals",
-      "en_template_hash": "sha256:26486d731a0fdb2010b57e32cf0a79e6d5d39f071efc19678dd503cbb7867a25"
+      "en_template_hash": "sha256:2824ba410734b560aa064cc2128072c51621625bc6bb25d53188fc3e1f7291d5"
     }
   ]
 }

--- a/scripts/tests/fixtures/annals/expected_branch_assign_after_setter.json
+++ b/scripts/tests/fixtures/annals/expected_branch_assign_after_setter.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "branch_assign_after_setter#gospel",
+      "source_file": "branch_assign_after_setter.cs",
+      "annal_class": "branch_assign_after_setter",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "{0}",
+      "extracted_pattern": "^(.+?)$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "unresolved-local",
+          "raw": "value",
+          "default": "{t0}"
+        }
+      ],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:26486d731a0fdb2010b57e32cf0a79e6d5d39f071efc19678dd503cbb7867a25"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_branch_fanout_with_setter_outside_if.json
+++ b/scripts/tests/fixtures/annals/expected_branch_fanout_with_setter_outside_if.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "branch_fanout_with_setter_outside_if#gospel#if:else",
+      "source_file": "branch_fanout_with_setter_outside_if.cs",
+      "annal_class": "branch_fanout_with_setter_outside_if",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "default",
+      "extracted_pattern": "^default$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:b5b8777804b4f33ed2c71542a0c9fdc76867d2bf55c2ae4b674dfd5f7bf82589"
+    },
+    {
+      "id": "branch_fanout_with_setter_outside_if#gospel#if:then",
+      "source_file": "branch_fanout_with_setter_outside_if.cs",
+      "annal_class": "branch_fanout_with_setter_outside_if",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "alt",
+      "extracted_pattern": "^alt$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:9d704dd815c313ad68422b0d346edc065f219e26211e8b8b851f394cc1b8fd33"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_duplicate_event_property_dedupe.json
+++ b/scripts/tests/fixtures/annals/expected_duplicate_event_property_dedupe.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "duplicate_event_property_dedupe#gospel",
+      "source_file": "duplicate_event_property_dedupe.cs",
+      "annal_class": "duplicate_event_property_dedupe",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "Resheph triumphed.",
+      "extracted_pattern": "^Resheph\\ triumphed\\.$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:be2e56f0a988944532e02decca69ef2b004cab0ff26657a98b6b0cf7ddc42d6c"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_elseif_chain_two_branches.json
+++ b/scripts/tests/fixtures/annals/expected_elseif_chain_two_branches.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "elseif_chain_two_branches#gospel#if:else",
+      "source_file": "elseif_chain_two_branches.cs",
+      "annal_class": "elseif_chain_two_branches",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "beta",
+      "extracted_pattern": "^beta$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:0f034a5574913678e47c4c46abd3fdf0cae12e7c61c74f12e66ab22e79fcb2d6"
+    },
+    {
+      "id": "elseif_chain_two_branches#gospel#if:then",
+      "source_file": "elseif_chain_two_branches.cs",
+      "annal_class": "elseif_chain_two_branches",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "alpha",
+      "extracted_pattern": "^alpha$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:2f1468e07e4991989d45d46aa27143ab687d3e5f1528a6a729180f0c98254898"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_escaped_braces_in_format.json
+++ b/scripts/tests/fixtures/annals/expected_escaped_braces_in_format.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "escaped_braces_in_format#gospel",
+      "source_file": "escaped_braces_in_format.cs",
+      "annal_class": "escaped_braces_in_format",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "{0} struck Hero.",
+      "extracted_pattern": "^\\{0}\\ struck\\ Hero\\.$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:aff1c39482f49a99ec9048d190c1222811489ea904a8adf038236c8f0efb1dd0"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_historykit_token_repeated_local.json
+++ b/scripts/tests/fixtures/annals/expected_historykit_token_repeated_local.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "historykit_token_repeated_local#gospel",
+      "source_file": "historykit_token_repeated_local.cs",
+      "annal_class": "historykit_token_repeated_local",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "{0}",
+      "extracted_pattern": "^(.+?)$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "historykit-token",
+          "raw": "<entity.name><entity.type>",
+          "default": "{t0}"
+        }
+      ],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:4d33c12c0b17f56c6cc13cc4f5c941e822416313bc46c4045c75aeb37cce343e"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_historykit_token_via_local.json
+++ b/scripts/tests/fixtures/annals/expected_historykit_token_via_local.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "historykit_token_via_local#gospel",
+      "source_file": "historykit_token_via_local.cs",
+      "annal_class": "historykit_token_via_local",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "{0}",
+      "extracted_pattern": "^(.+?)$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "historykit-token",
+          "raw": "<entity.name>",
+          "default": "{t0}"
+        }
+      ],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:f7a5802002a1f0a53a62ed990e45ffba627f032e8f38298e16e121e794c62bf8"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_historykit_tokens.json
+++ b/scripts/tests/fixtures/annals/expected_historykit_tokens.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "historykit_tokens#gospel",
+      "source_file": "historykit_tokens.cs",
+      "annal_class": "historykit_tokens",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "{0} was adopted by {1} who love {2}.",
+      "extracted_pattern": "^(.+?)\\ was\\ adopted\\ by\\ (.+?)\\ who\\ love\\ (.+?)\\.$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "historykit-token",
+          "raw": "<entity.name>",
+          "default": "{t0}"
+        },
+        {
+          "index": 1,
+          "type": "historykit-token",
+          "raw": "<$chosenSpice.professions.!random>",
+          "default": "{t1}"
+        },
+        {
+          "index": 2,
+          "type": "historykit-token",
+          "raw": "<$chosenSpice.practices.!random>",
+          "default": "{t2}"
+        }
+      ],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:2e19049f5919fa0b80215755cf4f95bddf48fa6f8922296f3e61833cbf075c67"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_if_dedupe_preserves_arm_suffix.json
+++ b/scripts/tests/fixtures/annals/expected_if_dedupe_preserves_arm_suffix.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "if_dedupe_preserves_arm_suffix#gospel#arm:0",
+      "source_file": "if_dedupe_preserves_arm_suffix.cs",
+      "annal_class": "if_dedupe_preserves_arm_suffix",
+      "switch_case": "0",
+      "event_property": "gospel",
+      "sample_source": "base alpha",
+      "extracted_pattern": "^base\\ alpha$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:7e89309514fc2e36e7cbc548b0fc90b95edb35389beffbbac8cffe1890346bf0"
+    },
+    {
+      "id": "if_dedupe_preserves_arm_suffix#gospel#arm:_",
+      "source_file": "if_dedupe_preserves_arm_suffix.cs",
+      "annal_class": "if_dedupe_preserves_arm_suffix",
+      "switch_case": "_",
+      "event_property": "gospel",
+      "sample_source": "base beta",
+      "extracted_pattern": "^base\\ beta$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:1c5f87f8999320546df2a07d80bde5ccc2b33575713f884b81c19f072d8f5a97"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_if_optional_append.json
+++ b/scripts/tests/fixtures/annals/expected_if_optional_append.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "if_optional_append#gospel#opt:base",
+      "source_file": "if_optional_append.cs",
+      "annal_class": "if_optional_append",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "Resheph married Rebekah.",
+      "extracted_pattern": "^Resheph\\ married\\ Rebekah\\.$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:c0fbaf7898f4024c5a5955bffecda6792a39ef1be52423bab147d089e7baea92"
+    },
+    {
+      "id": "if_optional_append#gospel#opt:with1",
+      "source_file": "if_optional_append.cs",
+      "annal_class": "if_optional_append",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "Resheph married Rebekah. They received a gift.",
+      "extracted_pattern": "^Resheph\\ married\\ Rebekah\\.\\ They\\ received\\ a\\ gift\\.$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:41b5a39a65097a6f9309f97d83bc599504463257f1c6bd250979122b1d4e4f63"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_latest_assignment_inside_block.json
+++ b/scripts/tests/fixtures/annals/expected_latest_assignment_inside_block.json
@@ -2,7 +2,7 @@
   "schema_version": "1",
   "candidates": [
     {
-      "id": "latest_assignment_inside_block#gospel",
+      "id": "latest_assignment_inside_block#gospel#if:else",
       "source_file": "latest_assignment_inside_block.cs",
       "annal_class": "latest_assignment_inside_block",
       "switch_case": "default",
@@ -16,6 +16,22 @@
       "review_notes": "",
       "route": "annals",
       "en_template_hash": "sha256:9d704dd815c313ad68422b0d346edc065f219e26211e8b8b851f394cc1b8fd33"
+    },
+    {
+      "id": "latest_assignment_inside_block#gospel#if:then",
+      "source_file": "latest_assignment_inside_block.cs",
+      "annal_class": "latest_assignment_inside_block",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "second",
+      "extracted_pattern": "^second$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:b445b0f2cdcb454472ae96ce0fa08703d74c7bdcbd6302dad3215b8549cd0b5d"
     }
   ]
 }

--- a/scripts/tests/fixtures/annals/expected_latest_assignment_inside_block.json
+++ b/scripts/tests/fixtures/annals/expected_latest_assignment_inside_block.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "latest_assignment_inside_block#gospel",
+      "source_file": "latest_assignment_inside_block.cs",
+      "annal_class": "latest_assignment_inside_block",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "alt",
+      "extracted_pattern": "^alt$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:9d704dd815c313ad68422b0d346edc065f219e26211e8b8b851f394cc1b8fd33"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_latest_assignment_wins.json
+++ b/scripts/tests/fixtures/annals/expected_latest_assignment_wins.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "latest_assignment_wins#gospel",
+      "source_file": "latest_assignment_wins.cs",
+      "annal_class": "latest_assignment_wins",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "second",
+      "extracted_pattern": "^second$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:b445b0f2cdcb454472ae96ce0fa08703d74c7bdcbd6302dad3215b8549cd0b5d"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_mixed_required_and_optional_append.json
+++ b/scripts/tests/fixtures/annals/expected_mixed_required_and_optional_append.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "mixed_required_and_optional_append#gospel#opt:base",
+      "source_file": "mixed_required_and_optional_append.cs",
+      "annal_class": "mixed_required_and_optional_append",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "base always",
+      "extracted_pattern": "^base\\ always$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:2140c6de0c7bac64f8de67c9408a51179eed89ec0be6814dea048df35992a308"
+    },
+    {
+      "id": "mixed_required_and_optional_append#gospel#opt:with1",
+      "source_file": "mixed_required_and_optional_append.cs",
+      "annal_class": "mixed_required_and_optional_append",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "base maybe always",
+      "extracted_pattern": "^base\\ maybe\\ always$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:117b8ae281abdc1e7de07e333ad9dee4964c47e91baf615927f1c80adaa289a5"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_needs_manual_collapse_preserves_reason.json
+++ b/scripts/tests/fixtures/annals/expected_needs_manual_collapse_preserves_reason.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "needs_manual_collapse_preserves_reason#gospel#if:else",
+      "source_file": "needs_manual_collapse_preserves_reason.cs",
+      "annal_class": "needs_manual_collapse_preserves_reason",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "",
+      "extracted_pattern": "",
+      "slots": [],
+      "status": "needs_manual",
+      "reason": "unsupported expression for PR1 AST subset: ElementAccessExpression 'new[] { \"x\" }[0]'",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:4af8b073c3946dbda6f29fa0b8cab26f5b11015ccdc56bafc8839c9b756bfac7"
+    },
+    {
+      "id": "needs_manual_collapse_preserves_reason#gospel#if:then",
+      "source_file": "needs_manual_collapse_preserves_reason.cs",
+      "annal_class": "needs_manual_collapse_preserves_reason",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "",
+      "extracted_pattern": "",
+      "slots": [],
+      "status": "needs_manual",
+      "reason": "unsupported expression for PR1 AST subset: ConditionalExpression 'true ? \"x\" : \"y\"'",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:4af8b073c3946dbda6f29fa0b8cab26f5b11015ccdc56bafc8839c9b756bfac7"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_partial_rollback.json
+++ b/scripts/tests/fixtures/annals/expected_partial_rollback.json
@@ -7,13 +7,13 @@
       "annal_class": "partial_rollback",
       "switch_case": "default",
       "event_property": "gospel",
-      "sample_source": "{0} world",
-      "extracted_pattern": "^(.+?)\\ world$",
+      "sample_source": "lit{0}rest world",
+      "extracted_pattern": "^lit(.+?)rest\\ world$",
       "slots": [
         {
           "index": 0,
-          "type": "unresolved-local",
-          "raw": "a",
+          "type": "format-arg",
+          "raw": "SomeClass.UnsupportedMethod()",
           "default": "{t0}"
         }
       ],
@@ -22,7 +22,7 @@
       "ja_template": "",
       "review_notes": "",
       "route": "annals",
-      "en_template_hash": "sha256:15308c4902af61d7a4e8ac5dccb5ad9d311f3ae8664436bd2d73d3e0ca53d0c2"
+      "en_template_hash": "sha256:9a2a880b99b2a5bc5cf485871ec94e316079596db040ed480033daf124e9070c"
     }
   ]
 }

--- a/scripts/tests/fixtures/annals/expected_simple_concat.json
+++ b/scripts/tests/fixtures/annals/expected_simple_concat.json
@@ -7,15 +7,22 @@
       "annal_class": "simple_concat",
       "switch_case": "default",
       "event_property": "gospel",
-      "sample_source": "<spice.commonPhrases.oneStarryNight.!random.capitalize>, a sultan was born in the salt marsh.",
-      "extracted_pattern": "^<spice\\.commonPhrases\\.oneStarryNight\\.!random\\.capitalize>,\\ a\\ sultan\\ was\\ born\\ in\\ the\\ salt\\ marsh\\.$",
-      "slots": [],
+      "sample_source": "{0}, a sultan was born in the salt marsh.",
+      "extracted_pattern": "^(.+?),\\ a\\ sultan\\ was\\ born\\ in\\ the\\ salt\\ marsh\\.$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "historykit-token",
+          "raw": "<spice.commonPhrases.oneStarryNight.!random.capitalize>",
+          "default": "{t0}"
+        }
+      ],
       "status": "pending",
       "reason": "",
       "ja_template": "",
       "review_notes": "",
       "route": "annals",
-      "en_template_hash": "sha256:ec84bfa3e97fb2e16498ce51c1b44e7de8f71664d9a8b4370cbc1db0aac64f86"
+      "en_template_hash": "sha256:c32f4b55791af68e16b3d7e076a5071fc111f27a4deab0b84bd105555a11d232"
     }
   ]
 }

--- a/scripts/tests/fixtures/annals/expected_string_format.json
+++ b/scripts/tests/fixtures/annals/expected_string_format.json
@@ -7,15 +7,15 @@
       "annal_class": "string_format",
       "switch_case": "default",
       "event_property": "tombInscription",
-      "sample_source": "",
-      "extracted_pattern": "",
+      "sample_source": "In the year, Resheph vanquished an enemy.",
+      "extracted_pattern": "^In\\ the\\ year,\\ Resheph\\ vanquished\\ an\\ enemy\\.$",
       "slots": [],
-      "status": "needs_manual",
-      "reason": "string.Format(...) extraction is out of scope for PR1 (deferred to #422)",
+      "status": "pending",
+      "reason": "",
       "ja_template": "",
       "review_notes": "",
       "route": "annals",
-      "en_template_hash": "sha256:f163bd2cf1e8b7b059f545e317a003b6fea6306504901f13aac5c913a175ed18"
+      "en_template_hash": "sha256:046f78c0c39a9c3cf61517dc164dbc63e58b8d50be2b256325076fc36fdfc1c7"
     }
   ]
 }

--- a/scripts/tests/fixtures/annals/expected_string_format_local.json
+++ b/scripts/tests/fixtures/annals/expected_string_format_local.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "string_format_local#gospel",
+      "source_file": "string_format_local.cs",
+      "annal_class": "string_format_local",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "In the salt marsh, a healthy child was born at Joppa.",
+      "extracted_pattern": "^In\\ the\\ salt\\ marsh,\\ a\\ healthy\\ child\\ was\\ born\\ at\\ Joppa\\.$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:75b1df3e8d0c6974b0bb3b2878f4dacd0a86df72b5b459b5eb17a8aea23c3f3c"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_string_format_via_local_fmt.json
+++ b/scripts/tests/fixtures/annals/expected_string_format_via_local_fmt.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "string_format_via_local_fmt#gospel",
+      "source_file": "string_format_via_local_fmt.cs",
+      "annal_class": "string_format_via_local_fmt",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "Alice struck Bob.",
+      "extracted_pattern": "^Alice\\ struck\\ Bob\\.$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:1beaf842bafeb12146c98e2047477336e2cfb76310faa83eddf65ae945d21ccf"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_string_format_with_helpers.json
+++ b/scripts/tests/fixtures/annals/expected_string_format_with_helpers.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "string_format_with_helpers#gospel",
+      "source_file": "string_format_with_helpers.cs",
+      "annal_class": "string_format_with_helpers",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "Resheph cemented {0} friendship with {1} by marrying {2}.",
+      "extracted_pattern": "^Resheph\\ cemented\\ (.+?)\\ friendship\\ with\\ (.+?)\\ by\\ marrying\\ (.+?)\\.$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "helper-call",
+          "raw": "Grammar.PossessivePronoun(\"he\")",
+          "default": "{t0}"
+        },
+        {
+          "index": 1,
+          "type": "helper-call",
+          "raw": "Faction.GetFormattedName(\"highly entropic beings\")",
+          "default": "{t1}"
+        },
+        {
+          "index": 2,
+          "type": "helper-call",
+          "raw": "NameMaker.MakeName(null, null, null, null, \"Qudish\")",
+          "default": "{t2}"
+        }
+      ],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:8fe9379242f37e12e83df8d5e41b2f3a1d97fe6579d920692dc2c00c9f6265f2"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_switch_branch_candidates.json
+++ b/scripts/tests/fixtures/annals/expected_switch_branch_candidates.json
@@ -2,9 +2,9 @@
   "schema_version": "1",
   "candidates": [
     {
-      "id": "switch_cases#gospel#case:0",
-      "source_file": "switch_cases.cs",
-      "annal_class": "switch_cases",
+      "id": "switch_branch_candidates#gospel#case:0",
+      "source_file": "switch_branch_candidates.cs",
+      "annal_class": "switch_branch_candidates",
       "switch_case": "0",
       "event_property": "gospel",
       "sample_source": "case zero gospel.",
@@ -18,9 +18,9 @@
       "en_template_hash": "sha256:4462bd69db58726a1731f053a8479943dbbc1cccb74aec68978f192d98cd5cc5"
     },
     {
-      "id": "switch_cases#gospel#case:1",
-      "source_file": "switch_cases.cs",
-      "annal_class": "switch_cases",
+      "id": "switch_branch_candidates#gospel#case:1",
+      "source_file": "switch_branch_candidates.cs",
+      "annal_class": "switch_branch_candidates",
       "switch_case": "1",
       "event_property": "gospel",
       "sample_source": "case one gospel.",
@@ -34,9 +34,9 @@
       "en_template_hash": "sha256:0e3610d9e7d85a17f459ba03b48183ceb2f2ba36afaaedcabb1143c623a0c093"
     },
     {
-      "id": "switch_cases#gospel#case:default",
-      "source_file": "switch_cases.cs",
-      "annal_class": "switch_cases",
+      "id": "switch_branch_candidates#gospel#case:default",
+      "source_file": "switch_branch_candidates.cs",
+      "annal_class": "switch_branch_candidates",
       "switch_case": "default",
       "event_property": "gospel",
       "sample_source": "default gospel.",

--- a/scripts/tests/fixtures/annals/expected_switch_expression_local.json
+++ b/scripts/tests/fixtures/annals/expected_switch_expression_local.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "switch_expression_local#gospel#arm:0",
+      "source_file": "switch_expression_local.cs",
+      "annal_class": "switch_expression_local",
+      "switch_case": "0",
+      "event_property": "gospel",
+      "sample_source": "deep in the marsh, Resheph discovered Joppa.",
+      "extracted_pattern": "^deep\\ in\\ the\\ marsh,\\ Resheph\\ discovered\\ Joppa\\.$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:b162bff05d18f4b530497e19df21e7f13c0a73d1cc273bc2e71ab4a53457eb24"
+    },
+    {
+      "id": "switch_expression_local#gospel#arm:1",
+      "source_file": "switch_expression_local.cs",
+      "annal_class": "switch_expression_local",
+      "switch_case": "1",
+      "event_property": "gospel",
+      "sample_source": "while wandering, Resheph discovered Joppa.",
+      "extracted_pattern": "^while\\ wandering,\\ Resheph\\ discovered\\ Joppa\\.$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:a01e5b4d93dffa726878342ab27d0c07149974f78a653cbad8eacec7cb46f4d5"
+    },
+    {
+      "id": "switch_expression_local#gospel#arm:_",
+      "source_file": "switch_expression_local.cs",
+      "annal_class": "switch_expression_local",
+      "switch_case": "_",
+      "event_property": "gospel",
+      "sample_source": "deep in the wilds, Resheph discovered Joppa.",
+      "extracted_pattern": "^deep\\ in\\ the\\ wilds,\\ Resheph\\ discovered\\ Joppa\\.$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:d8e3daf585e78c7c10c8e248a1d2db796e3e91f1d594af9cf22ce3b28a5333d3"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_unconditional_append_no_fanout.json
+++ b/scripts/tests/fixtures/annals/expected_unconditional_append_no_fanout.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "unconditional_append_no_fanout#gospel",
+      "source_file": "unconditional_append_no_fanout.cs",
+      "annal_class": "unconditional_append_no_fanout",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "Hello",
+      "extracted_pattern": "^Hello$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:d1113a4e6ceb378b6dd09c48172cc6098ee1838a78a7fd0fb92f3105cdce52d1"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_unconditional_append_no_fanout.json
+++ b/scripts/tests/fixtures/annals/expected_unconditional_append_no_fanout.json
@@ -7,15 +7,15 @@
       "annal_class": "unconditional_append_no_fanout",
       "switch_case": "default",
       "event_property": "gospel",
-      "sample_source": "Hello",
-      "extracted_pattern": "^Hello$",
+      "sample_source": "Hello, world.",
+      "extracted_pattern": "^Hello,\\ world\\.$",
       "slots": [],
       "status": "pending",
       "reason": "",
       "ja_template": "",
       "review_notes": "",
       "route": "annals",
-      "en_template_hash": "sha256:d1113a4e6ceb378b6dd09c48172cc6098ee1838a78a7fd0fb92f3105cdce52d1"
+      "en_template_hash": "sha256:6b23d8e11800ba9d0cf4662709fc264c271cf1a6a1e6ae9237b2e85c43144cca"
     }
   ]
 }

--- a/scripts/tests/fixtures/annals/expected_unresolved_variable.json
+++ b/scripts/tests/fixtures/annals/expected_unresolved_variable.json
@@ -12,8 +12,8 @@
       "slots": [
         {
           "index": 0,
-          "type": "unresolved-local",
-          "raw": "mystery",
+          "type": "format-arg",
+          "raw": "SomeHelper.Compute()",
           "default": "{t0}"
         }
       ],
@@ -22,7 +22,7 @@
       "ja_template": "",
       "review_notes": "",
       "route": "annals",
-      "en_template_hash": "sha256:e732b3a280b10565a34fee9cba3c58a0ffa7266325af3d6d2848561b39016fd0"
+      "en_template_hash": "sha256:73b725f3ef1306874eaabccf55b20d26358f9000cc6340ceb3fa0fe12373b2fa"
     }
   ]
 }

--- a/scripts/tests/fixtures/annals/historykit_token_repeated_local.cs
+++ b/scripts/tests/fixtures/annals/historykit_token_repeated_local.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class HistorykitTokenRepeatedLocalFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string prefix = "<entity.";
+        string composed = prefix + "name>" + prefix + "type>";
+        SetEventProperty("gospel", ExpandString(composed));
+    }
+}

--- a/scripts/tests/fixtures/annals/historykit_token_via_local.cs
+++ b/scripts/tests/fixtures/annals/historykit_token_via_local.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class HistorykitTokenViaLocalFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string tok = "<entity.name>";
+        SetEventProperty("gospel", ExpandString(tok));
+    }
+}

--- a/scripts/tests/fixtures/annals/historykit_tokens.cs
+++ b/scripts/tests/fixtures/annals/historykit_tokens.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class HistoryKitTokensFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        SetEventProperty("gospel", "<$chosenSpice=spice.elements.entity$elements[random]><entity.name> was adopted by <$chosenSpice.professions.!random> who love <$chosenSpice.practices.!random>.");
+    }
+}

--- a/scripts/tests/fixtures/annals/if_dedupe_preserves_arm_suffix.cs
+++ b/scripts/tests/fixtures/annals/if_dedupe_preserves_arm_suffix.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class IfDedupePreservesArmSuffixFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        int num = Random(0, 1);
+        string text = num switch
+        {
+            0 => "alpha",
+            _ => "beta",
+        };
+        if (Random(0, 1) == 0)
+        {
+            SetEventProperty("gospel", "base " + text);
+        }
+        else
+        {
+            SetEventProperty("gospel", "base " + text);
+        }
+    }
+}

--- a/scripts/tests/fixtures/annals/if_optional_append.cs
+++ b/scripts/tests/fixtures/annals/if_optional_append.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class IfOptionalAppendFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string text = "Resheph married Rebekah.";
+        if (Random(0, 1) == 0)
+        {
+            text += " They received a gift.";
+        }
+        SetEventProperty("gospel", text);
+    }
+}

--- a/scripts/tests/fixtures/annals/latest_assignment_inside_block.cs
+++ b/scripts/tests/fixtures/annals/latest_assignment_inside_block.cs
@@ -2,6 +2,16 @@ using System;
 
 namespace XRL.Annals;
 
+// Regression test for the inner-loop reverse fix (CR R2 #1): given multiple
+// SimpleAssignments to the same local within a single sibling stmt, the
+// extractor must pick the source-LATEST assignment, not the first.
+//
+// The expected pattern resolves to "alt" — the source-last assignment among
+// the if/else descendants. Per-branch fanout (which would yield two
+// candidates "second" and "alt", one per branch) is intentionally NOT asserted
+// here: that architectural extension is out of scope for #430. None of the 5
+// PR2a target files exhibit this shape (setter outside if/else with branch-
+// distinct SimpleAssignments inside).
 [Serializable]
 public class LatestAssignmentInsideBlockFixture : HistoricEvent
 {

--- a/scripts/tests/fixtures/annals/latest_assignment_inside_block.cs
+++ b/scripts/tests/fixtures/annals/latest_assignment_inside_block.cs
@@ -2,16 +2,17 @@ using System;
 
 namespace XRL.Annals;
 
-// Regression test for the inner-loop reverse fix (CR R2 #1): given multiple
-// SimpleAssignments to the same local within a single sibling stmt, the
-// extractor must pick the source-LATEST assignment, not the first.
+// Regression test for the inner-loop reverse fix (CR R2 #1) AND the branch-
+// fanout extension (CR R3): given multiple SimpleAssignments to the same local
+// within a single sibling stmt, the extractor picks the source-LATEST per
+// branch, then emits ONE candidate per branch of the enclosing if/else.
 //
-// The expected pattern resolves to "alt" — the source-last assignment among
-// the if/else descendants. Per-branch fanout (which would yield two
-// candidates "second" and "alt", one per branch) is intentionally NOT asserted
-// here: that architectural extension is out of scope for #430. None of the 5
-// PR2a target files exhibit this shape (setter outside if/else with branch-
-// distinct SimpleAssignments inside).
+// Runtime values: "second" (then-branch, source-latest of `value="first"; value="second"`)
+// OR "alt" (else-branch). Both are reachable, so the extractor emits two
+// candidates (`#if:then` → `^second$`, `#if:else` → `^alt$`). None of the 5
+// PR2a target files exhibit this shape, but Resheph 16 byte-identicality is
+// preserved because no Resheph file has setter-outside-if with branch-distinct
+// SimpleAssignments either.
 [Serializable]
 public class LatestAssignmentInsideBlockFixture : HistoricEvent
 {

--- a/scripts/tests/fixtures/annals/latest_assignment_inside_block.cs
+++ b/scripts/tests/fixtures/annals/latest_assignment_inside_block.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class LatestAssignmentInsideBlockFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string value;
+        if (Random(0, 1) == 0)
+        {
+            value = "first";
+            value = "second";
+        }
+        else
+        {
+            value = "alt";
+        }
+        SetEventProperty("gospel", value);
+    }
+}

--- a/scripts/tests/fixtures/annals/latest_assignment_wins.cs
+++ b/scripts/tests/fixtures/annals/latest_assignment_wins.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class LatestAssignmentWinsFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string value;
+        value = "first";
+        value = "second";
+        SetEventProperty("gospel", value);
+    }
+}

--- a/scripts/tests/fixtures/annals/mixed_required_and_optional_append.cs
+++ b/scripts/tests/fixtures/annals/mixed_required_and_optional_append.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class MixedRequiredAndOptionalAppendFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string text = "base";
+        if (Random(0, 1) == 0)
+        {
+            text += " maybe";
+        }
+        text += " always";
+        SetEventProperty("gospel", text);
+    }
+}

--- a/scripts/tests/fixtures/annals/needs_manual_collapse_preserves_reason.cs
+++ b/scripts/tests/fixtures/annals/needs_manual_collapse_preserves_reason.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class NeedsManualCollapsePreservesReasonFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        if (Random(0, 1) == 0)
+        {
+            // ConditionalExpression — unsupported AST kind for PR1 subset.
+            SetEventProperty("gospel", true ? "x" : "y");
+        }
+        else
+        {
+            // ElementAccessExpression — unsupported AST kind for PR1 subset.
+            SetEventProperty("gospel", new[] { "x" }[0]);
+        }
+    }
+}

--- a/scripts/tests/fixtures/annals/string_format_local.cs
+++ b/scripts/tests/fixtures/annals/string_format_local.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class StringFormatLocalFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string region = "the salt marsh";
+        string location = "Joppa";
+        string value = string.Format("In {0}, a healthy child was born at {1}.", region, location);
+        SetEventProperty("gospel", value);
+    }
+}

--- a/scripts/tests/fixtures/annals/string_format_via_local_fmt.cs
+++ b/scripts/tests/fixtures/annals/string_format_via_local_fmt.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class StringFormatViaLocalFmtFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string fmt = "{0} struck {1}.";
+        string a = "Alice";
+        string b = "Bob";
+        SetEventProperty("gospel", string.Format(fmt, a, b));
+    }
+}

--- a/scripts/tests/fixtures/annals/string_format_with_helpers.cs
+++ b/scripts/tests/fixtures/annals/string_format_with_helpers.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class StringFormatWithHelpersFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string value = string.Format(
+            "{0} cemented {1} friendship with {2} by marrying {3}.",
+            "Resheph",
+            Grammar.PossessivePronoun("he"),
+            Faction.GetFormattedName("highly entropic beings"),
+            NameMaker.MakeName(null, null, null, null, "Qudish"));
+        SetEventProperty("gospel", Grammar.InitCap(value));
+    }
+}

--- a/scripts/tests/fixtures/annals/switch_branch_candidates.cs
+++ b/scripts/tests/fixtures/annals/switch_branch_candidates.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class SwitchBranchCandidatesFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        switch (Random(0, 2))
+        {
+            case 0:
+                SetEventProperty("gospel", "case zero gospel.");
+                break;
+            case 1:
+                SetEventProperty("gospel", "case one gospel.");
+                break;
+            default:
+                SetEventProperty("gospel", "default gospel.");
+                break;
+        }
+    }
+}

--- a/scripts/tests/fixtures/annals/switch_expression_local.cs
+++ b/scripts/tests/fixtures/annals/switch_expression_local.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class SwitchExpressionLocalFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        int num = Random(0, 2);
+        string prefix = num switch
+        {
+            0 => "deep in the marsh, ",
+            1 => "while wandering, ",
+            _ => "deep in the wilds, ",
+        };
+        SetEventProperty("gospel", prefix + "Resheph discovered Joppa.");
+    }
+}

--- a/scripts/tests/fixtures/annals/unconditional_append_no_fanout.cs
+++ b/scripts/tests/fixtures/annals/unconditional_append_no_fanout.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class UnconditionalAppendNoFanoutFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        string text = "Hello";
+        text += ", world.";
+        SetEventProperty("gospel", text);
+    }
+}

--- a/scripts/tests/test_extract_annals_patterns.py
+++ b/scripts/tests/test_extract_annals_patterns.py
@@ -51,6 +51,7 @@ _FIXTURES = [
     "string_format_with_helpers",
     "switch_branch_candidates",
     "switch_expression_local",
+    "if_optional_append",
 ]
 
 

--- a/scripts/tests/test_extract_annals_patterns.py
+++ b/scripts/tests/test_extract_annals_patterns.py
@@ -41,13 +41,18 @@ def _discover_fixtures() -> list[str]:
     """Discover fixture names from `expected_*.json` files paired with a sibling `.cs` file.
 
     Auto-discovery prevents the parametrize list from rotting when new fixtures are added.
-    Sorted to keep test-run order deterministic.
+    Sorted to keep test-run order deterministic. Fails loud at import time if the fixture
+    directory is empty — pytest 8.x silently `skip`s an empty `parametrize` list, which
+    would let CI go green even with no extractor coverage.
     """
     fixtures: list[str] = []
     for expected in FIXTURES.glob("expected_*.json"):
         name = expected.name.removeprefix("expected_").removesuffix(".json")
         if (FIXTURES / f"{name}.cs").exists():
             fixtures.append(name)
+    if not fixtures:
+        msg = f"no annals extractor fixtures discovered under {FIXTURES}"
+        raise RuntimeError(msg)
     return sorted(fixtures)
 
 

--- a/scripts/tests/test_extract_annals_patterns.py
+++ b/scripts/tests/test_extract_annals_patterns.py
@@ -55,6 +55,9 @@ _FIXTURES = [
     "duplicate_event_property_dedupe",
     "append_after_setter",
     "branch_assign_after_setter",
+    "latest_assignment_wins",
+    "string_format_via_local_fmt",
+    "if_dedupe_preserves_arm_suffix",
 ]
 
 

--- a/scripts/tests/test_extract_annals_patterns.py
+++ b/scripts/tests/test_extract_annals_patterns.py
@@ -37,29 +37,21 @@ def _run_extractor(include: str, output: Path) -> subprocess.CompletedProcess[st
     )
 
 
-_FIXTURES = [
-    "simple_concat",
-    "string_format",
-    "switch_cases",
-    "unresolved_variable",
-    "concat_initialized_local",
-    "cyclic_locals",
-    "partial_rollback",
-    "hse_marker_year",
-    "historykit_tokens",
-    "string_format_local",
-    "string_format_with_helpers",
-    "switch_branch_candidates",
-    "switch_expression_local",
-    "if_optional_append",
-    "duplicate_event_property_dedupe",
-    "append_after_setter",
-    "branch_assign_after_setter",
-    "latest_assignment_wins",
-    "latest_assignment_inside_block",
-    "string_format_via_local_fmt",
-    "if_dedupe_preserves_arm_suffix",
-]
+def _discover_fixtures() -> list[str]:
+    """Discover fixture names from `expected_*.json` files paired with a sibling `.cs` file.
+
+    Auto-discovery prevents the parametrize list from rotting when new fixtures are added.
+    Sorted to keep test-run order deterministic.
+    """
+    fixtures: list[str] = []
+    for expected in FIXTURES.glob("expected_*.json"):
+        name = expected.name.removeprefix("expected_").removesuffix(".json")
+        if (FIXTURES / f"{name}.cs").exists():
+            fixtures.append(name)
+    return sorted(fixtures)
+
+
+_FIXTURES = _discover_fixtures()
 
 
 @pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")

--- a/scripts/tests/test_extract_annals_patterns.py
+++ b/scripts/tests/test_extract_annals_patterns.py
@@ -48,6 +48,7 @@ _FIXTURES = [
     "hse_marker_year",
     "historykit_tokens",
     "string_format_local",
+    "string_format_with_helpers",
 ]
 
 

--- a/scripts/tests/test_extract_annals_patterns.py
+++ b/scripts/tests/test_extract_annals_patterns.py
@@ -44,16 +44,31 @@ def _discover_fixtures() -> list[str]:
     Sorted to keep test-run order deterministic. Fails loud at import time if the fixture
     directory is empty — pytest 8.x silently `skip`s an empty `parametrize` list, which
     would let CI go green even with no extractor coverage.
+
+    Also fails loud on orphans in either direction: every `expected_*.json` must have a
+    sibling `<name>.cs`, and every `<name>.cs` (excluding the canonical `expected_*.json`
+    pairing) must have a sibling `expected_<name>.json`. CR R8: silently dropping
+    orphans lets a fixture go untested or an expected golden go unbacked.
     """
-    fixtures: list[str] = []
-    for expected in FIXTURES.glob("expected_*.json"):
-        name = expected.name.removeprefix("expected_").removesuffix(".json")
-        if (FIXTURES / f"{name}.cs").exists():
-            fixtures.append(name)
+    expected_names = {p.name.removeprefix("expected_").removesuffix(".json") for p in FIXTURES.glob("expected_*.json")}
+    source_names = {p.stem for p in FIXTURES.glob("*.cs")}
+
+    missing_source = expected_names - source_names
+    missing_expected = source_names - expected_names
+    if missing_source or missing_expected:
+        details: list[str] = []
+        if missing_source:
+            details.append("expected_*.json without sibling .cs: " + ", ".join(sorted(missing_source)))
+        if missing_expected:
+            details.append(".cs without sibling expected_*.json: " + ", ".join(sorted(missing_expected)))
+        msg = f"orphaned annals extractor fixtures under {FIXTURES}: " + "; ".join(details)
+        raise RuntimeError(msg)
+
+    fixtures = sorted(expected_names & source_names)
     if not fixtures:
         msg = f"no annals extractor fixtures discovered under {FIXTURES}"
         raise RuntimeError(msg)
-    return sorted(fixtures)
+    return fixtures
 
 
 _FIXTURES = _discover_fixtures()

--- a/scripts/tests/test_extract_annals_patterns.py
+++ b/scripts/tests/test_extract_annals_patterns.py
@@ -52,6 +52,7 @@ _FIXTURES = [
     "switch_branch_candidates",
     "switch_expression_local",
     "if_optional_append",
+    "duplicate_event_property_dedupe",
 ]
 
 

--- a/scripts/tests/test_extract_annals_patterns.py
+++ b/scripts/tests/test_extract_annals_patterns.py
@@ -56,6 +56,7 @@ _FIXTURES = [
     "append_after_setter",
     "branch_assign_after_setter",
     "latest_assignment_wins",
+    "latest_assignment_inside_block",
     "string_format_via_local_fmt",
     "if_dedupe_preserves_arm_suffix",
 ]

--- a/scripts/tests/test_extract_annals_patterns.py
+++ b/scripts/tests/test_extract_annals_patterns.py
@@ -49,6 +49,7 @@ _FIXTURES = [
     "historykit_tokens",
     "string_format_local",
     "string_format_with_helpers",
+    "switch_branch_candidates",
 ]
 
 

--- a/scripts/tests/test_extract_annals_patterns.py
+++ b/scripts/tests/test_extract_annals_patterns.py
@@ -53,6 +53,8 @@ _FIXTURES = [
     "switch_expression_local",
     "if_optional_append",
     "duplicate_event_property_dedupe",
+    "append_after_setter",
+    "branch_assign_after_setter",
 ]
 
 

--- a/scripts/tests/test_extract_annals_patterns.py
+++ b/scripts/tests/test_extract_annals_patterns.py
@@ -50,6 +50,7 @@ _FIXTURES = [
     "string_format_local",
     "string_format_with_helpers",
     "switch_branch_candidates",
+    "switch_expression_local",
 ]
 
 

--- a/scripts/tests/test_extract_annals_patterns.py
+++ b/scripts/tests/test_extract_annals_patterns.py
@@ -47,6 +47,7 @@ _FIXTURES = [
     "partial_rollback",
     "hse_marker_year",
     "historykit_tokens",
+    "string_format_local",
 ]
 
 

--- a/scripts/tests/test_extract_annals_patterns.py
+++ b/scripts/tests/test_extract_annals_patterns.py
@@ -37,20 +37,21 @@ def _run_extractor(include: str, output: Path) -> subprocess.CompletedProcess[st
     )
 
 
+_FIXTURES = [
+    "simple_concat",
+    "string_format",
+    "switch_cases",
+    "unresolved_variable",
+    "concat_initialized_local",
+    "cyclic_locals",
+    "partial_rollback",
+    "hse_marker_year",
+    "historykit_tokens",
+]
+
+
 @pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
-@pytest.mark.parametrize(
-    "fixture",
-    [
-        "simple_concat",
-        "string_format",
-        "switch_cases",
-        "unresolved_variable",
-        "concat_initialized_local",
-        "cyclic_locals",
-        "partial_rollback",
-        "hse_marker_year",
-    ],
-)
+@pytest.mark.parametrize("fixture", _FIXTURES)
 def test_extractor_matches_golden(fixture: str, tmp_path: Path) -> None:
     """Extractor output for each fixture must match the committed golden JSON exactly."""
     output = tmp_path / f"{fixture}.json"
@@ -70,19 +71,7 @@ def test_extractor_matches_golden(fixture: str, tmp_path: Path) -> None:
     assert actual == expected, f"extractor output diverged from golden for {fixture}"
 
 
-@pytest.mark.parametrize(
-    "fixture",
-    [
-        "simple_concat",
-        "string_format",
-        "switch_cases",
-        "unresolved_variable",
-        "concat_initialized_local",
-        "cyclic_locals",
-        "partial_rollback",
-        "hse_marker_year",
-    ],
-)
+@pytest.mark.parametrize("fixture", _FIXTURES)
 def test_csharp_and_python_hashes_match(fixture: str) -> None:
     """The C# extractor and Python translator must compute the same en_template_hash."""
     import importlib.util  # noqa: PLC0415

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -347,6 +347,16 @@ internal sealed class Extractor
     /// `if (flag) local += suffix;` blocks and represent optional-append branches we want to fan
     /// out as additional candidates.
     /// </summary>
+    /// <remarks>
+    /// Only `+=` statements with an enclosing `IfStatementSyntax` are collected. A `+=` inside a
+    /// switch-case body but not inside an `if` is unconditional within that case's runtime path
+    /// (case selection itself is already modelled by the `#case:N` id suffix), so fanning out a
+    /// `#opt:base` variant that omits it would emit a candidate for a runtime state that never
+    /// occurs. Filtering them here means an unconditional `+=` becomes invisible to the resolved
+    /// local's value (BuildSetterScopedLocals only follows simple assignments), but trading
+    /// "false candidate" for "less-detailed candidate with a slot" is preferred — translation
+    /// review can fill the gap, while a phantom variant cannot be reasoned about post-hoc.
+    /// </remarks>
     private static IReadOnlyDictionary<string, List<ExpressionSyntax>> CollectCompoundAppends(MethodDeclarationSyntax method)
     {
         var dict = new Dictionary<string, List<ExpressionSyntax>>(StringComparer.Ordinal);
@@ -354,6 +364,11 @@ internal sealed class Extractor
         {
             if (!assignment.IsKind(SyntaxKind.AddAssignmentExpression)) continue;
             if (assignment.Left is not IdentifierNameSyntax lhs) continue;
+            // Skip unconditional appends — only `+=` wrapped in an `if` represents a fanout.
+            if (!assignment.Ancestors().OfType<IfStatementSyntax>().Any())
+            {
+                continue;
+            }
             var name = lhs.Identifier.ValueText;
             if (!dict.TryGetValue(name, out var list))
             {

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -403,19 +403,32 @@ internal sealed class Extractor
                     }
                 }
 
-                // Iterate descendants in reverse source order too, so multiple assignments to
-                // the same local *within a single sibling stmt* (e.g. `if (cond) { x="a"; x="b"; }`)
-                // also yield first-seen-wins = source-last-wins.
-                foreach (var assign in stmt.DescendantNodesAndSelf()
-                    .OfType<AssignmentExpressionSyntax>()
-                    .OrderByDescending(a => a.SpanStart))
+                // Iterate descendants in reverse source order so multiple assignments to the
+                // same local *within a single sibling stmt* (e.g. `if (cond) { x="a"; x="b"; }`)
+                // yield first-seen-wins = source-last-wins. CR R8: also consider
+                // VariableDeclaratorSyntax with non-null Initializer — a `string value = "base"`
+                // sibling holds the local's declared value as `Initializer.Value`, NOT as a
+                // SimpleAssignmentExpression, so without this an excluded-from-method-locals
+                // local (one reassigned later) would resolve to `unresolved-local` even when
+                // the declared initializer is the only pre-setter source. Both kinds are
+                // unified by SpanStart so source-latest still wins via `alreadyOverridden`.
+                var contributors = new List<(string Name, ExpressionSyntax Right, int SpanStart)>();
+                foreach (var assign in stmt.DescendantNodesAndSelf().OfType<AssignmentExpressionSyntax>())
                 {
                     if (!assign.IsKind(SyntaxKind.SimpleAssignmentExpression)) continue;
                     if (assign.Left is not IdentifierNameSyntax lhs) continue;
-                    var name = lhs.Identifier.ValueText;
+                    contributors.Add((lhs.Identifier.ValueText, assign.Right, assign.SpanStart));
+                }
+                foreach (var declarator in stmt.DescendantNodesAndSelf().OfType<VariableDeclaratorSyntax>())
+                {
+                    if (declarator.Initializer?.Value is not { } init) continue;
+                    contributors.Add((declarator.Identifier.ValueText, init, declarator.SpanStart));
+                }
+                foreach (var (name, right, _) in contributors.OrderByDescending(c => c.SpanStart))
+                {
                     if (alreadyOverridden.Contains(name)) continue;
                     if (methodLocals.ContainsKey(name)) continue;
-                    overrides[name] = assign.Right;
+                    overrides[name] = right;
                     alreadyOverridden.Add(name);
                 }
             }
@@ -606,6 +619,12 @@ internal sealed class Extractor
         // `DescendantNodes` yields nodes in document order, so the resulting per-local list is
         // already in source order — needed by `ExpandOptionalAppends` to interleave optional and
         // required appends correctly when synthesising the per-variant value chain.
+        // CR R8: optional vs required is currently approximated by IfStatement-ancestor
+        // presence. A reachability-based classification (does every path from method
+        // entry to setter pass through this `+=`?) would be more precise but requires
+        // control-flow analysis. None of the current PR1/PR2a targets exhibit the
+        // approximation's failure mode (`+=` in same branch as setter producing
+        // spurious `#opt:base`), so the precise fix is deferred to a follow-up.
         foreach (var assignment in method.DescendantNodes().OfType<AssignmentExpressionSyntax>())
         {
             if (!assignment.IsKind(SyntaxKind.AddAssignmentExpression)) continue;

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -388,6 +388,9 @@ internal sealed class Extractor
             case InvocationExpressionSyntax invoc when IsStringFormatCall(invoc):
                 return FlattenStringFormat(invoc, locals, pieces, slots, visited, out unsupportedReason);
 
+            case InvocationExpressionSyntax invoc when IsPatternPreservingWrapper(invoc):
+                return FlattenConcat(invoc.ArgumentList.Arguments[0].Expression, locals, pieces, slots, visited, out unsupportedReason);
+
             case InvocationExpressionSyntax invoc when IsEntityGetProperty(invoc):
                 AddSlot(slots, $"entity.GetProperty({GetFirstStringArg(invoc)})", type: "entity-property");
                 pieces.Add($"{{{slots.Count - 1}}}");
@@ -547,6 +550,26 @@ internal sealed class Extractor
     private static bool IsRandomCall(InvocationExpressionSyntax invoc)
     {
         if (invoc.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == "Random") return true;
+        return false;
+    }
+
+    // Wrappers whose return value matches their first argument modulo capitalization /
+    // HSE expansion — both invisible to a runtime regex match. Unwrapping lets us see
+    // the inner pattern (e.g. `Grammar.InitCap(string.Format(...))`).
+    private static bool IsPatternPreservingWrapper(InvocationExpressionSyntax invoc)
+    {
+        if (invoc.ArgumentList.Arguments.Count < 1) return false;
+        if (invoc.Expression is IdentifierNameSyntax bareId && bareId.Identifier.ValueText == "ExpandString") return true;
+        if (invoc.Expression is MemberAccessExpressionSyntax m)
+        {
+            var receiver = m.Expression.ToString();
+            var name = m.Name.Identifier.ValueText;
+            if (name == "ExpandString") return true;
+            if (receiver == "Grammar")
+            {
+                return name is "InitCap" or "InitialCap" or "MakeTitleCase" or "MakeTitleCaseWithArticle";
+            }
+        }
         return false;
     }
 

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -25,6 +25,14 @@ internal sealed class Extractor
 
     private static readonly char[] FormatAlignmentSeparators = { ',', ':' };
 
+    // Sentinels that survive ParsePieceIntoStream / BuildAnchoredRegex without colliding with the
+    // slot-ref braces (`{N}`) that the same passes use as control characters. FlattenStringFormat
+    // emits these in place of `{`/`}` produced by `{{`/`}}` escapes; the regex builder translates
+    // them to `\{`/`\}` and BuildCandidate restores them to literal braces in the human-facing
+    // sample_source. Using PUA codepoints keeps them unambiguous and well outside any source text.
+    private const char LiteralBraceOpenSentinel = '';
+    private const char LiteralBraceCloseSentinel = '';
+
     private readonly List<CandidateEntry> candidates = new();
     private readonly List<string> diagnostics = new();
 
@@ -825,13 +833,16 @@ internal sealed class Extractor
             var c = format[i];
             if (c == '{' && i + 1 < format.Length && format[i + 1] == '{')
             {
-                literalSb.Append('{');
+                // Use a sentinel so downstream passes that interpret `{N}` as a slot reference
+                // (ParsePieceIntoStream, BuildAnchoredRegex) cannot mistake an escaped literal
+                // brace for one. Translated back to `{` for sample_source / `\{` for the regex.
+                literalSb.Append(LiteralBraceOpenSentinel);
                 i += 2;
                 continue;
             }
             if (c == '}' && i + 1 < format.Length && format[i + 1] == '}')
             {
-                literalSb.Append('}');
+                literalSb.Append(LiteralBraceCloseSentinel);
                 i += 2;
                 continue;
             }
@@ -1083,8 +1094,15 @@ internal sealed class Extractor
         string eventProperty,
         ResolutionResult resolved)
     {
+        // BuildAnchoredRegex MUST run on the sentinel-bearing sample so it can distinguish
+        // literal-brace sentinels (→ `\{`/`\}`) from real slot-ref braces (→ `(.+?)`). Only
+        // after the regex is built do we restore the sentinels to literal `{`/`}` for the
+        // human-facing sample_source field.
         var sample = resolved.SampleSource;
         var pattern = BuildAnchoredRegex(sample, resolved.Slots);
+        var humanSample = sample
+            .Replace(LiteralBraceOpenSentinel, '{')
+            .Replace(LiteralBraceCloseSentinel, '}');
         var c = new CandidateEntry
         {
             Id = id,
@@ -1092,7 +1110,7 @@ internal sealed class Extractor
             AnnalClass = annalClass,
             SwitchCase = switchCase,
             EventProperty = eventProperty,
-            SampleSource = sample,
+            SampleSource = humanSample,
             ExtractedPattern = pattern,
             Slots = resolved.Slots,
             Status = "pending",
@@ -1128,6 +1146,21 @@ internal sealed class Extractor
                     }
                     continue;
                 }
+            }
+            // Translate literal-brace sentinels (planted by FlattenStringFormat for `{{`/`}}`)
+            // back to regex-escaped literal braces. Regex.Escape on the sentinel codepoint would
+            // emit the bare PUA char, which would silently fail to match the runtime `{`/`}`.
+            if (sample[i] == LiteralBraceOpenSentinel)
+            {
+                sb.Append(Regex.Escape("{"));
+                i++;
+                continue;
+            }
+            if (sample[i] == LiteralBraceCloseSentinel)
+            {
+                sb.Append(Regex.Escape("}"));
+                i++;
+                continue;
             }
             sb.Append(Regex.Escape(sample[i].ToString()));
             i++;

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -263,9 +263,15 @@ internal sealed class Extractor
                 _ => null,
             };
             if (statements is null) continue;
-            foreach (var stmt in statements)
+            // Walk pre-setter siblings in REVERSE source order so the most-recent assignment
+            // (closest to the setter) wins per local. With forward iteration the first-seen-wins
+            // logic of `alreadyOverridden` would lock the EARLIEST assignment, which is the
+            // opposite of the runtime semantic.
+            foreach (var stmt in statements.Reverse())
             {
-                if (stmt.SpanStart >= setter.SpanStart) break;
+                // `continue` (not `break`) for post-setter stmts: in reverse order they appear
+                // first, but earlier siblings still need to be visited.
+                if (stmt.SpanStart >= setter.SpanStart) continue;
                 // Skip stmts that *contain* the setter — they're an ancestor of the setter and
                 // are handled at deeper cursor levels. Their descendants include assignments
                 // that lexically follow the setter (e.g. inside the same if-branch), which must
@@ -800,12 +806,11 @@ internal sealed class Extractor
             return false;
         }
         var fmtExpr = args[0].Expression;
-        if (fmtExpr is not LiteralExpressionSyntax fmtLit || !fmtLit.IsKind(SyntaxKind.StringLiteralExpression))
+        if (!TryResolveStringLiteral(fmtExpr, locals, out var format))
         {
             unsupportedReason = $"string.Format format string is not a literal: {fmtExpr.Kind()}";
             return false;
         }
-        var format = fmtLit.Token.ValueText;
 
         // Walk the format string. Each `{N}` (with optional `,W` or `:fmt`) substitutes args[N+1].
         var i = 0;
@@ -954,6 +959,34 @@ internal sealed class Extractor
     {
         if (invoc.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == "Random") return true;
         return false;
+    }
+
+    // Follow IdentifierNameSyntax through the locals table until a string literal is found
+    // (or the chain breaks). Bounded by the locals dictionary size via a visited set so a
+    // malformed `a = b; b = a;` cycle terminates instead of recursing forever.
+    private static bool TryResolveStringLiteral(
+        ExpressionSyntax expr,
+        IReadOnlyDictionary<string, ExpressionSyntax> locals,
+        out string value)
+    {
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var current = expr;
+        while (true)
+        {
+            switch (current)
+            {
+                case LiteralExpressionSyntax lit when lit.IsKind(SyntaxKind.StringLiteralExpression):
+                    value = lit.Token.ValueText;
+                    return true;
+                case IdentifierNameSyntax id when visited.Add(id.Identifier.ValueText)
+                    && locals.TryGetValue(id.Identifier.ValueText, out var init):
+                    current = init;
+                    continue;
+                default:
+                    value = "";
+                    return false;
+            }
+        }
     }
 
     // True when the wrapper invocation is `ExpandString(...)` (free function or member).

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -37,6 +37,7 @@ internal sealed class Extractor
 
         // Build local-variable initializer table (expression-level resolution within Generate())
         var localInitializers = CollectResolvableLocals(generateMethod);
+        var appendsByLocal = CollectCompoundAppends(generateMethod);
 
         // Find SetEventProperty calls
         var setterCalls = generateMethod.DescendantNodes()
@@ -65,26 +66,31 @@ internal sealed class Extractor
                 var armSwitchCase = armLabel is null ? switchLabel : armLabel;
                 var armId = armLabel is null ? idPrefix : $"{idPrefix}#arm:{armLabel}";
 
-                var resolution = ResolveValueExpression(valueExpr, armLocals);
-                if (!resolution.Resolved)
+                var optExpansions = ExpandOptionalAppends(valueExpr, armLocals, appendsByLocal);
+                foreach (var (optLabel, optLocals) in optExpansions)
                 {
-                    candidates.Add(NeedsManual(
-                        id: armId,
+                    var optId = optLabel is null ? armId : $"{armId}#opt:{optLabel}";
+                    var resolution = ResolveValueExpression(valueExpr, optLocals);
+                    if (!resolution.Resolved)
+                    {
+                        candidates.Add(NeedsManual(
+                            id: optId,
+                            sourceFile: fileName,
+                            annalClass: className,
+                            switchCase: armSwitchCase,
+                            eventProperty: eventProperty,
+                            reason: resolution.Reason));
+                        continue;
+                    }
+
+                    candidates.Add(BuildCandidate(
+                        id: optId,
                         sourceFile: fileName,
                         annalClass: className,
                         switchCase: armSwitchCase,
                         eventProperty: eventProperty,
-                        reason: resolution.Reason));
-                    continue;
+                        resolved: resolution));
                 }
-
-                candidates.Add(BuildCandidate(
-                    id: armId,
-                    sourceFile: fileName,
-                    annalClass: className,
-                    switchCase: armSwitchCase,
-                    eventProperty: eventProperty,
-                    resolved: resolution));
             }
         }
     }
@@ -170,6 +176,107 @@ internal sealed class Extractor
             dict[name] = initValue;
         }
         return dict;
+    }
+
+    /// <summary>
+    /// Collect compound `+=` reassignments (`local += expr`) per local. These typically come from
+    /// `if (flag) local += suffix;` blocks and represent optional-append branches we want to fan
+    /// out as additional candidates.
+    /// </summary>
+    private static IReadOnlyDictionary<string, List<ExpressionSyntax>> CollectCompoundAppends(MethodDeclarationSyntax method)
+    {
+        var dict = new Dictionary<string, List<ExpressionSyntax>>(StringComparer.Ordinal);
+        foreach (var assignment in method.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        {
+            if (!assignment.IsKind(SyntaxKind.AddAssignmentExpression)) continue;
+            if (assignment.Left is not IdentifierNameSyntax lhs) continue;
+            var name = lhs.Identifier.ValueText;
+            if (!dict.TryGetValue(name, out var list))
+            {
+                list = new List<ExpressionSyntax>();
+                dict[name] = list;
+            }
+            list.Add(assignment.Right);
+        }
+        return dict;
+    }
+
+    /// <summary>
+    /// If the value expression depends on a local that has compound `+=` appends, fan out one
+    /// (label="base", initializer-only) entry plus one (label="withN", initializer + N-th append)
+    /// entry per append. Otherwise returns a single (label=null, original-locals) pair.
+    /// Only the first such local found is expanded; nested cross-products are not emitted (target
+    /// files have at most one optionally-appended local in the value-expression tree).
+    /// </summary>
+    private static List<(string? optLabel, IReadOnlyDictionary<string, ExpressionSyntax> locals)>
+        ExpandOptionalAppends(
+            ExpressionSyntax valueExpr,
+            IReadOnlyDictionary<string, ExpressionSyntax> locals,
+            IReadOnlyDictionary<string, List<ExpressionSyntax>> appendsByLocal)
+    {
+        var result = new List<(string?, IReadOnlyDictionary<string, ExpressionSyntax>)>();
+        if (appendsByLocal.Count == 0)
+        {
+            result.Add((null, locals));
+            return result;
+        }
+        var (appendLocalName, appends) = FindAppendableLocal(valueExpr, locals, appendsByLocal, new HashSet<string>(StringComparer.Ordinal));
+        if (appendLocalName is null || appends is null)
+        {
+            result.Add((null, locals));
+            return result;
+        }
+        if (!locals.TryGetValue(appendLocalName, out var baseInit))
+        {
+            result.Add((null, locals));
+            return result;
+        }
+
+        result.Add(("base", BuildAppendOverride(locals, appendLocalName, baseInit)));
+        for (var i = 0; i < appends.Count; i++)
+        {
+            var combined = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.BinaryExpression(
+                SyntaxKind.AddExpression, baseInit, appends[i]);
+            result.Add(($"with{i + 1}", BuildAppendOverride(locals, appendLocalName, combined)));
+        }
+        return result;
+    }
+
+    private static IReadOnlyDictionary<string, ExpressionSyntax> BuildAppendOverride(
+        IReadOnlyDictionary<string, ExpressionSyntax> locals,
+        string name,
+        ExpressionSyntax newInit)
+    {
+        var copy = new Dictionary<string, ExpressionSyntax>(locals, StringComparer.Ordinal)
+        {
+            [name] = newInit,
+        };
+        return copy;
+    }
+
+    private static (string? name, List<ExpressionSyntax>? appends) FindAppendableLocal(
+        ExpressionSyntax expr,
+        IReadOnlyDictionary<string, ExpressionSyntax> locals,
+        IReadOnlyDictionary<string, List<ExpressionSyntax>> appendsByLocal,
+        HashSet<string> visited)
+    {
+        foreach (var id in expr.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+        {
+            var name = id.Identifier.ValueText;
+            if (visited.Contains(name)) continue;
+            if (appendsByLocal.TryGetValue(name, out var appends) && appends.Count > 0
+                && locals.ContainsKey(name))
+            {
+                return (name, appends);
+            }
+            if (locals.TryGetValue(name, out var init))
+            {
+                visited.Add(name);
+                var nested = FindAppendableLocal(init, locals, appendsByLocal, visited);
+                if (nested.name is not null) return nested;
+            }
+        }
+        return (null, null);
     }
 
     /// <summary>

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -234,28 +234,62 @@ internal sealed class Extractor
     /// exists in this if (i.e., a `tombInscription` fallback like `If.Chance(80) tomb=long; else
     /// tomb=short;`), still suffix to keep the runtime variants distinct.
     /// </summary>
+    /// <remarks>
+    /// CR R8: For `else if` chains, the C# parser models `else if (...) { ... }` as the outer
+    /// if's `Else.Statement` being a NESTED `IfStatementSyntax`. `Ancestors().OfType&lt;
+    /// IfStatementSyntax&gt;().FirstOrDefault()` therefore returns the INNER if for setters in
+    /// the inner branch, and the OUTER if for setters in the outer-then branch — siblings in
+    /// the same chain stop matching, and no `#if:` suffix is emitted, leading to id collision
+    /// at dedupe time. We normalize the resolved if to the OUTERMOST `IfStatementSyntax` in the
+    /// chain (walking up `Parent.Parent` through `ElseClauseSyntax` → `IfStatementSyntax` links)
+    /// for both the sibling check and the then/else branch test.
+    ///
+    /// Limitation: 3+ branch chains (e.g. `if A else if B else C`) collapse the trailing `else`
+    /// into the outermost-if's else and would label B as `else` (because B lives in the
+    /// outer-else span) and C also as `else`, causing collision. PR1/PR2a target files do not
+    /// contain 3+ branch chains, so the normalize-to-outermost approach is sufficient for the
+    /// current scope; a richer per-arm labelling is deferred.
+    /// </remarks>
     private static string? ResolveIfBranchSuffix(
         InvocationExpressionSyntax setter,
         List<InvocationExpressionSyntax> allSetters,
         string eventProperty)
     {
-        var ifStmt = setter.Ancestors().OfType<IfStatementSyntax>().FirstOrDefault();
-        if (ifStmt is null) return null;
+        var nearestIf = setter.Ancestors().OfType<IfStatementSyntax>().FirstOrDefault();
+        if (nearestIf is null) return null;
+        var ifStmt = NormalizeToChainRoot(nearestIf);
         // Only suffix when at least one other setter for this same event property exists in a
-        // distinct branch of the *same* if statement.
+        // distinct branch of the *same* if-chain (using the chain root for both sides).
         var siblingsInSameIf = allSetters.Where(other =>
         {
             if (other == setter) return false;
             if (ParseSetterArgs(other).property != eventProperty) return false;
-            var otherIf = other.Ancestors().OfType<IfStatementSyntax>().FirstOrDefault();
-            return otherIf == ifStmt;
+            var otherNearest = other.Ancestors().OfType<IfStatementSyntax>().FirstOrDefault();
+            if (otherNearest is null) return false;
+            return NormalizeToChainRoot(otherNearest) == ifStmt;
         }).ToList();
         if (siblingsInSameIf.Count == 0) return null;
 
-        // Determine which branch this setter lives in.
+        // Determine which branch this setter lives in (relative to the chain root).
         if (IsInThenBranch(setter, ifStmt)) return "then";
         if (IsInElseBranch(setter, ifStmt)) return "else";
         return null;
+    }
+
+    /// <summary>
+    /// Walk up an else-if chain to the OUTERMOST `IfStatementSyntax`. C# models `else if` as
+    /// `IfStatementSyntax.Else.Statement` being a nested `IfStatementSyntax`; this method
+    /// follows the `Parent`/`Parent.Parent` chain until it reaches the chain root.
+    /// </summary>
+    private static IfStatementSyntax NormalizeToChainRoot(IfStatementSyntax ifStmt)
+    {
+        var current = ifStmt;
+        while (current.Parent is ElseClauseSyntax elseClause
+            && elseClause.Parent is IfStatementSyntax outer)
+        {
+            current = outer;
+        }
+        return current;
     }
 
     private static bool IsInThenBranch(SyntaxNode node, IfStatementSyntax ifStmt)

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -59,14 +59,17 @@ internal sealed class Extractor
             var idPrefix = switchSection is null
                 ? $"{className}#{eventProperty}"
                 : $"{className}#{eventProperty}#case:{switchLabel}";
+            var ifBranchSuffix = ResolveIfBranchSuffix(invocation, setterCalls, eventProperty);
+            if (ifBranchSuffix is not null) idPrefix += $"#if:{ifBranchSuffix}";
 
-            var armings = ExpandSwitchExpressionArms(valueExpr, localInitializers);
+            var setterLocals = BuildSetterScopedLocals(invocation, localInitializers);
+            var armings = ExpandSwitchExpressionArms(valueExpr, setterLocals);
             foreach (var (armLabel, armLocals) in armings)
             {
                 var armSwitchCase = armLabel is null ? switchLabel : armLabel;
                 var armId = armLabel is null ? idPrefix : $"{idPrefix}#arm:{armLabel}";
 
-                var optExpansions = ExpandOptionalAppends(valueExpr, armLocals, appendsByLocal);
+                var optExpansions = ExpandOptionalAppends(valueExpr, armLocals, FilterAppendsToLocals(armLocals, appendsByLocal));
                 foreach (var (optLabel, optLocals) in optExpansions)
                 {
                     var optId = optLabel is null ? armId : $"{armId}#opt:{optLabel}";
@@ -174,6 +177,104 @@ internal sealed class Extractor
             var initValue = declarators[0].Initializer?.Value;
             if (initValue is null) continue;
             dict[name] = initValue;
+        }
+        return dict;
+    }
+
+    /// <summary>
+    /// When two SetEventProperty calls for the same event property appear in distinct branches of
+    /// the same `if/else` statement, return a `then`/`else`/`elseN` suffix so the extractor can
+    /// emit one candidate per branch (each with its own shape). If only one setter for the event
+    /// exists in this if (i.e., a `tombInscription` fallback like `If.Chance(80) tomb=long; else
+    /// tomb=short;`), still suffix to keep the runtime variants distinct.
+    /// </summary>
+    private static string? ResolveIfBranchSuffix(
+        InvocationExpressionSyntax setter,
+        List<InvocationExpressionSyntax> allSetters,
+        string eventProperty)
+    {
+        var ifStmt = setter.Ancestors().OfType<IfStatementSyntax>().FirstOrDefault();
+        if (ifStmt is null) return null;
+        // Only suffix when at least one other setter for this same event property exists in a
+        // distinct branch of the *same* if statement.
+        var siblingsInSameIf = allSetters.Where(other =>
+        {
+            if (other == setter) return false;
+            if (ParseSetterArgs(other).property != eventProperty) return false;
+            var otherIf = other.Ancestors().OfType<IfStatementSyntax>().FirstOrDefault();
+            return otherIf == ifStmt;
+        }).ToList();
+        if (siblingsInSameIf.Count == 0) return null;
+
+        // Determine which branch this setter lives in.
+        if (IsInThenBranch(setter, ifStmt)) return "then";
+        if (IsInElseBranch(setter, ifStmt)) return "else";
+        return null;
+    }
+
+    private static bool IsInThenBranch(SyntaxNode node, IfStatementSyntax ifStmt)
+    {
+        return ifStmt.Statement.Span.Contains(node.Span);
+    }
+
+    private static bool IsInElseBranch(SyntaxNode node, IfStatementSyntax ifStmt)
+    {
+        return ifStmt.Else is not null && ifStmt.Else.Statement.Span.Contains(node.Span);
+    }
+
+    /// <summary>
+    /// Add per-setter overrides for locals that were excluded from method-scope locals because of
+    /// SimpleAssignmentExpression reassignment, when a flow-sensitive lookup at the setter's
+    /// location identifies a single dominating assignment (the most recent assignment within the
+    /// nearest enclosing block, e.g. a switch case body or an if branch). This recovers `value`
+    /// in patterns like `string value; if (cond) { value = ...; SetEventProperty(_, value); }`.
+    /// </summary>
+    private static IReadOnlyDictionary<string, ExpressionSyntax> BuildSetterScopedLocals(
+        InvocationExpressionSyntax setter,
+        IReadOnlyDictionary<string, ExpressionSyntax> methodLocals)
+    {
+        var overrides = new Dictionary<string, ExpressionSyntax>(methodLocals, StringComparer.Ordinal);
+        var alreadyOverridden = new HashSet<string>(StringComparer.Ordinal);
+        // Walk enclosing statement-containers (BlockSyntax or SwitchSectionSyntax) from innermost
+        // to outermost; within each container, scan preceding sibling statements for simple
+        // assignments to names that aren't already in the method-scope locals table.
+        SyntaxNode? cursor = setter;
+        while (cursor?.Parent is not null)
+        {
+            cursor = cursor.Parent;
+            IEnumerable<StatementSyntax>? statements = cursor switch
+            {
+                BlockSyntax b => b.Statements,
+                SwitchSectionSyntax s => s.Statements,
+                _ => null,
+            };
+            if (statements is null) continue;
+            foreach (var stmt in statements)
+            {
+                if (stmt.SpanStart >= setter.SpanStart) break;
+                foreach (var assign in stmt.DescendantNodesAndSelf().OfType<AssignmentExpressionSyntax>())
+                {
+                    if (!assign.IsKind(SyntaxKind.SimpleAssignmentExpression)) continue;
+                    if (assign.Left is not IdentifierNameSyntax lhs) continue;
+                    var name = lhs.Identifier.ValueText;
+                    if (alreadyOverridden.Contains(name)) continue;
+                    if (methodLocals.ContainsKey(name)) continue;
+                    overrides[name] = assign.Right;
+                    alreadyOverridden.Add(name);
+                }
+            }
+        }
+        return overrides;
+    }
+
+    private static IReadOnlyDictionary<string, List<ExpressionSyntax>> FilterAppendsToLocals(
+        IReadOnlyDictionary<string, ExpressionSyntax> activeLocals,
+        IReadOnlyDictionary<string, List<ExpressionSyntax>> appendsByLocal)
+    {
+        var dict = new Dictionary<string, List<ExpressionSyntax>>(StringComparer.Ordinal);
+        foreach (var (name, appends) in appendsByLocal)
+        {
+            if (activeLocals.ContainsKey(name)) dict[name] = appends;
         }
         return dict;
     }
@@ -381,65 +482,131 @@ internal sealed class Extractor
 
     private static void ApplyHistoryKitTokenLexer(List<string> pieces, List<SlotEntry> slots)
     {
-        // Renumbering is required because we splice new slots into the middle of the slot list.
-        // Strategy: rebuild pieces+slots from scratch, scanning every existing piece. Existing
-        // slot references (e.g. `{0}` already produced by FlattenConcat) are remapped to the new
-        // index space.
+        // Strategy: scan the joined character stream, treating each existing slot reference
+        // (`{N}`) as a single atomic "metachar" so cross-piece HistoryKit tokens
+        // (e.g. `<spice.elements.{0}.babeTrait.!random>` formed by `"<...." + local + "....>"`
+        // get collapsed into a single `historykit-token` slot.
         var oldSlots = new List<SlotEntry>(slots);
-        var oldPieces = new List<string>(pieces);
+        var streamItems = new List<StreamItem>();
+        foreach (var piece in pieces)
+        {
+            ParsePieceIntoStream(piece, oldSlots, streamItems);
+        }
+
         slots.Clear();
         pieces.Clear();
 
-        foreach (var piece in oldPieces)
+        // Two-pass: scan streamItems for `<...>` runs; emit slots/pieces per run.
+        var i = 0;
+        var sb = new StringBuilder();
+        while (i < streamItems.Count)
         {
-            if (piece.Length >= 3 && piece[0] == '{' && piece[^1] == '}'
-                && int.TryParse(piece.AsSpan(1, piece.Length - 2), System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var oldIndex)
-                && (uint)oldIndex < (uint)oldSlots.Count)
+            var item = streamItems[i];
+            if (item.Kind == StreamItemKind.Literal && item.Char == '<')
             {
-                var slot = oldSlots[oldIndex];
-                slot.Index = slots.Count;
-                slot.Default = $"{{t{slots.Count}}}";
-                slots.Add(slot);
-                pieces.Add($"{{{slot.Index}}}");
-                continue;
-            }
-
-            // Literal piece: scan for `<...>` tokens.
-            var i = 0;
-            var sb = new StringBuilder();
-            while (i < piece.Length)
-            {
-                if (piece[i] != '<')
+                // Find matching '>' in subsequent items
+                var close = -1;
+                for (var j = i + 1; j < streamItems.Count; j++)
                 {
-                    sb.Append(piece[i]);
-                    i++;
-                    continue;
+                    if (streamItems[j].Kind == StreamItemKind.Literal && streamItems[j].Char == '>')
+                    {
+                        close = j;
+                        break;
+                    }
                 }
-                var close = piece.IndexOf('>', i + 1);
-                if (close < 0)
+                if (close >= 0)
                 {
-                    sb.Append(piece[i]);
-                    i++;
-                    continue;
-                }
-                var token = piece.Substring(i, close - i + 1);
-                if (IsHistoryKitAssignmentToken(token))
-                {
-                    // Zero-width: assignment-form tokens (`<$var=...>`) emit "" at runtime.
+                    if (sb.Length > 0)
+                    {
+                        pieces.Add(sb.ToString());
+                        sb.Clear();
+                    }
+                    var (rawSpan, isAssignment) = BuildTokenRaw(streamItems, i, close, oldSlots);
+                    if (!isAssignment)
+                    {
+                        AddSlot(slots, rawSpan, type: HistoryKitTokenType);
+                        pieces.Add($"{{{slots.Count - 1}}}");
+                    }
                     i = close + 1;
                     continue;
                 }
+            }
+            if (item.Kind == StreamItemKind.SlotRef)
+            {
                 if (sb.Length > 0)
                 {
                     pieces.Add(sb.ToString());
                     sb.Clear();
                 }
-                AddSlot(slots, token, type: HistoryKitTokenType);
-                pieces.Add($"{{{slots.Count - 1}}}");
-                i = close + 1;
+                var slot = oldSlots[item.SlotIndex];
+                slot.Index = slots.Count;
+                slot.Default = $"{{t{slots.Count}}}";
+                slots.Add(slot);
+                pieces.Add($"{{{slot.Index}}}");
+                i++;
+                continue;
             }
-            if (sb.Length > 0) pieces.Add(sb.ToString());
+            sb.Append(item.Char);
+            i++;
         }
+        if (sb.Length > 0) pieces.Add(sb.ToString());
+    }
+
+    private enum StreamItemKind { Literal, SlotRef }
+
+    private readonly struct StreamItem
+    {
+        public StreamItemKind Kind { get; init; }
+        public char Char { get; init; }
+        public int SlotIndex { get; init; }
+    }
+
+    private static void ParsePieceIntoStream(string piece, List<SlotEntry> slots, List<StreamItem> items)
+    {
+        var i = 0;
+        while (i < piece.Length)
+        {
+            if (piece[i] == '{')
+            {
+                var close = piece.IndexOf('}', i);
+                if (close > i
+                    && int.TryParse(piece.AsSpan(i + 1, close - i - 1), System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var idx)
+                    && (uint)idx < (uint)slots.Count)
+                {
+                    items.Add(new StreamItem { Kind = StreamItemKind.SlotRef, SlotIndex = idx });
+                    i = close + 1;
+                    continue;
+                }
+            }
+            items.Add(new StreamItem { Kind = StreamItemKind.Literal, Char = piece[i] });
+            i++;
+        }
+    }
+
+    private static (string raw, bool isAssignment) BuildTokenRaw(
+        List<StreamItem> stream,
+        int openIdx,
+        int closeIdx,
+        List<SlotEntry> oldSlots)
+    {
+        var sb = new StringBuilder();
+        var hasEquals = false;
+        for (var k = openIdx; k <= closeIdx; k++)
+        {
+            var item = stream[k];
+            if (item.Kind == StreamItemKind.Literal)
+            {
+                sb.Append(item.Char);
+                if (k > openIdx + 1 && item.Char == '=') hasEquals = true;
+            }
+            else
+            {
+                sb.Append('{').Append(oldSlots[item.SlotIndex].Raw).Append('}');
+            }
+        }
+        var raw = sb.ToString();
+        var isAssignment = raw.Length > 3 && raw[1] == '$' && hasEquals;
+        return (raw, isAssignment);
     }
 
     private static bool IsHistoryKitAssignmentToken(string token)
@@ -550,6 +717,13 @@ internal sealed class Extractor
             case InvocationExpressionSyntax invoc when IsStringFormatCall(invoc):
                 return FlattenStringFormat(invoc, locals, pieces, slots, visited, out unsupportedReason);
 
+            case InvocationExpressionSyntax invoc when IsExpandStringWrapper(invoc) && IsTokenShapedExpression(invoc.ArgumentList.Arguments[0].Expression, locals):
+            {
+                AddSlot(slots, RenderTokenRaw(invoc.ArgumentList.Arguments[0].Expression), type: HistoryKitTokenType);
+                pieces.Add($"{{{slots.Count - 1}}}");
+                return true;
+            }
+
             case InvocationExpressionSyntax invoc when IsPatternPreservingWrapper(invoc):
                 return FlattenConcat(invoc.ArgumentList.Arguments[0].Expression, locals, pieces, slots, visited, out unsupportedReason);
 
@@ -560,6 +734,11 @@ internal sealed class Extractor
 
             case InvocationExpressionSyntax invoc when IsRandomCall(invoc):
                 AddSlot(slots, "Random(...)", type: "string-format-arg");
+                pieces.Add($"{{{slots.Count - 1}}}");
+                return true;
+
+            case InvocationExpressionSyntax invoc:
+                AddSlot(slots, ClassifyHelperCallRaw(invoc), type: ClassifyHelperCallSlotType(invoc));
                 pieces.Add($"{{{slots.Count - 1}}}");
                 return true;
 
@@ -679,6 +858,35 @@ internal sealed class Extractor
         return string.Join(" ", expr.ToString().Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()));
     }
 
+    /// <summary>
+    /// Render a HistoryKit-token-shaped expression's raw text by concatenating its leaf literals
+    /// (unquoted) and any non-literal sub-expressions wrapped in `{...}` placeholders. This keeps
+    /// the raw stable across re-runs and avoids embedding C# string literal quotes.
+    /// </summary>
+    private static string RenderTokenRaw(ExpressionSyntax expr)
+    {
+        var sb = new StringBuilder();
+        AppendTokenRaw(expr, sb);
+        return sb.ToString();
+    }
+
+    private static void AppendTokenRaw(ExpressionSyntax expr, StringBuilder sb)
+    {
+        switch (expr)
+        {
+            case LiteralExpressionSyntax lit when lit.IsKind(SyntaxKind.StringLiteralExpression):
+                sb.Append(lit.Token.ValueText);
+                break;
+            case BinaryExpressionSyntax bin when bin.IsKind(SyntaxKind.AddExpression):
+                AppendTokenRaw(bin.Left, sb);
+                AppendTokenRaw(bin.Right, sb);
+                break;
+            default:
+                sb.Append('{').Append(ClassifyHelperCallRaw(expr)).Append('}');
+                break;
+        }
+    }
+
     private static string ClassifyHelperCallSlotType(ExpressionSyntax expr)
     {
         // Helper-call slot type for invocations from the known game-helper namespaces, format-arg
@@ -713,6 +921,54 @@ internal sealed class Extractor
     {
         if (invoc.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == "Random") return true;
         return false;
+    }
+
+    // True when the wrapper invocation is `ExpandString(...)` (free function or member).
+    private static bool IsExpandStringWrapper(InvocationExpressionSyntax invoc)
+    {
+        if (invoc.ArgumentList.Arguments.Count < 1) return false;
+        if (invoc.Expression is IdentifierNameSyntax bareId && bareId.Identifier.ValueText == "ExpandString") return true;
+        if (invoc.Expression is MemberAccessExpressionSyntax m && m.Name.Identifier.ValueText == "ExpandString") return true;
+        return false;
+    }
+
+    /// <summary>
+    /// True when the expression is a concat that begins with a `<` literal and ends with a `>`
+    /// literal — a HistoryKit token spanning multiple pieces. The runtime ExpandString collapses
+    /// the whole assembled string into a single arbitrary-text expansion, so we model it as a
+    /// single `historykit-token` slot rather than letting the inner structure leak through as
+    /// brittle literal-and-slot fragments.
+    /// </summary>
+    private static bool IsTokenShapedExpression(ExpressionSyntax expr, IReadOnlyDictionary<string, ExpressionSyntax> locals)
+    {
+        var leftmost = LeftmostLiteral(expr, locals, new HashSet<string>(StringComparer.Ordinal));
+        var rightmost = RightmostLiteral(expr, locals, new HashSet<string>(StringComparer.Ordinal));
+        if (leftmost is null || rightmost is null) return false;
+        return leftmost.Length > 0 && leftmost[0] == '<' && rightmost.Length > 0 && rightmost[^1] == '>';
+    }
+
+    private static string? LeftmostLiteral(ExpressionSyntax expr, IReadOnlyDictionary<string, ExpressionSyntax> locals, HashSet<string> visited)
+    {
+        return expr switch
+        {
+            LiteralExpressionSyntax lit when lit.IsKind(SyntaxKind.StringLiteralExpression) => lit.Token.ValueText,
+            BinaryExpressionSyntax bin when bin.IsKind(SyntaxKind.AddExpression) => LeftmostLiteral(bin.Left, locals, visited),
+            IdentifierNameSyntax id when locals.TryGetValue(id.Identifier.ValueText, out var init) && visited.Add(id.Identifier.ValueText)
+                => LeftmostLiteral(init, locals, visited),
+            _ => null,
+        };
+    }
+
+    private static string? RightmostLiteral(ExpressionSyntax expr, IReadOnlyDictionary<string, ExpressionSyntax> locals, HashSet<string> visited)
+    {
+        return expr switch
+        {
+            LiteralExpressionSyntax lit when lit.IsKind(SyntaxKind.StringLiteralExpression) => lit.Token.ValueText,
+            BinaryExpressionSyntax bin when bin.IsKind(SyntaxKind.AddExpression) => RightmostLiteral(bin.Right, locals, visited),
+            IdentifierNameSyntax id when locals.TryGetValue(id.Identifier.ValueText, out var init) && visited.Add(id.Identifier.ValueText)
+                => RightmostLiteral(init, locals, visited),
+            _ => null,
+        };
     }
 
     // Wrappers whose return value matches their first argument modulo capitalization /

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -53,20 +53,11 @@ internal sealed class Extractor
 
             // Include event_property in the id so a single Generate() that sets both
             // "gospel" and "tombInscription" produces distinct ids (no downstream collision).
-            var candidateId = $"{className}#{eventProperty}";
-            // PR1 does not handle switch/case; if the call is inside a SwitchSectionSyntax, mark needs_manual.
             var switchSection = invocation.Ancestors().OfType<SwitchSectionSyntax>().FirstOrDefault();
-            if (switchSection is not null)
-            {
-                candidates.Add(NeedsManual(
-                    id: $"{className}#{eventProperty}#switch{i}",
-                    sourceFile: fileName,
-                    annalClass: className,
-                    switchCase: ExtractSwitchLabel(switchSection),
-                    eventProperty: eventProperty,
-                    reason: "switch/case decomposition is out of scope for PR1 (deferred to #422)"));
-                continue;
-            }
+            var switchLabel = switchSection is null ? "default" : (ExtractSwitchLabel(switchSection) ?? "default");
+            var candidateId = switchSection is null
+                ? $"{className}#{eventProperty}"
+                : $"{className}#{eventProperty}#case:{switchLabel}";
 
             var resolution = ResolveValueExpression(valueExpr, localInitializers);
             if (!resolution.Resolved)
@@ -75,7 +66,7 @@ internal sealed class Extractor
                     id: candidateId,
                     sourceFile: fileName,
                     annalClass: className,
-                    switchCase: "default",
+                    switchCase: switchLabel,
                     eventProperty: eventProperty,
                     reason: resolution.Reason));
                 continue;
@@ -85,7 +76,7 @@ internal sealed class Extractor
                 id: candidateId,
                 sourceFile: fileName,
                 annalClass: className,
-                switchCase: "default",
+                switchCase: switchLabel,
                 eventProperty: eventProperty,
                 resolved: resolution);
 

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -69,7 +69,8 @@ internal sealed class Extractor
                 var armSwitchCase = armLabel is null ? switchLabel : armLabel;
                 var armId = armLabel is null ? idPrefix : $"{idPrefix}#arm:{armLabel}";
 
-                var optExpansions = ExpandOptionalAppends(valueExpr, armLocals, FilterAppendsToLocals(armLocals, appendsByLocal));
+                var setterScopedAppends = FilterAppendsBeforeSetter(appendsByLocal, invocation);
+                var optExpansions = ExpandOptionalAppends(valueExpr, armLocals, FilterAppendsToLocals(armLocals, setterScopedAppends));
                 foreach (var (optLabel, optLocals) in optExpansions)
                 {
                     var optId = optLabel is null ? armId : $"{armId}#opt:{optLabel}";
@@ -252,6 +253,11 @@ internal sealed class Extractor
             foreach (var stmt in statements)
             {
                 if (stmt.SpanStart >= setter.SpanStart) break;
+                // Skip stmts that *contain* the setter — they're an ancestor of the setter and
+                // are handled at deeper cursor levels. Their descendants include assignments
+                // that lexically follow the setter (e.g. inside the same if-branch), which must
+                // not influence the setter's value resolution.
+                if (stmt.Span.Contains(setter.Span)) continue;
                 foreach (var assign in stmt.DescendantNodesAndSelf().OfType<AssignmentExpressionSyntax>())
                 {
                     if (!assign.IsKind(SyntaxKind.SimpleAssignmentExpression)) continue;
@@ -265,6 +271,31 @@ internal sealed class Extractor
             }
         }
         return overrides;
+    }
+
+    /// <summary>
+    /// Drop compound-append rhs entries whose owning append statement starts at or after the
+    /// setter's span. Appends that execute after the setter never influence the value the runtime
+    /// stores, so they must not be fanned out as `#opt:withN` candidates.
+    /// </summary>
+    private static IReadOnlyDictionary<string, List<ExpressionSyntax>> FilterAppendsBeforeSetter(
+        IReadOnlyDictionary<string, List<ExpressionSyntax>> appendsByLocal,
+        InvocationExpressionSyntax setter)
+    {
+        var dict = new Dictionary<string, List<ExpressionSyntax>>(StringComparer.Ordinal);
+        foreach (var (name, appends) in appendsByLocal)
+        {
+            var kept = new List<ExpressionSyntax>();
+            foreach (var rhs in appends)
+            {
+                // The rhs is the right-hand side of `local += rhs`; walk up to the owning
+                // assignment expression (its parent) and use its span as the append's span.
+                var assignSpanStart = rhs.Parent?.SpanStart ?? rhs.SpanStart;
+                if (assignSpanStart < setter.SpanStart) kept.Add(rhs);
+            }
+            if (kept.Count > 0) dict[name] = kept;
+        }
+        return dict;
     }
 
     private static IReadOnlyDictionary<string, List<ExpressionSyntax>> FilterAppendsToLocals(

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -1324,18 +1324,24 @@ internal sealed class Extractor
         IReadOnlyDictionary<string, ExpressionSyntax> locals,
         HashSet<string> visited)
     {
-        return expr switch
+        // `visited` must be cleaned up via try/finally; an earlier expression-switch added the
+        // name as a side-effect of the `when` clause and never removed it, so `a + a` (same
+        // local on both sides) flipped the right-hand recursion to `false` even when the
+        // initializer was literal-only.
+        switch (expr)
         {
-            LiteralExpressionSyntax lit when lit.IsKind(SyntaxKind.StringLiteralExpression) => true,
-            BinaryExpressionSyntax bin when bin.IsKind(SyntaxKind.AddExpression)
-                => IsLiteralOnlyConcat(bin.Left, locals, visited)
-                    && IsLiteralOnlyConcat(bin.Right, locals, visited),
-            IdentifierNameSyntax id
-                when locals.TryGetValue(id.Identifier.ValueText, out var init)
-                && visited.Add(id.Identifier.ValueText)
-                => IsLiteralOnlyConcat(init, locals, visited),
-            _ => false,
-        };
+            case LiteralExpressionSyntax lit when lit.IsKind(SyntaxKind.StringLiteralExpression):
+                return true;
+            case BinaryExpressionSyntax bin when bin.IsKind(SyntaxKind.AddExpression):
+                return IsLiteralOnlyConcat(bin.Left, locals, visited)
+                    && IsLiteralOnlyConcat(bin.Right, locals, visited);
+            case IdentifierNameSyntax id when locals.TryGetValue(id.Identifier.ValueText, out var init):
+                if (!visited.Add(id.Identifier.ValueText)) return false;
+                try { return IsLiteralOnlyConcat(init, locals, visited); }
+                finally { visited.Remove(id.Identifier.ValueText); }
+            default:
+                return false;
+        }
     }
 
     private static string ClassifyHelperCallSlotType(ExpressionSyntax expr)

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -277,7 +277,12 @@ internal sealed class Extractor
                 // that lexically follow the setter (e.g. inside the same if-branch), which must
                 // not influence the setter's value resolution.
                 if (stmt.Span.Contains(setter.Span)) continue;
-                foreach (var assign in stmt.DescendantNodesAndSelf().OfType<AssignmentExpressionSyntax>())
+                // Iterate descendants in reverse source order too, so multiple assignments to
+                // the same local *within a single sibling stmt* (e.g. `if (cond) { x="a"; x="b"; }`)
+                // also yield first-seen-wins = source-last-wins.
+                foreach (var assign in stmt.DescendantNodesAndSelf()
+                    .OfType<AssignmentExpressionSyntax>()
+                    .OrderByDescending(a => a.SpanStart))
                 {
                     if (!assign.IsKind(SyntaxKind.SimpleAssignmentExpression)) continue;
                     if (assign.Left is not IdentifierNameSyntax lhs) continue;

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -55,32 +55,37 @@ internal sealed class Extractor
             // "gospel" and "tombInscription" produces distinct ids (no downstream collision).
             var switchSection = invocation.Ancestors().OfType<SwitchSectionSyntax>().FirstOrDefault();
             var switchLabel = switchSection is null ? "default" : (ExtractSwitchLabel(switchSection) ?? "default");
-            var candidateId = switchSection is null
+            var idPrefix = switchSection is null
                 ? $"{className}#{eventProperty}"
                 : $"{className}#{eventProperty}#case:{switchLabel}";
 
-            var resolution = ResolveValueExpression(valueExpr, localInitializers);
-            if (!resolution.Resolved)
+            var armings = ExpandSwitchExpressionArms(valueExpr, localInitializers);
+            foreach (var (armLabel, armLocals) in armings)
             {
-                candidates.Add(NeedsManual(
-                    id: candidateId,
+                var armSwitchCase = armLabel is null ? switchLabel : armLabel;
+                var armId = armLabel is null ? idPrefix : $"{idPrefix}#arm:{armLabel}";
+
+                var resolution = ResolveValueExpression(valueExpr, armLocals);
+                if (!resolution.Resolved)
+                {
+                    candidates.Add(NeedsManual(
+                        id: armId,
+                        sourceFile: fileName,
+                        annalClass: className,
+                        switchCase: armSwitchCase,
+                        eventProperty: eventProperty,
+                        reason: resolution.Reason));
+                    continue;
+                }
+
+                candidates.Add(BuildCandidate(
+                    id: armId,
                     sourceFile: fileName,
                     annalClass: className,
-                    switchCase: switchLabel,
+                    switchCase: armSwitchCase,
                     eventProperty: eventProperty,
-                    reason: resolution.Reason));
-                continue;
+                    resolved: resolution));
             }
-
-            var candidate = BuildCandidate(
-                id: candidateId,
-                sourceFile: fileName,
-                annalClass: className,
-                switchCase: switchLabel,
-                eventProperty: eventProperty,
-                resolved: resolution);
-
-            candidates.Add(candidate);
         }
     }
 
@@ -165,6 +170,65 @@ internal sealed class Extractor
             dict[name] = initValue;
         }
         return dict;
+    }
+
+    /// <summary>
+    /// If the value expression depends on a local whose initializer is a SwitchExpressionSyntax,
+    /// fan out one entry per arm (the local is overridden with the arm's expression). Otherwise
+    /// returns a single (label=null, original-locals) pair so callers can use a single code path.
+    /// Only the first switch-expression local found is expanded; nested cross-products are not
+    /// emitted by design (PR2a target files use one switch expression at a time).
+    /// </summary>
+    private static List<(string? armLabel, IReadOnlyDictionary<string, ExpressionSyntax> locals)>
+        ExpandSwitchExpressionArms(
+            ExpressionSyntax valueExpr,
+            IReadOnlyDictionary<string, ExpressionSyntax> locals)
+    {
+        var result = new List<(string?, IReadOnlyDictionary<string, ExpressionSyntax>)>();
+        var (switchLocalName, switchExpr) = FindSwitchExpressionLocal(valueExpr, locals, new HashSet<string>(StringComparer.Ordinal));
+        if (switchLocalName is null || switchExpr is null)
+        {
+            result.Add((null, locals));
+            return result;
+        }
+        foreach (var arm in switchExpr.Arms)
+        {
+            var label = SwitchExpressionArmLabel(arm);
+            var overrideLocals = new Dictionary<string, ExpressionSyntax>(locals, StringComparer.Ordinal)
+            {
+                [switchLocalName] = arm.Expression,
+            };
+            result.Add((label, overrideLocals));
+        }
+        return result;
+    }
+
+    private static (string? name, SwitchExpressionSyntax? expr) FindSwitchExpressionLocal(
+        ExpressionSyntax expr,
+        IReadOnlyDictionary<string, ExpressionSyntax> locals,
+        HashSet<string> visited)
+    {
+        foreach (var id in expr.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+        {
+            var name = id.Identifier.ValueText;
+            if (visited.Contains(name)) continue;
+            if (!locals.TryGetValue(name, out var init)) continue;
+            if (init is SwitchExpressionSyntax sw) return (name, sw);
+            visited.Add(name);
+            var nested = FindSwitchExpressionLocal(init, locals, visited);
+            if (nested.name is not null) return nested;
+        }
+        return (null, null);
+    }
+
+    private static string SwitchExpressionArmLabel(SwitchExpressionArmSyntax arm)
+    {
+        return arm.Pattern switch
+        {
+            ConstantPatternSyntax c => c.Expression.ToString(),
+            DiscardPatternSyntax => "_",
+            _ => arm.Pattern.ToString(),
+        };
     }
 
     private sealed class ResolutionResult

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -68,19 +68,6 @@ internal sealed class Extractor
                 continue;
             }
 
-            // Other unsupported shapes also degrade.
-            if (IsStringFormatCall(valueExpr))
-            {
-                candidates.Add(NeedsManual(
-                    id: candidateId,
-                    sourceFile: fileName,
-                    annalClass: className,
-                    switchCase: "default",
-                    eventProperty: eventProperty,
-                    reason: "string.Format(...) extraction is out of scope for PR1 (deferred to #422)"));
-                continue;
-            }
-
             var resolution = ResolveValueExpression(valueExpr, localInitializers);
             if (!resolution.Resolved)
             {
@@ -398,6 +385,9 @@ internal sealed class Extractor
                 if (!FlattenConcat(bin.Right, locals, pieces, slots, visited, out unsupportedReason)) return false;
                 return true;
 
+            case InvocationExpressionSyntax invoc when IsStringFormatCall(invoc):
+                return FlattenStringFormat(invoc, locals, pieces, slots, visited, out unsupportedReason);
+
             case InvocationExpressionSyntax invoc when IsEntityGetProperty(invoc):
                 AddSlot(slots, $"entity.GetProperty({GetFirstStringArg(invoc)})", type: "entity-property");
                 pieces.Add($"{{{slots.Count - 1}}}");
@@ -413,6 +403,131 @@ internal sealed class Extractor
                     $"unsupported expression for PR1 AST subset: {expr.Kind()} '{expr.ToString()}'";
                 return false;
         }
+    }
+
+    private static bool FlattenStringFormat(
+        InvocationExpressionSyntax invoc,
+        IReadOnlyDictionary<string, ExpressionSyntax> locals,
+        List<string> pieces,
+        List<SlotEntry> slots,
+        HashSet<string> visited,
+        out string unsupportedReason)
+    {
+        unsupportedReason = "";
+        var args = invoc.ArgumentList.Arguments;
+        if (args.Count < 1)
+        {
+            unsupportedReason = "string.Format with no arguments";
+            return false;
+        }
+        var fmtExpr = args[0].Expression;
+        if (fmtExpr is not LiteralExpressionSyntax fmtLit || !fmtLit.IsKind(SyntaxKind.StringLiteralExpression))
+        {
+            unsupportedReason = $"string.Format format string is not a literal: {fmtExpr.Kind()}";
+            return false;
+        }
+        var format = fmtLit.Token.ValueText;
+
+        // Walk the format string. Each `{N}` (with optional `,W` or `:fmt`) substitutes args[N+1].
+        var i = 0;
+        var literalSb = new StringBuilder();
+        while (i < format.Length)
+        {
+            var c = format[i];
+            if (c == '{' && i + 1 < format.Length && format[i + 1] == '{')
+            {
+                literalSb.Append('{');
+                i += 2;
+                continue;
+            }
+            if (c == '}' && i + 1 < format.Length && format[i + 1] == '}')
+            {
+                literalSb.Append('}');
+                i += 2;
+                continue;
+            }
+            if (c == '{')
+            {
+                var close = format.IndexOf('}', i);
+                if (close < 0)
+                {
+                    unsupportedReason = $"string.Format format string has unclosed '{{': {format}";
+                    return false;
+                }
+                var holderBody = format.Substring(i + 1, close - i - 1);
+                var sepIdx = holderBody.IndexOfAny(new[] { ',', ':' });
+                var indexStr = sepIdx < 0 ? holderBody : holderBody[..sepIdx];
+                if (!int.TryParse(indexStr, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var argIdx))
+                {
+                    unsupportedReason = $"string.Format placeholder index is not an integer: {{{holderBody}}}";
+                    return false;
+                }
+                if (argIdx + 1 >= args.Count)
+                {
+                    unsupportedReason = $"string.Format placeholder {{{argIdx}}} has no matching argument";
+                    return false;
+                }
+                if (literalSb.Length > 0)
+                {
+                    pieces.Add(literalSb.ToString());
+                    literalSb.Clear();
+                }
+                if (!FlattenFormatArgument(args[argIdx + 1].Expression, locals, pieces, slots, visited))
+                {
+                    return false;
+                }
+                i = close + 1;
+                continue;
+            }
+            literalSb.Append(c);
+            i++;
+        }
+        if (literalSb.Length > 0) pieces.Add(literalSb.ToString());
+        return true;
+    }
+
+    private static bool FlattenFormatArgument(
+        ExpressionSyntax argExpr,
+        IReadOnlyDictionary<string, ExpressionSyntax> locals,
+        List<string> pieces,
+        List<SlotEntry> slots,
+        HashSet<string> visited)
+    {
+        // Try the structural concat/literal/local resolver first; if it fails, fall back to a
+        // single helper-call slot so the format isn't aborted by one un-resolvable argument.
+        var piecesSnapshot = pieces.Count;
+        var slotsSnapshot = slots.Count;
+        if (FlattenConcat(argExpr, locals, pieces, slots, visited, out _))
+        {
+            return true;
+        }
+        pieces.RemoveRange(piecesSnapshot, pieces.Count - piecesSnapshot);
+        slots.RemoveRange(slotsSnapshot, slots.Count - slotsSnapshot);
+        AddSlot(slots, ClassifyHelperCallRaw(argExpr), type: ClassifyHelperCallSlotType(argExpr));
+        pieces.Add($"{{{slots.Count - 1}}}");
+        return true;
+    }
+
+    private static string ClassifyHelperCallRaw(ExpressionSyntax expr)
+    {
+        // Strip whitespace/newlines so multi-line helper invocations produce stable raw strings.
+        return string.Join(" ", expr.ToString().Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()));
+    }
+
+    private static string ClassifyHelperCallSlotType(ExpressionSyntax expr)
+    {
+        // Helper-call slot type for invocations from the known game-helper namespaces, format-arg
+        // for everything else (literals already resolved by FlattenConcat, so this hits unknown
+        // identifiers or expressions).
+        if (expr is InvocationExpressionSyntax invoc)
+        {
+            if (invoc.Expression is MemberAccessExpressionSyntax m)
+            {
+                var receiver = m.Expression.ToString();
+                if (receiver is "Grammar" or "QudHistoryHelpers" or "Faction" or "NameMaker") return "helper-call";
+            }
+        }
+        return "format-arg";
     }
 
     // NOTE: Receiver type is intentionally not validated here. PR1's Resheph 16

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -155,7 +155,19 @@ internal sealed class Extractor
         {
             // `string` keyword parses as PredefinedTypeSyntax in Roslyn, not IdentifierNameSyntax.
             if (m.Expression is PredefinedTypeSyntax pt && pt.Keyword.ValueText == "string") return true;
-            if (m.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == "string") return true;
+            if (m.Expression is IdentifierNameSyntax id
+                && (id.Identifier.ValueText == "string" || id.Identifier.ValueText == "String"))
+            {
+                return true;
+            }
+            // Fully-qualified `System.String.Format(...)`.
+            if (m.Expression is MemberAccessExpressionSyntax inner
+                && inner.Name.Identifier.ValueText == "String"
+                && inner.Expression is IdentifierNameSyntax sys
+                && sys.Identifier.ValueText == "System")
+            {
+                return true;
+            }
         }
         return false;
     }

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -83,38 +83,50 @@ internal sealed class Extractor
             var ifBranchSuffix = ResolveIfBranchSuffix(invocation, setterCalls, eventProperty);
             if (ifBranchSuffix is not null) idPrefix += CandidateIdSuffix.If + ifBranchSuffix;
 
-            var setterLocals = BuildSetterScopedLocals(invocation, localInitializers);
+            // BuildSetterScopedLocals returns one entry when the local resolves unconditionally
+            // (IfBranchLabel = null) and two entries (`then`/`else`) when a setter-scope local
+            // has branch-distinct SimpleAssignments in a pre-setter `if/else` sibling. The
+            // branch-fanout case is mutually exclusive with `ResolveIfBranchSuffix` (setter
+            // INSIDE an if-branch with a sibling setter for the same property in the other
+            // branch); when that fires, we suppress branch-fanout to avoid `#if:then#if:else`
+            // double-suffixing.
+            var suppressBranchFanout = ifBranchSuffix is not null;
+            var setterLocalsBranches = BuildSetterScopedLocals(invocation, localInitializers, generateMethod, suppressBranchFanout);
             var setterScopedAppends = FilterAppendsBeforeSetter(appendsByLocal, invocation);
-            var armings = ExpandSwitchExpressionArms(valueExpr, setterLocals);
-            foreach (var (armLabel, armLocals) in armings)
+            foreach (var (branchLabel, setterLocals) in setterLocalsBranches)
             {
-                var armSwitchCase = armLabel is null ? switchLabel : armLabel;
-                var armId = armLabel is null ? idPrefix : idPrefix + CandidateIdSuffix.Arm + armLabel;
-
-                var optExpansions = ExpandOptionalAppends(valueExpr, armLocals, FilterAppendsToLocals(armLocals, setterScopedAppends));
-                foreach (var (optLabel, optLocals) in optExpansions)
+                var branchedIdPrefix = branchLabel is null ? idPrefix : idPrefix + CandidateIdSuffix.If + branchLabel;
+                var armings = ExpandSwitchExpressionArms(valueExpr, setterLocals);
+                foreach (var (armLabel, armLocals) in armings)
                 {
-                    var optId = optLabel is null ? armId : armId + CandidateIdSuffix.Opt + optLabel;
-                    var resolution = ResolveValueExpression(valueExpr, optLocals);
-                    if (!resolution.Resolved)
+                    var armSwitchCase = armLabel is null ? switchLabel : armLabel;
+                    var armId = armLabel is null ? branchedIdPrefix : branchedIdPrefix + CandidateIdSuffix.Arm + armLabel;
+
+                    var optExpansions = ExpandOptionalAppends(valueExpr, armLocals, FilterAppendsToLocals(armLocals, setterScopedAppends));
+                    foreach (var (optLabel, optLocals) in optExpansions)
                     {
-                        candidates.Add(NeedsManual(
+                        var optId = optLabel is null ? armId : armId + CandidateIdSuffix.Opt + optLabel;
+                        var resolution = ResolveValueExpression(valueExpr, optLocals);
+                        if (!resolution.Resolved)
+                        {
+                            candidates.Add(NeedsManual(
+                                id: optId,
+                                sourceFile: fileName,
+                                annalClass: className,
+                                switchCase: armSwitchCase,
+                                eventProperty: eventProperty,
+                                reason: resolution.Reason));
+                            continue;
+                        }
+
+                        candidates.Add(BuildCandidate(
                             id: optId,
                             sourceFile: fileName,
                             annalClass: className,
                             switchCase: armSwitchCase,
                             eventProperty: eventProperty,
-                            reason: resolution.Reason));
-                        continue;
+                            resolved: resolution));
                     }
-
-                    candidates.Add(BuildCandidate(
-                        id: optId,
-                        sourceFile: fileName,
-                        annalClass: className,
-                        switchCase: armSwitchCase,
-                        eventProperty: eventProperty,
-                        resolved: resolution));
                 }
             }
         }
@@ -251,12 +263,53 @@ internal sealed class Extractor
     /// nearest enclosing block, e.g. a switch case body or an if branch). This recovers `value`
     /// in patterns like `string value; if (cond) { value = ...; SetEventProperty(_, value); }`.
     /// </summary>
-    private static IReadOnlyDictionary<string, ExpressionSyntax> BuildSetterScopedLocals(
-        InvocationExpressionSyntax setter,
-        IReadOnlyDictionary<string, ExpressionSyntax> methodLocals)
+    /// <remarks>
+    /// Returns one entry (label = null) for the unconditional case. When a pre-setter
+    /// `IfStatementSyntax` sibling holds branch-distinct SimpleAssignments to a single live
+    /// local, returns two entries (`then` / `else`) so the caller emits one candidate per
+    /// branch. Decisions:
+    /// <list type="bullet">
+    ///   <item>
+    ///     <b>Cross-product policy (PR2a)</b>: at most ONE branched local drives fanout. When
+    ///     multiple if-stmt siblings or multiple locals would qualify, only the FIRST encountered
+    ///     branched name (in reverse-sibling-then-DFS order) fans out; other locals fold into
+    ///     the unconditional source-latest override.
+    ///   </item>
+    ///   <item>
+    ///     <b>Single-branch-assign</b>: when only ONE branch assigns the local, the other branch
+    ///     keeps the local's prior state — runtime-faithfully a distinct value. We still emit
+    ///     two candidates; the unassigned branch resolves the local from the declared
+    ///     initializer (when present) or falls back to the unconditional `overrides[name]`
+    ///     (which today degrades to an `unresolved-local` slot).
+    ///   </item>
+    ///   <item>
+    ///     <b>Identical-rhs in both branches</b>: not branch-distinct — folds unconditionally
+    ///     via the existing source-latest reverse-iter rule.
+    ///   </item>
+    ///   <item>
+    ///     <b>Mutual exclusion with `ResolveIfBranchSuffix`</b>: when the setter is INSIDE an
+    ///     if-branch and a sibling setter exists in the other branch (driving an `#if:then` /
+    ///     `#if:else` suffix), branch-fanout is suppressed by the caller via
+    ///     <paramref name="suppressBranchFanout"/> so the id never carries two `#if:` segments.
+    ///   </item>
+    /// </list>
+    /// </remarks>
+    private static IReadOnlyList<(string? IfBranchLabel, IReadOnlyDictionary<string, ExpressionSyntax> Overrides)>
+        BuildSetterScopedLocals(
+            InvocationExpressionSyntax setter,
+            IReadOnlyDictionary<string, ExpressionSyntax> methodLocals,
+            MethodDeclarationSyntax method,
+            bool suppressBranchFanout)
     {
         var overrides = new Dictionary<string, ExpressionSyntax>(methodLocals, StringComparer.Ordinal);
         var alreadyOverridden = new HashSet<string>(StringComparer.Ordinal);
+
+        // First branched local found (innermost sibling, reverse source order). Once non-null,
+        // further branched candidates are ignored — the spec limits fanout to a single local.
+        string? branchedName = null;
+        ExpressionSyntax? branchedThen = null;
+        ExpressionSyntax? branchedElse = null;
+
         // Walk enclosing statement-containers (BlockSyntax or SwitchSectionSyntax) from innermost
         // to outermost; within each container, scan preceding sibling statements for simple
         // assignments to names that aren't already in the method-scope locals table.
@@ -285,6 +338,25 @@ internal sealed class Extractor
                 // that lexically follow the setter (e.g. inside the same if-branch), which must
                 // not influence the setter's value resolution.
                 if (stmt.Span.Contains(setter.Span)) continue;
+
+                // Branched-local detection — only fires for top-level if-stmt siblings (not
+                // nested ifs inside other stmts) and only for the FIRST qualifying name. A
+                // `value = "post-if"` assignment closer to the setter shadows the if-stmt via
+                // `alreadyOverridden`, matching today's source-latest-wins semantic.
+                if (!suppressBranchFanout && branchedName is null && stmt is IfStatementSyntax ifStmt)
+                {
+                    var detected = TryDetectBranchedLocal(ifStmt, methodLocals, alreadyOverridden);
+                    if (detected.Name is not null)
+                    {
+                        branchedName = detected.Name;
+                        branchedThen = detected.ThenRhs;
+                        branchedElse = detected.ElseRhs;
+                        // Shield the branched name from the unconditional fold below: its
+                        // value is owned by the per-branch override dicts.
+                        alreadyOverridden.Add(detected.Name);
+                    }
+                }
+
                 // Iterate descendants in reverse source order too, so multiple assignments to
                 // the same local *within a single sibling stmt* (e.g. `if (cond) { x="a"; x="b"; }`)
                 // also yield first-seen-wins = source-last-wins.
@@ -302,7 +374,118 @@ internal sealed class Extractor
                 }
             }
         }
-        return overrides;
+
+        if (branchedName is null)
+        {
+            return new[] { ((string?)null, (IReadOnlyDictionary<string, ExpressionSyntax>)overrides) };
+        }
+
+        // Resolve missing branches via the local's declared initializer. When neither branch
+        // assigns AND no initializer exists, fall back to the unconditional override (whatever
+        // outer-scope assignment happened to land in `overrides[name]` — typically nothing,
+        // leaving the name to degrade to an `unresolved-local` slot at FlattenConcat time).
+        var initializerFallback = LookupDeclaredInitializer(branchedName, method);
+        var thenValue = branchedThen ?? initializerFallback;
+        var elseValue = branchedElse ?? initializerFallback;
+
+        var thenOverrides = new Dictionary<string, ExpressionSyntax>(overrides, StringComparer.Ordinal);
+        if (thenValue is not null) thenOverrides[branchedName] = thenValue;
+        var elseOverrides = new Dictionary<string, ExpressionSyntax>(overrides, StringComparer.Ordinal);
+        if (elseValue is not null) elseOverrides[branchedName] = elseValue;
+
+        return new[]
+        {
+            ((string?)"then", (IReadOnlyDictionary<string, ExpressionSyntax>)thenOverrides),
+            ((string?)"else", (IReadOnlyDictionary<string, ExpressionSyntax>)elseOverrides),
+        };
+    }
+
+    /// <summary>
+    /// Inspect the THEN/ELSE branches of <paramref name="ifStmt"/> for SimpleAssignments to live
+    /// locals (names not in <paramref name="methodLocals"/> and not already overridden by a
+    /// closer-to-setter assignment) and return the first qualifying branched local. Returns
+    /// (null, null, null) when no branch-distinct local is present.
+    /// </summary>
+    /// <remarks>
+    /// Per-branch picks the SOURCE-LATEST assignment (mirrors the within-branch reverse-iter
+    /// rule). A name qualifies as "branched" when:
+    /// <list type="bullet">
+    ///   <item>Both branches assign it with DIFFERENT rhs nodes; or</item>
+    ///   <item>Only ONE branch assigns it — the other branch retains the local's prior state,
+    ///   which is runtime-faithfully a distinct value worth a separate candidate.</item>
+    /// </list>
+    /// Search order is the if-stmt's source-DFS assignment order so the FIRST qualifying name
+    /// wins deterministically.
+    /// </remarks>
+    private static (string? Name, ExpressionSyntax? ThenRhs, ExpressionSyntax? ElseRhs) TryDetectBranchedLocal(
+        IfStatementSyntax ifStmt,
+        IReadOnlyDictionary<string, ExpressionSyntax> methodLocals,
+        HashSet<string> alreadyOverridden)
+    {
+        // ELSE may be null (`if (cond) { ... }`). An empty else map drives the single-branch
+        // case: any THEN-branch assignment qualifies as branched (else-branch keeps prior state).
+        var thenAssigns = CollectBranchAssignments(ifStmt.Statement);
+        var elseAssigns = ifStmt.Else is null
+            ? new Dictionary<string, ExpressionSyntax>(StringComparer.Ordinal)
+            : CollectBranchAssignments(ifStmt.Else.Statement);
+
+        // Walk if-stmt-internal SimpleAssignments in source order; first qualifying name wins.
+        // Skip post-setter assigns? Not applicable — caller filters via stmt.Span checks.
+        foreach (var assign in ifStmt.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        {
+            if (!assign.IsKind(SyntaxKind.SimpleAssignmentExpression)) continue;
+            if (assign.Left is not IdentifierNameSyntax lhs) continue;
+            var name = lhs.Identifier.ValueText;
+            if (methodLocals.ContainsKey(name)) continue;
+            if (alreadyOverridden.Contains(name)) continue;
+
+            thenAssigns.TryGetValue(name, out var t);
+            elseAssigns.TryGetValue(name, out var e);
+            if (t is null && e is null) continue;
+            // Both branches assigning IDENTICAL rhs → fold unconditionally (existing reverse-
+            // iter logic handles it). Only branch-distinct rhs OR single-branch-assign qualifies.
+            if (t is not null && e is not null && SyntaxFactory.AreEquivalent(t, e)) continue;
+            return (name, t, e);
+        }
+        return (null, null, null);
+    }
+
+    /// <summary>
+    /// Build a name → source-latest-rhs map for SimpleAssignments inside one branch's
+    /// statement subtree. When the same local is assigned multiple times within the branch
+    /// (e.g. `value = "first"; value = "second";`), the LATER assignment wins, matching the
+    /// runtime semantic of "the last write before the branch ends is the observed value".
+    /// </summary>
+    private static Dictionary<string, ExpressionSyntax> CollectBranchAssignments(StatementSyntax branch)
+    {
+        var map = new Dictionary<string, ExpressionSyntax>(StringComparer.Ordinal);
+        foreach (var assign in branch.DescendantNodesAndSelf().OfType<AssignmentExpressionSyntax>())
+        {
+            if (!assign.IsKind(SyntaxKind.SimpleAssignmentExpression)) continue;
+            if (assign.Left is not IdentifierNameSyntax lhs) continue;
+            // DescendantNodesAndSelf yields source-document order, so a later assignment
+            // overwrites an earlier one — exactly the source-latest-wins semantic we want.
+            map[lhs.Identifier.ValueText] = assign.Right;
+        }
+        return map;
+    }
+
+    /// <summary>
+    /// Look up the declared initializer for <paramref name="name"/> when the local has exactly
+    /// one declarator with a non-null initializer in <paramref name="method"/>. Used to recover
+    /// the "no-assign branch keeps prior state" value during branch fanout when only one branch
+    /// assigns the local. Returns null when no usable initializer is found.
+    /// </summary>
+    private static ExpressionSyntax? LookupDeclaredInitializer(string name, MethodDeclarationSyntax method)
+    {
+        VariableDeclaratorSyntax? sole = null;
+        foreach (var declarator in method.DescendantNodes().OfType<VariableDeclaratorSyntax>())
+        {
+            if (declarator.Identifier.ValueText != name) continue;
+            if (sole is not null) return null;  // multi-declarator — ambiguous
+            sole = declarator;
+        }
+        return sole?.Initializer?.Value;
     }
 
     /// <summary>

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -306,35 +306,54 @@ internal sealed class Extractor
     }
 
     /// <summary>
-    /// Drop compound-append rhs entries whose owning append statement starts at or after the
-    /// setter's span. Appends that execute after the setter never influence the value the runtime
-    /// stores, so they must not be fanned out as `#opt:withN` candidates.
+    /// One `local += rhs` statement, tagged with whether its execution is gated by an enclosing
+    /// `if`. Required (Optional=false) appends always run on the runtime path that reaches the
+    /// setter, so they fold into the local's resolved value. Optional (Optional=true) appends
+    /// drive `#opt:withN` fanout — one variant per optional, in source order, with all required
+    /// appends still folded in.
     /// </summary>
-    private static IReadOnlyDictionary<string, List<ExpressionSyntax>> FilterAppendsBeforeSetter(
-        IReadOnlyDictionary<string, List<ExpressionSyntax>> appendsByLocal,
+    private readonly struct AppendEntry
+    {
+        public AppendEntry(ExpressionSyntax right, bool optional)
+        {
+            Right = right;
+            Optional = optional;
+        }
+
+        public ExpressionSyntax Right { get; }
+        public bool Optional { get; }
+    }
+
+    /// <summary>
+    /// Drop compound-append entries whose owning append statement starts at or after the setter's
+    /// span. Appends that execute after the setter never influence the value the runtime stores,
+    /// so they must neither fold into the resolved value nor fan out as `#opt:withN` candidates.
+    /// </summary>
+    private static IReadOnlyDictionary<string, List<AppendEntry>> FilterAppendsBeforeSetter(
+        IReadOnlyDictionary<string, List<AppendEntry>> appendsByLocal,
         InvocationExpressionSyntax setter)
     {
-        var dict = new Dictionary<string, List<ExpressionSyntax>>(StringComparer.Ordinal);
+        var dict = new Dictionary<string, List<AppendEntry>>(StringComparer.Ordinal);
         foreach (var (name, appends) in appendsByLocal)
         {
-            var kept = new List<ExpressionSyntax>();
-            foreach (var rhs in appends)
+            var kept = new List<AppendEntry>();
+            foreach (var entry in appends)
             {
                 // The rhs is the right-hand side of `local += rhs`; walk up to the owning
                 // assignment expression (its parent) and use its span as the append's span.
-                var assignSpanStart = rhs.Parent?.SpanStart ?? rhs.SpanStart;
-                if (assignSpanStart < setter.SpanStart) kept.Add(rhs);
+                var assignSpanStart = entry.Right.Parent?.SpanStart ?? entry.Right.SpanStart;
+                if (assignSpanStart < setter.SpanStart) kept.Add(entry);
             }
             if (kept.Count > 0) dict[name] = kept;
         }
         return dict;
     }
 
-    private static IReadOnlyDictionary<string, List<ExpressionSyntax>> FilterAppendsToLocals(
+    private static IReadOnlyDictionary<string, List<AppendEntry>> FilterAppendsToLocals(
         IReadOnlyDictionary<string, ExpressionSyntax> activeLocals,
-        IReadOnlyDictionary<string, List<ExpressionSyntax>> appendsByLocal)
+        IReadOnlyDictionary<string, List<AppendEntry>> appendsByLocal)
     {
-        var dict = new Dictionary<string, List<ExpressionSyntax>>(StringComparer.Ordinal);
+        var dict = new Dictionary<string, List<AppendEntry>>(StringComparer.Ordinal);
         foreach (var (name, appends) in appendsByLocal)
         {
             if (activeLocals.ContainsKey(name)) dict[name] = appends;
@@ -343,55 +362,60 @@ internal sealed class Extractor
     }
 
     /// <summary>
-    /// Collect compound `+=` reassignments (`local += expr`) per local. These typically come from
-    /// `if (flag) local += suffix;` blocks and represent optional-append branches we want to fan
-    /// out as additional candidates.
+    /// Collect compound `+=` reassignments (`local += expr`) per local, tagging each entry with
+    /// whether it is conditionally executed (Optional = wrapped in an `IfStatementSyntax`).
     /// </summary>
     /// <remarks>
-    /// Only `+=` statements with an enclosing `IfStatementSyntax` are collected. A `+=` inside a
-    /// switch-case body but not inside an `if` is unconditional within that case's runtime path
-    /// (case selection itself is already modelled by the `#case:N` id suffix), so fanning out a
-    /// `#opt:base` variant that omits it would emit a candidate for a runtime state that never
-    /// occurs. Filtering them here means an unconditional `+=` becomes invisible to the resolved
-    /// local's value (BuildSetterScopedLocals only follows simple assignments), but trading
-    /// "false candidate" for "less-detailed candidate with a slot" is preferred — translation
-    /// review can fill the gap, while a phantom variant cannot be reasoned about post-hoc.
+    /// Required (`Optional=false`) appends are folded into the resolved local value so the
+    /// extracted candidate matches the runtime string. Optional (`Optional=true`) appends drive
+    /// `#opt:base` / `#opt:withN` fanout. Switch-case ancestry is intentionally not treated as
+    /// optional — case selection is already modelled by the `#case:N` id suffix.
     /// </remarks>
-    private static IReadOnlyDictionary<string, List<ExpressionSyntax>> CollectCompoundAppends(MethodDeclarationSyntax method)
+    private static IReadOnlyDictionary<string, List<AppendEntry>> CollectCompoundAppends(MethodDeclarationSyntax method)
     {
-        var dict = new Dictionary<string, List<ExpressionSyntax>>(StringComparer.Ordinal);
+        var dict = new Dictionary<string, List<AppendEntry>>(StringComparer.Ordinal);
+        // `DescendantNodes` yields nodes in document order, so the resulting per-local list is
+        // already in source order — needed by `ExpandOptionalAppends` to interleave optional and
+        // required appends correctly when synthesising the per-variant value chain.
         foreach (var assignment in method.DescendantNodes().OfType<AssignmentExpressionSyntax>())
         {
             if (!assignment.IsKind(SyntaxKind.AddAssignmentExpression)) continue;
             if (assignment.Left is not IdentifierNameSyntax lhs) continue;
-            // Skip unconditional appends — only `+=` wrapped in an `if` represents a fanout.
-            if (!assignment.Ancestors().OfType<IfStatementSyntax>().Any())
-            {
-                continue;
-            }
+            var optional = assignment.Ancestors().OfType<IfStatementSyntax>().Any();
             var name = lhs.Identifier.ValueText;
             if (!dict.TryGetValue(name, out var list))
             {
-                list = new List<ExpressionSyntax>();
+                list = new List<AppendEntry>();
                 dict[name] = list;
             }
-            list.Add(assignment.Right);
+            list.Add(new AppendEntry(assignment.Right, optional));
         }
         return dict;
     }
 
     /// <summary>
-    /// If the value expression depends on a local that has compound `+=` appends, fan out one
-    /// (label="base", initializer-only) entry plus one (label="withN", initializer + N-th append)
-    /// entry per append. Otherwise returns a single (label=null, original-locals) pair.
-    /// Only the first such local found is expanded; nested cross-products are not emitted (target
-    /// files have at most one optionally-appended local in the value-expression tree).
+    /// Resolve a local that has compound `+=` appends into one or more variants:
+    /// <list type="bullet">
+    ///   <item>Required appends always fold into the local's resolved value.</item>
+    ///   <item>If the local also has optional appends, emit a `#opt:base` variant (required-only)
+    ///   plus one `#opt:withN` variant per optional. Within each `withN`, the optional is
+    ///   inserted at its source position relative to the required appends so the synthesised
+    ///   chain matches the runtime concatenation order.</item>
+    ///   <item>If the local has only required appends (no optionals), emit a single (label=null,
+    ///   locals) pair where the local's override value carries all required appends folded in —
+    ///   no fanout, but the resolved value still matches the runtime string.</item>
+    ///   <item>If the value expression has no append-bearing local, emit a single (label=null,
+    ///   original-locals) pair.</item>
+    /// </list>
+    /// Only the first append-bearing local found is expanded; nested cross-products are not
+    /// emitted (target files have at most one optionally-appended local in the value-expression
+    /// tree).
     /// </summary>
     private static List<(string? optLabel, IReadOnlyDictionary<string, ExpressionSyntax> locals)>
         ExpandOptionalAppends(
             ExpressionSyntax valueExpr,
             IReadOnlyDictionary<string, ExpressionSyntax> locals,
-            IReadOnlyDictionary<string, List<ExpressionSyntax>> appendsByLocal)
+            IReadOnlyDictionary<string, List<AppendEntry>> appendsByLocal)
     {
         var result = new List<(string?, IReadOnlyDictionary<string, ExpressionSyntax>)>();
         if (appendsByLocal.Count == 0)
@@ -411,14 +435,56 @@ internal sealed class Extractor
             return result;
         }
 
-        result.Add(("base", BuildAppendOverride(locals, appendLocalName, baseInit)));
+        // Indices (within `appends`, in source order) of the optional entries.
+        var optionalIndices = new List<int>();
         for (var i = 0; i < appends.Count; i++)
         {
-            var combined = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.BinaryExpression(
-                SyntaxKind.AddExpression, baseInit, appends[i]);
-            result.Add(($"with{i + 1}", BuildAppendOverride(locals, appendLocalName, combined)));
+            if (appends[i].Optional) optionalIndices.Add(i);
+        }
+
+        if (optionalIndices.Count == 0)
+        {
+            // Required-only: fold every append into the resolved value, no fanout.
+            var folded = ChainAppends(baseInit, appends, includeIndex: -1);
+            result.Add((null, BuildAppendOverride(locals, appendLocalName, folded)));
+            return result;
+        }
+
+        // `#opt:base` = initializer + all required appends (in source order); optionals omitted.
+        var baseChain = ChainAppends(baseInit, appends, includeIndex: -1);
+        result.Add(("base", BuildAppendOverride(locals, appendLocalName, baseChain)));
+
+        // `#opt:withK` = initializer + all required + the K-th optional, in source order.
+        for (var k = 0; k < optionalIndices.Count; k++)
+        {
+            var withChain = ChainAppends(baseInit, appends, includeIndex: optionalIndices[k]);
+            result.Add(($"with{k + 1}", BuildAppendOverride(locals, appendLocalName, withChain)));
         }
         return result;
+    }
+
+    /// <summary>
+    /// Build a left-leaning `+`-concat chain `init + a_i1 + a_i2 + ...` from the source-ordered
+    /// `appends`, including every required entry plus the entry at <paramref name="includeIndex"/>
+    /// (when non-negative). The result is a synthetic <see cref="BinaryExpressionSyntax"/> tree
+    /// that <see cref="ResolveValueExpression"/> / <see cref="FlattenConcat"/> can flatten as if
+    /// the local were declared with that concat as its initializer.
+    /// </summary>
+    private static ExpressionSyntax ChainAppends(
+        ExpressionSyntax init,
+        List<AppendEntry> appends,
+        int includeIndex)
+    {
+        var chain = init;
+        for (var i = 0; i < appends.Count; i++)
+        {
+            var entry = appends[i];
+            // Required entries always fold in. Optional entries fold in only when this is the
+            // specific optional being expanded (`includeIndex == i`).
+            if (entry.Optional && i != includeIndex) continue;
+            chain = SyntaxFactory.BinaryExpression(SyntaxKind.AddExpression, chain, entry.Right);
+        }
+        return chain;
     }
 
     private static IReadOnlyDictionary<string, ExpressionSyntax> BuildAppendOverride(
@@ -433,10 +499,10 @@ internal sealed class Extractor
         return copy;
     }
 
-    private static (string? name, List<ExpressionSyntax>? appends) FindAppendableLocal(
+    private static (string? name, List<AppendEntry>? appends) FindAppendableLocal(
         ExpressionSyntax expr,
         IReadOnlyDictionary<string, ExpressionSyntax> locals,
-        IReadOnlyDictionary<string, List<ExpressionSyntax>> appendsByLocal,
+        IReadOnlyDictionary<string, List<AppendEntry>> appendsByLocal,
         HashSet<string> visited)
     {
         foreach (var id in expr.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -10,8 +10,21 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace QudJP.Tools.AnnalsPatternExtractor;
 
+internal static class CandidateIdSuffix
+{
+    public const string Case = "#case:";
+    public const string Arm = "#arm:";
+    public const string Opt = "#opt:";
+    public const string If = "#if:";
+}
+
 internal sealed class Extractor
 {
+    private static readonly HashSet<string> KnownHelperReceivers =
+        new(StringComparer.Ordinal) { "Grammar", "QudHistoryHelpers", "Faction", "NameMaker" };
+
+    private static readonly char[] FormatAlignmentSeparators = { ',', ':' };
+
     private readonly List<CandidateEntry> candidates = new();
     private readonly List<string> diagnostics = new();
 
@@ -58,22 +71,22 @@ internal sealed class Extractor
             var switchLabel = switchSection is null ? "default" : (ExtractSwitchLabel(switchSection) ?? "default");
             var idPrefix = switchSection is null
                 ? $"{className}#{eventProperty}"
-                : $"{className}#{eventProperty}#case:{switchLabel}";
+                : $"{className}#{eventProperty}{CandidateIdSuffix.Case}{switchLabel}";
             var ifBranchSuffix = ResolveIfBranchSuffix(invocation, setterCalls, eventProperty);
-            if (ifBranchSuffix is not null) idPrefix += $"#if:{ifBranchSuffix}";
+            if (ifBranchSuffix is not null) idPrefix += CandidateIdSuffix.If + ifBranchSuffix;
 
             var setterLocals = BuildSetterScopedLocals(invocation, localInitializers);
+            var setterScopedAppends = FilterAppendsBeforeSetter(appendsByLocal, invocation);
             var armings = ExpandSwitchExpressionArms(valueExpr, setterLocals);
             foreach (var (armLabel, armLocals) in armings)
             {
                 var armSwitchCase = armLabel is null ? switchLabel : armLabel;
-                var armId = armLabel is null ? idPrefix : $"{idPrefix}#arm:{armLabel}";
+                var armId = armLabel is null ? idPrefix : idPrefix + CandidateIdSuffix.Arm + armLabel;
 
-                var setterScopedAppends = FilterAppendsBeforeSetter(appendsByLocal, invocation);
                 var optExpansions = ExpandOptionalAppends(valueExpr, armLocals, FilterAppendsToLocals(armLocals, setterScopedAppends));
                 foreach (var (optLabel, optLocals) in optExpansions)
                 {
-                    var optId = optLabel is null ? armId : $"{armId}#opt:{optLabel}";
+                    var optId = optLabel is null ? armId : armId + CandidateIdSuffix.Opt + optLabel;
                     var resolution = ResolveValueExpression(valueExpr, optLocals);
                     if (!resolution.Resolved)
                     {
@@ -640,15 +653,6 @@ internal sealed class Extractor
         return (raw, isAssignment);
     }
 
-    private static bool IsHistoryKitAssignmentToken(string token)
-    {
-        // Form: `<$name=...>` — the first character after `<` is `$` and the body contains `=`.
-        if (token.Length < 4 || token[0] != '<' || token[^1] != '>') return false;
-        if (token[1] != '$') return false;
-        // Search only inside the angle brackets.
-        return token.AsSpan(2, token.Length - 3).IndexOf('=') >= 0;
-    }
-
     // HistoricStringExpander rewrites %name% in the runtime value before the regex matches.
     private const string HseExpansionType = "hse-expansion";
 
@@ -830,7 +834,7 @@ internal sealed class Extractor
                     return false;
                 }
                 var holderBody = format.Substring(i + 1, close - i - 1);
-                var sepIdx = holderBody.IndexOfAny(new[] { ',', ':' });
+                var sepIdx = holderBody.IndexOfAny(FormatAlignmentSeparators);
                 var indexStr = sepIdx < 0 ? holderBody : holderBody[..sepIdx];
                 if (!int.TryParse(indexStr, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var argIdx))
                 {
@@ -923,13 +927,11 @@ internal sealed class Extractor
         // Helper-call slot type for invocations from the known game-helper namespaces, format-arg
         // for everything else (literals already resolved by FlattenConcat, so this hits unknown
         // identifiers or expressions).
-        if (expr is InvocationExpressionSyntax invoc)
+        if (expr is InvocationExpressionSyntax invoc
+            && invoc.Expression is MemberAccessExpressionSyntax m
+            && KnownHelperReceivers.Contains(m.Expression.ToString()))
         {
-            if (invoc.Expression is MemberAccessExpressionSyntax m)
-            {
-                var receiver = m.Expression.ToString();
-                if (receiver is "Grammar" or "QudHistoryHelpers" or "Faction" or "NameMaker") return "helper-call";
-            }
+            return "helper-call";
         }
         return "format-arg";
     }
@@ -1007,17 +1009,12 @@ internal sealed class Extractor
     // the inner pattern (e.g. `Grammar.InitCap(string.Format(...))`).
     private static bool IsPatternPreservingWrapper(InvocationExpressionSyntax invoc)
     {
+        if (IsExpandStringWrapper(invoc)) return true;
         if (invoc.ArgumentList.Arguments.Count < 1) return false;
-        if (invoc.Expression is IdentifierNameSyntax bareId && bareId.Identifier.ValueText == "ExpandString") return true;
-        if (invoc.Expression is MemberAccessExpressionSyntax m)
+        if (invoc.Expression is MemberAccessExpressionSyntax m
+            && m.Expression.ToString() == "Grammar")
         {
-            var receiver = m.Expression.ToString();
-            var name = m.Name.Identifier.ValueText;
-            if (name == "ExpandString") return true;
-            if (receiver == "Grammar")
-            {
-                return name is "InitCap" or "InitialCap" or "MakeTitleCase" or "MakeTitleCaseWithArticle";
-            }
+            return m.Name.Identifier.ValueText is "InitCap" or "InitialCap" or "MakeTitleCase" or "MakeTitleCaseWithArticle";
         }
         return false;
     }

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -213,6 +213,7 @@ internal sealed class Extractor
             return new ResolutionResult { Resolved = false, Reason = unsupportedReason };
         }
 
+        ApplyHistoryKitTokenLexer(pieces, slots);
         ApplyHseExpansion(pieces, slots);
 
         var sample = string.Concat(pieces);
@@ -222,6 +223,83 @@ internal sealed class Extractor
             SampleSource = sample,
             Slots = slots,
         };
+    }
+
+    // HistoryKit `<...>` tokens are expanded by HistoricStringExpander.ExpandString to arbitrary
+    // text (or empty for assignment-form `<$var=...>`). We slot them so the runtime regex matches
+    // the post-expansion stored value, not the pre-expansion source literal.
+    private const string HistoryKitTokenType = "historykit-token";
+
+    private static void ApplyHistoryKitTokenLexer(List<string> pieces, List<SlotEntry> slots)
+    {
+        // Renumbering is required because we splice new slots into the middle of the slot list.
+        // Strategy: rebuild pieces+slots from scratch, scanning every existing piece. Existing
+        // slot references (e.g. `{0}` already produced by FlattenConcat) are remapped to the new
+        // index space.
+        var oldSlots = new List<SlotEntry>(slots);
+        var oldPieces = new List<string>(pieces);
+        slots.Clear();
+        pieces.Clear();
+
+        foreach (var piece in oldPieces)
+        {
+            if (piece.Length >= 3 && piece[0] == '{' && piece[^1] == '}'
+                && int.TryParse(piece.AsSpan(1, piece.Length - 2), System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var oldIndex)
+                && (uint)oldIndex < (uint)oldSlots.Count)
+            {
+                var slot = oldSlots[oldIndex];
+                slot.Index = slots.Count;
+                slot.Default = $"{{t{slots.Count}}}";
+                slots.Add(slot);
+                pieces.Add($"{{{slot.Index}}}");
+                continue;
+            }
+
+            // Literal piece: scan for `<...>` tokens.
+            var i = 0;
+            var sb = new StringBuilder();
+            while (i < piece.Length)
+            {
+                if (piece[i] != '<')
+                {
+                    sb.Append(piece[i]);
+                    i++;
+                    continue;
+                }
+                var close = piece.IndexOf('>', i + 1);
+                if (close < 0)
+                {
+                    sb.Append(piece[i]);
+                    i++;
+                    continue;
+                }
+                var token = piece.Substring(i, close - i + 1);
+                if (IsHistoryKitAssignmentToken(token))
+                {
+                    // Zero-width: assignment-form tokens (`<$var=...>`) emit "" at runtime.
+                    i = close + 1;
+                    continue;
+                }
+                if (sb.Length > 0)
+                {
+                    pieces.Add(sb.ToString());
+                    sb.Clear();
+                }
+                AddSlot(slots, token, type: HistoryKitTokenType);
+                pieces.Add($"{{{slots.Count - 1}}}");
+                i = close + 1;
+            }
+            if (sb.Length > 0) pieces.Add(sb.ToString());
+        }
+    }
+
+    private static bool IsHistoryKitAssignmentToken(string token)
+    {
+        // Form: `<$name=...>` — the first character after `<` is `$` and the body contains `=`.
+        if (token.Length < 4 || token[0] != '<' || token[^1] != '>') return false;
+        if (token[1] != '$') return false;
+        // Search only inside the angle brackets.
+        return token.AsSpan(2, token.Length - 3).IndexOf('=') >= 0;
     }
 
     // HistoricStringExpander rewrites %name% in the runtime value before the regex matches.

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -1083,7 +1083,7 @@ internal sealed class Extractor
 
             case InvocationExpressionSyntax invoc when IsExpandStringWrapper(invoc) && IsTokenShapedExpression(invoc.ArgumentList.Arguments[0].Expression, locals):
             {
-                AddSlot(slots, RenderTokenRaw(invoc.ArgumentList.Arguments[0].Expression), type: HistoryKitTokenType);
+                AddSlot(slots, RenderTokenRaw(invoc.ArgumentList.Arguments[0].Expression, locals), type: HistoryKitTokenType);
                 pieces.Add($"{{{slots.Count - 1}}}");
                 return true;
             }
@@ -1229,14 +1229,29 @@ internal sealed class Extractor
     /// (unquoted) and any non-literal sub-expressions wrapped in `{...}` placeholders. This keeps
     /// the raw stable across re-runs and avoids embedding C# string literal quotes.
     /// </summary>
-    private static string RenderTokenRaw(ExpressionSyntax expr)
+    /// <remarks>
+    /// CR R8: when the expression is a local whose initializer is itself a literal-only
+    /// concat that yields a token-shaped string (e.g. `var tok = "&lt;entity.name&gt;";
+    /// ExpandString(tok)`), follow the local through `locals` so the slot raw matches what the
+    /// runtime expands — not the C# identifier name. The follow-through is intentionally
+    /// limited to literal-only initializers: locals whose RHS is a method call or another
+    /// non-literal expression keep the prior `{name}` placeholder rendering, so PR2a outputs
+    /// where helper-derived locals appear inside cross-piece tokens (e.g. `text3 = ExpandString
+    /// (...)` in MeetFaction) remain byte-identical. Visited-set guard mirrors
+    /// `LeftmostLiteral`/`RightmostLiteral` to prevent infinite recursion on cyclic locals.
+    /// </remarks>
+    private static string RenderTokenRaw(ExpressionSyntax expr, IReadOnlyDictionary<string, ExpressionSyntax> locals)
     {
         var sb = new StringBuilder();
-        AppendTokenRaw(expr, sb);
+        AppendTokenRaw(expr, locals, new HashSet<string>(StringComparer.Ordinal), sb);
         return sb.ToString();
     }
 
-    private static void AppendTokenRaw(ExpressionSyntax expr, StringBuilder sb)
+    private static void AppendTokenRaw(
+        ExpressionSyntax expr,
+        IReadOnlyDictionary<string, ExpressionSyntax> locals,
+        HashSet<string> visited,
+        StringBuilder sb)
     {
         switch (expr)
         {
@@ -1244,13 +1259,51 @@ internal sealed class Extractor
                 sb.Append(lit.Token.ValueText);
                 break;
             case BinaryExpressionSyntax bin when bin.IsKind(SyntaxKind.AddExpression):
-                AppendTokenRaw(bin.Left, sb);
-                AppendTokenRaw(bin.Right, sb);
+                AppendTokenRaw(bin.Left, locals, visited, sb);
+                AppendTokenRaw(bin.Right, locals, visited, sb);
+                break;
+            case IdentifierNameSyntax id
+                when locals.TryGetValue(id.Identifier.ValueText, out var init)
+                && IsLiteralOnlyConcat(init, locals, new HashSet<string>(StringComparer.Ordinal))
+                && visited.Add(id.Identifier.ValueText):
+                try
+                {
+                    AppendTokenRaw(init, locals, visited, sb);
+                }
+                finally
+                {
+                    visited.Remove(id.Identifier.ValueText);
+                }
                 break;
             default:
                 sb.Append('{').Append(ClassifyHelperCallRaw(expr)).Append('}');
                 break;
         }
+    }
+
+    /// <summary>
+    /// True when <paramref name="expr"/> is a string literal, a `+`-concat of literal-only
+    /// sub-expressions, or an identifier that resolves through `locals` to a literal-only
+    /// expression. Used by `AppendTokenRaw` to decide whether following an identifier through
+    /// the locals table is safe (i.e., yields a stable string with no embedded helper calls).
+    /// </summary>
+    private static bool IsLiteralOnlyConcat(
+        ExpressionSyntax expr,
+        IReadOnlyDictionary<string, ExpressionSyntax> locals,
+        HashSet<string> visited)
+    {
+        return expr switch
+        {
+            LiteralExpressionSyntax lit when lit.IsKind(SyntaxKind.StringLiteralExpression) => true,
+            BinaryExpressionSyntax bin when bin.IsKind(SyntaxKind.AddExpression)
+                => IsLiteralOnlyConcat(bin.Left, locals, visited)
+                    && IsLiteralOnlyConcat(bin.Right, locals, visited),
+            IdentifierNameSyntax id
+                when locals.TryGetValue(id.Identifier.ValueText, out var init)
+                && visited.Add(id.Identifier.ValueText)
+                => IsLiteralOnlyConcat(init, locals, visited),
+            _ => false,
+        };
     }
 
     private static string ClassifyHelperCallSlotType(ExpressionSyntax expr)

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -1438,6 +1438,14 @@ internal sealed class Extractor
     // Wrappers whose return value matches their first argument modulo capitalization /
     // HSE expansion — both invisible to a runtime regex match. Unwrapping lets us see
     // the inner pattern (e.g. `Grammar.InitCap(string.Format(...))`).
+    //
+    // Receiver matching is intentionally syntax-only (`m.Expression.ToString() == "Grammar"`),
+    // mirroring `KnownHelperReceivers` and the rest of the extractor — no Compilation /
+    // SemanticModel is built. Fully-qualified usages (`XRL.Core.Grammar.InitCap`) would slip
+    // through this check, but the decompiled `XRL.Annals/*.cs` corpus only emits the bare-
+    // identifier form. Migrating to SemanticModel-based symbol resolution would require
+    // building a Compilation with the full game's MetadataReferences and converting every
+    // string-match site for consistency, which is out of scope for #430. CR R9 noted; deferred.
     private static bool IsPatternPreservingWrapper(InvocationExpressionSyntax invoc)
     {
         if (IsExpandStringWrapper(invoc)) return true;

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -570,21 +570,34 @@ internal sealed class Extractor
     /// Drop compound-append entries whose owning append statement starts at or after the setter's
     /// span. Appends that execute after the setter never influence the value the runtime stores,
     /// so they must neither fold into the resolved value nor fan out as `#opt:withN` candidates.
+    /// Also drop appends that are wiped by an intervening simple assignment to the same local —
+    /// `text += " mid"; text = "override"; setter` runs `text="override"` at the setter, not
+    /// `"override mid"`, so the stale `+=` must not chain onto the resolved value.
     /// </summary>
     private static IReadOnlyDictionary<string, List<AppendEntry>> FilterAppendsBeforeSetter(
         IReadOnlyDictionary<string, List<AppendEntry>> appendsByLocal,
         InvocationExpressionSyntax setter)
     {
         var dict = new Dictionary<string, List<AppendEntry>>(StringComparer.Ordinal);
+        var method = setter.FirstAncestorOrSelf<MethodDeclarationSyntax>();
         foreach (var (name, appends) in appendsByLocal)
         {
+            var resetSpans = method?.DescendantNodes()
+                .OfType<AssignmentExpressionSyntax>()
+                .Where(a => a.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                    && a.Left is IdentifierNameSyntax lhs
+                    && lhs.Identifier.ValueText == name)
+                .Select(a => a.SpanStart)
+                .ToList() ?? new List<int>();
             var kept = new List<AppendEntry>();
             foreach (var entry in appends)
             {
                 // The rhs is the right-hand side of `local += rhs`; walk up to the owning
                 // assignment expression (its parent) and use its span as the append's span.
                 var assignSpanStart = entry.Right.Parent?.SpanStart ?? entry.Right.SpanStart;
-                if (assignSpanStart < setter.SpanStart) kept.Add(entry);
+                if (assignSpanStart >= setter.SpanStart) continue;
+                if (resetSpans.Any(r => r > assignSpanStart && r < setter.SpanStart)) continue;
+                kept.Add(entry);
             }
             if (kept.Count > 0) dict[name] = kept;
         }

--- a/scripts/tools/AnnalsPatternExtractor/Program.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Program.cs
@@ -124,8 +124,13 @@ foreach (var candidate in collapsed)
 
 static string StripIfBranchSuffix(string id)
 {
-    var idx = id.IndexOf("#if:", StringComparison.Ordinal);
-    return idx < 0 ? id : id[..idx];
+    // Remove ONLY the `#if:<label>` segment, preserving downstream suffixes like
+    // `#arm:` or `#opt:`. Otherwise `foo#if:then#arm:0` and `foo#if:else#opt:with1`
+    // would both collapse to `foo` and either falsely merge or false-collide.
+    var idx = id.IndexOf(CandidateIdSuffix.If, StringComparison.Ordinal);
+    if (idx < 0) return id;
+    var nextSuffix = id.IndexOf('#', idx + CandidateIdSuffix.If.Length);
+    return nextSuffix < 0 ? id[..idx] : id[..idx] + id[nextSuffix..];
 }
 
 var doc = new CandidateDocument

--- a/scripts/tools/AnnalsPatternExtractor/Program.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Program.cs
@@ -92,7 +92,12 @@ foreach (var bucket in groups.Values)
     }
     var firstHash = bucket[0].EnTemplateHash;
     var allSameShape = bucket.All(c => c.EnTemplateHash == firstHash);
-    if (allSameShape)
+    // Only collapse buckets where every member is `pending`. EnTemplateHash does not
+    // include status/reason, so a bucket of `needs_manual` candidates with identical
+    // empty patterns but DIFFERENT failure reasons would otherwise collapse to one,
+    // losing the per-branch reason.
+    var allPending = bucket.All(c => c.Status == "pending");
+    if (allPending && allSameShape)
     {
         var first = bucket[0];
         first.Id = StripIfBranchSuffix(first.Id);

--- a/scripts/tools/AnnalsPatternExtractor/Program.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Program.cs
@@ -65,9 +65,49 @@ foreach (var diag in extractor.Diagnostics)
     Console.Error.WriteLine($"[warn] {diag}");
 }
 
+// Pre-pass: collapse if-branch siblings whose patterns turned out structurally identical so the
+// `#if:then`/`#if:else` suffix only survives when the branches *differ*. We pair them by the
+// "id with the if-suffix stripped" — if all members of the group share one hash, replace their
+// ids with the stripped form and keep one. This realises Option A (dedupe identical shapes) for
+// if-branches without losing distinctness in the divergent-shape case.
+var groups = new Dictionary<string, List<CandidateEntry>>(StringComparer.Ordinal);
+foreach (var candidate in extractor.Candidates)
+{
+    var key = StripIfBranchSuffix(candidate.Id);
+    if (!groups.TryGetValue(key, out var bucket))
+    {
+        bucket = new List<CandidateEntry>();
+        groups[key] = bucket;
+    }
+    bucket.Add(candidate);
+}
+
+var collapsed = new List<CandidateEntry>();
+foreach (var bucket in groups.Values)
+{
+    if (bucket.Count == 1)
+    {
+        collapsed.Add(bucket[0]);
+        continue;
+    }
+    var firstHash = bucket[0].EnTemplateHash;
+    var allSameShape = bucket.All(c => c.EnTemplateHash == firstHash);
+    if (allSameShape)
+    {
+        var first = bucket[0];
+        first.Id = StripIfBranchSuffix(first.Id);
+        first.EnTemplateHash = HashHelper.ComputeEnTemplateHash(first);
+        collapsed.Add(first);
+    }
+    else
+    {
+        collapsed.AddRange(bucket);
+    }
+}
+
 var deduped = new List<CandidateEntry>();
 var seenById = new Dictionary<string, CandidateEntry>(StringComparer.Ordinal);
-foreach (var candidate in extractor.Candidates)
+foreach (var candidate in collapsed)
 {
     if (seenById.TryGetValue(candidate.Id, out var prior))
     {
@@ -80,6 +120,12 @@ foreach (var candidate in extractor.Candidates)
     }
     seenById[candidate.Id] = candidate;
     deduped.Add(candidate);
+}
+
+static string StripIfBranchSuffix(string id)
+{
+    var idx = id.IndexOf("#if:", StringComparison.Ordinal);
+    return idx < 0 ? id : id[..idx];
 }
 
 var doc = new CandidateDocument

--- a/scripts/tools/AnnalsPatternExtractor/Program.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Program.cs
@@ -116,11 +116,21 @@ foreach (var candidate in collapsed)
 {
     if (seenById.TryGetValue(candidate.Id, out var prior))
     {
-        if (prior.EnTemplateHash == candidate.EnTemplateHash) continue;
+        // Hash equality alone is not enough to silently dedupe: EnTemplateHash does not
+        // include Status/Reason, so two `needs_manual` candidates with identical empty
+        // shapes but DIFFERENT failure reasons would otherwise merge and lose one reason.
+        var sameShape = prior.EnTemplateHash == candidate.EnTemplateHash;
+        var sameOutcome =
+            string.Equals(prior.Status, candidate.Status, StringComparison.Ordinal)
+            && string.Equals(prior.Reason, candidate.Reason, StringComparison.Ordinal);
+        if (sameShape && sameOutcome) continue;
+
         Console.Error.WriteLine(
-            $"[error] duplicate candidate id with divergent shape: {candidate.Id} "
-            + $"(prior={prior.EnTemplateHash}, new={candidate.EnTemplateHash}). "
-            + "Resolve via branch/path id suffixes (`#case:`, `#arm:`, `#opt:`).");
+            $"[error] duplicate candidate id with divergent outcome: {candidate.Id} "
+            + $"(priorHash={prior.EnTemplateHash}, newHash={candidate.EnTemplateHash}, "
+            + $"priorStatus={prior.Status}, newStatus={candidate.Status}, "
+            + $"priorReason={prior.Reason}, newReason={candidate.Reason}). "
+            + "Resolve via branch/path id suffixes (`#case:`, `#arm:`, `#opt:`) or preserve both reasons.");
         return 1;
     }
     seenById[candidate.Id] = candidate;

--- a/scripts/tools/AnnalsPatternExtractor/Program.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Program.cs
@@ -124,13 +124,17 @@ foreach (var candidate in collapsed)
 
 static string StripIfBranchSuffix(string id)
 {
-    // Remove ONLY the `#if:<label>` segment, preserving downstream suffixes like
+    // Remove ONLY the `#if:<label>` segment(s), preserving downstream suffixes like
     // `#arm:` or `#opt:`. Otherwise `foo#if:then#arm:0` and `foo#if:else#opt:with1`
     // would both collapse to `foo` and either falsely merge or false-collide.
-    var idx = id.IndexOf(CandidateIdSuffix.If, StringComparison.Ordinal);
-    if (idx < 0) return id;
-    var nextSuffix = id.IndexOf('#', idx + CandidateIdSuffix.If.Length);
-    return nextSuffix < 0 ? id[..idx] : id[..idx] + id[nextSuffix..];
+    // Loop until no `#if:` remains so any future nested-if extraction stays in sync.
+    while (true)
+    {
+        var idx = id.IndexOf(CandidateIdSuffix.If, StringComparison.Ordinal);
+        if (idx < 0) return id;
+        var nextSuffix = id.IndexOf('#', idx + CandidateIdSuffix.If.Length);
+        id = nextSuffix < 0 ? id[..idx] : id[..idx] + id[nextSuffix..];
+    }
 }
 
 var doc = new CandidateDocument

--- a/scripts/tools/AnnalsPatternExtractor/Program.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Program.cs
@@ -65,10 +65,27 @@ foreach (var diag in extractor.Diagnostics)
     Console.Error.WriteLine($"[warn] {diag}");
 }
 
+var deduped = new List<CandidateEntry>();
+var seenById = new Dictionary<string, CandidateEntry>(StringComparer.Ordinal);
+foreach (var candidate in extractor.Candidates)
+{
+    if (seenById.TryGetValue(candidate.Id, out var prior))
+    {
+        if (prior.EnTemplateHash == candidate.EnTemplateHash) continue;
+        Console.Error.WriteLine(
+            $"[error] duplicate candidate id with divergent shape: {candidate.Id} "
+            + $"(prior={prior.EnTemplateHash}, new={candidate.EnTemplateHash}). "
+            + "Resolve via branch/path id suffixes (`#case:`, `#arm:`, `#opt:`).");
+        return 1;
+    }
+    seenById[candidate.Id] = candidate;
+    deduped.Add(candidate);
+}
+
 var doc = new CandidateDocument
 {
     SchemaVersion = "1",
-    Candidates = extractor.Candidates.OrderBy(c => c.Id, StringComparer.Ordinal).ToList(),
+    Candidates = deduped.OrderBy(c => c.Id, StringComparer.Ordinal).ToList(),
 };
 CandidateWriter.WriteToFile(output, doc);
 

--- a/scripts/validate_candidate_schema.py
+++ b/scripts/validate_candidate_schema.py
@@ -36,6 +36,10 @@ VALID_SLOT_TYPES = {
     "string-format-arg",
     "unresolved-local",
     "hse-expansion",
+    "historykit-token",
+    "helper-call",
+    "format-arg",
+    "switch-branch",
 }
 VALID_EVENT_PROPERTIES = {"gospel", "tombInscription"}
 PLACEHOLDER_RE = re.compile(r"\{(t?)(\d+)\}")


### PR DESCRIPTION
## Summary

Closes #430. Blocks #422 PR2a (Birth/origin Annals files).

Extends `AnnalsPatternExtractor` so PR2a's 5 target files (`Adopted`, `BornAsHeir`, `FoundAsBabe`, `Marry`, `MeetFaction`) can be safely extracted into `pending` candidates rather than producing broad `^(.+?)$` patterns or `needs_manual` falls. Strictly tooling — no dictionary, runtime, or translation changes.

### What's new

- **HistoryKit token slot lexer**: `<spice...>`, `<entity.*>`, `<$node=...>` (including cross-piece assemblies via `+` concat) collapse to a `historykit-token` slot with `(.+?)` regex. Necessary because `HistoricEvent.SetEventProperty` runtime-expands `<...>` via `HistoricStringExpander.ExpandString` BEFORE storage.
- **`string.Format` flattener** (top-level + via local): `value = string.Format(fmt, a, b, ...)` resolved to the format string; placeholder `{N}` mapped to per-argument slots.
- **Helper-call slots + pattern-preserving wrapper unwrap**: invocations on `Grammar` / `QudHistoryHelpers` / `Faction` / `NameMaker` get classified as `helper-call` slots; `ExpandString(...)`, `Grammar.{InitCap, InitialCap, MakeTitleCase, MakeTitleCaseWithArticle}` are unwrapped to expose the inner pattern.
- **Branch enumeration**: switch-section per-case (`#case:N`), switch-expression-as-local fanout (`#arm:N`), if-branch siblings (`#if:then`/`#if:else`), and optional-append (`#opt:base`/`#opt:withN` for `if (flag) text += ...`).
- **Dedupe pass** in `Program.cs`: collapses identical-shape `#if:then`/`#if:else` siblings to the unsuffixed id; errors out on same-id-different-shape collisions.
- **Schema validator**: 4 new slot types — `historykit-token`, `helper-call`, `format-arg`, `switch-branch`.

### TDD-driven additions

7 new fixture pairs under `scripts/tests/fixtures/annals/` plus 2 regression fixtures from the Codex P2 fix. Each one drove a single new feature in Red→Green→Refactor:

| Fixture | Drives |
|---|---|
| `historykit_tokens` | HistoryKit `<...>` slot lexer |
| `string_format_local` | `value = string.Format(...)` local resolution |
| `string_format_with_helpers` | helper-call slots + wrapper unwrap whitelist |
| `switch_branch_candidates` | switch-section per-case enumeration |
| `switch_expression_local` | switch-expression-as-local fanout |
| `if_optional_append` | `local += suffix` optional-append fanout |
| `duplicate_event_property_dedupe` | identical-shape sibling dedupe |
| `append_after_setter` | append-after-setter NOT fanned out (Codex P2) |
| `branch_assign_after_setter` | post-setter assignment NOT used as setter-scoped value (Codex P2) |

### Codex review (P2 correctness fix)

Codex review on the implementation surfaced two flow-analysis bugs where span ordering alone admitted post-setter values into the candidate output. Both fixed with dominator-path filtering:

- **`BuildSetterScopedLocals`**: skip stmts whose span *contains* the setter (those are ancestors handled at deeper cursor levels and include post-setter assignments by definition).
- **`FilterAppendsBeforeSetter`**: filter compound `+=` to those starting strictly before the setter.

`Marry.cs`'s legitimate `text10 += ...` BEFORE the setter still produces the desired `#opt:with1` variant.

### Simplify pass (3 parallel reviewers)

Aggregated findings:
- Deduped `IsPatternPreservingWrapper` ExpandString check via `IsExpandStringWrapper` delegation.
- Removed dead `IsHistoryKitAssignmentToken` (`BuildTokenRaw` already returned the same flag).
- Extracted suffix scheme constants (`CandidateIdSuffix.Case/Arm/Opt/If`).
- Extracted `KnownHelperReceivers` HashSet.
- Hoisted `FilterAppendsBeforeSetter` out of the per-arm loop.
- Hoisted the `{','‚':'}` array allocation to a static readonly field.

## PR1 regression check

All 16 Resheph `extracted_pattern` strings remain **byte-identical** vs main. One slot's metadata upgraded from `unresolved-local`/`raw=newRegion` to `helper-call`/`raw=QudHistoryHelpers.GetNewRegion(...)` — strict accuracy improvement; `merge_annals_patterns.py` keys on `extracted_pattern`, so the shipped `annals-patterns.ja.json` is unaffected.

## PR2a target candidate summary

Total: **24 candidates, 24 pending, 0 needs_manual, 0 broad `^(.+?)$`** — meets the issue acceptance criteria.

| File | count | breakdown |
|---|---:|---|
| `Adopted.cs` | 1 | gospel |
| `BornAsHeir.cs` | 2 | gospel, tombInscription |
| `FoundAsBabe.cs` | 6 | gospel#case:0, gospel#case:1, gospel#case:default#opt:base/with1/with2, tombInscription |
| `Marry.cs` | 3 | gospel#opt:base, gospel#opt:with1, tombInscription |
| `MeetFaction.cs` | 12 | gospel × 3 arms × 2 if-branches + tombInscription × 3 arms × 2 if-branches |

Codex's 13–21 estimate; 24 includes the if-branch × switch-arm cross-product for MeetFaction (some siblings share `extracted_pattern` but differ in slot `raw` text — PR2a will dedupe during translation review).

## Out of scope (explicit)

- No `annals-patterns.ja.json` modifications (PR2a's job)
- No Japanese strings introduced
- No runtime translator changes (`AnnalsPatternTranslator` etc. unchanged)

## Test plan

- [x] `dotnet build Mods/QudJP/Assemblies/QudJP.csproj` — 0 warnings
- [x] `dotnet build scripts/tools/AnnalsPatternExtractor/AnnalsPatternExtractor.csproj` — 0 warnings
- [x] `dotnet test ... TestCategory=L1` — 1355/1355
- [x] `dotnet test ... TestCategory=L2` — 760/760
- [x] `uv run pytest scripts/tests/` — 635/635 (was 617 baseline; +18 from new fixtures × 2 parametrize axes)
- [x] `ruff check scripts/` — clean
- [x] `python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json` — clean
- [x] PR1 16 Resheph extracted_pattern: byte-identical vs main
- [x] PR2a 5 target files: 24 pending, 0 broad

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  - annals向けの多数の新規/更新テストフィクスチャを追加し、分岐・オプション追記・スイッチ腕・文字列フォーマット・エスケープ中括弧・履歴トークン・スロット抽出のカバレッジを拡張
  - フィクスチャ一覧をディスク上の期待ファイルから自動検出し、不整合時に失敗するよう検証を強化

* **Chores**
  - 抽出器の出力正規化、候補集約・重複除去・崩壊条件の改善を導入
  - 履歴トークンや新スロット種類を扱えるようスキーマ検証を更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->