### PR TITLE
chore(#376): scaffold color-tag static analysis (L1/L2 ignored + plan)

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -21,21 +21,27 @@ public sealed class ColorTagAllowlistCoverageTests
     private const string SkipReason = "issue-376 — production code pending; catalog allowlist not yet defined";
 
     // Catalog-1: every Patches/*.cs that calls ColorAwareTranslationComposer.Strip
-    // OR ColorAwareTranslationComposer.RestoreCapture must also call exactly one
-    // of TranslatePreservingColors / RestoreCapture / Restore — i.e. no orphan
-    // strip-without-restore call sites that silently drop spans.
+    // must also reach a paired Restore site (RestoreCapture / RestoreSpans /
+    // TranslatePreservingColors). The check is per-call-site, NOT a count match:
+    // one Strip can fan out to multiple RestoreCapture calls (one per capture
+    // group), and TranslatePreservingColors performs Strip+Restore internally
+    // and shouldn't be paired with a sibling Strip at all.
     [Test]
     [Ignore(SkipReason)]
     public void EveryStripCallSite_HasMatchingRestoreCallSite()
     {
         // Production rule (to encode here):
         //   for each *.cs under Mods/QudJP/Assemblies/src/Patches:
-        //     count(Strip)   ==  count(Restore | RestoreCapture | TranslatePreservingColors)
-        //   exemptions live in an explicit allowlist (path -> reason) that this test reads.
+        //     each `Strip(` call site must have at least one Restore* / TranslatePreservingColors
+        //     reachable in the same control-flow path (function or method). Files where
+        //     `TranslatePreservingColors(` already encapsulates the round-trip do NOT need
+        //     an explicit sibling Restore. Exemptions live in an explicit allowlist
+        //     (path -> reason) that this test reads.
         // Implementation hint: extend `ColorRouteCatalog.RouteSymbols` with
         // `"ColorAwareTranslationComposer.Strip("` and `"ColorAwareTranslationComposer.RestoreCapture("`,
-        // then reuse `ColorRouteCatalogTests.ScanSymbolOccurrences` rather than rolling a parallel scan.
-        Assert.Pass("Scaffold; replace with real catalog scan when production lands.");
+        // then reuse `ColorRouteCatalogTests.ScanSymbolOccurrences` for the per-file
+        // symbol map; the pairing logic is what's new (counts alone are not the contract).
+        Assert.Pass("Scaffold; replace with per-call-site reachability scan when production lands.");
     }
 
     // Catalog-2: routes that call GetDisplayNameRouteTranslator.TranslatePreservingColors
@@ -59,19 +65,25 @@ public sealed class ColorTagAllowlistCoverageTests
     }
 
     // Catalog-3: every owner route that performs RestoreCapture on a capture group
-    // whose value can carry pre-existing markup must branch on HasColorMarkup
-    // (mirroring DeathWrapperFamilyTranslator.cs:326-328). Static check: any file
-    // that contains both "RestoreCapture(" and a non-trivial capture group named
-    // "killer" / "name" / "subject" / "target" must also reference a HasColorMarkup
-    // (or equivalent) guard.
+    // whose value can carry pre-existing markup must branch on a markup-aware guard
+    // (mirroring DeathWrapperFamilyTranslator.cs:326-328 which uses HasColorMarkup).
+    // Static check: any file that contains both "RestoreCapture(" and a name-like
+    // capture group ("killer" / "name" / "subject" / "target") must also reference
+    // an equivalent guard or markup-aware abstraction.
     [Test]
     [Ignore(SkipReason)]
     public void RestoreCapture_OnNameLikeCapture_HasMarkupGuard()
     {
         // Production rule:
         //   files matching `RestoreCapture\(.*Groups\["(killer|name|subject|target)"\]\)`
-        //   must also match `HasColorMarkup\(` in the same file. Otherwise the file
-        //   is a candidate for the double-restoration regression seen in issue-376.
+        //   must also match ONE OF the equivalent guards the plan doc enumerates:
+        //     `HasColorMarkup(`            (current canonical guard)
+        //     `MarkupAwareRestoreCapture(` (planned wrapper from Phase C)
+        //     `IsAlreadyLocalized*(`       (broader idempotency guard family)
+        //   Pin the guard NAMES in a `static readonly string[] AllowedGuardSymbols`
+        //   constant so renames stay one-line edits and a future MarkupAware* wrapper
+        //   doesn't false-positive trip this test. Otherwise the file is a candidate
+        //   for the double-restoration regression seen in issue-376.
         Assert.Pass("Scaffold; replace with regex-based catalog scan when production lands.");
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -7,17 +7,19 @@ namespace QudJP.Tests.L1;
 // project does not use xUnit; see ColorTagStaticAnalysisTests.cs for rationale).
 //
 // Layer rationale per docs/test-architecture.md:
-//   L1 here is a static catalog over `Mods/QudJP/Assemblies/src/`. No HarmonyLib,
-//   no Assembly-CSharp.dll, no Unity. Pair this with the L2 DummyTarget tests in
-//   ColorTagStaticAnalysisTests.cs which exercise the runtime code path.
+//   Both this file and ColorTagStaticAnalysisTests.cs sit at L1 (no HarmonyLib,
+//   no Assembly-CSharp.dll, no Unity). This file is the static catalog scan
+//   layer; ColorTagStaticAnalysisTests.cs is the translator-surface drop-scenario
+//   layer. Catalog-1/-2/-3 here scan `Mods/QudJP/Assemblies/src/`; Catalog-4
+//   scans `Mods/QudJP/Localization/Dictionaries/*.json`.
 
 [TestFixture]
 [Category("L1")]
 public sealed class ColorTagAllowlistCoverageTests
 {
-    // Common prefix `"issue-376 — production code pending"` is shared with the L2
-    // counterpart (ColorTagStaticAnalysisTests.SkipReason) so a single grep
-    // surfaces every scaffold the production PR must address.
+    // Common prefix `"issue-376 — production code pending"` is shared with
+    // ColorTagStaticAnalysisTests.SkipReason so a single grep surfaces every
+    // scaffold the production PR must address.
     private const string SkipReason = "issue-376 — production code pending; catalog allowlist not yet defined";
 
     // Catalog-1: every Patches/*.cs that calls ColorAwareTranslationComposer.Strip
@@ -74,16 +76,18 @@ public sealed class ColorTagAllowlistCoverageTests
     [Ignore(SkipReason)]
     public void RestoreCapture_OnNameLikeCapture_HasMarkupGuard()
     {
-        // Production rule:
-        //   files matching `RestoreCapture\(.*Groups\["(killer|name|subject|target)"\]\)`
-        //   must also match ONE OF the equivalent guards the plan doc enumerates:
-        //     `HasColorMarkup(`            (current canonical guard)
-        //     `MarkupAwareRestoreCapture(` (planned wrapper from Phase C)
-        //     `IsAlreadyLocalized*(`       (broader idempotency guard family)
-        //   Pin the guard NAMES in a `static readonly string[] AllowedGuardSymbols`
-        //   constant so renames stay one-line edits and a future MarkupAware* wrapper
-        //   doesn't false-positive trip this test. Otherwise the file is a candidate
-        //   for the double-restoration regression seen in issue-376.
+        // Production rule (the GUARD side is intentionally an OPEN set, not a literal):
+        //   trigger: file contains `RestoreCapture(` against any name-like capture group
+        //            (current corpus uses killer / name / subject / target — extend as
+        //            new owner routes appear).
+        //   guard:   file must also contain a call into ANY symbol from
+        //            `static readonly string[] AllowedGuardSymbols` defined in this test.
+        //            Initial set: { "HasColorMarkup(", "MarkupAwareRestoreCapture(",
+        //            "IsAlreadyLocalized" }. Renames or new abstractions land as one-line
+        //            additions to that constant; the test must NOT pin to a single
+        //            literal like `HasColorMarkup\(`.
+        //   exempt:  pre-rendered sinks listed in an explicit (path -> reason) allowlist
+        //            this test reads.
         Assert.Pass("Scaffold; replace with regex-based catalog scan when production lands.");
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -33,7 +33,10 @@ public sealed class ColorTagAllowlistCoverageTests
     public void EveryStripCallSite_HasMatchingRestoreCallSite()
     {
         // Production rule (to encode here):
-        //   for each *.cs under Mods/QudJP/Assemblies/src/Patches:
+        //   for each *.cs under Mods/QudJP/Assemblies/src/ that actually calls
+        //   ColorAwareTranslationComposer.Strip / RestoreCapture (i.e. NOT limited to
+        //   src/Patches/ — translator-layer files like
+        //   Translation/MessagePatternTranslator.cs are equally subject to the rule):
         //     each `Strip(` call site must have at least one Restore* / TranslatePreservingColors
         //     reachable in the same control-flow path (function or method). Files where
         //     `TranslatePreservingColors(` already encapsulates the round-trip do NOT need

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -1,0 +1,81 @@
+namespace QudJP.Tests.L1;
+
+// issue-376: color tag application/restoration static analysis — L1 supplement.
+//
+// Catalog-level allowlist tests that would have caught past color-tag drops once
+// the static-analysis layer is wired up. They are NUnit `[Test, Ignore(...)]` (the
+// project does not use xUnit; see ColorTagStaticAnalysisTests.cs for rationale).
+//
+// Layer rationale per docs/test-architecture.md:
+//   L1 here is a static catalog over `Mods/QudJP/Assemblies/src/`. No HarmonyLib,
+//   no Assembly-CSharp.dll, no Unity. Pair this with the L2 DummyTarget tests in
+//   ColorTagStaticAnalysisTests.cs which exercise the runtime code path.
+
+[TestFixture]
+[Category("L1")]
+public sealed class ColorTagAllowlistCoverageTests
+{
+    private const string SkipReason = "issue-376 — production code pending; catalog allowlist not yet defined";
+
+    // Catalog-1: every Patches/*.cs that calls ColorAwareTranslationComposer.Strip
+    // OR ColorAwareTranslationComposer.RestoreCapture must also call exactly one
+    // of TranslatePreservingColors / RestoreCapture / Restore — i.e. no orphan
+    // strip-without-restore call sites that silently drop spans.
+    [Test]
+    [Ignore(SkipReason)]
+    public void EveryStripCallSite_HasMatchingRestoreCallSite()
+    {
+        // Production rule (to encode here):
+        //   for each *.cs under Mods/QudJP/Assemblies/src/Patches:
+        //     count(Strip)   ==  count(Restore | RestoreCapture | TranslatePreservingColors)
+        //   exemptions live in an explicit allowlist (path -> reason) that this test reads.
+        Assert.Pass("Scaffold; replace with real catalog scan when production lands.");
+    }
+
+    // Catalog-2: routes that call GetDisplayNameRouteTranslator.TranslatePreservingColors
+    // from inside a wrapper translator must be in the wrapper-owner allowlist —
+    // observation-only / sink routes must NOT call it.
+    // This guards the "ownership at producer / mid-pipeline, not sink" rule from
+    // docs/RULES.md.
+    [Test]
+    [Ignore(SkipReason)]
+    public void DisplayNameTranslate_OnlyCalled_FromOwnerRouteAllowlist()
+    {
+        // Production rule:
+        //   the set of files calling GetDisplayNameRouteTranslator.TranslatePreservingColors
+        //   must be a subset of OwnerRouteAllowlist (defined in this test file or a
+        //   shared catalog).
+        Assert.Pass("Scaffold; pair with ColorRouteCatalog OwnerRouteAllowlist when production lands.");
+    }
+
+    // Catalog-3: every owner route that performs RestoreCapture on a capture group
+    // whose value can carry pre-existing markup must branch on HasColorMarkup
+    // (mirroring DeathWrapperFamilyTranslator.cs:326-328). Static check: any file
+    // that contains both "RestoreCapture(" and a non-trivial capture group named
+    // "killer" / "name" / "subject" / "target" must also reference a HasColorMarkup
+    // (or equivalent) guard.
+    [Test]
+    [Ignore(SkipReason)]
+    public void RestoreCapture_OnNameLikeCapture_HasMarkupGuard()
+    {
+        // Production rule:
+        //   files matching `RestoreCapture\(.*Groups\["(killer|name|subject|target)"\]\)`
+        //   must also match `HasColorMarkup\(` in the same file. Otherwise the file
+        //   is a candidate for the double-restoration regression seen in issue-376.
+        Assert.Pass("Scaffold; replace with regex-based catalog scan when production lands.");
+    }
+
+    // Catalog-4: the dictionary corpus must not contain unbalanced markup tokens.
+    // (Closely related to issue #404 but distinct: #404 was about a single XML
+    // entry; this catalog enforces the invariant repository-wide.)
+    [Test]
+    [Ignore(SkipReason)]
+    public void DictionaryCorpus_HasBalancedMarkupTokens()
+    {
+        // Production rule:
+        //   for every translated value in Mods/QudJP/Localization/Dictionaries/*.json
+        //   the multiset of `{{`, `}}`, `&<letter>` opening/closing markers must be
+        //   token-balanced. Mirrors scripts/validate_xml.py's invariant for JSON.
+        Assert.Pass("Scaffold; defer to issue #409 if a CI gate already covers this.");
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -15,6 +15,9 @@ namespace QudJP.Tests.L1;
 [Category("L1")]
 public sealed class ColorTagAllowlistCoverageTests
 {
+    // Common prefix `"issue-376 — production code pending"` is shared with the L2
+    // counterpart (ColorTagStaticAnalysisTests.SkipReason) so a single grep
+    // surfaces every scaffold the production PR must address.
     private const string SkipReason = "issue-376 — production code pending; catalog allowlist not yet defined";
 
     // Catalog-1: every Patches/*.cs that calls ColorAwareTranslationComposer.Strip
@@ -29,6 +32,9 @@ public sealed class ColorTagAllowlistCoverageTests
         //   for each *.cs under Mods/QudJP/Assemblies/src/Patches:
         //     count(Strip)   ==  count(Restore | RestoreCapture | TranslatePreservingColors)
         //   exemptions live in an explicit allowlist (path -> reason) that this test reads.
+        // Implementation hint: extend `ColorRouteCatalog.RouteSymbols` with
+        // `"ColorAwareTranslationComposer.Strip("` and `"ColorAwareTranslationComposer.RestoreCapture("`,
+        // then reuse `ColorRouteCatalogTests.ScanSymbolOccurrences` rather than rolling a parallel scan.
         Assert.Pass("Scaffold; replace with real catalog scan when production lands.");
     }
 
@@ -45,6 +51,10 @@ public sealed class ColorTagAllowlistCoverageTests
         //   the set of files calling GetDisplayNameRouteTranslator.TranslatePreservingColors
         //   must be a subset of OwnerRouteAllowlist (defined in this test file or a
         //   shared catalog).
+        // Implementation hint: `ColorRouteCatalog.ExpectedSymbolOccurrences` already
+        // tracks per-file counts of `GetDisplayNameRouteTranslator.TranslatePreservingColors(`
+        // — the allowlist is just the keys of that map filtered by owner-vs-observation
+        // classification.
         Assert.Pass("Scaffold; pair with ColorRouteCatalog OwnerRouteAllowlist when production lands.");
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagStaticAnalysisTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagStaticAnalysisTests.cs
@@ -1,13 +1,15 @@
 using QudJP.Patches;
 
-namespace QudJP.Tests.L2;
+namespace QudJP.Tests.L1;
 
 // issue-376: color tag application/restoration static analysis.
 //
-// These DummyTarget-shape L2 tests pin the post-translation behavior we expect once
-// the static-analysis-driven detection layer lands. They are intentionally skipped
-// (NUnit Ignore) so CI stays green; they become discoverable failures the moment a
-// production fix is wired up that flips them to passing.
+// These tests pin the post-translation behavior we expect once the static-analysis-
+// driven detection layer lands. They sit in L1 (no HarmonyLib, no Assembly-CSharp.dll,
+// no UnityEngine — see docs/test-architecture.md): every translator path they touch
+// is pure C# string logic. Tests are intentionally skipped (NUnit Ignore) so CI stays
+// green; they become discoverable failures the moment a production fix is wired up
+// that flips them to passing.
 //
 // Skip pattern note:
 //   The umbrella prompt asked for `[Fact(Skip = "...")]` (xUnit). The QudJP test
@@ -27,13 +29,13 @@ namespace QudJP.Tests.L2;
 // full reset surface). The scaffold itself is read-only, but flipping any
 // `[Ignore]` should not require remembering to add the attribute.
 [TestFixture]
-[Category("L2")]
+[Category("L1")]
 [NonParallelizable]
 public sealed class ColorTagStaticAnalysisTests
 {
-    // Common prefix `"issue-376 — production code pending"` is shared with the L1
-    // counterpart (ColorTagAllowlistCoverageTests.SkipReason) so a single grep
-    // surfaces every scaffold the production PR must address.
+    // Common prefix `"issue-376 — production code pending"` is shared with
+    // ColorTagAllowlistCoverageTests.SkipReason so a single grep surfaces every
+    // scaffold the production PR must address.
     private const string SkipReason = "issue-376 — production code pending; static analysis layer not yet implemented";
 
     // Scenario 1: triple-nested {{r|...}} accumulation reproduced in Player.log
@@ -61,6 +63,14 @@ public sealed class ColorTagStaticAnalysisTests
         Assert.Multiple(() =>
         {
             Assert.That(translated, Is.True);
+            // Positive: the actual death-popup translation must contain the
+            // Japanese localizations the production PR is responsible for emitting.
+            // Without these positive anchors, an English pass-through would also
+            // satisfy the negative assertions vacuously.
+            Assert.That(
+                popupTranslated,
+                Does.Contain("血まみれの").And.Contain("殺された"),
+                "Expected the localized killer fragment and the death-verb in the output.");
             Assert.That(
                 popupTranslated,
                 Does.Not.Contain("{{r|{{r|"),
@@ -89,6 +99,12 @@ public sealed class ColorTagStaticAnalysisTests
         Assert.Multiple(() =>
         {
             Assert.That(translated, Is.True);
+            // Positive: the localized death-message body must be present so a
+            // pass-through (English or partial) cannot satisfy the negative below.
+            Assert.That(
+                messageTranslated,
+                Does.Contain("血まみれの").And.Contain("殺された"),
+                "Expected localized killer fragment and death verb.");
             Assert.That(
                 messageTranslated,
                 Does.Not.Match("\\[座ってい&[a-zA-Z]る\\]"),
@@ -114,6 +130,12 @@ public sealed class ColorTagStaticAnalysisTests
         Assert.Multiple(() =>
         {
             Assert.That(translated, Is.True);
+            // Positive: the localized killer phrase must be present so a pass-through
+            // can't satisfy the negative regex vacuously.
+            Assert.That(
+                messageTranslated,
+                Does.Contain("血まみれの").And.Contain("殺された"),
+                "Expected localized killer phrase and death verb.");
             // No stray "}}" inside the Japanese display name body.
             // NOTE: this regex assumes `Tam` survives un-translated. The production PR
             // must update the right-hand anchor to whatever the actual dictionary entry

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagStaticAnalysisTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagStaticAnalysisTests.cs
@@ -23,11 +23,17 @@ namespace QudJP.Tests.L1;
 // expected post-fix behavior. Implementation hooks are deliberately sketched
 // (commented out) — wiring them up is the responsibility of the future production PR.
 
-// `[NonParallelizable]` because the un-ignored production tests will mutate the
-// shared MessagePatternTranslator / Translator / DynamicTextObservability /
-// SinkObservation static state (see PopupPickOptionTranslationPatchTests for the
-// full reset surface). The scaffold itself is read-only, but flipping any
-// `[Ignore]` should not require remembering to add the attribute.
+// NonParallelizable: the un-ignored production tests will mutate shared static
+// state on MessagePatternTranslator, Translator, DynamicTextObservability, and
+// SinkObservation. The scaffold itself is read-only, but flipping any Ignore
+// must not require remembering to add the attribute.
+//
+// When un-ignoring, the production PR must add a SetUp/TearDown pair modeled on
+// PopupPickOptionTranslationPatchTests — SetUp seeds the dictionary directory
+// and any pattern fixtures via the *ForTests entry points; TearDown calls the
+// matching ResetForTests on each translator surface. Without that pair, the
+// translator surfaces see uninitialized dictionary state and either throw or
+// pass through the input unchanged.
 [TestFixture]
 [Category("L1")]
 [NonParallelizable]
@@ -136,13 +142,13 @@ public sealed class ColorTagStaticAnalysisTests
                 messageTranslated,
                 Does.Contain("血まみれの").And.Contain("殺された"),
                 "Expected localized killer phrase and death verb.");
-            // No stray "}}" inside the Japanese display name body.
-            // NOTE: this regex assumes `Tam` survives un-translated. The production PR
-            // must update the right-hand anchor to whatever the actual dictionary entry
-            // emits (e.g. `タム`) — otherwise this assertion becomes vacuously true.
+            // No stray "}}" inside the Japanese display name body. The right-hand
+            // anchor is the localized display name `タム`, NOT the source-side `Tam` —
+            // pinning to English here would make the assertion vacuously true on a
+            // pass-through.
             Assert.That(
                 messageTranslated,
-                Does.Not.Match("血まみれの.*}}.*Tam"),
+                Does.Not.Match("血まみれの.*}}.*タム"),
                 "RestoreCapture inserted close tag into translated display-name body.");
         });
     }
@@ -159,10 +165,20 @@ public sealed class ColorTagStaticAnalysisTests
         var first = ColorAwareTranslationComposer.TranslatePreservingColors(preLocalized);
         var second = ColorAwareTranslationComposer.TranslatePreservingColors(first);
 
-        Assert.That(
-            second,
-            Is.EqualTo(first),
-            "Second pass through TranslatePreservingColors must be identity on already-localized text.");
+        Assert.Multiple(() =>
+        {
+            // Positive: the first pass must keep the Japanese form intact (no
+            // English fragments leaking back in) — otherwise idempotency could
+            // hold on a damaged-but-stable string.
+            Assert.That(
+                first,
+                Does.Contain("血まみれの").And.Contain("タム").And.Contain("座っている"),
+                "Localized fragments must survive the first pass unchanged.");
+            Assert.That(
+                second,
+                Is.EqualTo(first),
+                "Second pass through TranslatePreservingColors must be identity on already-localized text.");
+        });
     }
 
     // Scenario 5: MessagePatternTranslator capture restoration must not duplicate

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ColorTagStaticAnalysisTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ColorTagStaticAnalysisTests.cs
@@ -140,18 +140,17 @@ public sealed class ColorTagStaticAnalysisTests
     [Ignore(SkipReason)]
     public void MessagePattern_CaptureRestoration_DoesNotDoubleWrapMarkupCarryingCapture()
     {
-        const string source = "{{Y|You hit {{r|bloody Tam}} for {{R|10}} damage.}}";
-
-        var translated = MessagePatternTranslator.Translate(
-            source,
-            context: nameof(ColorTagStaticAnalysisTests));
-
-        // Contract: pass-through (no pattern) and pattern-match paths must both leave the
-        // inner `{{r|...}}` capture singly wrapped — never `{{r|{{r|...}}}}`.
-        Assert.That(
-            translated,
-            Does.Not.Contain("{{r|{{r|"),
-            "MessagePatternTranslator double-wrapped a capture that already carried its own markup.");
+        // Production PR prerequisites (replace this body):
+        //   1. Use `MessagePatternTranslator.SetPatternFileForTests(path)` to load a fixture
+        //      pattern whose template wraps a capture (e.g. `{{r|{0}}}`).
+        //   2. Pick a `source` whose Strip+pattern-match path actually fires that template,
+        //      and whose capture value already carries its own `{{r|...}}` markup.
+        //   3. Translate; assert exact output equals the markup-aware expectation, AND
+        //      `Does.Not.Contain("{{r|{{r|")`. The exact-output assertion catches the case
+        //      where the translator silently passes through and the negative assertion
+        //      becomes vacuously true.
+        // Reset state in `[TearDown]` via `MessagePatternTranslator.ResetForTests()`.
+        Assert.Pass("Scaffold; production PR replaces with pattern-fixture-driven exact-output test.");
     }
 
     // Scenario 6: sentence-specific owner route (DescriptionTextTranslator) must
@@ -160,19 +159,17 @@ public sealed class ColorTagStaticAnalysisTests
     [Ignore(SkipReason)]
     public void DescriptionText_BalancedCapture_DoesNotSpliceColorAcrossSentences()
     {
-        // Two-sentence English description with the color span fully enclosing the
-        // first sentence only.
-        const string source = "{{W|This is a Tam.}} It is bloody.";
-
-        var translated = DescriptionTextTranslator.TranslateLongDescription(
-            source,
-            route: nameof(ColorTagStaticAnalysisTests));
-
-        // Contract: the {{W|...}} span must stay confined to sentence 1. A regression
-        // would let the opening `{{W|` survive into sentence 2 (e.g. as `{{W|...It is`).
-        Assert.That(
-            translated,
-            Does.Not.Match(@"\{\{W\|[^}]*It is bloody"),
-            "DescriptionTextTranslator spliced the {{W|...}} span across the sentence boundary.");
+        // Production PR prerequisites (replace this body):
+        //   1. Pick an input that actually engages a `DescriptionTextTranslator`
+        //      regex route (FactionDispositionPattern / LabeledListPattern /
+        //      VillageDispositionTargetPattern), e.g. multiline
+        //      `"{{W|Hated by the bandits for stealing.}}\nIt is dangerous."`
+        //      and inject a matching dictionary entry via the test scope.
+        //   2. Call `TranslateLongDescription`; assert exact output equals the
+        //      translated-with-confined-wrapper expectation (e.g. line 1 fully
+        //      Japanese-translated and re-wrapped, line 2 left alone) AND that
+        //      no `{{W|` survives onto line 2.
+        //   3. Reset dictionary scope in `[TearDown]`.
+        Assert.Pass("Scaffold; production PR replaces with regex-fixture-driven exact-output test.");
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ColorTagStaticAnalysisTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ColorTagStaticAnalysisTests.cs
@@ -140,15 +140,18 @@ public sealed class ColorTagStaticAnalysisTests
     [Ignore(SkipReason)]
     public void MessagePattern_CaptureRestoration_DoesNotDoubleWrapMarkupCarryingCapture()
     {
-        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
-            "{{Y|You hit {{r|bloody Tam}} for {{R|10}} damage.}}");
+        const string source = "{{Y|You hit {{r|bloody Tam}} for {{R|10}} damage.}}";
 
-        // Scaffold: route through MessagePatternTranslator once a pattern is loaded.
-        // The expected behavior under issue-376 is "no nested {{r|{{r|...}}}}".
-        // Production wiring lands later; this assertion locks the contract.
-        var (firstPass, _) = ColorAwareTranslationComposer.Strip(stripped);
-        Assert.That(spans, Is.Not.Null);
-        Assert.That(firstPass, Does.Not.Contain("{{r|{{r|"));
+        var translated = MessagePatternTranslator.Translate(
+            source,
+            context: nameof(ColorTagStaticAnalysisTests));
+
+        // Contract: pass-through (no pattern) and pattern-match paths must both leave the
+        // inner `{{r|...}}` capture singly wrapped — never `{{r|{{r|...}}}}`.
+        Assert.That(
+            translated,
+            Does.Not.Contain("{{r|{{r|"),
+            "MessagePatternTranslator double-wrapped a capture that already carried its own markup.");
     }
 
     // Scenario 6: sentence-specific owner route (DescriptionTextTranslator) must
@@ -159,15 +162,17 @@ public sealed class ColorTagStaticAnalysisTests
     {
         // Two-sentence English description with the color span fully enclosing the
         // first sentence only.
-        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
-            "{{W|This is a Tam.}} It is bloody.");
+        const string source = "{{W|This is a Tam.}} It is bloody.";
 
-        Assert.Multiple(() =>
-        {
-            Assert.That(spans, Is.Not.Null);
-            Assert.That(stripped, Does.Not.Contain("{{W|"));
-            // Production hook: post-DescriptionTextTranslator output must keep the
-            // {{W|...}} span confined to sentence 1 with no leak into sentence 2.
-        });
+        var translated = DescriptionTextTranslator.TranslateLongDescription(
+            source,
+            route: nameof(ColorTagStaticAnalysisTests));
+
+        // Contract: the {{W|...}} span must stay confined to sentence 1. A regression
+        // would let the opening `{{W|` survive into sentence 2 (e.g. as `{{W|...It is`).
+        Assert.That(
+            translated,
+            Does.Not.Match(@"\{\{W\|[^}]*It is bloody"),
+            "DescriptionTextTranslator spliced the {{W|...}} span across the sentence boundary.");
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ColorTagStaticAnalysisTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ColorTagStaticAnalysisTests.cs
@@ -21,11 +21,19 @@ namespace QudJP.Tests.L2;
 // expected post-fix behavior. Implementation hooks are deliberately sketched
 // (commented out) — wiring them up is the responsibility of the future production PR.
 
+// `[NonParallelizable]` because the un-ignored production tests will mutate the
+// shared MessagePatternTranslator / Translator / DynamicTextObservability /
+// SinkObservation static state (see PopupPickOptionTranslationPatchTests for the
+// full reset surface). The scaffold itself is read-only, but flipping any
+// `[Ignore]` should not require remembering to add the attribute.
 [TestFixture]
 [Category("L2")]
 [NonParallelizable]
 public sealed class ColorTagStaticAnalysisTests
 {
+    // Common prefix `"issue-376 — production code pending"` is shared with the L1
+    // counterpart (ColorTagAllowlistCoverageTests.SkipReason) so a single grep
+    // surfaces every scaffold the production PR must address.
     private const string SkipReason = "issue-376 — production code pending; static analysis layer not yet implemented";
 
     // Scenario 1: triple-nested {{r|...}} accumulation reproduced in Player.log
@@ -107,6 +115,9 @@ public sealed class ColorTagStaticAnalysisTests
         {
             Assert.That(translated, Is.True);
             // No stray "}}" inside the Japanese display name body.
+            // NOTE: this regex assumes `Tam` survives un-translated. The production PR
+            // must update the right-hand anchor to whatever the actual dictionary entry
+            // emits (e.g. `タム`) — otherwise this assertion becomes vacuously true.
             Assert.That(
                 messageTranslated,
                 Does.Not.Match("血まみれの.*}}.*Tam"),
@@ -140,7 +151,8 @@ public sealed class ColorTagStaticAnalysisTests
     [Ignore(SkipReason)]
     public void MessagePattern_CaptureRestoration_DoesNotDoubleWrapMarkupCarryingCapture()
     {
-        // Production PR prerequisites (replace this body):
+        // Production PR prerequisites (replace this body — model on
+        // `PopupPickOptionTranslationPatchTests` SetUp/TearDown):
         //   1. Use `MessagePatternTranslator.SetPatternFileForTests(path)` to load a fixture
         //      pattern whose template wraps a capture (e.g. `{{r|{0}}}`).
         //   2. Pick a `source` whose Strip+pattern-match path actually fires that template,
@@ -149,7 +161,9 @@ public sealed class ColorTagStaticAnalysisTests
         //      `Does.Not.Contain("{{r|{{r|")`. The exact-output assertion catches the case
         //      where the translator silently passes through and the negative assertion
         //      becomes vacuously true.
-        // Reset state in `[TearDown]` via `MessagePatternTranslator.ResetForTests()`.
+        // Reset state in `[TearDown]` via `MessagePatternTranslator.ResetForTests()`,
+        // `Translator.ResetForTests()`, `DynamicTextObservability.ResetForTests()`,
+        // `SinkObservation.ResetForTests()`.
         Assert.Pass("Scaffold; production PR replaces with pattern-fixture-driven exact-output test.");
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ColorTagStaticAnalysisTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ColorTagStaticAnalysisTests.cs
@@ -1,0 +1,173 @@
+using QudJP.Patches;
+
+namespace QudJP.Tests.L2;
+
+// issue-376: color tag application/restoration static analysis.
+//
+// These DummyTarget-shape L2 tests pin the post-translation behavior we expect once
+// the static-analysis-driven detection layer lands. They are intentionally skipped
+// (NUnit Ignore) so CI stays green; they become discoverable failures the moment a
+// production fix is wired up that flips them to passing.
+//
+// Skip pattern note:
+//   The umbrella prompt asked for `[Fact(Skip = "...")]` (xUnit). The QudJP test
+//   project is NUnit (see QudJP.Tests.csproj `<Using Include="NUnit.Framework" />`),
+//   so we use the NUnit-equivalent `[Test, Ignore("issue-376 — production code pending")]`.
+//   Behavior contract is identical: the test is discoverable but does not run.
+//
+// Each scenario below corresponds to a concrete drop pattern documented in the issue
+// body and in `docs/superpowers/plans/2026-04-27-issue-376-color-static-analysis.md`.
+// The tests are written in arrange/act/assert form with comments describing the
+// expected post-fix behavior. Implementation hooks are deliberately sketched
+// (commented out) — wiring them up is the responsibility of the future production PR.
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class ColorTagStaticAnalysisTests
+{
+    private const string SkipReason = "issue-376 — production code pending; static analysis layer not yet implemented";
+
+    // Scenario 1: triple-nested {{r|...}} accumulation reproduced in Player.log
+    //   "{{r|{{r|{{r|血ま}}みれの}}タム、ドロマド商団 [座ってい}}る]}}"
+    // Expectation post-fix: outer wrapper restoration must NOT reapply on already-
+    // localized killer fragments that already carry markup.
+    [Test]
+    [Ignore(SkipReason)]
+    public void DeathPopup_DoesNotAccumulateNestedRedWrappers_OnAlreadyLocalizedKiller()
+    {
+        // Arrange: source carries one outer {{r|...}} and the localized killer
+        // already injects its own {{r|血まみれの}} via dictionary lookup.
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
+            "You died.\n\nYou were killed by {{r|bloody Tam, dromad merchant [sitting]}}.");
+
+        // Act
+        var translated = DeathWrapperFamilyTranslator.TryTranslatePopup(
+            stripped,
+            spans,
+            nameof(PopupTranslationPatch),
+            out var popupTranslated);
+
+        // Assert: the killer's own injected markup must remain singly-wrapped and
+        // the outer span must not bleed into the trailing "[座っている]" bracket.
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(
+                popupTranslated,
+                Does.Not.Contain("{{r|{{r|"),
+                "Detected {{r|{{r|... — wrapper double-restoration regressed.");
+            Assert.That(
+                popupTranslated,
+                Does.Not.Match("\\[座ってい}}る\\]"),
+                "Closing }} must not land mid-bracket.");
+        });
+    }
+
+    // Scenario 2: ampersand color code {&y} eats into a Japanese bracketed token.
+    //   "&r血まみれのタム、ドロマド商団 [座ってい&yる]に殺された。"
+    [Test]
+    [Ignore(SkipReason)]
+    public void DeathReason_AmpersandCode_DoesNotSplitBracketedJapaneseToken()
+    {
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
+            "&rbloody Tam, dromad merchant [sitting]&y was killed by you.");
+
+        var translated = DeathWrapperFamilyTranslator.TryTranslateMessage(
+            stripped,
+            spans,
+            out var messageTranslated);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(
+                messageTranslated,
+                Does.Not.Match("\\[座ってい&[a-zA-Z]る\\]"),
+                "Ampersand color code must not split bracketed Japanese token.");
+        });
+    }
+
+    // Scenario 3: capture-group RestoreCapture must not insert close tags into
+    // already-translated display name internals (issue body "double restoration").
+    [Test]
+    [Ignore(SkipReason)]
+    public void RestoreCapture_DoesNotInjectCloseTagInsideTranslatedDisplayName()
+    {
+        // Source has a {{C|...whole...}} wrapper around an English display name.
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
+            "You were killed by {{C|bloody Tam, dromad merchant [sitting]}}.");
+
+        var translated = DeathWrapperFamilyTranslator.TryTranslateMessage(
+            stripped,
+            spans,
+            out var messageTranslated);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            // No stray "}}" inside the Japanese display name body.
+            Assert.That(
+                messageTranslated,
+                Does.Not.Match("血まみれの.*}}.*Tam"),
+                "RestoreCapture inserted close tag into translated display-name body.");
+        });
+    }
+
+    // Scenario 4: pre-rendered string passed through the translator twice.
+    // When a sink receives an already-translated and already-color-restored string,
+    // the second pass must be a no-op (idempotency contract).
+    [Test]
+    [Ignore(SkipReason)]
+    public void Translator_IsIdempotent_OnAlreadyLocalizedColoredDisplayName()
+    {
+        const string preLocalized = "{{r|血まみれの}}タム、ドロマド商人 [座っている]";
+
+        var first = ColorAwareTranslationComposer.TranslatePreservingColors(preLocalized);
+        var second = ColorAwareTranslationComposer.TranslatePreservingColors(first);
+
+        Assert.That(
+            second,
+            Is.EqualTo(first),
+            "Second pass through TranslatePreservingColors must be identity on already-localized text.");
+    }
+
+    // Scenario 5: MessagePatternTranslator capture restoration must not duplicate
+    // wrapper spans when the captured group already carries its own markup.
+    // Mirrors the DeathWrapperFamilyTranslator HasColorMarkup branch but at the
+    // generic message-pattern layer (decompiled-source families using {0}/{1}).
+    [Test]
+    [Ignore(SkipReason)]
+    public void MessagePattern_CaptureRestoration_DoesNotDoubleWrapMarkupCarryingCapture()
+    {
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
+            "{{Y|You hit {{r|bloody Tam}} for {{R|10}} damage.}}");
+
+        // Scaffold: route through MessagePatternTranslator once a pattern is loaded.
+        // The expected behavior under issue-376 is "no nested {{r|{{r|...}}}}".
+        // Production wiring lands later; this assertion locks the contract.
+        var (firstPass, _) = ColorAwareTranslationComposer.Strip(stripped);
+        Assert.That(spans, Is.Not.Null);
+        Assert.That(firstPass, Does.Not.Contain("{{r|{{r|"));
+    }
+
+    // Scenario 6: sentence-specific owner route (DescriptionTextTranslator) must
+    // not splice color tags across sentence boundaries during balanced-capture.
+    [Test]
+    [Ignore(SkipReason)]
+    public void DescriptionText_BalancedCapture_DoesNotSpliceColorAcrossSentences()
+    {
+        // Two-sentence English description with the color span fully enclosing the
+        // first sentence only.
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
+            "{{W|This is a Tam.}} It is bloody.");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(spans, Is.Not.Null);
+            Assert.That(stripped, Does.Not.Contain("{{W|"));
+            // Production hook: post-DescriptionTextTranslator output must keep the
+            // {{W|...}} span confined to sentence 1 with no leak into sentence 2.
+        });
+    }
+}

--- a/docs/superpowers/plans/2026-04-27-issue-376-color-static-analysis.md
+++ b/docs/superpowers/plans/2026-04-27-issue-376-color-static-analysis.md
@@ -61,15 +61,25 @@ False-positive mitigation:
 
 ## Test architecture per `docs/test-architecture.md`
 
-- **L1** — pure-string catalog scan over `src/Patches/*.cs`. No HarmonyLib,
-  no `Assembly-CSharp.dll`. Lives in
-  `Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs`.
-- **L2** — DummyTarget tests for each drop scenario in the issue body. Lives
-  in `Mods/QudJP/Assemblies/QudJP.Tests/L2/ColorTagStaticAnalysisTests.cs`.
-- **No L0.** This work has no math/algorithm core that can be tested in
-  isolation from the existing translator surfaces; the smallest meaningful
-  unit is "translator pipeline output", which is already L1.
-- **No L3 in the first cut.** Once the L1+L2 layer is green we add a smoke
+Both files live in **L1** (pure C#, no HarmonyLib, no `Assembly-CSharp.dll`,
+no UnityEngine — see `docs/test-architecture.md` for layer boundaries):
+
+- `Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs` —
+  static catalog scans (Catalog-1, Catalog-2, Catalog-3 over
+  `Mods/QudJP/Assemblies/src/`; Catalog-4 over
+  `Mods/QudJP/Localization/Dictionaries/*.json`). The scan target is
+  per-Catalog, not "all of L1 is `src/Patches/*.cs`".
+- `Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagStaticAnalysisTests.cs` —
+  six representative drop-scenario tests that call the pure-C# translator
+  surface (`ColorAwareTranslationComposer`, `DeathWrapperFamilyTranslator`,
+  `MessagePatternTranslator`, `DescriptionTextTranslator`) directly. No
+  HarmonyLib / DummyTarget, so L1 not L2.
+- **No L0.** No math/algorithm core that can be tested in isolation from the
+  translator surface.
+- **No L2 / L2G.** None of the scenarios need Harmony patch resolution or
+  game-DLL signature integration to verify the contract. Phase F runtime
+  proof remains separate per `docs/RULES.md`.
+- **No L3 in the first cut.** Once the L1 layer is green we add a smoke
   step that diffs a fresh `Player.log`. Captured separately in the
   acceptance criteria below.
 
@@ -95,7 +105,7 @@ code pending")]` which has the same "discoverable but not run" semantics.
 1. L1 catalog test: every `Strip` has a matching `Restore*` (with allowlist).
 2. L1 catalog test: every `RestoreCapture` on a name-like group has a
    markup guard in the same file (allowlist exempts pre-rendered sinks).
-3. L2 DummyTarget tests for the six representative drop scenarios captured in
+3. L1 translator-surface tests for the six representative drop scenarios in
    `ColorTagStaticAnalysisTests.cs` (four canonical drops from the issue body
    plus two adjacent-translator contract tests for `MessagePatternTranslator`
    and `DescriptionTextTranslator`).
@@ -106,7 +116,8 @@ code pending")]` which has the same "discoverable but not run" semantics.
    `ColorAwareTranslationComposer` that delegates to `RestoreCapture` only
    when `!HasColorMarkup(value)`.
 2. Migrate the `MessagePatternTranslator.cs:575` call site first (highest
-   blast radius). DummyTarget tests must flip from skipped to passing.
+   blast radius). The L1 translator-surface tests must flip from skipped
+   to passing.
 3. Migrate remaining call sites flagged by the L1 catalog.
 4. Tighten the L1 allowlist to forbid the un-guarded `RestoreCapture` shape
    project-wide.
@@ -134,8 +145,9 @@ code pending")]` which has the same "discoverable but not run" semantics.
 - A fresh `Player.log` from a death-popup smoke run shows zero
   `{{r|{{r|...}}` occurrences and zero `&<letter>` codes inside Japanese
   bracketed tokens.
-- `dotnet test ... --filter TestCategory=L1` and `--filter TestCategory=L2`
-  remain green (target counts: current totals + new tests, all passing).
+- `dotnet test ... --filter TestCategory=L1` remains green (target counts:
+  current totals + new tests, all passing). L2 / L2G are not affected by
+  this work.
 
 ## Open questions
 

--- a/docs/superpowers/plans/2026-04-27-issue-376-color-static-analysis.md
+++ b/docs/superpowers/plans/2026-04-27-issue-376-color-static-analysis.md
@@ -139,7 +139,7 @@ code pending")]` which has the same "discoverable but not run" semantics.
 
 - The six representative drop scenarios in `ColorTagStaticAnalysisTests.cs`
   flip from skipped to passing under one production PR (no skips remain
-  cited to issue-376 outside of intentional, allowlisted exemptions).
+  cited to issue-376 outside intentional, allowlisted exemptions).
 - The L1 catalog asserts non-empty coverage and rejects new `Strip`
   call sites that lack a paired `Restore*`.
 - A fresh `Player.log` from a death-popup smoke run shows zero

--- a/docs/superpowers/plans/2026-04-27-issue-376-color-static-analysis.md
+++ b/docs/superpowers/plans/2026-04-27-issue-376-color-static-analysis.md
@@ -95,8 +95,10 @@ code pending")]` which has the same "discoverable but not run" semantics.
 1. L1 catalog test: every `Strip` has a matching `Restore*` (with allowlist).
 2. L1 catalog test: every `RestoreCapture` on a name-like group has a
    markup guard in the same file (allowlist exempts pre-rendered sinks).
-3. L2 DummyTarget tests for the four representative drop scenarios captured
-   in `ColorTagStaticAnalysisTests.cs`.
+3. L2 DummyTarget tests for the six representative drop scenarios captured in
+   `ColorTagStaticAnalysisTests.cs` (four canonical drops from the issue body
+   plus two adjacent-translator contract tests for `MessagePatternTranslator`
+   and `DescriptionTextTranslator`).
 
 ### Phase C — regression guard wiring
 
@@ -124,7 +126,7 @@ code pending")]` which has the same "discoverable but not run" semantics.
 
 ## Acceptance criteria
 
-- The four representative drop scenarios in `ColorTagStaticAnalysisTests.cs`
+- The six representative drop scenarios in `ColorTagStaticAnalysisTests.cs`
   flip from skipped to passing under one production PR (no skips remain
   cited to issue-376 outside of intentional, allowlisted exemptions).
 - The L1 catalog asserts non-empty coverage and rejects new `Strip`

--- a/docs/superpowers/plans/2026-04-27-issue-376-color-static-analysis.md
+++ b/docs/superpowers/plans/2026-04-27-issue-376-color-static-analysis.md
@@ -1,0 +1,151 @@
+# issue-376 — Color tag application/restoration static analysis
+
+Investigation-only scoping doc. No production code is shipped in the same commit;
+this plan exists so the next implementation PR can run against a fixed contract.
+
+## Problem statement
+
+Display names rendered in combat / death / ability-bar paths exhibit two shapes
+of color-tag corruption (see `gh issue view 376` body):
+
+- Triple-nested `{{r|{{r|{{r|...}}}}}}` accumulation around the killer.
+- Ampersand-prefix codes (`&r`, `&y`) splicing into Japanese bracketed tokens
+  such as `[座っている]`, e.g. `[座ってい&yる]`.
+
+Empirical pivots from prior PRs:
+
+- `Mods/QudJP/Assemblies/src/Patches/DeathWrapperFamilyTranslator.cs:326-328` —
+  the `HasColorMarkup` branch is the only place we currently guard against
+  re-applying outer wrapper spans onto an already-marked-up localized killer.
+  No equivalent guard exists in `MessagePatternTranslator` or
+  `DescriptionTextTranslator`.
+- `Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs:575` —
+  capture-group `RestoreCapture` is called unconditionally; if the capture
+  value carries its own markup the closing `}}` can land mid-token.
+- `Mods/QudJP/Assemblies/src/Translation/ColorAwareTranslationComposer.cs:85` —
+  `RestoreCapture` is span-driven and has no notion of "the value already owns
+  its own opening/closing markup".
+- PR #432 lesson (`Grammar.InitCap`): runtime regex options
+  `RegexOptions.Compiled | CultureInvariant` only uppercase ASCII `a-z`. A
+  pattern's source-side casing is not the runtime casing. Color-tag analysis
+  has the analogous gotcha — source-side `{{r|...}}` is not always the
+  runtime-emitted shape; producers can emit `&r…&y` or `<color=…>…</color>`
+  and the static catalog has to enumerate every shape.
+
+## Detection strategy
+
+Three anchor points, in priority order:
+
+1. **Translator pipeline (preferred).** Add a "markup-aware" branch to every
+   `RestoreCapture` call site, mirroring `DeathWrapperFamilyTranslator`'s
+   `HasColorMarkup` guard. Producer-owned, deterministic, testable in L1.
+2. **Validator (CI gate).** Static scan over `Mods/QudJP/Assemblies/src/` for
+   `Strip` / `Restore` symmetry and for `RestoreCapture` calls that target
+   name-like capture groups without a markup guard. Encodes the rule once and
+   runs on every PR.
+3. **Runtime observability (last resort).** Extend `DynamicTextObservability`
+   to log "wrapper-double-restored" events. Useful for L3 smoke runs but not
+   the source of truth.
+
+False-positive mitigation:
+
+- Allowlist file (path → reason). Each entry must cite the issue or PR that
+  blessed the exemption. Example: pre-rendered fragments produced by sinks.
+- Symbolic guards over regex-only matching. The validator must look for the
+  guard *or* an equivalent abstraction (`HasColorMarkup`,
+  `IsAlreadyLocalized*`, `MarkupAwareRestore`, …) — the catalog rule is "the
+  guard exists", not "the guard is named `HasColorMarkup`".
+- Runtime-shape enumeration. Catalog the producers that emit `&<letter>` and
+  `<color=…>` separately from the `{{shader|…}}` form so the regex has full
+  coverage.
+
+## Test architecture per `docs/test-architecture.md`
+
+- **L1** — pure-string catalog scan over `src/Patches/*.cs`. No HarmonyLib,
+  no `Assembly-CSharp.dll`. Lives in
+  `Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs`.
+- **L2** — DummyTarget tests for each drop scenario in the issue body. Lives
+  in `Mods/QudJP/Assemblies/QudJP.Tests/L2/ColorTagStaticAnalysisTests.cs`.
+- **No L0.** This work has no math/algorithm core that can be tested in
+  isolation from the existing translator surfaces; the smallest meaningful
+  unit is "translator pipeline output", which is already L1.
+- **No L3 in the first cut.** Once the L1+L2 layer is green we add a smoke
+  step that diffs a fresh `Player.log`. Captured separately in the
+  acceptance criteria below.
+
+Skip-pattern note: the prompt asked for `[Fact(Skip = "...")]` (xUnit). The
+QudJP test project is NUnit. We use `[Test, Ignore("issue-376 — production
+code pending")]` which has the same "discoverable but not run" semantics.
+
+## Implementation phases
+
+### Phase A — catalog of expected tag-flow shapes
+
+1. Enumerate every Patches/translator file that calls `Strip` or
+   `RestoreCapture`. Group by route family
+   (death, popup, message-pattern, description, journal, owner, observation).
+2. For each call site, record:
+   `(path, line, capture-group-name, has-markup-guard, owner-or-observation)`.
+3. Land the catalog as a `SortedDictionary` next to
+   `ColorRouteCatalog.ExpectedSymbolOccurrences` so it is human-reviewable
+   and PR-diffable.
+
+### Phase B — detection layer
+
+1. L1 catalog test: every `Strip` has a matching `Restore*` (with allowlist).
+2. L1 catalog test: every `RestoreCapture` on a name-like group has a
+   markup guard in the same file (allowlist exempts pre-rendered sinks).
+3. L2 DummyTarget tests for the four representative drop scenarios captured
+   in `ColorTagStaticAnalysisTests.cs`.
+
+### Phase C — regression guard wiring
+
+1. Add `MarkupAwareRestoreCapture(value, spans, group)` to
+   `ColorAwareTranslationComposer` that delegates to `RestoreCapture` only
+   when `!HasColorMarkup(value)`.
+2. Migrate the `MessagePatternTranslator.cs:575` call site first (highest
+   blast radius). DummyTarget tests must flip from skipped to passing.
+3. Migrate remaining call sites flagged by the L1 catalog.
+4. Tighten the L1 allowlist to forbid the un-guarded `RestoreCapture` shape
+   project-wide.
+
+## Cross-references
+
+- **#401 (ColorRoute).** Closed. JSON-dictionary token-loss bug. Fixed at the
+  dictionary level. Issue-376 is *runtime* tag flow — a different layer.
+  Borrow #401's token-multiset invariant for the L1 dictionary corpus check
+  (Catalog-4) but do not reopen #401's surface.
+- **#404 (Preacher color).** Closed. Single unbalanced `{{W|` in Creatures.jp.xml.
+  Issue-376 catalog covers the *general* shape; #404's specific entry is a
+  one-off that is already fixed in shipped XML.
+- **#409 (translation consistency CI gate).** Open. Tech-debt umbrella for the
+  CI gate side. Defer Catalog-4 (dictionary balance) to #409 if the gate
+  already covers it; otherwise land it here and reference back.
+
+## Acceptance criteria
+
+- The four representative drop scenarios in `ColorTagStaticAnalysisTests.cs`
+  flip from skipped to passing under one production PR (no skips remain
+  cited to issue-376 outside of intentional, allowlisted exemptions).
+- The L1 catalog asserts non-empty coverage and rejects new `Strip`
+  call sites that lack a paired `Restore*`.
+- A fresh `Player.log` from a death-popup smoke run shows zero
+  `{{r|{{r|...}}` occurrences and zero `&<letter>` codes inside Japanese
+  bracketed tokens.
+- `dotnet test ... --filter TestCategory=L1` and `--filter TestCategory=L2`
+  remain green (target counts: current totals + new tests, all passing).
+
+## Open questions
+
+1. **Allowlist storage.** Inline `HashSet<string>` in the L1 test, or a
+   committed JSON file under `scripts/_artifacts/` like
+   `validate_xml_warning_baseline.json`? Latter mirrors existing tooling.
+2. **Sink-vs-owner classification.** The catalog distinguishes "owner"
+   from "observation-only" routes. Do we trust `docs/RULES.md` as the
+   single source of truth, or do we re-derive the classification from
+   `ColorRouteCatalog.ExpectedSymbolOccurrences`? Mixed signals exist
+   today.
+3. **Runtime shape coverage.** Should phase A enumerate `&<letter>` and
+   `<color=…>` producer paths via decompiled-source scan
+   (`~/dev/coq-decompiled_stable/`) or rely on runtime log evidence
+   only? Decompiled scan is more thorough but not committable.


### PR DESCRIPTION
## Summary

- Investigation-only commit. NO production code. Lands the contract / acceptance criteria so the next PR has clear targets.
- Plan doc at `docs/superpowers/plans/2026-04-27-issue-376-color-static-analysis.md`: problem statement (`{{r|{{r|{{r|...}}}}}}` triple-nest + `&y` splice into Japanese brackets), 3-tier detection strategy (translator pipeline → validator CI gate → runtime observability), L1+L2 layering, phase A/B/C, cross-references to #401/#404/#409, six acceptance scenarios.
- L1 catalog scaffold: 4 `[Ignore]`-marked tests covering Strip/Restore symmetry, owner-route allowlist, name-like-capture markup-guard requirement, and dictionary corpus markup balance. Comments point at the existing `ColorRouteCatalog.RouteSymbols` / `ScanSymbolOccurrences` infrastructure for reuse.
- L2 DummyTarget scaffold: 6 `[Ignore]`-marked tests. Scenarios 1–4 call real translators (`DeathWrapperFamilyTranslator`, `ColorAwareTranslationComposer`) and assert meaningful contracts. Scenarios 5–6 use `Assert.Pass` placeholders with explicit production-PR prerequisite checklists (test pattern fixture for MessagePatternTranslator, regex+dictionary scope for DescriptionTextTranslator).
- 4 codex review rounds (R0–R3 APPROVE) plus a /simplify pass (shared SkipReason prefix, `[NonParallelizable]` rationale, full reset surface for Scenario 5, Tam anchor fragility note, ColorRouteCatalog reuse hints). Post-simplify R4 APPROVE.

## Test plan

- [ ] `dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj`
- [ ] `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1` — green; 4 new ColorTagAllowlistCoverageTests skipped
- [ ] `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2` — green; 6 new ColorTagStaticAnalysisTests skipped
- [ ] Confirm no `[Ignore]` is dropped accidentally; CI must remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 色タグ破損防止のための複数のL1テストを追加しました（Strip/Restore対称性、表示名翻訳の許可経路、キャプチャ復元のマークアップ保護、辞書値のトークン整合性、冪等性などを想定）。現状は検出用スケルトンで全てスキップ済みのテストです。

* **Documentation**
  * 色タグの静的解析・検出・段階的導入に関する実施計画と受入基準を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->