### PR TITLE
feat(#422): PR2a — translate 24 birth/origin Annals + InitCap fix + collision guard

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/AnnalsPatternsCollisionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/AnnalsPatternsCollisionTests.cs
@@ -97,11 +97,16 @@ public sealed class AnnalsPatternsCollisionTests
             {
                 var later = annals[j];
                 if (later?.Pattern is null) continue;
-                if (earlier.Pattern == later.Pattern) continue;
-                var laterSample = StripCapturesToPlaceholder(later.Pattern, "X");
+                // Build a literal sample by replacing the LATER pattern's capture groups with
+                // a placeholder, then unescaping the regex source so that `\.` becomes `.` etc.
+                // Without unescape we'd be matching regex source against regex source — duplicate
+                // and swallowing patterns silently slip through. Exact-equal patterns are
+                // intentionally NOT skipped: a duplicate pattern means later entries are
+                // first-match-wins-unreachable and must surface as a test failure.
+                var laterSample = Regex.Unescape(StripCapturesToPlaceholder(later.Pattern, "X"));
                 Assert.That(earlierRe.IsMatch(laterSample), Is.False,
                     $"earlier annals pattern '{earlier.Pattern}' (index {i}) swallows later pattern '{later.Pattern}' (index {j}, sample={laterSample}). "
-                    + "Reorder so concrete patterns precede generic ones, or fix the merge sort.");
+                    + "Reorder so concrete patterns precede generic ones, fix the merge sort, or deduplicate.");
             }
         }
     }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/AnnalsPatternsCollisionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/AnnalsPatternsCollisionTests.cs
@@ -75,4 +75,34 @@ public sealed class AnnalsPatternsCollisionTests
         var noAnchors = pattern.TrimStart('^').TrimEnd('$');
         return Regex.Replace(noAnchors, @"\([^)]*\)", placeholder);
     }
+
+    [Test]
+    public void EarlierAnnalsPattern_DoesNotSwallowLaterAnnalsPattern_FirstMatchWins()
+    {
+        // Intra-annals collision: a generic PR2+ pattern (FoundAsBabe with `(.+?)` slots)
+        // can share its literal anchor structure with a concrete Resheph pattern. The
+        // runtime regex iterates patterns in file order and uses the first match, so a
+        // generic pattern appearing BEFORE a concrete one masks the concrete one and its
+        // crafted translation is lost. The merge step sorts by length descending so
+        // concrete (longer literal) patterns win — this test guards that invariant.
+        var localizationRoot = GetLocalizationRoot();
+        var annals = LoadPatterns(Path.Combine(localizationRoot, "Dictionaries", "annals-patterns.ja.json"));
+        for (var i = 0; i < annals.Count; i++)
+        {
+            var earlier = annals[i];
+            if (earlier?.Pattern is null) continue;
+            Regex earlierRe;
+            try { earlierRe = new Regex(earlier.Pattern); } catch { continue; }
+            for (var j = i + 1; j < annals.Count; j++)
+            {
+                var later = annals[j];
+                if (later?.Pattern is null) continue;
+                if (earlier.Pattern == later.Pattern) continue;
+                var laterSample = StripCapturesToPlaceholder(later.Pattern, "X");
+                Assert.That(earlierRe.IsMatch(laterSample), Is.False,
+                    $"earlier annals pattern '{earlier.Pattern}' (index {i}) swallows later pattern '{later.Pattern}' (index {j}, sample={laterSample}). "
+                    + "Reorder so concrete patterns precede generic ones, or fix the merge sort.");
+            }
+        }
+    }
 }

--- a/Mods/QudJP/Localization/Dictionaries/annals-patterns.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/annals-patterns.ja.json
@@ -2,63 +2,13 @@
   "entries": [],
   "patterns": [
     {
-      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ Rebekah\\ died\\ of\\ glotrot,\\ and\\ on\\ her\\ deathbed\\ Resheph\\ forgave\\ her\\ and\\ absolved\\ her\\ of\\ sin\\.\\ He\\ allowed\\ her\\ to\\ be\\ buried\\ in\\ the\\ village\\ of\\ Ezra,\\ outside\\ the\\ gate\\ to\\ the\\ Tomb\\ of\\ the\\ Eaters\\ and\\ beneath\\ the\\ shadow\\ of\\ the\\ Spindle\\.$",
-      "template": "{0}年、レベカはグロットロットにより死し、その臨終の床にてレシェフは彼女を赦し、その罪を解き放った。彼は彼女がエズラの村、喰らう者の墓所の門の外、スピンドルの影の下に葬られることを許した。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ Resheph\\ appointed\\ Rebekah\\ administrator\\ of\\ (.+?)\\.\\ She\\ tendered\\ alms\\ for\\ the\\ sick\\ in\\ his\\ name\\.$",
-      "template": "{0}年、レシェフはレベカを{t1}の施政官に任じた。彼女は彼の名において病める者へ施しを捧げた。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^Acting\\ against\\ a\\ prohibition\\ on\\ the\\ practice\\ of\\ worshipping\\ the\\ stars,\\ Resheph\\ led\\ an\\ army\\ to\\ the\\ gates\\ of\\ Omonporch\\.\\ There\\ he\\ defeated\\ his\\ brothers\\ in\\ battle\\ and\\ liberated\\ its\\ citizens,\\ and\\ they\\ crowned\\ him\\ the\\ sultan\\ of\\ Qud\\.$",
-      "template": "星々を崇める営みへの禁令に背き、レシェフは軍勢を率いてオモンポーチの門へ至った。そこで彼は兄弟たちを戦に破り、その市民を解き放った。かくして彼らは彼にクッドのスルタンの冠を授けた。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ Rebekah\\ betrayed\\ Resheph\\ by\\ stealing\\ the\\ Mark\\ of\\ Death\\ from\\ the\\ gate\\ to\\ the\\ Tomb\\ of\\ the\\ Eaters\\.\\ In\\ punishment,\\ Resheph\\ excommunicated\\ her\\ from\\ the\\ sultanate\\.$",
-      "template": "{0}年、レベカは喰らう者の墓所の門より死の印を盗み、レシェフを裏切った。その罰として、レシェフは彼女をスルタン国より破門した。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ Resheph\\ cleansed\\ the\\ marshlands\\ of\\ the\\ plagues\\ of\\ the\\ Gyre\\ and\\ taught\\ Abram\\ to\\ sow\\ watervine\\ along\\ its\\ fertile\\ tracks\\.$",
-      "template": "{0}年、レシェフは湿地帯よりジャイアの災厄を祓い、その肥沃なる道筋に沿ってワターヴァインを蒔く術をアブラムに授けた。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ Resheph\\ closed\\ the\\ gates\\ to\\ the\\ Tomb\\ of\\ the\\ Eaters,\\ abdicated\\ the\\ throne,\\ and\\ dissolved\\ the\\ sultanate\\ in\\ order\\ to\\ lift\\ the\\ curse\\ of\\ the\\ Gyre\\.$",
-      "template": "{0}年、レシェフはジャイアの呪いを解くため、喰らう者の墓所の門を閉ざし、王座を退き、スルタン国を解いた。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ Resheph,\\ the\\ Above,\\ Ghost-in-Cerulean,\\ the\\ Coiled\\ Lamb\\ of\\ Baetyls,\\ died\\ of\\ natural\\ causes\\.\\ He\\ was\\ 216\\ years\\ old\\.$",
-      "template": "{0}年、レシェフ、天上なる者、瑠璃の幽鬼、ベテルのとぐろ巻く仔羊は、自然の理により身罷った。享年216歳であった。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^After\\ conferring\\ with\\ mysterious\\ strangers,\\ Resheph\\ convinced\\ them\\ to\\ help\\ him\\ found\\ a\\ harborage\\ for\\ the\\ purpose\\ of\\ receiving\\ visitors\\ from\\ across\\ the\\ clustered\\ cosmos\\.\\ They\\ named\\ it\\ Starfarer's\\ Quay\\.$",
-      "template": "謎めいた異邦人らと協議したのち、レシェフは群集せる宇宙の彼方より訪う者を迎えるための泊地を築く助力を彼らに約させた。彼らはそれを星渡りの埠頭と名づけた。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^While\\ traveling\\ alone\\ through\\ the\\ Rust\\ Wells,\\ Resheph\\ came\\ across\\ a\\ trove\\ of\\ gleaming\\ stars\\ in\\ a\\ bottle\\.\\ From\\ that\\ day\\ forth,\\ he\\ always\\ kept\\ some\\ stardust\\ on\\ his\\ person\\.$",
-      "template": "錆の井戸を独り旅せし折、レシェフは瓶に収められた輝ける星々の宝庫を見いだした。その日より後、彼は常に星屑を身に携えた。",
-      "route": "annals"
-    },
-    {
       "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ the\\ Gyre\\ widened,\\ and\\ the\\ first\\ triad\\ of\\ plagues\\ afflicted\\ the\\ land\\.\\ The\\ water\\ was\\ poisoned\\ with\\ salt,\\ girshlings\\ ravaged\\ the\\ fruit\\ and\\ wheat,\\ and\\ tongues\\ rotted\\ away\\ in\\ the\\ mouths\\ of\\ kith\\ and\\ kin\\.\\ Resheph\\ walked\\ below\\ the\\ chrome\\ arches\\ and\\ healed\\ the\\ sick\\.$",
       "template": "{0}年、ジャイアは広がり、第一の三つの災厄が地を苦しめた。水は塩に毒され、ギルシュリングどもは果実と小麦を荒らし、親しき者らの口の中で舌が腐り落ちた。レシェフはクロームのアーチの下を歩み、病める者を癒やした。",
       "route": "annals"
     },
     {
-      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ the\\ Gyre\\ widened,\\ and\\ the\\ second\\ triad\\ of\\ plagues\\ afflicted\\ the\\ land\\.\\ The\\ legs\\ of\\ kith\\ and\\ kin\\ annealed\\ to\\ iron,\\ darkness\\ bloomed\\ from\\ the\\ earth,\\ and\\ the\\ svardym\\ blackened\\ the\\ sky\\.\\ Resheph\\ walked\\ below\\ the\\ chrome\\ arches\\ and\\ healed\\ the\\ sick\\.$",
-      "template": "{0}年、ジャイアは広がり、第二の三つの災厄が地を苦しめた。親しき者らの脚は鉄へと焼き固まり、闇は大地より咲き、スヴァルディムは空を黒く染めた。レシェフはクロームのアーチの下を歩み、病める者を癒やした。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^One\\ starry\\ evening,\\ a\\ babe\\ was\\ found\\ swaddled\\ with\\ its\\ mouth\\ full\\ of\\ circuits\\ by\\ a\\ group\\ of\\ baetyls\\ in\\ Red\\ Rock\\.\\ They\\ took\\ him\\ into\\ their\\ fold\\ and\\ fostered\\ him,\\ and\\ he\\ became\\ known\\ as\\ Resheph,\\ the\\ Coiled\\ Lamb\\ of\\ Baetyls\\.$",
-      "template": "星降るある宵、赤岩にて、回路で口を満たした嬰児が産着に包まれ、ベテルの一団に見いだされた。彼らはその子を己らの群れに迎えて育み、やがて彼はレシェフ、ベテルのとぐろ巻く仔羊として知られるようになった。",
+      "pattern": "^At\\ twilight\\ in\\ the\\ shadow\\ of\\ the\\ Spindle,\\ the\\ people\\ of\\ Omonporch\\ saw\\ an\\ image\\ on\\ the\\ horizon\\ that\\ looked\\ like\\ a\\ ghost\\ bathed\\ in\\ cerulean\\.\\ It\\ was\\ Resheph,\\ and\\ after\\ he\\ came\\ and\\ left\\ Omonporch,\\ the\\ people\\ built\\ a\\ monument\\ to\\ him,\\ and\\ thenceforth\\ called\\ him\\ Ghost-in-Cerulean\\.$",
+      "template": "薄暮、スピンドルの影にて、オモンポーチの民は、地平に蒼き色に浸された幽霊のごとき像を見た。それはレシェフであり、彼がオモンポーチに来たりて去った後、民は彼の記念碑を建て、それより後、彼を蒼衣の幽霊と呼んだ。",
       "route": "annals"
     },
     {
@@ -67,8 +17,13 @@
       "route": "annals"
     },
     {
-      "pattern": "^While\\ traveling\\ near\\ Bethesda\\ Susa,\\ Resheph\\ lost\\ control\\ of\\ his\\ chariot\\ and\\ drove\\ it\\ off\\ a\\ cliff\\.\\ Luckily,\\ a\\ local\\ physician\\ named\\ Rebekah\\ came\\ to\\ his\\ rescue\\.\\ Moved\\ by\\ her\\ kindness,\\ Resheph\\ enrolled\\ at\\ a\\ nearby\\ hospice\\ as\\ her\\ apprentice\\.$",
-      "template": "ベセスダ・スーサ近くを旅せし折、レシェフは戦車の制御を失い、崖より走り落ちた。幸いにも、レベカという地元の医師が彼を救いに来た。その慈しみに心動かされ、レシェフは近くの施療院に入り、彼女の徒弟となった。",
+      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ the\\ Gyre\\ widened,\\ and\\ the\\ second\\ triad\\ of\\ plagues\\ afflicted\\ the\\ land\\.\\ The\\ legs\\ of\\ kith\\ and\\ kin\\ annealed\\ to\\ iron,\\ darkness\\ bloomed\\ from\\ the\\ earth,\\ and\\ the\\ svardym\\ blackened\\ the\\ sky\\.\\ Resheph\\ walked\\ below\\ the\\ chrome\\ arches\\ and\\ healed\\ the\\ sick\\.$",
+      "template": "{0}年、ジャイアは広がり、第二の三つの災厄が地を苦しめた。親しき者らの脚は鉄へと焼き固まり、闇は大地より咲き、スヴァルディムは空を黒く染めた。レシェフはクロームのアーチの下を歩み、病める者を癒やした。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ Rebekah\\ died\\ of\\ glotrot,\\ and\\ on\\ her\\ deathbed\\ Resheph\\ forgave\\ her\\ and\\ absolved\\ her\\ of\\ sin\\.\\ He\\ allowed\\ her\\ to\\ be\\ buried\\ in\\ the\\ village\\ of\\ Ezra,\\ outside\\ the\\ gate\\ to\\ the\\ Tomb\\ of\\ the\\ Eaters\\ and\\ beneath\\ the\\ shadow\\ of\\ the\\ Spindle\\.$",
+      "template": "{0}年、レベカはグロットロットにより死し、その臨終の床にてレシェフは彼女を赦し、その罪を解き放った。彼は彼女がエズラの村、喰らう者の墓所の門の外、スピンドルの影の下に葬られることを許した。",
       "route": "annals"
     },
     {
@@ -77,8 +32,173 @@
       "route": "annals"
     },
     {
-      "pattern": "^At\\ twilight\\ in\\ the\\ shadow\\ of\\ the\\ Spindle,\\ the\\ people\\ of\\ Omonporch\\ saw\\ an\\ image\\ on\\ the\\ horizon\\ that\\ looked\\ like\\ a\\ ghost\\ bathed\\ in\\ cerulean\\.\\ It\\ was\\ Resheph,\\ and\\ after\\ he\\ came\\ and\\ left\\ Omonporch,\\ the\\ people\\ built\\ a\\ monument\\ to\\ him,\\ and\\ thenceforth\\ called\\ him\\ Ghost-in-Cerulean\\.$",
-      "template": "薄暮、スピンドルの影にて、オモンポーチの民は、地平に蒼き色に浸された幽霊のごとき像を見た。それはレシェフであり、彼がオモンポーチに来たりて去った後、民は彼の記念碑を建て、それより後、彼を蒼衣の幽霊と呼んだ。",
+      "pattern": "^While\\ traveling\\ near\\ Bethesda\\ Susa,\\ Resheph\\ lost\\ control\\ of\\ his\\ chariot\\ and\\ drove\\ it\\ off\\ a\\ cliff\\.\\ Luckily,\\ a\\ local\\ physician\\ named\\ Rebekah\\ came\\ to\\ his\\ rescue\\.\\ Moved\\ by\\ her\\ kindness,\\ Resheph\\ enrolled\\ at\\ a\\ nearby\\ hospice\\ as\\ her\\ apprentice\\.$",
+      "template": "ベセスダ・スーサ近くを旅せし折、レシェフは戦車の制御を失い、崖より走り落ちた。幸いにも、レベカという地元の医師が彼を救いに来た。その慈しみに心動かされ、レシェフは近くの施療院に入り、彼女の徒弟となった。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^Acting\\ against\\ a\\ prohibition\\ on\\ the\\ practice\\ of\\ worshipping\\ the\\ stars,\\ Resheph\\ led\\ an\\ army\\ to\\ the\\ gates\\ of\\ Omonporch\\.\\ There\\ he\\ defeated\\ his\\ brothers\\ in\\ battle\\ and\\ liberated\\ its\\ citizens,\\ and\\ they\\ crowned\\ him\\ the\\ sultan\\ of\\ Qud\\.$",
+      "template": "星々を崇める営みへの禁令に背き、レシェフは軍勢を率いてオモンポーチの門へ至った。そこで彼は兄弟たちを戦に破り、その市民を解き放った。かくして彼らは彼にクッドのスルタンの冠を授けた。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^One\\ starry\\ evening,\\ a\\ babe\\ was\\ found\\ swaddled\\ with\\ its\\ mouth\\ full\\ of\\ circuits\\ by\\ a\\ group\\ of\\ baetyls\\ in\\ Red\\ Rock\\.\\ They\\ took\\ him\\ into\\ their\\ fold\\ and\\ fostered\\ him,\\ and\\ he\\ became\\ known\\ as\\ Resheph,\\ the\\ Coiled\\ Lamb\\ of\\ Baetyls\\.$",
+      "template": "星降るある宵、赤岩にて、回路で口を満たした嬰児が産着に包まれ、ベテルの一団に見いだされた。彼らはその子を己らの群れに迎えて育み、やがて彼はレシェフ、ベテルのとぐろ巻く仔羊として知られるようになった。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^(.+?)\\ in\\ (.+?),\\ a\\ healthy\\ child\\ was\\ born\\ to\\ the\\ sultan\\ at\\ (.+?)\\.\\ At\\ the\\ moment\\ of\\ (.+?)\\ birth,\\ (.+?),\\ and\\ in\\ celebration\\ the\\ people\\ (.+?)\\.\\ The\\ babe\\ was\\ named\\ (.+?),\\ but\\ the\\ people\\ called\\ (.+?)\\ (.+?)\\.$",
+      "template": "{t0}、{t1}の{t2}にて、スルタンに健やかなる子が生まれた。{t3}誕生の瞬間、{t4}、祝賀として民は{t5}。その嬰児は{t6}と名づけられたが、民は{t7}を{t8}と呼んだ。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^After\\ conferring\\ with\\ mysterious\\ strangers,\\ Resheph\\ convinced\\ them\\ to\\ help\\ him\\ found\\ a\\ harborage\\ for\\ the\\ purpose\\ of\\ receiving\\ visitors\\ from\\ across\\ the\\ clustered\\ cosmos\\.\\ They\\ named\\ it\\ Starfarer's\\ Quay\\.$",
+      "template": "謎めいた異邦人らと協議したのち、レシェフは群集せる宇宙の彼方より訪う者を迎えるための泊地を築く助力を彼らに約させた。彼らはそれを星渡りの埠頭と名づけた。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^(.+?)!\\ (.+?)\\ the\\ life\\ of\\ (.+?)\\ --\\ called\\ (.+?)!\\ --\\ scion\\ of\\ the\\ Fossilized\\ Saads\\ and\\ (.+?)\\ who\\ was\\ dowered\\ the\\ (.+?)\\.\\ Observe\\ the\\ twin\\ miracles\\ of\\ the\\ (.+?):\\ the\\ (.+?)\\ was\\ born,\\ and\\ (.+?)\\.$",
+      "template": "{t0}よ！ {t2}の生涯を{t1}、すなわち{t3}と呼ばれし者の生涯を！ 化石化せしサアドの裔にして、{t5}を授けられし{t4}なり。{t6}の双つの奇跡を見よ。{t7}が生まれ、そして{t8}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^(.+?),\\ a\\ babe\\ was\\ found\\ swaddled\\ (.+?)\\ by\\ a\\ group\\ of\\ (.+?)\\ in\\ (.+?)\\.\\ They\\ took\\ (.+?)\\ into\\ their\\ fold\\ and\\ fostered\\ (.+?),\\ and\\ (.+?)\\ became\\ known\\ as\\ (.+?),\\ the\\ (.+?)\\ (.+?)\\ of\\ (.+?)\\.$",
+      "template": "{t0}、ひとりの嬰児が{t3}にて、{t2}の一団により{t1}に包まれて見いだされた。彼らは{t4}を仲間に迎えて{t5}を育み、{t6}は{t7}、{t10}の{t8}{t9}として知られるようになった。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^(.+?),\\ a\\ babe\\ was\\ found\\ swaddled\\ (.+?)\\ by\\ a\\ group\\ of\\ (.+?)\\ in\\ (.+?)\\.\\ They\\ took\\ (.+?)\\ into\\ their\\ fold\\ and\\ fostered\\ (.+?),\\ and\\ (.+?)\\ became\\ known\\ as\\ (.+?),\\ the\\ (.+?)\\ (.+?)\\ of\\ (.+?)\\.$",
+      "template": "{t0}、{t3}にて、{t2}の一団により、{t1}産着に包まれし嬰児が見いだされた。彼らは{t4}を群れへ迎え入れ、{t5}を養い育てた。そして{t6}は{t7}、{t10}の{t8}{t9}として知られるようになった。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^(.+?),\\ a\\ babe\\ was\\ found\\ swaddled\\ (.+?)\\ by\\ a\\ group\\ of\\ (.+?)\\ in\\ (.+?)\\.\\ They\\ took\\ (.+?)\\ into\\ their\\ fold\\ and\\ fostered\\ (.+?),\\ and\\ (.+?)\\ became\\ known\\ as\\ (.+?),\\ (.+?)\\ (.+?)\\ of\\ (.+?)\\.$",
+      "template": "{t0}、ひとりの嬰児が{t3}にて、{t2}の一団により{t1}に包まれて見いだされた。彼らは{t4}を仲間に迎えて{t5}を育み、{t6}は{t7}、{t10}の{t8}{t9}として知られるようになった。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^(.+?),\\ a\\ babe\\ was\\ found\\ swaddled\\ (.+?)\\ by\\ a\\ group\\ of\\ (.+?)\\ in\\ (.+?)\\.\\ They\\ took\\ (.+?)\\ into\\ their\\ fold\\ and\\ fostered\\ (.+?),\\ and\\ (.+?)\\ became\\ known\\ as\\ (.+?),\\ (.+?)\\ (.+?)\\ of\\ (.+?)\\.$",
+      "template": "{t0}、ひとりの嬰児が{t3}にて、{t2}の一団により{t1}に包まれて見いだされた。彼らは{t4}を仲間に迎えて{t5}を育み、{t6}は{t7}、{t10}の{t8}{t9}として知られるようになった。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ Rebekah\\ betrayed\\ Resheph\\ by\\ stealing\\ the\\ Mark\\ of\\ Death\\ from\\ the\\ gate\\ to\\ the\\ Tomb\\ of\\ the\\ Eaters\\.\\ In\\ punishment,\\ Resheph\\ excommunicated\\ her\\ from\\ the\\ sultanate\\.$",
+      "template": "{0}年、レベカは喰らう者の墓所の門より死の印を盗み、レシェフを裏切った。その罰として、レシェフは彼女をスルタン国より破門した。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^While\\ traveling\\ alone\\ through\\ the\\ Rust\\ Wells,\\ Resheph\\ came\\ across\\ a\\ trove\\ of\\ gleaming\\ stars\\ in\\ a\\ bottle\\.\\ From\\ that\\ day\\ forth,\\ he\\ always\\ kept\\ some\\ stardust\\ on\\ his\\ person\\.$",
+      "template": "錆の井戸を独り旅せし折、レシェフは瓶に収められた輝ける星々の宝庫を見いだした。その日より後、彼は常に星屑を身に携えた。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^Let\\ us\\ (.+?)\\ the\\ (.+?),\\ when,\\ while\\ wandering\\ around\\ (.+?),\\ (.+?)\\ (.+?)\\ (.+?)\\ and\\ (.+?)\\ the\\ (.+?)\\ (.+?)\\ who\\ lived\\ there\\.\\ To\\ (.+?)\\ (.+?)\\ (.+?)\\ to\\ them,\\ (.+?)\\ (.+?)\\.$",
+      "template": "われら{t1}を{t0}ん。その時、{t2}をさまよううち、{t3}は{t5}を{t4}、そこに住まいし{t7}{t8}を{t6}たり。彼らに{t10}{t11}を{t9}さんとして、{t12}は{t13}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^Let\\ us\\ (.+?)\\ the\\ (.+?),\\ when,\\ deep\\ in\\ the\\ wilds\\ of\\ (.+?),\\ (.+?)\\ (.+?)\\ (.+?)\\ and\\ (.+?)\\ the\\ (.+?)\\ (.+?)\\ who\\ lived\\ there\\.\\ To\\ (.+?)\\ (.+?)\\ (.+?)\\ to\\ them,\\ (.+?)\\ (.+?)\\.$",
+      "template": "われら{t1}を{t0}ん。その時、{t2}の荒野深くにて、{t3}は{t5}を{t4}、そこに住まいし{t7}{t8}を{t6}たり。彼らに{t10}{t11}を{t9}さんとして、{t12}は{t13}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ Resheph\\ closed\\ the\\ gates\\ to\\ the\\ Tomb\\ of\\ the\\ Eaters,\\ abdicated\\ the\\ throne,\\ and\\ dissolved\\ the\\ sultanate\\ in\\ order\\ to\\ lift\\ the\\ curse\\ of\\ the\\ Gyre\\.$",
+      "template": "{0}年、レシェフはジャイアの呪いを解くため、喰らう者の墓所の門を閉ざし、王座を退き、スルタン国を解いた。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^Let\\ us\\ (.+?)\\ the\\ (.+?),\\ when,\\ deep\\ in\\ (.+?),\\ (.+?)\\ (.+?)\\ (.+?)\\ and\\ (.+?)\\ the\\ (.+?)\\ (.+?)\\ who\\ lived\\ there\\.\\ To\\ (.+?)\\ (.+?)\\ (.+?)\\ to\\ them,\\ (.+?)\\ (.+?)\\.$",
+      "template": "われら{t1}を{t0}ん。その時、{t2}の深きところにて、{t3}は{t5}を{t4}、そこに住まいし{t7}{t8}を{t6}たり。彼らに{t10}{t11}を{t9}さんとして、{t12}は{t13}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^(.+?),\\ (.+?)\\ cemented\\ (.+?)\\ friendship\\ with\\ (.+?)\\ by\\ marrying\\ (.+?)\\.\\ (.+?),\\ the\\ (.+?)\\ bestowed\\ upon\\ (.+?)\\ a\\ wedding\\ gift\\ they\\ called\\ (.+?)\\.$",
+      "template": "{t0}、{t1}は{t4}と婚姻を結ぶことにより、{t3}との{t2}友誼を固めた。{t5}、{t6}は{t7}に、彼らが{t8}と呼ぶ婚礼の贈り物を授けた。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ Resheph\\ cleansed\\ the\\ marshlands\\ of\\ the\\ plagues\\ of\\ the\\ Gyre\\ and\\ taught\\ Abram\\ to\\ sow\\ watervine\\ along\\ its\\ fertile\\ tracks\\.$",
+      "template": "{0}年、レシェフは湿地帯よりジャイアの災厄を祓い、その肥沃なる道筋に沿ってワターヴァインを蒔く術をアブラムに授けた。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ Resheph,\\ the\\ Above,\\ Ghost-in-Cerulean,\\ the\\ Coiled\\ Lamb\\ of\\ Baetyls,\\ died\\ of\\ natural\\ causes\\.\\ He\\ was\\ 216\\ years\\ old\\.$",
+      "template": "{0}年、レシェフ、天上なる者、瑠璃の幽鬼、ベテルのとぐろ巻く仔羊は、自然の理により身罷った。享年216歳であった。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^(.+?),\\ a\\ (.+?)\\ found\\ a\\ babe\\ (.+?)\\ outside\\ (.+?)\\ (.+?)\\.\\ (.+?)\\ and\\ (.+?)\\ fellow\\ (.+?)\\ adopted\\ the\\ babe\\ and\\ named\\ (.+?)\\ (.+?)\\.$",
+      "template": "{t0}、ひとりの{t1}が、{t3}{t4}の外で{t2}嬰児を見いだした。{t5}と{t6}仲間の{t7}はその嬰児を養子に迎え、{t8}を{t9}と名づけた。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ Resheph\\ appointed\\ Rebekah\\ administrator\\ of\\ (.+?)\\.\\ She\\ tendered\\ alms\\ for\\ the\\ sick\\ in\\ his\\ name\\.$",
+      "template": "{0}年、レシェフはレベカを{t1}の施政官に任じた。彼女は彼の名において病める者へ施しを捧げた。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^While\\ wandering\\ around\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
+      "template": "{t0}の辺りをさまよううち、{t1}は{t2}を見いだした。そこで{t3}は{t4}と親交を結び、{t5}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^Deep\\ in\\ the\\ wilds\\ of\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
+      "template": "{t0}の荒野の奥深くにて、{t1}は{t2}を見いだした。そこで{t3}は{t4}と親交を結び、{t5}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^While\\ wandering\\ around\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
+      "template": "{t0}をさまよううち、{t1}は{t2}を発見した。そこで{t3}は{t4}と親交を結び、{t5}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^Deep\\ in\\ the\\ wilds\\ of\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
+      "template": "{t0}の荒野深くにて、{t1}は{t2}を発見した。そこで{t3}は{t4}と親交を結び、{t5}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^While\\ wandering\\ around\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
+      "template": "{t0}をさまよううち、{t1}は{t2}を発見した。そこで{t3}は{t4}と親交を結び、{t5}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^Deep\\ in\\ the\\ wilds\\ of\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
+      "template": "{t0}の荒野深くにて、{t1}は{t2}を発見した。そこで{t3}は{t4}と親交を結び、{t5}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^(.+?),\\ a\\ babe\\ was\\ found\\ swaddled\\ (.+?)\\ (.+?)\\.\\ That\\ babe\\ came\\ to\\ be\\ known\\ as\\ (.+?)\\.$",
+      "template": "{t0}、ひとりの嬰児が{t1}{t2}に包まれて見いだされた。その嬰児はのちに{t3}として知られるようになった。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^Deep\\ in\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
+      "template": "{t0}の奥深くにて、{t1}は{t2}を見いだした。そこで{t3}は{t4}と親交を結び、{t5}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^Deep\\ in\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
+      "template": "{t0}の奥深くにて、{t1}は{t2}を見いだした。そこで{t3}は{t4}と親交を結び、{t5}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^Deep\\ in\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
+      "template": "{t0}の深きところにて、{t1}は{t2}を発見した。そこで{t3}は{t4}と親交を結び、{t5}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^(.+?),\\ (.+?)\\ cemented\\ (.+?)\\ friendship\\ with\\ (.+?)\\ by\\ marrying\\ (.+?)\\.$",
+      "template": "{t0}、{t1}は{t4}と婚姻を結ぶことにより、{t3}との{t2}友誼を固めた。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^(.+?),\\ (.+?)\\ and\\ (.+?),\\ whose\\ (.+?)\\ alliance\\ by\\ marriage\\ (.+?)\\.$",
+      "template": "{t0}、{t1}と{t2}、その{t3}婚姻の同盟は{t4}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^(.+?)\\ was\\ adopted\\ by\\ (.+?)\\ who\\ love\\ (.+?)\\.$",
+      "template": "{t0}は、{t2}を愛する{t1}に養子として迎えられた。",
       "route": "annals"
     }
   ]

--- a/Mods/QudJP/Localization/Dictionaries/annals-patterns.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/annals-patterns.ja.json
@@ -67,16 +67,6 @@
       "route": "annals"
     },
     {
-      "pattern": "^(.+?),\\ a\\ babe\\ was\\ found\\ swaddled\\ (.+?)\\ by\\ a\\ group\\ of\\ (.+?)\\ in\\ (.+?)\\.\\ They\\ took\\ (.+?)\\ into\\ their\\ fold\\ and\\ fostered\\ (.+?),\\ and\\ (.+?)\\ became\\ known\\ as\\ (.+?),\\ the\\ (.+?)\\ (.+?)\\ of\\ (.+?)\\.$",
-      "template": "{t0}、{t3}にて、{t2}の一団により、{t1}産着に包まれし嬰児が見いだされた。彼らは{t4}を群れへ迎え入れ、{t5}を養い育てた。そして{t6}は{t7}、{t10}の{t8}{t9}として知られるようになった。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^(.+?),\\ a\\ babe\\ was\\ found\\ swaddled\\ (.+?)\\ by\\ a\\ group\\ of\\ (.+?)\\ in\\ (.+?)\\.\\ They\\ took\\ (.+?)\\ into\\ their\\ fold\\ and\\ fostered\\ (.+?),\\ and\\ (.+?)\\ became\\ known\\ as\\ (.+?),\\ (.+?)\\ (.+?)\\ of\\ (.+?)\\.$",
-      "template": "{t0}、ひとりの嬰児が{t3}にて、{t2}の一団により{t1}に包まれて見いだされた。彼らは{t4}を仲間に迎えて{t5}を育み、{t6}は{t7}、{t10}の{t8}{t9}として知られるようになった。",
-      "route": "annals"
-    },
-    {
       "pattern": "^(.+?),\\ a\\ babe\\ was\\ found\\ swaddled\\ (.+?)\\ by\\ a\\ group\\ of\\ (.+?)\\ in\\ (.+?)\\.\\ They\\ took\\ (.+?)\\ into\\ their\\ fold\\ and\\ fostered\\ (.+?),\\ and\\ (.+?)\\ became\\ known\\ as\\ (.+?),\\ (.+?)\\ (.+?)\\ of\\ (.+?)\\.$",
       "template": "{t0}、ひとりの嬰児が{t3}にて、{t2}の一団により{t1}に包まれて見いだされた。彼らは{t4}を仲間に迎えて{t5}を育み、{t6}は{t7}、{t10}の{t8}{t9}として知られるようになった。",
       "route": "annals"
@@ -147,26 +137,6 @@
       "route": "annals"
     },
     {
-      "pattern": "^While\\ wandering\\ around\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
-      "template": "{t0}をさまよううち、{t1}は{t2}を発見した。そこで{t3}は{t4}と親交を結び、{t5}。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^Deep\\ in\\ the\\ wilds\\ of\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
-      "template": "{t0}の荒野深くにて、{t1}は{t2}を発見した。そこで{t3}は{t4}と親交を結び、{t5}。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^While\\ wandering\\ around\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
-      "template": "{t0}をさまよううち、{t1}は{t2}を発見した。そこで{t3}は{t4}と親交を結び、{t5}。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^Deep\\ in\\ the\\ wilds\\ of\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
-      "template": "{t0}の荒野深くにて、{t1}は{t2}を発見した。そこで{t3}は{t4}と親交を結び、{t5}。",
-      "route": "annals"
-    },
-    {
       "pattern": "^(.+?),\\ a\\ babe\\ was\\ found\\ swaddled\\ (.+?)\\ (.+?)\\.\\ That\\ babe\\ came\\ to\\ be\\ known\\ as\\ (.+?)\\.$",
       "template": "{t0}、ひとりの嬰児が{t1}{t2}に包まれて見いだされた。その嬰児はのちに{t3}として知られるようになった。",
       "route": "annals"
@@ -174,16 +144,6 @@
     {
       "pattern": "^Deep\\ in\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
       "template": "{t0}の奥深くにて、{t1}は{t2}を見いだした。そこで{t3}は{t4}と親交を結び、{t5}。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^Deep\\ in\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
-      "template": "{t0}の奥深くにて、{t1}は{t2}を見いだした。そこで{t3}は{t4}と親交を結び、{t5}。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^Deep\\ in\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
-      "template": "{t0}の深きところにて、{t1}は{t2}を発見した。そこで{t3}は{t4}と親交を結び、{t5}。",
       "route": "annals"
     },
     {

--- a/scripts/merge_annals_patterns.py
+++ b/scripts/merge_annals_patterns.py
@@ -88,6 +88,58 @@ def detect_collisions(
     return conflicts
 
 
+def _strip_captures_to_placeholder(pattern: str, placeholder: str = "X") -> str:
+    """Replace `(.+?)` style capture groups with a literal placeholder for sampling.
+
+    Mirrors the L1 test's `StripCapturesToPlaceholder` so the merge-time and
+    test-time shadowing checks treat patterns the same way.
+    """
+    no_anchors = pattern.lstrip("^").rstrip("$")
+    return re.sub(r"\([^)]*\)", placeholder, no_anchors)
+
+
+def detect_intra_annals_shadowing(candidates: list[dict[str, Any]]) -> list[str]:
+    """Fail-loud guard against earlier patterns swallowing later patterns at runtime.
+
+    The runtime regex iterates patterns in file order and uses the first match,
+    so when a generic pattern precedes a concrete one whose literal text it covers,
+    the concrete pattern's translation is unreachable. The merge sort puts longer
+    patterns first, but equal-length patterns sort by id alone, which can leave a
+    generic-with-many-captures ahead of a concrete-with-fewer-captures of the same
+    overall length. Mirrors `AnnalsPatternsCollisionTests.EarlierAnnalsPattern_
+    DoesNotSwallowLaterAnnalsPattern_FirstMatchWins` so merge fails the same way
+    L1 would.
+
+    Returns a list of human-readable error strings (one per shadowing pair); empty
+    list means no shadowing detected.
+    """
+    errors: list[str] = []
+    compiled: list[tuple[re.Pattern[str], dict[str, Any]]] = []
+    for cand in candidates:
+        try:
+            cand_re = re.compile(cand["extracted_pattern"])
+        except re.error:
+            continue
+        sample_source = _strip_captures_to_placeholder(cand["extracted_pattern"])
+        # Crude unescape: backslash + any single char -> that char. Matches the
+        # `Regex.Unescape` semantic used by the L1 test for our limited pattern set
+        # (no octal / hex / character-class escapes are emitted by the extractor).
+        sample_literal = re.sub(r"\\(.)", r"\1", sample_source)
+        for earlier_re, earlier_cand in compiled:
+            if earlier_cand["extracted_pattern"] == cand["extracted_pattern"]:
+                continue
+            if earlier_re.match(sample_literal):
+                errors.append(
+                    f"earlier pattern {earlier_cand['extracted_pattern']!r} "
+                    f"(id {earlier_cand['id']!r}) swallows later pattern "
+                    f"{cand['extracted_pattern']!r} (id {cand['id']!r}, "
+                    f"sample {sample_literal!r}). Reorder so concrete patterns "
+                    "precede generic ones."
+                )
+        compiled.append((cand_re, cand))
+    return errors
+
+
 def dedupe_by_pattern(
     candidates: list[dict[str, Any]],
 ) -> tuple[list[dict[str, Any]], list[str]]:
@@ -233,6 +285,12 @@ def run_merge(
             print(f"error: {err}", file=sys.stderr)
         return 1
     accepted_sorted = deduped
+
+    shadowing_errors = detect_intra_annals_shadowing(accepted_sorted)
+    if shadowing_errors:
+        for err in shadowing_errors:
+            print(f"error: {err}", file=sys.stderr)
+        return 1
     annals_doc = {
         "entries": [],
         "patterns": [

--- a/scripts/merge_annals_patterns.py
+++ b/scripts/merge_annals_patterns.py
@@ -1,5 +1,5 @@
 """Merge translated annals candidates into Mods/QudJP/Localization/Dictionaries/annals-patterns.ja.json."""
-# ruff: noqa: T201, D103, C901, PLR0911
+# ruff: noqa: T201, D103, PLR0911
 
 from __future__ import annotations
 
@@ -88,36 +88,67 @@ def detect_collisions(
     return conflicts
 
 
-def run_merge(
+def dedupe_by_pattern(
+    candidates: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Group candidates by extracted_pattern, return dedup + divergent errors.
+
+    Same regex from multiple ids (one local feeding two SetEventProperty calls,
+    branch arms with different slot raws but same regex shape) is legitimate —
+    but runtime first-match-wins drops everything past the first occurrence, so
+    identical templates collapse silently and divergent ones are surfaced as
+    errors so the operator reconciles to a single canonical translation.
+    """
+    by_pattern: dict[str, list[dict[str, Any]]] = {}
+    for candidate in candidates:
+        by_pattern.setdefault(candidate["extracted_pattern"], []).append(candidate)
+    duplicate_errors: list[str] = []
+    deduped: list[dict[str, Any]] = []
+    for pattern, members in by_pattern.items():
+        if len(members) == 1:
+            deduped.append(members[0])
+            continue
+        templates = {m["ja_template"] for m in members}
+        if len(templates) > 1:
+            ids_and_templates = "; ".join(f"{m['id']!r}={m['ja_template']!r}" for m in members)
+            duplicate_errors.append(
+                f"pattern {pattern!r} has divergent ja_templates across ids: {ids_and_templates}. "
+                "Reconcile to a single canonical translation or split the pattern."
+            )
+            continue
+        deduped.append(members[0])
+    return deduped, duplicate_errors
+
+
+def load_inputs(
     candidates_path: Path,
     existing_journal: Path,
     annals_output: Path,
-    conflicts_output: Path,
-) -> int:
+) -> tuple[dict[str, Any], list[dict[str, Any]]] | int:
+    """Load + validate candidates JSON and existing journal/annals dicts.
+
+    Returns (candidates_doc, journal_patterns) on success, or an int exit code on
+    any failure (with a message already printed to stderr).
+    """
     try:
         doc = json.loads(candidates_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         print(f"error: cannot read candidates from {candidates_path}: {exc}", file=sys.stderr)
         return 1
-
     try:
         schema.validate_doc(doc)
     except schema.ValidationError as exc:
         print(f"error: candidate schema invalid: {exc}", file=sys.stderr)
         return 1
-
     try:
         journal_doc = json.loads(existing_journal.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         print(f"error: cannot read existing journal-patterns from {existing_journal}: {exc}", file=sys.stderr)
         return 1
-
     journal_patterns = journal_doc.get("patterns", [])
     if not isinstance(journal_patterns, list):
         print("error: journal-patterns.ja.json has no 'patterns' array", file=sys.stderr)
         return 1
-
-    # Verify any pre-existing annals-patterns.ja.json is well-formed
     if annals_output.exists():
         try:
             existing_annals = json.loads(annals_output.read_text(encoding="utf-8"))
@@ -127,6 +158,19 @@ def run_merge(
         if "patterns" not in existing_annals:
             print("error: existing annals-patterns.ja.json missing 'patterns' field", file=sys.stderr)
             return 1
+    return doc, journal_patterns
+
+
+def run_merge(
+    candidates_path: Path,
+    existing_journal: Path,
+    annals_output: Path,
+    conflicts_output: Path,
+) -> int:
+    loaded = load_inputs(candidates_path, existing_journal, annals_output)
+    if isinstance(loaded, int):
+        return loaded
+    doc, journal_patterns = loaded
 
     accepted = [c for c in doc["candidates"] if c["status"] == "accepted" and c["ja_template"]]
 
@@ -156,30 +200,7 @@ def run_merge(
     # Within equal pattern length, sort by id for deterministic output.
     accepted_sorted = sorted(accepted, key=lambda c: (-len(c["extracted_pattern"]), c["id"]))
 
-    # Deduplicate: multiple candidate ids may share an extracted_pattern (e.g. one local
-    # feeding two SetEventProperty calls, or branch arms differing only in slot raw).
-    # Runtime keeps only the first match per pattern, so divergent translations for the
-    # same pattern would silently lose all but the first. Group by pattern; within a
-    # group, all ja_templates must agree — otherwise fail loudly.
-    by_pattern: dict[str, list[dict[str, Any]]] = {}
-    for candidate in accepted_sorted:
-        by_pattern.setdefault(candidate["extracted_pattern"], []).append(candidate)
-    duplicate_errors: list[str] = []
-    deduped: list[dict[str, Any]] = []
-    for pattern, members in by_pattern.items():
-        if len(members) == 1:
-            deduped.append(members[0])
-            continue
-        templates = {m["ja_template"] for m in members}
-        if len(templates) > 1:
-            ids_and_templates = "; ".join(f"{m['id']!r}={m['ja_template']!r}" for m in members)
-            duplicate_errors.append(
-                f"pattern {pattern!r} has divergent ja_templates across ids: {ids_and_templates}. "
-                "Reconcile to a single canonical translation or split the pattern."
-            )
-            continue
-        # Identical translations — keep the first (sort-canonical) entry, drop the rest.
-        deduped.append(members[0])
+    deduped, duplicate_errors = dedupe_by_pattern(accepted_sorted)
     if duplicate_errors:
         for err in duplicate_errors:
             print(f"error: {err}", file=sys.stderr)

--- a/scripts/merge_annals_patterns.py
+++ b/scripts/merge_annals_patterns.py
@@ -170,6 +170,30 @@ def run_merge(
     annals_output: Path,
     conflicts_output: Path,
 ) -> int:
+    """Merge translated annals candidates into the shipped annals dictionary.
+
+    Loads accepted candidates from `candidates_path`, checks each for collisions
+    against the existing `journal-patterns.ja.json` at `existing_journal`,
+    deduplicates candidates that share an `extracted_pattern`, and writes the
+    final pattern set to `annals_output`. When collisions are found, the
+    detail is written to `conflicts_output` and the run fails.
+
+    Args:
+        candidates_path: JSON produced by `translate_annals_patterns.py` (status,
+            extracted_pattern, ja_template per candidate).
+        existing_journal: Existing `journal-patterns.ja.json` used as the
+            collision baseline.
+        annals_output: Destination `annals-patterns.ja.json`. Overwritten on
+            success, left untouched on failure.
+        conflicts_output: Where collision detail JSON is written when collisions
+            are detected; removed on a clean run.
+
+    Returns:
+        0 on success, 1 on any input/parse error, schema-validation failure,
+        collision-against-journal-patterns, or divergent-template duplicate
+        within the accepted set. Error detail is printed to stderr; collision
+        detail is also written to `conflicts_output`.
+    """
     loaded = load_inputs(candidates_path, existing_journal, annals_output)
     if isinstance(loaded, int):
         return loaded

--- a/scripts/merge_annals_patterns.py
+++ b/scripts/merge_annals_patterns.py
@@ -155,6 +155,36 @@ def run_merge(
     # whose literal text is fully covered by the FoundAsBabe template's `(.+?)` slots.
     # Within equal pattern length, sort by id for deterministic output.
     accepted_sorted = sorted(accepted, key=lambda c: (-len(c["extracted_pattern"]), c["id"]))
+
+    # Deduplicate: multiple candidate ids may share an extracted_pattern (e.g. one local
+    # feeding two SetEventProperty calls, or branch arms differing only in slot raw).
+    # Runtime keeps only the first match per pattern, so divergent translations for the
+    # same pattern would silently lose all but the first. Group by pattern; within a
+    # group, all ja_templates must agree — otherwise fail loudly.
+    by_pattern: dict[str, list[dict[str, Any]]] = {}
+    for candidate in accepted_sorted:
+        by_pattern.setdefault(candidate["extracted_pattern"], []).append(candidate)
+    duplicate_errors: list[str] = []
+    deduped: list[dict[str, Any]] = []
+    for pattern, members in by_pattern.items():
+        if len(members) == 1:
+            deduped.append(members[0])
+            continue
+        templates = {m["ja_template"] for m in members}
+        if len(templates) > 1:
+            ids_and_templates = "; ".join(f"{m['id']!r}={m['ja_template']!r}" for m in members)
+            duplicate_errors.append(
+                f"pattern {pattern!r} has divergent ja_templates across ids: {ids_and_templates}. "
+                "Reconcile to a single canonical translation or split the pattern."
+            )
+            continue
+        # Identical translations — keep the first (sort-canonical) entry, drop the rest.
+        deduped.append(members[0])
+    if duplicate_errors:
+        for err in duplicate_errors:
+            print(f"error: {err}", file=sys.stderr)
+        return 1
+    accepted_sorted = deduped
     annals_doc = {
         "entries": [],
         "patterns": [

--- a/scripts/merge_annals_patterns.py
+++ b/scripts/merge_annals_patterns.py
@@ -148,7 +148,13 @@ def run_merge(
     if conflicts_output.exists():
         conflicts_output.unlink()
 
-    accepted_sorted = sorted(accepted, key=lambda c: c["id"])
+    # Sort by pattern length descending so concrete (longer) patterns match before
+    # general (shorter, more `(.+?)` captures) patterns at runtime. The runtime regex
+    # iterates patterns in file order and uses the first match — without this ordering,
+    # a generic FoundAsBabe pattern from PR2a would swallow specific Resheph patterns
+    # whose literal text is fully covered by the FoundAsBabe template's `(.+?)` slots.
+    # Within equal pattern length, sort by id for deterministic output.
+    accepted_sorted = sorted(accepted, key=lambda c: (-len(c["extracted_pattern"]), c["id"]))
     annals_doc = {
         "entries": [],
         "patterns": [

--- a/scripts/merge_annals_patterns.py
+++ b/scripts/merge_annals_patterns.py
@@ -152,8 +152,11 @@ def load_inputs(
     if annals_output.exists():
         try:
             existing_annals = json.loads(annals_output.read_text(encoding="utf-8"))
-        except json.JSONDecodeError as exc:
-            print(f"error: existing annals-patterns is malformed JSON: {exc}", file=sys.stderr)
+        except (OSError, json.JSONDecodeError) as exc:
+            print(
+                f"error: cannot read existing annals-patterns from {annals_output}: {exc}",
+                file=sys.stderr,
+            )
             return 1
         if "patterns" not in existing_annals:
             print("error: existing annals-patterns.ja.json missing 'patterns' field", file=sys.stderr)

--- a/scripts/tests/fixtures/annals/expected_initcap_capitalizes_first_literal.json
+++ b/scripts/tests/fixtures/annals/expected_initcap_capitalizes_first_literal.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "initcap_capitalizes_first_literal#gospel",
+      "source_file": "initcap_capitalizes_first_literal.cs",
+      "annal_class": "initcap_capitalizes_first_literal",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "Deep in the wilds, {0} wandered.",
+      "extracted_pattern": "^Deep\\ in\\ the\\ wilds,\\ (.+?)\\ wandered\\.$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "historykit-token",
+          "raw": "<entity.name>",
+          "default": "{t0}"
+        }
+      ],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:6ea5a7e5d6a97728788245478766e254dd9540fa3abc7f413dab0607bbc95f54"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/initcap_capitalizes_first_literal.cs
+++ b/scripts/tests/fixtures/annals/initcap_capitalizes_first_literal.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace XRL.Annals;
+
+[Serializable]
+public class InitcapCapitalizesFirstLiteralFixture : HistoricEvent
+{
+    public override void Generate()
+    {
+        SetEventProperty("gospel", Grammar.InitCap(ExpandString("deep in the wilds, " + "<entity.name> wandered.")));
+    }
+}

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -1120,6 +1120,31 @@ internal sealed class Extractor
                 return true;
             }
 
+            case InvocationExpressionSyntax invoc when IsCapitalizingFirstCharWrapper(invoc):
+            {
+                if (invoc.ArgumentList.Arguments.Count < 1)
+                {
+                    unsupportedReason = "InitCap/InitialCap with no arguments";
+                    return false;
+                }
+                var savedPieceCount = pieces.Count;
+                if (!FlattenConcat(invoc.ArgumentList.Arguments[0].Expression, locals, pieces, slots, visited, out unsupportedReason)) return false;
+                // Capitalize the first character of the first piece emitted by the wrapped
+                // expression — runtime `Grammar.InitCap` / `InitialCap` only touches the first
+                // character. Skip if the inner emitted nothing, an empty piece, or a slot
+                // placeholder (`{N}`): in those cases the runtime-capitalized character is
+                // captured by the slot's `(.+?)` group and the regex still matches.
+                if (pieces.Count > savedPieceCount)
+                {
+                    var first = pieces[savedPieceCount];
+                    if (first.Length > 0 && first[0] != '{')
+                    {
+                        pieces[savedPieceCount] = char.ToUpperInvariant(first[0]) + first[1..];
+                    }
+                }
+                return true;
+            }
+
             case InvocationExpressionSyntax invoc when IsPatternPreservingWrapper(invoc):
                 return FlattenConcat(invoc.ArgumentList.Arguments[0].Expression, locals, pieces, slots, visited, out unsupportedReason);
 
@@ -1454,9 +1479,13 @@ internal sealed class Extractor
         };
     }
 
-    // Wrappers whose return value matches their first argument modulo capitalization /
-    // HSE expansion — both invisible to a runtime regex match. Unwrapping lets us see
-    // the inner pattern (e.g. `Grammar.InitCap(string.Format(...))`).
+    // Wrappers whose return value matches their first argument modulo HSE expansion (and
+    // word-level title-casing for `MakeTitleCase` / `MakeTitleCaseWithArticle`, which currently
+    // wrap slot-bound identifiers only — the slot's `(.+?)` group captures whatever case the
+    // runtime emits). `Grammar.InitCap` / `InitialCap` are NOT included here: they capitalize
+    // the first character of the result, which IS visible to a case-sensitive regex when the
+    // pattern starts with a literal. Those go through a dedicated branch in FlattenConcat that
+    // uppercases the first emitted literal piece.
     //
     // Receiver matching is intentionally syntax-only (`m.Expression.ToString() == "Grammar"`),
     // mirroring `KnownHelperReceivers` and the rest of the extractor — no Compilation /
@@ -1464,7 +1493,7 @@ internal sealed class Extractor
     // through this check, but the decompiled `XRL.Annals/*.cs` corpus only emits the bare-
     // identifier form. Migrating to SemanticModel-based symbol resolution would require
     // building a Compilation with the full game's MetadataReferences and converting every
-    // string-match site for consistency, which is out of scope for #430. CR R9 noted; deferred.
+    // string-match site for consistency, which is out of scope. CR R9 noted; deferred.
     private static bool IsPatternPreservingWrapper(InvocationExpressionSyntax invoc)
     {
         if (IsExpandStringWrapper(invoc)) return true;
@@ -1472,9 +1501,21 @@ internal sealed class Extractor
         if (invoc.Expression is MemberAccessExpressionSyntax m
             && m.Expression.ToString() == "Grammar")
         {
-            return m.Name.Identifier.ValueText is "InitCap" or "InitialCap" or "MakeTitleCase" or "MakeTitleCaseWithArticle";
+            return m.Name.Identifier.ValueText is "MakeTitleCase" or "MakeTitleCaseWithArticle";
         }
         return false;
+    }
+
+    // `Grammar.InitCap(s)` / `Grammar.InitialCap(s)` uppercase only the first character of `s`
+    // at runtime. When the wrapped expression flattens to a pattern starting with a literal
+    // (e.g. MeetFaction's `"deep in ..."`), the case-sensitive runtime regex needs the literal's
+    // first char uppercased — `^deep` would not match the runtime-emitted `Deep`.
+    private static bool IsCapitalizingFirstCharWrapper(InvocationExpressionSyntax invoc)
+    {
+        if (invoc.ArgumentList.Arguments.Count < 1) return false;
+        if (invoc.Expression is not MemberAccessExpressionSyntax m) return false;
+        if (m.Expression.ToString() != "Grammar") return false;
+        return m.Name.Identifier.ValueText is "InitCap" or "InitialCap";
     }
 
     private static string GetFirstStringArg(InvocationExpressionSyntax invoc)

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -1134,17 +1134,22 @@ internal sealed class Extractor
                 // character. Skip if the inner emitted nothing, an empty piece, or a slot
                 // placeholder (`{N}`): in those cases the runtime-capitalized character is
                 // captured by the slot's `(.+?)` group and the regex still matches.
-                if (pieces.Count > savedPieceCount)
+                // Walk forward from `savedPieceCount` skipping empty pieces (FlattenStringFormat
+                // can emit `""` between back-to-back slots) until we find the first non-empty
+                // piece. If that piece is a `{N}` slot placeholder, the runtime-capitalized
+                // character is already captured by the slot's `(.+?)` group and there is
+                // nothing to rewrite. Otherwise apply the runtime `Grammar.InitCap` rule:
+                // only ASCII a-z is uppercased; other chars pass through unchanged.
+                for (var i = savedPieceCount; i < pieces.Count; i++)
                 {
-                    var first = pieces[savedPieceCount];
-                    // Match runtime `Grammar.InitCap`: only ASCII a-z is uppercased. Non-ASCII
-                    // letters / accented chars / digits / `{N}` placeholders pass through
-                    // unchanged so the extractor stays aligned with the runtime when those
-                    // chars eventually appear at the start of a literal piece.
-                    if (first.Length > 0 && first[0] is >= 'a' and <= 'z')
+                    var piece = pieces[i];
+                    if (piece.Length == 0) continue;
+                    if (piece[0] == '{') break;
+                    if (piece[0] is >= 'a' and <= 'z')
                     {
-                        pieces[savedPieceCount] = char.ToUpperInvariant(first[0]) + first[1..];
+                        pieces[i] = char.ToUpperInvariant(piece[0]) + piece[1..];
                     }
+                    break;
                 }
                 return true;
             }

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -1137,7 +1137,11 @@ internal sealed class Extractor
                 if (pieces.Count > savedPieceCount)
                 {
                     var first = pieces[savedPieceCount];
-                    if (first.Length > 0 && first[0] != '{')
+                    // Match runtime `Grammar.InitCap`: only ASCII a-z is uppercased. Non-ASCII
+                    // letters / accented chars / digits / `{N}` placeholders pass through
+                    // unchanged so the extractor stays aligned with the runtime when those
+                    // chars eventually appear at the start of a literal piece.
+                    if (first.Length > 0 && first[0] is >= 'a' and <= 'z')
                     {
                         pieces[savedPieceCount] = char.ToUpperInvariant(first[0]) + first[1..];
                     }


### PR DESCRIPTION
## Summary

Closes a portion of #422 (PR2a — birth/origin cluster: Adopted, BornAsHeir, FoundAsBabe, Marry, MeetFaction). Brings `annals-patterns.ja.json` from 16 patterns (Resheph PR1) to 40.

Three commits:

1. **dc61691** — `Grammar.InitCap` / `InitialCap` capitalize the first literal piece. This is a follow-up to #430 (extractor extension): the runtime regex (`RegexOptions.Compiled | CultureInvariant`) is case-sensitive, but `IsPatternPreservingWrapper` was treating `InitCap` / `InitialCap` as fully transparent. MeetFaction's `value = Grammar.InitialCap(ExpandString("deep in ..."))` produced `^deep` patterns that would never match the runtime-emitted `Deep`. Added `IsCapitalizingFirstCharWrapper` branch in `FlattenConcat` that uppercases the first emitted literal piece (skipping empty pieces and `{N}` slot placeholders). Regression fixture `initcap_capitalizes_first_literal` added.

2. **24b0d2c** — Merge by pattern length desc + intra-annals collision L1 test. Without this, the new generic `FoundAsBabe` template `^(.+?), a babe was found swaddled (.+?) by a group of (.+?) in (.+?)...` swallowed the concrete `ReshephIsBorn#gospel` pattern (the runtime regex iterates in file order, uses first match). `merge_annals_patterns.py` now sorts by `(-len(pattern), id)`, putting concrete patterns first. Added L1 test `EarlierAnnalsPattern_DoesNotSwallowLaterAnnalsPattern_FirstMatchWins` to guard the invariant for future PR2b/c/d/e clusters.

3. **0e86117** — The actual 24 translations.

## Pipeline run

```bash
python3.12 scripts/extract_annals_patterns.py --force --source-root /tmp/pr2a-all --include "*.cs" --output scripts/_artifacts/annals/candidates_pending.json
# 40 candidates: 16 Resheph + 24 PR2a, all status=pending

# Hydrate Resheph translations from existing dict (preserves byte-identical PR1 output)
# Flip PR2a candidates to status=accepted (Codex pre-review found 0 needs_manual after the InitCap fix)

python3.12 scripts/translate_annals_patterns.py scripts/_artifacts/annals/candidates_pending.json
# 24 candidate(s) pending across 3 chunk(s) → all translated

python3.12 scripts/validate_candidate_schema.py scripts/_artifacts/annals/candidates_pending.json
# 40 candidate(s) pass schema check

python3.12 scripts/merge_annals_patterns.py scripts/_artifacts/annals/candidates_pending.json
# wrote 40 pattern(s)
```

## Cluster breakdown (24 new patterns)

| Annal class | Patterns | Notes |
|---|---:|---|
| Adopted | 1 | clean (3 historykit-token slots) |
| BornAsHeir | 2 | gospel + tombInscription, both `string.Format` with 9 args |
| FoundAsBabe | 6 | 3-case switch × gospel, optional-append × tombInscription |
| Marry | 3 | gospel base/with-gift fanout + tombInscription |
| MeetFaction | 12 | if-then/else × 3 prefix arms × gospel/tombInscription |

## Test plan

- [x] `dotnet test ... --filter TestCategory=L1` → **1524 passed** (up from 1523; new collision test)
- [x] `dotnet test ... --filter TestCategory=L2` → **760 passed**
- [x] `uv run pytest scripts/tests/` → **663 passed** (up from 661; +2 from extractor fixture)
- [x] `python3.12 scripts/validate_xml.py ... --strict` → OK
- [x] PR1 Resheph 16 byte-identical preserved (extractor PR1 verification + dictionary hydration)
- [ ] Live runtime smoke (deferred to post-merge — no `wish` shortcut for birth/origin events; they arrive via world-builder play paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 先勝ちルールのパターン衝突を検出する自動テストを追加。
  * 新しいテスト用フィクスチャと生成データを追加。

* **改善**
  * マージ処理がパターンの重複統合と不一致検出を行い、出力順序を意図的に調整。
  * 展開時の初期化大文字化が改善され、先頭文字のみ正しく大文字化されるように。

* **変更**
  * Annals のパターン集を大幅に拡張・再構成し、旧パターンを置換。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->