### PR TITLE
[codex] advance release readiness localization slices

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
@@ -227,6 +227,55 @@ public sealed class LocalizationCoverageTests
     }
 
     [Test]
+    public void MutationAndAbilityStaticText_BatchA_DoesNotRegressKnownEnglishResidueOrMechanics()
+    {
+        var descriptions = LoadEntries(Path.Combine(localizationRoot, "Dictionaries", "mutation-descriptions.ja.json"))
+            .ToDictionary(static entry => entry.Key, static entry => entry.Text, StringComparer.Ordinal);
+        var rankTexts = LoadEntries(Path.Combine(localizationRoot, "Dictionaries", "mutation-ranktext.ja.json"))
+            .ToDictionary(static entry => entry.Key, static entry => entry.Text, StringComparer.Ordinal);
+        var abilitiesDocument = XDocument.Load(Path.Combine(localizationRoot, "ActivatedAbilities.jp.xml"));
+        var swoopDescription = abilitiesDocument.Root!
+            .Elements("ability")
+            .Single(element => string.Equals(element.Attribute("Command")?.Value, "CommandSwoopAttack", StringComparison.Ordinal))
+            .Element("description")!
+            .Value;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                swoopDescription,
+                Does.Contain("1ターンかけて攻撃し、もう1ターンで上空へ戻る"),
+                "CommandSwoopAttack must preserve the source meaning: one turn to attack, one turn to return.");
+
+            Assert.That(
+                descriptions["mutation:Metamorphosis"],
+                Is.EqualTo("触れたあらゆるクリーチャーの姿をとる。"),
+                "Metamorphosis long description should not add unsupported equipment or self-level claims.");
+            Assert.That(
+                descriptions["mutation:Blinking Tic"],
+                Does.Contain("戦闘中、毎ラウンド低確率で近くの場所へランダムに瞬間移動する。"),
+                "Blinking Tic must preserve the combat-per-round random nearby teleport behavior.");
+
+            Assert.That(descriptions["mutation:Photosynthetic Skin"], Does.Not.Contain("{{rules|1 day}}"));
+            Assert.That(descriptions["mutation:Photosynthetic Skin"], Does.Not.Contain("Consortium of Phyta"));
+
+            for (var rank = 1; rank <= 10; rank++)
+            {
+                var burrowingText = rankTexts[$"mutation:Burrowing Claws:rank:{rank}"];
+                Assert.That(burrowingText, Does.Not.Contain("penetrating hits"));
+                Assert.That(burrowingText, Does.Not.Contain("base damage to non-walls"));
+                Assert.That(burrowingText, Does.Contain("爪で4回貫通すると壁を破壊する。"));
+
+                var electricalText = rankTexts[$"mutation:Electrical Generation:rank:{rank}"];
+                Assert.That(electricalText, Does.Contain("1000チャージごとに1d4ダメージ"));
+                Assert.That(electricalText, Does.Contain("1000チャージごとに最大1体へ連鎖する。"));
+                Assert.That(electricalText, Does.Not.Contain("チャージ1点ごとに4d1000"));
+                Assert.That(electricalText, Does.Not.Contain("最大1チャージあたり1000体"));
+            }
+        });
+    }
+
+    [Test]
     public void WorldPartsDictionary_DoesNotReuseCookingOwnerKeys()
     {
         var dictionariesRoot = Path.Combine(localizationRoot, "Dictionaries");

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/Fixtures/annals-samples.json
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/Fixtures/annals-samples.json
@@ -152,6 +152,30 @@
       ]
     },
     {
+      "candidate_id": "FoundGuild#gospel",
+      "event_property": "gospel",
+      "input_source": "After treating with the Farmers' Guild, Nuntu convinced them to help him found a workshop in Hinnom for the purpose of studying glass. They named it the Glass Workshop.",
+      "expected_japanese_exact": "農夫ギルドとtreatingしたのち、NuntuはhimがHinnomにa workshopを創設する助力をするよう彼らを説得した。その目的はガラスのをstudyingことだった。彼らはそれをthe Glass Workshopと名づけた。"
+    },
+    {
+      "candidate_id": "CorruptAdministrator#gospel#case:0#if:then",
+      "event_property": "gospel",
+      "input_source": "In 1234 AR, a corrupt administrator was appointed minister of Salt Dunes. She outlawed the practice of glass-making, and Nuntu was forced to flee.",
+      "expected_japanese_exact": "1234年、腐敗した施政官がSalt Dunesの大臣に任じられた。その者はglass-makingの営みを禁じ、Nuntuは逃亡を余儀なくされた。"
+    },
+    {
+      "candidate_id": "CorruptAdministrator#gospel#case:1#if:then",
+      "event_property": "gospel",
+      "input_source": "In 1234 AR, a corrupt administrator was appointed minister of Salt Dunes. She outlawed association with the Farmers' Guild, and Nuntu was forced to flee.",
+      "expected_japanese_exact": "1234年、腐敗した施政官がSalt Dunesの大臣に任じられた。その者は農夫ギルドとの交わりを禁じ、Nuntuは逃亡を余儀なくされた。"
+    },
+    {
+      "candidate_id": "SecretRitual#gospel#if:then#arm:1",
+      "event_property": "gospel",
+      "input_source": "While wandering around Salt Dunes, Nuntu stumbled upon a clan of the Farmers' Guild performing a secret ritual. Because of his chromatic aura, they accepted him into their fold and taught him their secrets.",
+      "expected_japanese_exact": "Salt Dunesの辺りをさまよううち、Nuntuは秘密の儀式を行う農夫ギルドの一族に出くわした。his chromatic auraゆえ、彼らはhimを仲間に迎え入れ、himに彼らの秘密を授けた。"
+    },
+    {
       "candidate_id": "edge_empty_gospel",
       "event_property": "gospel",
       "input_source": "",

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/LookTooltipContentPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/LookTooltipContentPatchTests.cs
@@ -33,6 +33,7 @@ public sealed class LookTooltipContentPatchTests
     public void TearDown()
     {
         Translator.ResetForTests();
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
         DynamicTextObservability.ResetForTests();
         SinkObservation.ResetForTests();
 
@@ -69,6 +70,27 @@ public sealed class LookTooltipContentPatchTests
                         source),
                     Is.EqualTo(0));
             });
+        });
+    }
+
+    [Test]
+    public void TranslateTooltipContent_UsesPopupFixedLeafDictionary_ForPlayerLookPopup()
+    {
+        var localizationRoot = GetLocalizationRoot();
+        LocalizationAssetResolver.SetLocalizationRootForTests(localizationRoot);
+        Translator.SetDictionaryDirectoryForTests(Path.Combine(localizationRoot, "Dictionaries"));
+
+        const string source = "It's you.";
+        var result = LookTooltipContentPatch.TranslateTooltipContent(source);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo("あなた自身だ。"));
+            Assert.That(
+                DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                    nameof(LookTooltipContentPatch),
+                    "Description.ExactLeaf"),
+                Is.GreaterThan(0));
         });
     }
 
@@ -152,6 +174,11 @@ public sealed class LookTooltipContentPatchTests
     {
         return AccessTools.Method(type, methodName)
             ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private static string GetLocalizationRoot()
+    {
+        return Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "../../../../../Localization"));
     }
 
     private void WriteDictionary(params (string key, string text)[] entries)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs
@@ -142,6 +142,24 @@ public sealed class SultanShrineWrapperTranslatorTests
     }
 
     [Test]
+    public void Translate_TranslatesDiscoveredLocationAnnalsGospel()
+    {
+        const string source =
+            "The shrine depicts a significant event from the life of the ancient sultan Yla Haj:"
+            + "\n\ndiscovered Rust Wells"
+            + "\n\n{{Y|Perfect}}";
+
+        var translated = MessagePatternTranslator.Translate(source, nameof(DescriptionLongDescriptionPatch));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Does.Contain("Rust Wellsを発見した"));
+            Assert.That(translated, Does.Not.Contain("discovered Rust Wells"));
+            Assert.That(translated, Does.EndWith("{{Y|完璧}}"));
+        });
+    }
+
+    [Test]
     public void Translate_TranslatesTwoParagraphShape_WhenQualitySuffixAbsent()
     {
         // Shape produced directly by SultanShrine.ShrineInitialize (Description.Short).

--- a/Mods/QudJP/Localization/ActivatedAbilities.jp.xml
+++ b/Mods/QudJP/Localization/ActivatedAbilities.jp.xml
@@ -15,7 +15,7 @@
   </ability>
   <ability Command="CommandSwoopAttack">
 		<description>
-			<p>地上の目標へ急降下して攻撃し、1ターンで上空へ戻る。</p>
+			<p>地上の目標へ急降下し、1ターンかけて攻撃し、もう1ターンで上空へ戻る。</p>
 			<br />
 			<p><stat Name="SwoopCrashChance" />%の確率で地面に墜落する（攻撃が盾で防がれた場合は確率が倍増）。</p>
 		</description>
@@ -1731,4 +1731,3 @@
 	</ability>
 
 </activatedabilities>
-

--- a/Mods/QudJP/Localization/Dictionaries/annals-patterns.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/annals-patterns.ja.json
@@ -72,6 +72,11 @@
       "route": "annals"
     },
     {
+      "pattern": "^While\\ wandering\\ around\\ (.+?),\\ (.+?)\\ stumbled\\ upon\\ a\\ clan\\ of\\ (.+?)\\ performing\\ a\\ secret\\ ritual\\.\\ Because\\ of\\ (.+?)\\ (.+?),\\ they\\ accepted\\ (.+?)\\ into\\ their\\ fold\\ and\\ taught\\ (.+?)\\ their\\ secrets\\.$",
+      "template": "{t0}の辺りをさまよううち、{t1}は秘密の儀式を行う{t2}の一族に出くわした。{t3} {t4}ゆえ、彼らは{t5}を仲間に迎え入れ、{t6}に彼らの秘密を授けた。",
+      "route": "annals"
+    },
+    {
       "pattern": "^(.+?),\\ a\\ babe\\ was\\ found\\ swaddled\\ (.+?)\\ by\\ a\\ group\\ of\\ (.+?)\\ in\\ (.+?)\\.\\ They\\ took\\ (.+?)\\ into\\ their\\ fold\\ and\\ fostered\\ (.+?),\\ and\\ (.+?)\\ became\\ known\\ as\\ (.+?),\\ the\\ (.+?)\\ (.+?)\\ of\\ (.+?)\\.$",
       "template": "{t0}、ひとりの嬰児が{t3}にて、{t2}の一団により{t1}に包まれて見いだされた。彼らは{t4}を仲間に迎えて{t5}を育み、{t6}は{t7}、{t10}の{t8}{t9}として知られるようになった。",
       "route": "annals"
@@ -127,6 +132,16 @@
       "route": "annals"
     },
     {
+      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ a\\ corrupt\\ administrator\\ was\\ appointed\\ minister\\ of\\ (.+?)\\.\\ (.+?)\\ outlawed\\ the\\ practice\\ of\\ (.+?),\\ and\\ (.+?)\\ was\\ forced\\ to\\ flee\\.$",
+      "template": "{0}年、腐敗した施政官が{t1}の大臣に任じられた。その者は{t3}の営みを禁じ、{t4}は逃亡を余儀なくされた。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ a\\ corrupt\\ administrator\\ was\\ appointed\\ minister\\ of\\ (.+?)\\.\\ (.+?)\\ outlawed\\ association\\ with\\ (.+?),\\ and\\ (.+?)\\ was\\ forced\\ to\\ flee\\.$",
+      "template": "{0}年、腐敗した施政官が{t1}の大臣に任じられた。その者は{t3}との交わりを禁じ、{t4}は逃亡を余儀なくされた。",
+      "route": "annals"
+    },
+    {
       "pattern": "^While\\ traveling\\ near\\ (.+?)\\ in\\ (.+?),\\ (.+?)\\ was\\ captured\\ by\\ bandits\\.\\ (.+?)\\ languished\\ in\\ captivity\\ for\\ (.+?)\\ years,\\ eventually\\ escaping\\ to\\ (.+?)\\.$",
       "template": "{t1}の{t0}付近を旅する途上、{t2}は盗賊に捕らえられた。{t3}は捕囚のうちに{t4}年を苦しみ、ついには{t5}へ逃れ出た。",
       "route": "annals"
@@ -174,6 +189,11 @@
     {
       "pattern": "^Near\\ the\\ location\\ of\\ (.+?),\\ (.+?)\\ was\\ captured\\ by\\ bandits\\.\\ (.+?)\\ languished\\ in\\ captivity\\ for\\ (.+?)\\ years,\\ eventually\\ escaping\\ to\\ (.+?)\\.$",
       "template": "{t0}の地の近くで、{t1}は盗賊に捕らえられた。{t2}は捕囚のうちに{t3}年を苦しみ、ついには{t4}へ逃れ出た。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^After\\ (.+?)\\ with\\ (.+?),\\ (.+?)\\ convinced\\ them\\ to\\ help\\ (.+?)\\ found\\ (.+?)\\ in\\ (.+?)\\ for\\ the\\ purpose\\ of\\ (.+?)\\ (.+?)\\.\\ They\\ named\\ it\\ (.+?)\\.$",
+      "template": "{t1}と{t0}したのち、{t2}は{t3}が{t5}に{t4}を創設する助力をするよう彼らを説得した。その目的は{t7}を{t6}ことだった。彼らはそれを{t8}と名づけた。",
       "route": "annals"
     },
     {
@@ -239,6 +259,11 @@
     {
       "pattern": "^(.+?)\\ was\\ adopted\\ by\\ (.+?)\\ who\\ love\\ (.+?)\\.$",
       "template": "{t0}は、{t2}を愛する{t1}に養子として迎えられた。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^discovered\\ (.+?)$",
+      "template": "{t0}を発見した",
       "route": "annals"
     }
   ]

--- a/Mods/QudJP/Localization/Dictionaries/mutation-descriptions.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/mutation-descriptions.ja.json
@@ -242,7 +242,7 @@
     {
       "key": "mutation:Metamorphosis",
       "context": "Chargen.Mutation.LongDescription",
-      "text": "触れた生物の姿をコピーして変身できる。\n\n自分より高レベルの生物には変身できず、装備は元のまま維持される。"
+      "text": "触れたあらゆるクリーチャーの姿をとる。"
     },
     {
       "key": "mutation:Multiple Arms",
@@ -282,7 +282,7 @@
     {
       "key": "mutation:Photosynthetic Skin",
       "context": "Chargen.Mutation.LongDescription",
-      "text": "たくましい緑の皮膚で日光を吸収し、そこから養分を得る。\n\n食事の代わりに日光浴して{{rules|1日}}のあいだ特別な代謝効果を得られる: 自然回復速度が{{rules|+30%}}、俊敏が{{rules|+15}}。\n日光の下にいるとデンプンとリグニンを蓄え、調理にそれぞれ{{rules|1}}食分まで使える。\n植生と同じマスにいるあいだはDVに{{rules|+1}}の迷彩ボーナス。\n{{w|根}}、{{w|木々}}、{{w|蔦}}、{{w|フィタ・コンソーシアム（植物連合）}}との評判+200。"
+      "text": "たくましい緑の皮膚で日光を吸収し、そこから養分を得る。\n\n食事の代わりに日光浴して{{rules|1日}}のあいだ特別な代謝効果を得られる: 自然回復率が{{rules|+30%}}、迅速さが{{rules|+15}}。\n日光の下にいるとデンプンとリグニンを蓄え、調理にそれぞれ{{rules|1}}食分まで使える。\n植生と同じマスにいるあいだはDVに{{rules|+1}}の迷彩ボーナス。\n{{w|根}}、{{w|木々}}、{{w|蔦}}、{{w|フィタ連合}}との評判+200。"
     },
     {
       "key": "mutation:Plasma Emission",
@@ -642,7 +642,7 @@
     {
       "key": "mutation:Blinking Tic",
       "context": "Chargen.Mutation.LongDescription",
-      "text": "ときおり無意識に瞬間移動する。\n\n戦闘中の行動で低確率に発動する。"
+      "text": "制御できずにあちこちへ瞬間移動する。\n\n戦闘中、毎ラウンド低確率で近くの場所へランダムに瞬間移動する。"
     },
     {
       "key": "mutation:Dystechnia",

--- a/Mods/QudJP/Localization/Dictionaries/mutation-ranktext.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/mutation-ranktext.ja.json
@@ -2308,52 +2308,52 @@
         {
             "key": "mutation:Photosynthetic Skin:rank:1",
             "context": "Chargen.Mutation.RankText",
-            "text": "食事の代わりに日光浴して{{rules|1日}}の代謝効果を得られる: 自然治癒率+{{rules|30%}}、俊敏+{{rules|15}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|1食}}）。\n植生と同じマスにいるあいだDV+{{rules|1}}\n根・木・ツタ・フィタ連合との評判+200"
+            "text": "食事の代わりに日光浴して{{rules|1日}}の代謝効果を得られる: 自然回復率+{{rules|30%}}、迅速さ+{{rules|15}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|1食}}）。\n植生と同じマスにいるあいだDV+{{rules|1}}\n根・木・ツタ・フィタ連合との評判+200"
         },
         {
             "key": "mutation:Photosynthetic Skin:rank:2",
             "context": "Chargen.Mutation.RankText",
-            "text": "食事の代わりに日光浴して{{rules|1日}}の代謝効果を得られる: 自然治癒率+{{rules|40%}}、俊敏+{{rules|17}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|1食}}）。\n植生と同じマスにいるあいだDV+{{rules|1}}\n根・木・ツタ・フィタ連合との評判+200"
+            "text": "食事の代わりに日光浴して{{rules|1日}}の代謝効果を得られる: 自然回復率+{{rules|40%}}、迅速さ+{{rules|17}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|1食}}）。\n植生と同じマスにいるあいだDV+{{rules|1}}\n根・木・ツタ・フィタ連合との評判+200"
         },
         {
             "key": "mutation:Photosynthetic Skin:rank:3",
             "context": "Chargen.Mutation.RankText",
-            "text": "食事の代わりに日光浴して{{rules|1日}}の代謝効果を得られる: 自然治癒率+{{rules|50%}}、俊敏+{{rules|19}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|1食}}）。\n植生と同じマスにいるあいだDV+{{rules|1}}\n根・木・ツタ・フィタ連合との評判+200"
+            "text": "食事の代わりに日光浴して{{rules|1日}}の代謝効果を得られる: 自然回復率+{{rules|50%}}、迅速さ+{{rules|19}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|1食}}）。\n植生と同じマスにいるあいだDV+{{rules|1}}\n根・木・ツタ・フィタ連合との評判+200"
         },
         {
             "key": "mutation:Photosynthetic Skin:rank:4",
             "context": "Chargen.Mutation.RankText",
-            "text": "食事の代わりに日光浴して{{rules|1日}}の代謝効果を得られる: 自然治癒率+{{rules|60%}}、俊敏+{{rules|21}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|1食}}）。\n植生と同じマスにいるあいだDV+{{rules|1}}\n根・木・ツタ・フィタ連合との評判+200"
+            "text": "食事の代わりに日光浴して{{rules|1日}}の代謝効果を得られる: 自然回復率+{{rules|60%}}、迅速さ+{{rules|21}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|1食}}）。\n植生と同じマスにいるあいだDV+{{rules|1}}\n根・木・ツタ・フィタ連合との評判+200"
         },
         {
             "key": "mutation:Photosynthetic Skin:rank:5",
             "context": "Chargen.Mutation.RankText",
-            "text": "食事の代わりに日光浴して{{rules|2日}}の代謝効果を得られる: 自然治癒率+{{rules|70%}}、俊敏+{{rules|23}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|2食}}）。\n植生と同じマスにいるあいだDV+{{rules|2}}\n根・木・ツタ・フィタ連合との評判+200"
+            "text": "食事の代わりに日光浴して{{rules|2日}}の代謝効果を得られる: 自然回復率+{{rules|70%}}、迅速さ+{{rules|23}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|2食}}）。\n植生と同じマスにいるあいだDV+{{rules|2}}\n根・木・ツタ・フィタ連合との評判+200"
         },
         {
             "key": "mutation:Photosynthetic Skin:rank:6",
             "context": "Chargen.Mutation.RankText",
-            "text": "食事の代わりに日光浴して{{rules|2日}}の代謝効果を得られる: 自然治癒率+{{rules|80%}}、俊敏+{{rules|25}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|2食}}）。\n植生と同じマスにいるあいだDV+{{rules|2}}\n根・木・ツタ・フィタ連合との評判+200"
+            "text": "食事の代わりに日光浴して{{rules|2日}}の代謝効果を得られる: 自然回復率+{{rules|80%}}、迅速さ+{{rules|25}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|2食}}）。\n植生と同じマスにいるあいだDV+{{rules|2}}\n根・木・ツタ・フィタ連合との評判+200"
         },
         {
             "key": "mutation:Photosynthetic Skin:rank:7",
             "context": "Chargen.Mutation.RankText",
-            "text": "食事の代わりに日光浴して{{rules|2日}}の代謝効果を得られる: 自然治癒率+{{rules|90%}}、俊敏+{{rules|27}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|2食}}）。\n植生と同じマスにいるあいだDV+{{rules|2}}\n根・木・ツタ・フィタ連合との評判+200"
+            "text": "食事の代わりに日光浴して{{rules|2日}}の代謝効果を得られる: 自然回復率+{{rules|90%}}、迅速さ+{{rules|27}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|2食}}）。\n植生と同じマスにいるあいだDV+{{rules|2}}\n根・木・ツタ・フィタ連合との評判+200"
         },
         {
             "key": "mutation:Photosynthetic Skin:rank:8",
             "context": "Chargen.Mutation.RankText",
-            "text": "食事の代わりに日光浴して{{rules|2日}}の代謝効果を得られる: 自然治癒率+{{rules|100%}}、俊敏+{{rules|29}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|2食}}）。\n植生と同じマスにいるあいだDV+{{rules|2}}\n根・木・ツタ・フィタ連合との評判+200"
+            "text": "食事の代わりに日光浴して{{rules|2日}}の代謝効果を得られる: 自然回復率+{{rules|100%}}、迅速さ+{{rules|29}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|2食}}）。\n植生と同じマスにいるあいだDV+{{rules|2}}\n根・木・ツタ・フィタ連合との評判+200"
         },
         {
             "key": "mutation:Photosynthetic Skin:rank:9",
             "context": "Chargen.Mutation.RankText",
-            "text": "食事の代わりに日光浴して{{rules|3日}}の代謝効果を得られる: 自然治癒率+{{rules|110%}}、俊敏+{{rules|31}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|3食}}）。\n植生と同じマスにいるあいだDV+{{rules|3}}\n根・木・ツタ・フィタ連合との評判+200"
+            "text": "食事の代わりに日光浴して{{rules|3日}}の代謝効果を得られる: 自然回復率+{{rules|110%}}、迅速さ+{{rules|31}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|3食}}）。\n植生と同じマスにいるあいだDV+{{rules|3}}\n根・木・ツタ・フィタ連合との評判+200"
         },
         {
             "key": "mutation:Photosynthetic Skin:rank:10",
             "context": "Chargen.Mutation.RankText",
-            "text": "食事の代わりに日光浴して{{rules|3日}}の代謝効果を得られる: 自然治癒率+{{rules|120%}}、俊敏+{{rules|33}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|3食}}）。\n植生と同じマスにいるあいだDV+{{rules|3}}\n根・木・ツタ・フィタ連合との評判+200"
+            "text": "食事の代わりに日光浴して{{rules|3日}}の代謝効果を得られる: 自然回復率+{{rules|120%}}、迅速さ+{{rules|33}}\n日光下で澱粉とリグニンを蓄え、料理の材料に使える（各最大{{rules|3食}}）。\n植生と同じマスにいるあいだDV+{{rules|3}}\n根・木・ツタ・フィタ連合との評判+200"
         },
         {
             "key": "mutation:Regeneration:rank:1",

--- a/Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json
@@ -40,6 +40,11 @@
             "text": "調べる"
         },
         {
+            "key": "It's you.",
+            "context": "XRL.UI.Look.GenerateTooltipContent.PlayerSelf",
+            "text": "あなた自身だ。"
+        },
+        {
             "key": "{{W|[space]}} {{y|Continue}}",
             "context": "Qud.UI.PopupMessage.Button.Continue.Hotkey",
             "text": "{{W|[Space]}} {{y|続ける}}"

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud \u65e5\u672c\u8a9e\u5316",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.1.0",
+  "Version": "0.2.0",
   "PreviewImage": "",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/glossary.csv
+++ b/docs/glossary.csv
@@ -178,7 +178,7 @@ Merchants' Guild,商人ギルド,商人ギルド,交易者ネットワーク,dra
 Meyehind,メイエヒンド,,source: Conversations.jp.xml,draft
 Miryam,ミリアム,,source: Conversations.jp.xml,draft
 Modulo Moon Stair,モジュロの月階段と生命の木,,source: Books.jp.xml,draft
-Moghra'yi,モグラヤイ,モグラヤイ,大塩砂漠の正式名称。地名は常にこの表記,draft
+Moghra'yi,モグラヤイ,モグラヤイ,大塩砂漠の正式名称。地名は常にこの表記,confirmed
 molten wax,溶けた蝋,,source: ui-liquids.ja.json,draft
 Moon Stair,ムーン・ステアー,ムーン・ステアー,階段状地形の長大地域,draft
 Mopango,モパンゴ,モパンゴ,Eaters 墓域周辺の勢力,draft
@@ -204,7 +204,7 @@ Opal's Duskwaters,オパルの黄昏水,黄昏水,別案：逢魔水,draft
 Otho,オソ,,source: Conversations.jp.xml,draft
 Palladium Reef,パラジウム礁,パラジウム礁,海底域,draft
 Pariahs,棄民（パリア）,パリア,社会外の追放民。ヒンドレン出身者が多い,draft
-Pax Klanq,パクス・クランク,パクス・クランク,Barathrum 派と協働する菌学ティンカー（Spread Pax 導線）,draft
+Pax Klanq,パクス・クランク,パクス・クランク,Barathrum 派と協働する菌学ティンカー（Spread Pax 導線）,confirmed
 Phinae Hoshaiah,フィナエ・ホシャイア,,source: Conversations.jp.xml,draft
 Point of Tifaret,ティファレトの頂,,source: Worlds.jp.xml,draft
 primordial soup,原始スープ,,source: ui-liquids.ja.json,draft
@@ -286,7 +286,7 @@ Thicksalt,シックソルト,,source: Conversations.jp.xml,draft
 Thin World,薄界（シン・ワールド）,薄界,別名表記あり,draft
 Tikva,ティクヴァ,,source: Conversations.jp.xml,draft
 Tillifergaewicz,ティリフェルガウィッチ,,source: Conversations.jp.xml,draft
-Tinker,工匠,工匠,バラサラム派や各集落の技術職汎称。Naphtaali ほか種族を問わず「◯◯の工匠」と訳す,draft
+Tinker,工匠,工匠,バラサラム派や各集落の技術職汎称。Naphtaali ほか種族を問わず「◯◯の工匠」と訳す,confirmed
 Tomb of the Eaters,喰らう者の墓所,喰らう者の墓所,大規模終盤エリア,approved
 Tszappur,ツザップル,,source: Conversations.jp.xml,draft
 Tunnels of Ur,ウルの坑道,,source: Worlds.jp.xml,draft

--- a/docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md
+++ b/docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md
@@ -1,0 +1,54 @@
+# 2026-04-28 Issue #370 No-Context Rebucket Closeout
+
+## Conclusion
+
+Issue #370 acceptance criteria are satisfied by the current evidence. The current static inventory and runtime triage artifacts contain no `<no-context>` rows. The older 48-row `<no-context>` evidence in `.sisyphus/evidence/task-11-runtime-triage.json` is stale and superseded by the newer zero-count artifacts.
+
+No GitHub issue change was made in this local closeout pass. `gh` authentication was invalid in the earlier check, and no further `gh` commands were attempted.
+
+## Verified Counts
+
+| Artifact | Command/data checked | Result |
+| --- | --- | --- |
+| `docs/candidate-inventory.json` | `scan_date`, `len(sites)`, and `<no-context>` count across `route`, `context`, `owner_route`, `family` | `scan_date=2026-04-14`, `sites=4634`, `<no-context>` rows `0`; per field: `route=0`, `context=0`, `owner_route=0`, `family=0` |
+| `.sisyphus/evidence/task-12-triage.json` | `summary.total`, serialized `<no-context>` presence, `phase_f.summary.total` | `summary.total=0`, `<no-context>` absent, `phase_f.summary.total=0` |
+| `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json` | `summary.total`, serialized `<no-context>` presence, `phase_f.summary.total` | `summary.total=0`, `<no-context>` absent, `phase_f.summary.total=0` |
+| `.sisyphus/evidence/task-11-runtime-triage.json` | `sum(len(v) for v in by_route["<no-context>"].values())` | stale `<no-context>` rows `48` (`static_leaf=1`, `route_patch=0`, `logic_required=3`, `unresolved=44`) |
+
+## Closure Support
+
+The evidence supporting closure is:
+
+```bash
+python3 -c "import json; d=json.load(open('docs/candidate-inventory.json')); ks=('route','context','owner_route','family'); print(d['scan_date'], len(d['sites']), sum(any(s.get(k)=='<no-context>' for k in ks) for s in d['sites']), *(sum(s.get(k)=='<no-context>' for s in d['sites']) for k in ks))"
+python3 -c "import json; p='.sisyphus/evidence/task-12-triage.json'; d=json.load(open(p)); print(p, d['summary']['total'], '<no-context>' in json.dumps(d), d['phase_f']['summary']['total'])"
+python3 -c "import json; p='.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json'; d=json.load(open(p)); print(p, d['summary']['total'], '<no-context>' in json.dumps(d), d['phase_f']['summary']['total'])"
+python3 -c "import json; p='.sisyphus/evidence/task-11-runtime-triage.json'; d=json.load(open(p)); print(p, sum(len(v) for v in d['by_route']['<no-context>'].values()), '<no-context>' in d['by_route'])"
+```
+
+Observed output:
+
+```text
+2026-04-14 4634 0 0 0 0 0
+.sisyphus/evidence/task-12-triage.json 0 False 0
+.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json 0 False 0
+.sisyphus/evidence/task-11-runtime-triage.json 48 True
+```
+
+Interpretation: current evidence has no `<no-context>` inventory or runtime triage rows. The old task-11 artifact still records 48 stale rows, but it is superseded by `docs/candidate-inventory.json`, `.sisyphus/evidence/task-12-triage.json`, and `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json`.
+
+## Ready-to-Paste GitHub Close Comment
+
+```markdown
+Closing as satisfied by current evidence.
+
+Verified local artifacts on 2026-04-28:
+
+- `docs/candidate-inventory.json`: `scan_date=2026-04-14`, `sites=4634`, `<no-context>` rows across `route`, `context`, `owner_route`, and `family` = `0`.
+- `.sisyphus/evidence/task-12-triage.json`: `summary.total=0`, no serialized `<no-context>`, `phase_f.summary.total=0`.
+- `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json`: `summary.total=0`, no serialized `<no-context>`, `phase_f.summary.total=0`.
+
+The older `.sisyphus/evidence/task-11-runtime-triage.json` artifact still contains 48 `<no-context>` rows (`static_leaf=1`, `logic_required=3`, `unresolved=44`), but that evidence is stale and superseded by the current zero-count inventory and triage artifacts above.
+
+Closeout report: `docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md`
+```

--- a/docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md
+++ b/docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md
@@ -2,7 +2,7 @@
 
 ## Conclusion
 
-Issue #370 acceptance criteria are satisfied by the current evidence. The current static inventory and runtime triage artifacts contain no `<no-context>` rows. The older 48-row `<no-context>` evidence in `.sisyphus/evidence/task-11-runtime-triage.json` is stale and superseded by the newer zero-count artifacts.
+Issue #370 acceptance criteria are satisfied by the current evidence. The current static inventory contains no recursive serialized `<no-context>` occurrences, and the current runtime triage artifacts contain no `<no-context>` rows. The older 48-row `<no-context>` evidence in `.sisyphus/evidence/task-11-runtime-triage.json` is stale and superseded by the newer zero-count artifacts.
 
 No GitHub issue change was made in this local closeout pass. `gh` authentication was invalid in the earlier check, and no further `gh` commands were attempted.
 
@@ -10,9 +10,9 @@ No GitHub issue change was made in this local closeout pass. `gh` authentication
 
 | Artifact | Command/data checked | Result |
 | --- | --- | --- |
-| `docs/candidate-inventory.json` | `scan_date`, `len(sites)`, recursive serialized `<no-context>` count, and `<no-context>` count across actual route/status fields (`source_route`, `sink`, `ownership_class`, `destination_dictionary`, `rejection_reason`, `status`) | `scan_date=2026-04-14`, `sites=4634`, recursive serialized `<no-context>` rows `0`; per route/status field: `source_route=0`, `sink=0`, `ownership_class=0`, `destination_dictionary=0`, `rejection_reason=0`, `status=0` |
-| `.sisyphus/evidence/task-12-triage.json` | `summary.total`, serialized `<no-context>` presence, `phase_f.summary.total` | `summary.total=0`, `<no-context>` absent, `phase_f.summary.total=0` |
-| `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json` | `summary.total`, serialized `<no-context>` presence, `phase_f.summary.total` | `summary.total=0`, `<no-context>` absent, `phase_f.summary.total=0` |
+| `docs/candidate-inventory.json` | `scan_date`, `len(sites)`, recursive serialized `<no-context>` occurrence count, and occurrence count across actual route/status fields (`source_route`, `sink`, `ownership_class`, `destination_dictionary`, `rejection_reason`, `status`) | `scan_date=2026-04-14`, `sites=4634`, recursive serialized `<no-context>` occurrences `0`; per route/status field: `source_route=0`, `sink=0`, `ownership_class=0`, `destination_dictionary=0`, `rejection_reason=0`, `status=0` |
+| `.sisyphus/evidence/task-12-triage.json` | `summary.total`, `by_route["<no-context>"]` row count, `phase_f.summary.total` | `summary.total=0`, `by_route["<no-context>"]` rows `0`, `phase_f.summary.total=0` |
+| `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json` | `summary.total`, `by_route["<no-context>"]` row count, `phase_f.summary.total` | `summary.total=0`, `by_route["<no-context>"]` rows `0`, `phase_f.summary.total=0` |
 | `.sisyphus/evidence/task-11-runtime-triage.json` | `sum(len(v) for v in by_route["<no-context>"].values())` | stale `<no-context>` rows `48` (`static_leaf=1`, `route_patch=0`, `logic_required=3`, `unresolved=44`) |
 
 ## Closure Support
@@ -20,9 +20,9 @@ No GitHub issue change was made in this local closeout pass. `gh` authentication
 The evidence supporting closure is:
 
 ```bash
-python3 -c "import json; d=json.load(open('docs/candidate-inventory.json')); ks=('source_route','sink','ownership_class','destination_dictionary','rejection_reason','status'); f=lambda x: x=='<no-context>' if isinstance(x,str) else any(f(v) for v in x.values()) if isinstance(x,dict) else any(f(v) for v in x) if isinstance(x,list) else False; print(d['scan_date'], len(d['sites']), sum(f(s) for s in d['sites']), *(sum(s.get(k)=='<no-context>' for s in d['sites']) for k in ks))"
-python3 -c "import json; p='.sisyphus/evidence/task-12-triage.json'; d=json.load(open(p)); print(p, d['summary']['total'], '<no-context>' in json.dumps(d), d['phase_f']['summary']['total'])"
-python3 -c "import json; p='.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json'; d=json.load(open(p)); print(p, d['summary']['total'], '<no-context>' in json.dumps(d), d['phase_f']['summary']['total'])"
+python3 -c "import json; d=json.load(open('docs/candidate-inventory.json')); ks=('source_route','sink','ownership_class','destination_dictionary','rejection_reason','status'); cnt=lambda x: (1 if x=='<no-context>' else 0) if isinstance(x,str) else sum(cnt(v) for v in x.values()) if isinstance(x,dict) else sum(cnt(v) for v in x) if isinstance(x,list) else 0; print(d['scan_date'], len(d['sites']), sum(cnt(s) for s in d['sites']), *(sum(cnt(s.get(k)) for s in d['sites']) for k in ks))"
+python3 -c "import json; p='.sisyphus/evidence/task-12-triage.json'; d=json.load(open(p)); n=sum(len(v) for v in d.get('by_route', {}).get('<no-context>', {}).values()); print(p, d['summary']['total'], n, d['phase_f']['summary']['total'])"
+python3 -c "import json; p='.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json'; d=json.load(open(p)); n=sum(len(v) for v in d.get('by_route', {}).get('<no-context>', {}).values()); print(p, d['summary']['total'], n, d['phase_f']['summary']['total'])"
 python3 -c "import json; p='.sisyphus/evidence/task-11-runtime-triage.json'; d=json.load(open(p)); print(p, sum(len(v) for v in d['by_route']['<no-context>'].values()), '<no-context>' in d['by_route'])"
 ```
 
@@ -30,12 +30,12 @@ Observed output:
 
 ```text
 2026-04-14 4634 0 0 0 0 0 0 0
-.sisyphus/evidence/task-12-triage.json 0 False 0
-.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json 0 False 0
+.sisyphus/evidence/task-12-triage.json 0 0 0
+.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json 0 0 0
 .sisyphus/evidence/task-11-runtime-triage.json 48 True
 ```
 
-Interpretation: current evidence has no `<no-context>` inventory or runtime triage rows. The old task-11 artifact still records 48 stale rows, but it is superseded by `docs/candidate-inventory.json`, `.sisyphus/evidence/task-12-triage.json`, and `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json`.
+Interpretation: current evidence has no recursive serialized `<no-context>` inventory occurrences and no current runtime triage rows under `by_route["<no-context>"]`. The old task-11 artifact still records 48 stale rows, but it is superseded by `docs/candidate-inventory.json`, `.sisyphus/evidence/task-12-triage.json`, and `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json`.
 
 ## Ready-to-Paste GitHub Close Comment
 
@@ -44,9 +44,9 @@ Closing as satisfied by current evidence.
 
 Verified local artifacts on 2026-04-28:
 
-- `docs/candidate-inventory.json`: `scan_date=2026-04-14`, `sites=4634`, recursive serialized `<no-context>` rows = `0`; `<no-context>` rows across actual route/status fields (`source_route`, `sink`, `ownership_class`, `destination_dictionary`, `rejection_reason`, `status`) = `0`.
-- `.sisyphus/evidence/task-12-triage.json`: `summary.total=0`, no serialized `<no-context>`, `phase_f.summary.total=0`.
-- `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json`: `summary.total=0`, no serialized `<no-context>`, `phase_f.summary.total=0`.
+- `docs/candidate-inventory.json`: `scan_date=2026-04-14`, `sites=4634`, recursive serialized `<no-context>` occurrences = `0`; `<no-context>` occurrences across actual route/status fields (`source_route`, `sink`, `ownership_class`, `destination_dictionary`, `rejection_reason`, `status`) = `0`.
+- `.sisyphus/evidence/task-12-triage.json`: `summary.total=0`, `by_route["<no-context>"]` rows = `0`, `phase_f.summary.total=0`.
+- `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json`: `summary.total=0`, `by_route["<no-context>"]` rows = `0`, `phase_f.summary.total=0`.
 
 The older `.sisyphus/evidence/task-11-runtime-triage.json` artifact still contains 48 `<no-context>` rows (`static_leaf=1`, `logic_required=3`, `unresolved=44`), but that evidence is stale and superseded by the current zero-count inventory and triage artifacts above.
 

--- a/docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md
+++ b/docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md
@@ -10,7 +10,7 @@ No GitHub issue change was made in this local closeout pass. `gh` authentication
 
 | Artifact | Command/data checked | Result |
 | --- | --- | --- |
-| `docs/candidate-inventory.json` | `scan_date`, `len(sites)`, all serialized fields, and `<no-context>` count across actual route/status fields (`source_route`, `sink`, `ownership_class`, `destination_dictionary`, `rejection_reason`, `status`) | `scan_date=2026-04-14`, `sites=4634`, `<no-context>` rows across all serialized fields `0`; per route/status field: `source_route=0`, `sink=0`, `ownership_class=0`, `destination_dictionary=0`, `rejection_reason=0`, `status=0` |
+| `docs/candidate-inventory.json` | `scan_date`, `len(sites)`, recursive serialized `<no-context>` count, and `<no-context>` count across actual route/status fields (`source_route`, `sink`, `ownership_class`, `destination_dictionary`, `rejection_reason`, `status`) | `scan_date=2026-04-14`, `sites=4634`, recursive serialized `<no-context>` rows `0`; per route/status field: `source_route=0`, `sink=0`, `ownership_class=0`, `destination_dictionary=0`, `rejection_reason=0`, `status=0` |
 | `.sisyphus/evidence/task-12-triage.json` | `summary.total`, serialized `<no-context>` presence, `phase_f.summary.total` | `summary.total=0`, `<no-context>` absent, `phase_f.summary.total=0` |
 | `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json` | `summary.total`, serialized `<no-context>` presence, `phase_f.summary.total` | `summary.total=0`, `<no-context>` absent, `phase_f.summary.total=0` |
 | `.sisyphus/evidence/task-11-runtime-triage.json` | `sum(len(v) for v in by_route["<no-context>"].values())` | stale `<no-context>` rows `48` (`static_leaf=1`, `route_patch=0`, `logic_required=3`, `unresolved=44`) |
@@ -20,7 +20,7 @@ No GitHub issue change was made in this local closeout pass. `gh` authentication
 The evidence supporting closure is:
 
 ```bash
-python3 -c "import json; d=json.load(open('docs/candidate-inventory.json')); ks=('source_route','sink','ownership_class','destination_dictionary','rejection_reason','status'); print(d['scan_date'], len(d['sites']), sum(any(v=='<no-context>' for v in s.values()) for s in d['sites']), *(sum(s.get(k)=='<no-context>' for s in d['sites']) for k in ks))"
+python3 -c "import json; d=json.load(open('docs/candidate-inventory.json')); ks=('source_route','sink','ownership_class','destination_dictionary','rejection_reason','status'); f=lambda x: x=='<no-context>' if isinstance(x,str) else any(f(v) for v in x.values()) if isinstance(x,dict) else any(f(v) for v in x) if isinstance(x,list) else False; print(d['scan_date'], len(d['sites']), sum(f(s) for s in d['sites']), *(sum(s.get(k)=='<no-context>' for s in d['sites']) for k in ks))"
 python3 -c "import json; p='.sisyphus/evidence/task-12-triage.json'; d=json.load(open(p)); print(p, d['summary']['total'], '<no-context>' in json.dumps(d), d['phase_f']['summary']['total'])"
 python3 -c "import json; p='.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json'; d=json.load(open(p)); print(p, d['summary']['total'], '<no-context>' in json.dumps(d), d['phase_f']['summary']['total'])"
 python3 -c "import json; p='.sisyphus/evidence/task-11-runtime-triage.json'; d=json.load(open(p)); print(p, sum(len(v) for v in d['by_route']['<no-context>'].values()), '<no-context>' in d['by_route'])"
@@ -44,7 +44,7 @@ Closing as satisfied by current evidence.
 
 Verified local artifacts on 2026-04-28:
 
-- `docs/candidate-inventory.json`: `scan_date=2026-04-14`, `sites=4634`, `<no-context>` rows across all serialized fields = `0`; `<no-context>` rows across actual route/status fields (`source_route`, `sink`, `ownership_class`, `destination_dictionary`, `rejection_reason`, `status`) = `0`.
+- `docs/candidate-inventory.json`: `scan_date=2026-04-14`, `sites=4634`, recursive serialized `<no-context>` rows = `0`; `<no-context>` rows across actual route/status fields (`source_route`, `sink`, `ownership_class`, `destination_dictionary`, `rejection_reason`, `status`) = `0`.
 - `.sisyphus/evidence/task-12-triage.json`: `summary.total=0`, no serialized `<no-context>`, `phase_f.summary.total=0`.
 - `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json`: `summary.total=0`, no serialized `<no-context>`, `phase_f.summary.total=0`.
 

--- a/docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md
+++ b/docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md
@@ -10,7 +10,7 @@ No GitHub issue change was made in this local closeout pass. `gh` authentication
 
 | Artifact | Command/data checked | Result |
 | --- | --- | --- |
-| `docs/candidate-inventory.json` | `scan_date`, `len(sites)`, and `<no-context>` count across `route`, `context`, `owner_route`, `family` | `scan_date=2026-04-14`, `sites=4634`, `<no-context>` rows `0`; per field: `route=0`, `context=0`, `owner_route=0`, `family=0` |
+| `docs/candidate-inventory.json` | `scan_date`, `len(sites)`, all serialized fields, and `<no-context>` count across actual route/status fields (`source_route`, `sink`, `ownership_class`, `destination_dictionary`, `rejection_reason`, `status`) | `scan_date=2026-04-14`, `sites=4634`, `<no-context>` rows across all serialized fields `0`; per route/status field: `source_route=0`, `sink=0`, `ownership_class=0`, `destination_dictionary=0`, `rejection_reason=0`, `status=0` |
 | `.sisyphus/evidence/task-12-triage.json` | `summary.total`, serialized `<no-context>` presence, `phase_f.summary.total` | `summary.total=0`, `<no-context>` absent, `phase_f.summary.total=0` |
 | `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json` | `summary.total`, serialized `<no-context>` presence, `phase_f.summary.total` | `summary.total=0`, `<no-context>` absent, `phase_f.summary.total=0` |
 | `.sisyphus/evidence/task-11-runtime-triage.json` | `sum(len(v) for v in by_route["<no-context>"].values())` | stale `<no-context>` rows `48` (`static_leaf=1`, `route_patch=0`, `logic_required=3`, `unresolved=44`) |
@@ -20,7 +20,7 @@ No GitHub issue change was made in this local closeout pass. `gh` authentication
 The evidence supporting closure is:
 
 ```bash
-python3 -c "import json; d=json.load(open('docs/candidate-inventory.json')); ks=('route','context','owner_route','family'); print(d['scan_date'], len(d['sites']), sum(any(s.get(k)=='<no-context>' for k in ks) for s in d['sites']), *(sum(s.get(k)=='<no-context>' for s in d['sites']) for k in ks))"
+python3 -c "import json; d=json.load(open('docs/candidate-inventory.json')); ks=('source_route','sink','ownership_class','destination_dictionary','rejection_reason','status'); print(d['scan_date'], len(d['sites']), sum(any(v=='<no-context>' for v in s.values()) for s in d['sites']), *(sum(s.get(k)=='<no-context>' for s in d['sites']) for k in ks))"
 python3 -c "import json; p='.sisyphus/evidence/task-12-triage.json'; d=json.load(open(p)); print(p, d['summary']['total'], '<no-context>' in json.dumps(d), d['phase_f']['summary']['total'])"
 python3 -c "import json; p='.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json'; d=json.load(open(p)); print(p, d['summary']['total'], '<no-context>' in json.dumps(d), d['phase_f']['summary']['total'])"
 python3 -c "import json; p='.sisyphus/evidence/task-11-runtime-triage.json'; d=json.load(open(p)); print(p, sum(len(v) for v in d['by_route']['<no-context>'].values()), '<no-context>' in d['by_route'])"
@@ -29,7 +29,7 @@ python3 -c "import json; p='.sisyphus/evidence/task-11-runtime-triage.json'; d=j
 Observed output:
 
 ```text
-2026-04-14 4634 0 0 0 0 0
+2026-04-14 4634 0 0 0 0 0 0 0
 .sisyphus/evidence/task-12-triage.json 0 False 0
 .sisyphus/evidence/release-slice-0/runtime-triage-fresh.json 0 False 0
 .sisyphus/evidence/task-11-runtime-triage.json 48 True
@@ -44,7 +44,7 @@ Closing as satisfied by current evidence.
 
 Verified local artifacts on 2026-04-28:
 
-- `docs/candidate-inventory.json`: `scan_date=2026-04-14`, `sites=4634`, `<no-context>` rows across `route`, `context`, `owner_route`, and `family` = `0`.
+- `docs/candidate-inventory.json`: `scan_date=2026-04-14`, `sites=4634`, `<no-context>` rows across all serialized fields = `0`; `<no-context>` rows across actual route/status fields (`source_route`, `sink`, `ownership_class`, `destination_dictionary`, `rejection_reason`, `status`) = `0`.
 - `.sisyphus/evidence/task-12-triage.json`: `summary.total=0`, no serialized `<no-context>`, `phase_f.summary.total=0`.
 - `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json`: `summary.total=0`, no serialized `<no-context>`, `phase_f.summary.total=0`.
 

--- a/docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md
+++ b/docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md
@@ -23,7 +23,7 @@ The evidence supporting closure is:
 python3 -c "import json; d=json.load(open('docs/candidate-inventory.json')); ks=('source_route','sink','ownership_class','destination_dictionary','rejection_reason','status'); cnt=lambda x: (1 if x=='<no-context>' else 0) if isinstance(x,str) else sum(cnt(v) for v in x.values()) if isinstance(x,dict) else sum(cnt(v) for v in x) if isinstance(x,list) else 0; print(d['scan_date'], len(d['sites']), cnt(d), *(sum(cnt(s.get(k)) for s in d['sites']) for k in ks))"
 python3 -c "import json; p='.sisyphus/evidence/task-12-triage.json'; d=json.load(open(p)); n=sum(len(v) for v in d.get('by_route', {}).get('<no-context>', {}).values()); print(p, d['summary']['total'], n, d['phase_f']['summary']['total'])"
 python3 -c "import json; p='.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json'; d=json.load(open(p)); n=sum(len(v) for v in d.get('by_route', {}).get('<no-context>', {}).values()); print(p, d['summary']['total'], n, d['phase_f']['summary']['total'])"
-python3 -c "import json; p='.sisyphus/evidence/task-11-runtime-triage.json'; d=json.load(open(p)); print(p, sum(len(v) for v in d['by_route']['<no-context>'].values()), '<no-context>' in d['by_route'])"
+python3 -c "import json; p='.sisyphus/evidence/task-11-runtime-triage.json'; d=json.load(open(p)); n=sum(len(v) for v in d.get('by_route', {}).get('<no-context>', {}).values()); print(p, n, '<no-context>' in d.get('by_route', {}))"
 ```
 
 Observed output:
@@ -48,7 +48,7 @@ Verified local artifacts on 2026-04-28:
 - `.sisyphus/evidence/task-12-triage.json`: `summary.total=0`, `by_route["<no-context>"]` rows = `0`, `phase_f.summary.total=0`.
 - `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json`: `summary.total=0`, `by_route["<no-context>"]` rows = `0`, `phase_f.summary.total=0`.
 
-The older `.sisyphus/evidence/task-11-runtime-triage.json` artifact still contains 48 `<no-context>` rows (`static_leaf=1`, `logic_required=3`, `unresolved=44`), but that evidence is stale and superseded by the current zero-count inventory and triage artifacts above.
+The older `.sisyphus/evidence/task-11-runtime-triage.json` artifact still contains 48 `<no-context>` rows (`static_leaf=1`, `route_patch=0`, `logic_required=3`, `unresolved=44`), but that evidence is stale and superseded by the current zero-count inventory and triage artifacts above.
 
 Closeout report: `docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md`
 ```

--- a/docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md
+++ b/docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md
@@ -2,7 +2,7 @@
 
 ## Conclusion
 
-Issue #370 acceptance criteria are satisfied by the current evidence. The current static inventory contains no recursive serialized `<no-context>` occurrences, and the current runtime triage artifacts contain no `<no-context>` rows. The older 48-row `<no-context>` evidence in `.sisyphus/evidence/task-11-runtime-triage.json` is stale and superseded by the newer zero-count artifacts.
+Issue #370 acceptance criteria are satisfied by the current evidence. The current static inventory JSON contains no recursive serialized `<no-context>` occurrences, and the current runtime triage artifacts contain no `<no-context>` rows. The older 48-row `<no-context>` evidence in `.sisyphus/evidence/task-11-runtime-triage.json` is stale and superseded by the newer zero-count artifacts.
 
 No GitHub issue change was made in this local closeout pass. `gh` authentication was invalid in the earlier check, and no further `gh` commands were attempted.
 
@@ -10,7 +10,7 @@ No GitHub issue change was made in this local closeout pass. `gh` authentication
 
 | Artifact | Command/data checked | Result |
 | --- | --- | --- |
-| `docs/candidate-inventory.json` | `scan_date`, `len(sites)`, recursive serialized `<no-context>` occurrence count, and occurrence count across actual route/status fields (`source_route`, `sink`, `ownership_class`, `destination_dictionary`, `rejection_reason`, `status`) | `scan_date=2026-04-14`, `sites=4634`, recursive serialized `<no-context>` occurrences `0`; per route/status field: `source_route=0`, `sink=0`, `ownership_class=0`, `destination_dictionary=0`, `rejection_reason=0`, `status=0` |
+| `docs/candidate-inventory.json` | `scan_date`, `len(sites)`, recursive serialized `<no-context>` occurrence count across the entire JSON, and occurrence count across actual route/status fields (`source_route`, `sink`, `ownership_class`, `destination_dictionary`, `rejection_reason`, `status`) | `scan_date=2026-04-14`, `sites=4634`, recursive serialized `<no-context>` occurrences across the entire JSON `0`; per route/status field: `source_route=0`, `sink=0`, `ownership_class=0`, `destination_dictionary=0`, `rejection_reason=0`, `status=0` |
 | `.sisyphus/evidence/task-12-triage.json` | `summary.total`, `by_route["<no-context>"]` row count, `phase_f.summary.total` | `summary.total=0`, `by_route["<no-context>"]` rows `0`, `phase_f.summary.total=0` |
 | `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json` | `summary.total`, `by_route["<no-context>"]` row count, `phase_f.summary.total` | `summary.total=0`, `by_route["<no-context>"]` rows `0`, `phase_f.summary.total=0` |
 | `.sisyphus/evidence/task-11-runtime-triage.json` | `sum(len(v) for v in by_route["<no-context>"].values())` | stale `<no-context>` rows `48` (`static_leaf=1`, `route_patch=0`, `logic_required=3`, `unresolved=44`) |
@@ -20,7 +20,7 @@ No GitHub issue change was made in this local closeout pass. `gh` authentication
 The evidence supporting closure is:
 
 ```bash
-python3 -c "import json; d=json.load(open('docs/candidate-inventory.json')); ks=('source_route','sink','ownership_class','destination_dictionary','rejection_reason','status'); cnt=lambda x: (1 if x=='<no-context>' else 0) if isinstance(x,str) else sum(cnt(v) for v in x.values()) if isinstance(x,dict) else sum(cnt(v) for v in x) if isinstance(x,list) else 0; print(d['scan_date'], len(d['sites']), sum(cnt(s) for s in d['sites']), *(sum(cnt(s.get(k)) for s in d['sites']) for k in ks))"
+python3 -c "import json; d=json.load(open('docs/candidate-inventory.json')); ks=('source_route','sink','ownership_class','destination_dictionary','rejection_reason','status'); cnt=lambda x: (1 if x=='<no-context>' else 0) if isinstance(x,str) else sum(cnt(v) for v in x.values()) if isinstance(x,dict) else sum(cnt(v) for v in x) if isinstance(x,list) else 0; print(d['scan_date'], len(d['sites']), cnt(d), *(sum(cnt(s.get(k)) for s in d['sites']) for k in ks))"
 python3 -c "import json; p='.sisyphus/evidence/task-12-triage.json'; d=json.load(open(p)); n=sum(len(v) for v in d.get('by_route', {}).get('<no-context>', {}).values()); print(p, d['summary']['total'], n, d['phase_f']['summary']['total'])"
 python3 -c "import json; p='.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json'; d=json.load(open(p)); n=sum(len(v) for v in d.get('by_route', {}).get('<no-context>', {}).values()); print(p, d['summary']['total'], n, d['phase_f']['summary']['total'])"
 python3 -c "import json; p='.sisyphus/evidence/task-11-runtime-triage.json'; d=json.load(open(p)); print(p, sum(len(v) for v in d['by_route']['<no-context>'].values()), '<no-context>' in d['by_route'])"
@@ -35,7 +35,7 @@ Observed output:
 .sisyphus/evidence/task-11-runtime-triage.json 48 True
 ```
 
-Interpretation: current evidence has no recursive serialized `<no-context>` inventory occurrences and no current runtime triage rows under `by_route["<no-context>"]`. The old task-11 artifact still records 48 stale rows, but it is superseded by `docs/candidate-inventory.json`, `.sisyphus/evidence/task-12-triage.json`, and `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json`.
+Interpretation: current evidence has no recursive serialized `<no-context>` occurrences anywhere in the static inventory JSON and no current runtime triage rows under `by_route["<no-context>"]`. The old task-11 artifact still records 48 stale rows, but it is superseded by `docs/candidate-inventory.json`, `.sisyphus/evidence/task-12-triage.json`, and `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json`.
 
 ## Ready-to-Paste GitHub Close Comment
 
@@ -44,7 +44,7 @@ Closing as satisfied by current evidence.
 
 Verified local artifacts on 2026-04-28:
 
-- `docs/candidate-inventory.json`: `scan_date=2026-04-14`, `sites=4634`, recursive serialized `<no-context>` occurrences = `0`; `<no-context>` occurrences across actual route/status fields (`source_route`, `sink`, `ownership_class`, `destination_dictionary`, `rejection_reason`, `status`) = `0`.
+- `docs/candidate-inventory.json`: `scan_date=2026-04-14`, `sites=4634`, recursive serialized `<no-context>` occurrences across the entire JSON = `0`; `<no-context>` occurrences across actual route/status fields (`source_route`, `sink`, `ownership_class`, `destination_dictionary`, `rejection_reason`, `status`) = `0`.
 - `.sisyphus/evidence/task-12-triage.json`: `summary.total=0`, `by_route["<no-context>"]` rows = `0`, `phase_f.summary.total=0`.
 - `.sisyphus/evidence/release-slice-0/runtime-triage-fresh.json`: `summary.total=0`, `by_route["<no-context>"]` rows = `0`, `phase_f.summary.total=0`.
 

--- a/docs/reports/2026-04-28-release-slice-0-go-no-go-evidence.md
+++ b/docs/reports/2026-04-28-release-slice-0-go-no-go-evidence.md
@@ -1,0 +1,129 @@
+# 2026-04-28 Release Slice 0 Go/No-Go Evidence
+
+## 結論
+
+**Go/No-Go: No-Go.**
+
+Steam Workshop readiness を Yes と判定するための fresh QudJP runtime evidence は取れなかった。Rosetta launcher 自体は起動したが、今回のローカル game settings では `QudJP` が disabled で、fresh `Player.log` に QudJP build marker / patch success / `DynamicTextProbe` / `SinkObserve` が出なかった。さらに `translation_checker.py` の自動 combat/death smoke は macOS console lock で起動前に停止した。
+
+次 slice は、console を unlock し、`~/Library/Application Support/Freehold Games/CavesOfQud/Local/ModSettings.json` で `QudJP.Enabled=true` の状態を人間が確認してから、Rosetta で `translation_checker.py --flow final-smoke` を実行する必要がある。combat/death evidence が不足する場合のみ、追加で `translation_checker.py --flow combat-smoke` を狭く再実行する。
+
+## Evidence
+
+主な成果物は `.sisyphus/evidence/release-slice-0/` に保存した。
+
+- `commands-transcript.md`: fresh runtime evidence attempt commands の exact transcript
+- `dotnet-build-no-incremental.txt`: `dotnet build Mods/QudJP/Assemblies/QudJP.csproj --no-incremental`
+  - result: success, 0 warnings, 0 errors
+- `sync-mod-dry-run.txt`: `uv run python scripts/sync_mod.py --dry-run`
+  - result: default Steam `StreamingAssets/Mods/QudJP` への同期対象を確認
+- `sync-mod-real.txt`: `uv run python scripts/sync_mod.py`
+  - result: command succeeded
+- `translation-checker-combat-smoke.txt`: exact command:
+  ```bash
+  uv run python scripts/translation_checker.py \
+    --skip-sync \
+    --flow combat-smoke \
+    --input-backend osascript \
+    --flow-screenshot-dir .sisyphus/evidence/release-slice-0/combat-smoke \
+    --attack-sequence ctrl+numpad6 \
+    --attack-confirm-key "" \
+    --message-log-chord "" \
+    --death-attack-count 3 \
+    --load-ready-timeout 90 \
+    --launch-timeout 90 \
+    > .sisyphus/evidence/release-slice-0/translation-checker-combat-smoke.txt \
+    2>&1
+  ```
+  - result: `Error: macOS console session is locked. Unlock the Mac before running translation_checker.py.`
+- `launch-rosetta-direct.stdout.txt`, `launch-rosetta-direct.exit.txt`, `Player-after-rosetta.log`
+  - command:
+    ```bash
+    ./scripts/launch_rosetta.sh \
+      > .sisyphus/evidence/release-slice-0/launch-rosetta-direct.stdout.txt \
+      2> .sisyphus/evidence/release-slice-0/launch-rosetta-direct.stderr.txt &
+    pid=$!
+    printf '%s\n' "$pid" > .sisyphus/evidence/release-slice-0/launch-rosetta-direct.pid.txt
+    sleep 45
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -TERM "$pid" 2>/dev/null
+    fi
+    wait "$pid"
+    printf '%s\n' "$?" > .sisyphus/evidence/release-slice-0/launch-rosetta-direct.exit.txt
+    ```
+  - result: launcher printed `Launching Caves of Qud via Rosetta (x86_64)...`; exit code `143`
+- `player-log-markers-after.txt`
+  - result: `INFO - Enabled mods:` は空。`QudJP`, build marker, `DynamicTextProbe`, `SinkObserve` はなし
+- `ModSettings.snapshot.json`
+  - result: `QudJP.Enabled=false`, `LLMOfQud.Enabled=true`
+- `runtime-triage-fresh.json`
+  - command: `uv run python scripts/triage_untranslated.py --log "$HOME/Library/Logs/Freehold Games/CavesOfQud/Player.log" --output .sisyphus/evidence/release-slice-0/runtime-triage-fresh.json`
+  - result: `summary.total=0`, Phase F entries `0`
+- `validate-xml-strict-baseline.txt`
+  - command: `uv run python scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json`
+  - result: success with the known baseline warning only
+
+## Issue #363
+
+Fresh runtime triage was collected, but it is not useful for QudJP coverage because QudJP was disabled in the game settings for this run.
+
+Classification:
+
+- actionable from current `Player.log`: none (`runtime-triage-fresh.json` total `0`)
+- Phase F-only observations: none, because no QudJP Phase F emitters ran
+- blocker: local `ModSettings.json` has `QudJP.Enabled=false`; `Player-after-rosetta.log` shows `INFO - Enabled mods:` with no enabled QudJP entry
+
+## Slice Tracking
+
+| Issue | Local status | Tracking note |
+| --- | --- | --- |
+| #370 | Closed with evidence | Local closeout evidence is recorded in `docs/reports/2026-04-28-issue-370-no-context-rebucket-closeout.md`: current static inventory and runtime triage artifacts have zero `<no-context>` rows; the older 48-row artifact is stale and superseded. |
+| #422 | Done / APPROVED; final PR verified | The Annals batch was reviewed and APPROVED as one PR unit. Completed candidates for this slice remain `DiscoveredLocation#gospel`, `FoundGuild#gospel`, `CorruptAdministrator#gospel#case:0#if:then`, `CorruptAdministrator#gospel#case:1#if:then`, and `SecretRitual#gospel#if:then#arm:1`. Final verification passed: schema 63 candidates, merge 53 patterns clean, extractor golden 80 passed, focused L2 46 passed, and annals collision/markup/reachability 376 passed. `ChariotDrivesOffCliff#gospel#bl:else` was attempted, then rejected in review for spice phrase over-fragmentation and non-publication-quality output; it was reverted. The exact candidate ID is not present in `candidates_pending.json`, and no dictionary/L2 fixture leakage was found, so do not track it as pending from this evidence. The BattleItem broad `BattleItem#tombInscription` fallback is `skip`/superseded; no dictionary/L2 translation was added. Keep the broader Annals follow-up visible: remaining candidates still exist outside this completed slice and should stay in the Annals follow-up queue. |
+| #437 | Keep open | Minimal glossary promotion is done. Do not close yet; this slice only records the promotion state, not full issue completion. |
+| #433 | Keep open / blocker | Blocked for this release slice. No closure evidence was produced here. |
+| #434 | Keep open / blocker | Blocked for this release slice. No closure evidence was produced here. |
+| #438 | Keep open / blocker | Evidence classifies the empty `Tzedech` welcome text as upstream-preserved empty slot/noise, but the issue should remain open until the maintainer accepts that disposition. |
+
+## Issue #376
+
+Display-name / death-popup color markup corruption was **not reproduced** in this slice.
+
+Reason:
+
+- automated runtime path did not launch because the macOS console session was locked
+- direct Rosetta launch produced a fresh log, but QudJP was disabled, so no QudJP death/display-name route ran
+- no screenshot or live death popup evidence was captured
+
+Static fallback:
+
+- `dotnet-test-issue-376-l1.txt`: related L1 filter succeeded with 71 passed and 6 skipped
+- `dotnet-test-issue-376-l2.txt`: related L2 filter succeeded with 157 passed
+- `dotnet-test-color-catalog.txt`: color route/catalog filter succeeded with 3 passed and 4 skipped
+
+Concern:
+
+The skipped L1 tests are issue #376 scaffolds marked `issue-376 — production code pending; static analysis layer not yet implemented`. Therefore current evidence does not close #376. It only confirms adjacent existing tests still pass.
+
+## Issue #438
+
+Classification: **upstream-preserved empty slot/noise; not a QudJP missing translation.**
+
+Evidence:
+
+- `issue-438-empty-text-rg.txt`: the only `Conversations.jp.xml` empty text hit is `Mods/QudJP/Localization/Conversations.jp.xml:261`
+- `issue-438-jp-context.txt`: this is `conversation ID="Tzedech"`, `node ID="Welcome"`, with `<text />`
+- `issue-438-base-context.txt`: upstream base `Conversations.xml` has the same node as `<text></text>` at the matching `Tzedech` / `Welcome` slot
+- `issue-438-warning-baseline.txt`: `scripts/validate_xml_warning_baseline.json` already records the warning as `Empty text in element 'text'`
+- `validate-xml-strict-baseline.txt`: strict validation passes with the baseline warning
+
+No localization asset change is recommended for #438 based on this evidence.
+
+## Next Slice
+
+Run the fresh readiness check only after:
+
+1. macOS console session is unlocked.
+2. QudJP is enabled in the game Mod Manager or `ModSettings.json`.
+3. `LLMOfQud` is disabled or removed for the run, because fresh `build_log.txt` currently shows a compile error in that unrelated mod.
+4. Run `translation_checker.py --flow final-smoke` through Rosetta as the main readiness pass. This should produce screenshots, QudJP marker/probe lines, and any death/combat-end evidence that the final-smoke flow collects.
+5. Rerun `translation_checker.py --flow combat-smoke` only if final-smoke does not produce sufficient combat/death evidence or if #376 needs a narrower retry.

--- a/docs/reports/2026-04-28-release-slice-0-go-no-go-evidence.md
+++ b/docs/reports/2026-04-28-release-slice-0-go-no-go-evidence.md
@@ -20,6 +20,7 @@ Steam Workshop readiness を Yes と判定するための fresh QudJP runtime ev
 - `sync-mod-real.txt`: `uv run python scripts/sync_mod.py`
   - result: command succeeded
 - `translation-checker-combat-smoke.txt`: exact command:
+
   ```bash
   uv run python scripts/translation_checker.py \
     --skip-sync \
@@ -35,9 +36,11 @@ Steam Workshop readiness を Yes と判定するための fresh QudJP runtime ev
     > .sisyphus/evidence/release-slice-0/translation-checker-combat-smoke.txt \
     2>&1
   ```
+
   - result: `Error: macOS console session is locked. Unlock the Mac before running translation_checker.py.`
 - `launch-rosetta-direct.stdout.txt`, `launch-rosetta-direct.exit.txt`, `Player-after-rosetta.log`
   - command:
+
     ```bash
     ./scripts/launch_rosetta.sh \
       > .sisyphus/evidence/release-slice-0/launch-rosetta-direct.stdout.txt \
@@ -51,6 +54,7 @@ Steam Workshop readiness を Yes と判定するための fresh QudJP runtime ev
     wait "$pid"
     printf '%s\n' "$?" > .sisyphus/evidence/release-slice-0/launch-rosetta-direct.exit.txt
     ```
+
   - result: launcher printed `Launching Caves of Qud via Rosetta (x86_64)...`; exit code `143`
 - `player-log-markers-after.txt`
   - result: `INFO - Enabled mods:` は空。`QudJP`, build marker, `DynamicTextProbe`, `SinkObserve` はなし

--- a/scripts/_artifacts/annals/candidates_pending.json
+++ b/scripts/_artifacts/annals/candidates_pending.json
@@ -188,12 +188,12 @@
           "default": "{t0}"
         }
       ],
-      "status": "needs_manual",
-      "reason": "unresolved-local in ternary string.Format on local declaration; extractor cannot expose two arms — defer until extractor handles ternary RHS in local decls",
+      "status": "skip",
+      "reason": "Issue #422 superseded: current BattleItem-only extraction emits stable tombInscription arm candidates (#bl:else#if:else/#bl:else#if:then/#bl:then#if:else/#bl:then#if:then); keep this former broad unresolved-local fallback out of promotion",
       "ja_template": "",
       "review_notes": "",
       "route": "annals",
-      "en_template_hash": ""
+      "en_template_hash": "sha256:a94bc9cb95913a5ea1caeb8bdf90a3aaf943bed46dc85446da9c69b1506057b6"
     },
     {
       "id": "BloodyBattle#gospel#if:else",
@@ -3036,6 +3036,253 @@
       "review_notes": "override: outer prefix branch (text from outer switch) deferred from extractor; PR2b CR R7",
       "route": "annals",
       "en_template_hash": "sha256:1e7042be4a20e83e3c43bc78e8b9065f9cb065dd479c238ea9849572f6964017"
+    },
+    {
+      "id": "DiscoveredLocation#gospel",
+      "source_file": "DiscoveredLocation.cs",
+      "annal_class": "DiscoveredLocation",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "discovered {0}",
+      "extracted_pattern": "^discovered\\ (.+?)$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "entity-property",
+          "raw": "entity.GetProperty(\"name\")",
+          "default": "{t0}"
+        }
+      ],
+      "status": "accepted",
+      "reason": "",
+      "ja_template": "{t0}を発見した",
+      "review_notes": "PR2d civic micro-slice: exact DiscoveredLocation gospel fragment",
+      "route": "annals",
+      "en_template_hash": "sha256:acc9bbd7ae5451e68b81fea9aa22fed8d883183999d91de02fd76b70c90bad1b"
+    },
+    {
+      "id": "FoundGuild#gospel",
+      "source_file": "FoundGuild.cs",
+      "annal_class": "FoundGuild",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "After {0} with {1}, {2} convinced them to help {3} found {4} in {5} for the purpose of {6} {7}. They named it {8}.",
+      "extracted_pattern": "^After\\ (.+?)\\ with\\ (.+?),\\ (.+?)\\ convinced\\ them\\ to\\ help\\ (.+?)\\ found\\ (.+?)\\ in\\ (.+?)\\ for\\ the\\ purpose\\ of\\ (.+?)\\ (.+?)\\.\\ They\\ named\\ it\\ (.+?)\\.$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "historykit-token",
+          "raw": "<spice.commonPhrases.treating.!random>",
+          "default": "{t0}"
+        },
+        {
+          "index": 1,
+          "type": "helper-call",
+          "raw": "Faction.GetFormattedName(newFaction)",
+          "default": "{t1}"
+        },
+        {
+          "index": 2,
+          "type": "historykit-token",
+          "raw": "<entity.name>",
+          "default": "{t2}"
+        },
+        {
+          "index": 3,
+          "type": "historykit-token",
+          "raw": "<entity.objectPronoun>",
+          "default": "{t3}"
+        },
+        {
+          "index": 4,
+          "type": "historykit-token",
+          "raw": "<spice.professions.{text}.guildhall.article>",
+          "default": "{t4}"
+        },
+        {
+          "index": 5,
+          "type": "helper-call",
+          "raw": "QudHistoryHelpers.GetNewRegion(history, property)",
+          "default": "{t5}"
+        },
+        {
+          "index": 6,
+          "type": "historykit-token",
+          "raw": "<spice.professions.{text}.studying>",
+          "default": "{t6}"
+        },
+        {
+          "index": 7,
+          "type": "historykit-token",
+          "raw": "<spice.elements.{randomElement}.nounsPlural.!random>",
+          "default": "{t7}"
+        },
+        {
+          "index": 8,
+          "type": "unresolved-local",
+          "raw": "text3",
+          "default": "{t8}"
+        }
+      ],
+      "status": "accepted",
+      "reason": "",
+      "ja_template": "{t1}と{t0}したのち、{t2}は{t3}が{t5}に{t4}を創設する助力をするよう彼らを説得した。その目的は{t7}を{t6}ことだった。彼らはそれを{t8}と名づけた。",
+      "review_notes": "PR2d civic micro-slice: extractor-proven FoundGuild gospel",
+      "route": "annals",
+      "en_template_hash": "sha256:6f02a0325f361abd0140c8817fb101306688f01f3f0433a8e4e4fd2a9a5f8c94"
+    },
+    {
+      "id": "CorruptAdministrator#gospel#case:0#if:then",
+      "source_file": "CorruptAdministrator.cs",
+      "annal_class": "CorruptAdministrator",
+      "switch_case": "0",
+      "event_property": "gospel",
+      "sample_source": "In {0} AR, a corrupt administrator was appointed minister of {1}. {2} outlawed the practice of {3}, and {4} was forced to flee.",
+      "extracted_pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ a\\ corrupt\\ administrator\\ was\\ appointed\\ minister\\ of\\ (.+?)\\.\\ (.+?)\\ outlawed\\ the\\ practice\\ of\\ (.+?),\\ and\\ (.+?)\\ was\\ forced\\ to\\ flee\\.$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "hse-expansion",
+          "raw": "year",
+          "default": "{t0}"
+        },
+        {
+          "index": 1,
+          "type": "unresolved-local",
+          "raw": "regionToReveal",
+          "default": "{t1}"
+        },
+        {
+          "index": 2,
+          "type": "helper-call",
+          "raw": "Grammar.RandomShePronoun()",
+          "default": "{t2}"
+        },
+        {
+          "index": 3,
+          "type": "historykit-token",
+          "raw": "<spice.elements.entity$elements[random].practices.!random>",
+          "default": "{t3}"
+        },
+        {
+          "index": 4,
+          "type": "historykit-token",
+          "raw": "<entity.name>",
+          "default": "{t4}"
+        }
+      ],
+      "status": "accepted",
+      "reason": "",
+      "ja_template": "{0}年、腐敗した施政官が{t1}の大臣に任じられた。その者は{t3}の営みを禁じ、{t4}は逃亡を余儀なくされた。",
+      "review_notes": "Issue #422 annals micro-slice: extractor-proven CorruptAdministrator non-sultan practice-ban gospel",
+      "route": "annals",
+      "en_template_hash": "sha256:b148ec177f3e77c9d2521d4ec9786385a302537f5326096ef9533fe19d9a0993"
+    },
+    {
+      "id": "CorruptAdministrator#gospel#case:1#if:then",
+      "source_file": "CorruptAdministrator.cs",
+      "annal_class": "CorruptAdministrator",
+      "switch_case": "1",
+      "event_property": "gospel",
+      "sample_source": "In {0} AR, a corrupt administrator was appointed minister of {1}. {2} outlawed association with {3}, and {4} was forced to flee.",
+      "extracted_pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ a\\ corrupt\\ administrator\\ was\\ appointed\\ minister\\ of\\ (.+?)\\.\\ (.+?)\\ outlawed\\ association\\ with\\ (.+?),\\ and\\ (.+?)\\ was\\ forced\\ to\\ flee\\.$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "hse-expansion",
+          "raw": "year",
+          "default": "{t0}"
+        },
+        {
+          "index": 1,
+          "type": "unresolved-local",
+          "raw": "regionToReveal",
+          "default": "{t1}"
+        },
+        {
+          "index": 2,
+          "type": "helper-call",
+          "raw": "Grammar.RandomShePronoun()",
+          "default": "{t2}"
+        },
+        {
+          "index": 3,
+          "type": "helper-call",
+          "raw": "Faction.GetFormattedName(list[Random(0, list.Count - 1)])",
+          "default": "{t3}"
+        },
+        {
+          "index": 4,
+          "type": "historykit-token",
+          "raw": "<entity.name>",
+          "default": "{t4}"
+        }
+      ],
+      "status": "accepted",
+      "reason": "",
+      "ja_template": "{0}年、腐敗した施政官が{t1}の大臣に任じられた。その者は{t3}との交わりを禁じ、{t4}は逃亡を余儀なくされた。",
+      "review_notes": "Issue #422 annals micro-slice: extractor-proven CorruptAdministrator non-sultan association-ban gospel",
+      "route": "annals",
+      "en_template_hash": "sha256:bf84e1522b05936adc18747e2afea5045f2828cf6694f2649541e97dcc34d4a4"
+    },
+    {
+      "id": "SecretRitual#gospel#if:then#arm:1",
+      "source_file": "SecretRitual.cs",
+      "annal_class": "SecretRitual",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "While wandering around {0}, {1} stumbled upon a clan of {2} performing a secret ritual. Because of {3} {4}, they accepted {5} into their fold and taught {6} their secrets.",
+      "extracted_pattern": "^While\\ wandering\\ around\\ (.+?),\\ (.+?)\\ stumbled\\ upon\\ a\\ clan\\ of\\ (.+?)\\ performing\\ a\\ secret\\ ritual\\.\\ Because\\ of\\ (.+?)\\ (.+?),\\ they\\ accepted\\ (.+?)\\ into\\ their\\ fold\\ and\\ taught\\ (.+?)\\ their\\ secrets\\.$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "unresolved-local",
+          "raw": "regionToReveal",
+          "default": "{t0}"
+        },
+        {
+          "index": 1,
+          "type": "historykit-token",
+          "raw": "<entity.name>",
+          "default": "{t1}"
+        },
+        {
+          "index": 2,
+          "type": "helper-call",
+          "raw": "Faction.GetFormattedName(newFaction)",
+          "default": "{t2}"
+        },
+        {
+          "index": 3,
+          "type": "historykit-token",
+          "raw": "<entity.possessivePronoun>",
+          "default": "{t3}"
+        },
+        {
+          "index": 4,
+          "type": "historykit-token",
+          "raw": "<spice.elements.entity$elements[random].quality.!random>",
+          "default": "{t4}"
+        },
+        {
+          "index": 5,
+          "type": "historykit-token",
+          "raw": "<entity.objectPronoun>",
+          "default": "{t5}"
+        },
+        {
+          "index": 6,
+          "type": "historykit-token",
+          "raw": "<entity.objectPronoun>",
+          "default": "{t6}"
+        }
+      ],
+      "status": "accepted",
+      "reason": "",
+      "ja_template": "{t0}の辺りをさまよううち、{t1}は秘密の儀式を行う{t2}の一族に出くわした。{t3} {t4}ゆえ、彼らは{t5}を仲間に迎え入れ、{t6}に彼らの秘密を授けた。",
+      "review_notes": "Issue #422 annals micro-slice: extractor-proven SecretRitual accepted-gospel wandering arm",
+      "route": "annals",
+      "en_template_hash": "sha256:0eac0d08795b50b51649b0a693ad9b9da72a41c961f0d0b73cf5ad2e41e85a7f"
     }
   ]
 }

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -24,6 +24,8 @@ import sys
 import zipfile
 from pathlib import Path
 
+RELEASE_VERSION = "0.2.0"
+
 
 def _find_project_root() -> Path:
     """Locate the project root by traversing up to find pyproject.toml.

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -71,7 +71,10 @@ def read_version(manifest_path: Path) -> str:
         msg = f"Version field is empty in manifest.json: {manifest_path}"
         raise ValueError(msg)
     if re.fullmatch(r"\d+\.\d+\.\d+", version) is None:
-        msg = "Version field must be simple semver X.Y.Z in manifest.json"
+        msg = (
+            "Version field must be simple semver X.Y.Z in manifest.json: "
+            f"{manifest_path} (got {version!r})"
+        )
         raise ValueError(msg)
     return version
 

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -54,17 +54,19 @@ def read_version(manifest_path: Path) -> str:
 
     Raises:
         FileNotFoundError: If manifest.json does not exist.
-        KeyError: If the ``Version`` key is missing.
-        ValueError: If the version string is empty or not simple semver.
+        ValueError: If the ``Version`` key is missing, empty, or not simple semver.
     """
     if not manifest_path.exists():
         msg = f"manifest.json not found: {manifest_path}"
         raise FileNotFoundError(msg)
 
     data: dict[str, object] = json.loads(manifest_path.read_text(encoding="utf-8"))
-    version = str(data["Version"])
+    if "Version" not in data:
+        msg = f"Version field is missing in manifest.json: {manifest_path}"
+        raise ValueError(msg)
+    version = str(data["Version"]).strip()
     if not version:
-        msg = "Version field is empty in manifest.json"
+        msg = f"Version field is empty in manifest.json: {manifest_path}"
         raise ValueError(msg)
     if re.fullmatch(r"\d+\.\d+\.\d+", version) is None:
         msg = "Version field must be simple semver X.Y.Z in manifest.json"

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -18,6 +18,7 @@ directory.
 """
 
 import json
+import re
 import subprocess
 import sys
 import zipfile
@@ -54,7 +55,7 @@ def read_version(manifest_path: Path) -> str:
     Raises:
         FileNotFoundError: If manifest.json does not exist.
         KeyError: If the ``Version`` key is missing.
-        ValueError: If the version string is empty.
+        ValueError: If the version string is empty or not simple semver.
     """
     if not manifest_path.exists():
         msg = f"manifest.json not found: {manifest_path}"
@@ -64,6 +65,9 @@ def read_version(manifest_path: Path) -> str:
     version = str(data["Version"])
     if not version:
         msg = "Version field is empty in manifest.json"
+        raise ValueError(msg)
+    if re.fullmatch(r"\d+\.\d+\.\d+", version) is None:
+        msg = "Version field must be simple semver X.Y.Z in manifest.json"
         raise ValueError(msg)
     return version
 

--- a/scripts/tests/fixtures/annals/battleitem_parenthesized_local_ternary_string_format.cs
+++ b/scripts/tests/fixtures/annals/battleitem_parenthesized_local_ternary_string_format.cs
@@ -1,0 +1,34 @@
+public class battleitem_parenthesized_local_ternary_string_format
+{
+    public void Generate()
+    {
+        string value2 = ((num2 != 0)
+            ? string.Format("{0} the Battle of {1}, where -- {2} -- {3} wielded {5} {6} and struck down the {4} in the name of {7}. {0}, afterward, how {8} and {9} {10} in {11} for days and days.",
+                ExpandString("<spice.commonPhrases.remember.!random.capitalize>"),
+                newLocationInRegion,
+                ExpandString("<spice.elements." + randomElement + ".mythicalBattleVista.!random>").Replace("*var*", text2),
+                "<entity.name>",
+                ExpandString("<spice.history.gospels.EnemyHostName." + QudHistoryHelpers.GetSultanateEra(snapshotAtYear) + ".!random>"),
+                "<entity.possessivePronoun>",
+                text,
+                ExpandString("<spice.instancesOf.justice.!random>"),
+                Faction.GetFormattedName(text4),
+                ExpandString("<spice.instancesOf.dearOnes.!random>"),
+                ExpandString("<spice.instancesOf.criedOut.!random>"),
+                ExpandString("<spice.commonPhrases.woe.!random>"))
+            : string.Format("{0} the Battle of {1}, where -- {2} -- {3} wielded {5} {6} and struck down the {4} in the name of {7}. {0}, afterward, how {8} and {9} {10} in {11} for days and days.",
+                ExpandString("<spice.commonPhrases.remember.!random.capitalize>"),
+                newLocationInRegion,
+                ExpandString("<spice.elements." + randomElement + ".mythicalBattleVista.!random>").Replace("*var*", text2),
+                "<entity.name>",
+                ExpandString("<spice.history.gospels.EnemyHostName." + QudHistoryHelpers.GetSultanateEra(snapshotAtYear) + ".!random>"),
+                "<entity.possessivePronoun>",
+                text,
+                ExpandString("<spice.instancesOf.justice.!random>"),
+                Faction.GetFormattedName(text4),
+                ExpandString("<spice.instancesOf.dearOnes.!random>"),
+                ExpandString("<spice.instancesOf.criedOut.!random>"),
+                ExpandString("<spice.commonPhrases.celebration.!random>")));
+        SetEventProperty("tombInscription", value2);
+    }
+}

--- a/scripts/tests/fixtures/annals/expected_battleitem_parenthesized_local_ternary_string_format.json
+++ b/scripts/tests/fixtures/annals/expected_battleitem_parenthesized_local_ternary_string_format.json
@@ -1,0 +1,195 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "battleitem_parenthesized_local_ternary_string_format#tombInscription#if:else",
+      "source_file": "battleitem_parenthesized_local_ternary_string_format.cs",
+      "annal_class": "battleitem_parenthesized_local_ternary_string_format",
+      "switch_case": "default",
+      "event_property": "tombInscription",
+      "sample_source": "{0} the Battle of {1}, where -- {2} -- {3} wielded {4} {5} and struck down the {6} in the name of {7}. {8}, afterward, how {9} and {10} {11} in {12} for days and days.",
+      "extracted_pattern": "^(.+?)\\ the\\ Battle\\ of\\ (.+?),\\ where\\ --\\ (.+?)\\ --\\ (.+?)\\ wielded\\ (.+?)\\ (.+?)\\ and\\ struck\\ down\\ the\\ (.+?)\\ in\\ the\\ name\\ of\\ (.+?)\\.\\ (.+?),\\ afterward,\\ how\\ (.+?)\\ and\\ (.+?)\\ (.+?)\\ in\\ (.+?)\\ for\\ days\\ and\\ days\\.$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "historykit-token",
+          "raw": "<spice.commonPhrases.remember.!random.capitalize>",
+          "default": "{t0}"
+        },
+        {
+          "index": 1,
+          "type": "unresolved-local",
+          "raw": "newLocationInRegion",
+          "default": "{t1}"
+        },
+        {
+          "index": 2,
+          "type": "format-arg",
+          "raw": "ExpandString(\"<spice.elements.\" + randomElement + \".mythicalBattleVista.!random>\").Replace(\"*var*\", text2)",
+          "default": "{t2}"
+        },
+        {
+          "index": 3,
+          "type": "historykit-token",
+          "raw": "<entity.name>",
+          "default": "{t3}"
+        },
+        {
+          "index": 4,
+          "type": "historykit-token",
+          "raw": "<entity.possessivePronoun>",
+          "default": "{t4}"
+        },
+        {
+          "index": 5,
+          "type": "unresolved-local",
+          "raw": "text",
+          "default": "{t5}"
+        },
+        {
+          "index": 6,
+          "type": "historykit-token",
+          "raw": "<spice.history.gospels.EnemyHostName.{QudHistoryHelpers.GetSultanateEra(snapshotAtYear)}.!random>",
+          "default": "{t6}"
+        },
+        {
+          "index": 7,
+          "type": "historykit-token",
+          "raw": "<spice.instancesOf.justice.!random>",
+          "default": "{t7}"
+        },
+        {
+          "index": 8,
+          "type": "historykit-token",
+          "raw": "<spice.commonPhrases.remember.!random.capitalize>",
+          "default": "{t8}"
+        },
+        {
+          "index": 9,
+          "type": "helper-call",
+          "raw": "Faction.GetFormattedName(text4)",
+          "default": "{t9}"
+        },
+        {
+          "index": 10,
+          "type": "historykit-token",
+          "raw": "<spice.instancesOf.dearOnes.!random>",
+          "default": "{t10}"
+        },
+        {
+          "index": 11,
+          "type": "historykit-token",
+          "raw": "<spice.instancesOf.criedOut.!random>",
+          "default": "{t11}"
+        },
+        {
+          "index": 12,
+          "type": "historykit-token",
+          "raw": "<spice.commonPhrases.celebration.!random>",
+          "default": "{t12}"
+        }
+      ],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:34e617a867bbc88355d69f2e1cb79e76241f6c43ecf01e0a8b019a750bf5a8ff"
+    },
+    {
+      "id": "battleitem_parenthesized_local_ternary_string_format#tombInscription#if:then",
+      "source_file": "battleitem_parenthesized_local_ternary_string_format.cs",
+      "annal_class": "battleitem_parenthesized_local_ternary_string_format",
+      "switch_case": "default",
+      "event_property": "tombInscription",
+      "sample_source": "{0} the Battle of {1}, where -- {2} -- {3} wielded {4} {5} and struck down the {6} in the name of {7}. {8}, afterward, how {9} and {10} {11} in {12} for days and days.",
+      "extracted_pattern": "^(.+?)\\ the\\ Battle\\ of\\ (.+?),\\ where\\ --\\ (.+?)\\ --\\ (.+?)\\ wielded\\ (.+?)\\ (.+?)\\ and\\ struck\\ down\\ the\\ (.+?)\\ in\\ the\\ name\\ of\\ (.+?)\\.\\ (.+?),\\ afterward,\\ how\\ (.+?)\\ and\\ (.+?)\\ (.+?)\\ in\\ (.+?)\\ for\\ days\\ and\\ days\\.$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "historykit-token",
+          "raw": "<spice.commonPhrases.remember.!random.capitalize>",
+          "default": "{t0}"
+        },
+        {
+          "index": 1,
+          "type": "unresolved-local",
+          "raw": "newLocationInRegion",
+          "default": "{t1}"
+        },
+        {
+          "index": 2,
+          "type": "format-arg",
+          "raw": "ExpandString(\"<spice.elements.\" + randomElement + \".mythicalBattleVista.!random>\").Replace(\"*var*\", text2)",
+          "default": "{t2}"
+        },
+        {
+          "index": 3,
+          "type": "historykit-token",
+          "raw": "<entity.name>",
+          "default": "{t3}"
+        },
+        {
+          "index": 4,
+          "type": "historykit-token",
+          "raw": "<entity.possessivePronoun>",
+          "default": "{t4}"
+        },
+        {
+          "index": 5,
+          "type": "unresolved-local",
+          "raw": "text",
+          "default": "{t5}"
+        },
+        {
+          "index": 6,
+          "type": "historykit-token",
+          "raw": "<spice.history.gospels.EnemyHostName.{QudHistoryHelpers.GetSultanateEra(snapshotAtYear)}.!random>",
+          "default": "{t6}"
+        },
+        {
+          "index": 7,
+          "type": "historykit-token",
+          "raw": "<spice.instancesOf.justice.!random>",
+          "default": "{t7}"
+        },
+        {
+          "index": 8,
+          "type": "historykit-token",
+          "raw": "<spice.commonPhrases.remember.!random.capitalize>",
+          "default": "{t8}"
+        },
+        {
+          "index": 9,
+          "type": "helper-call",
+          "raw": "Faction.GetFormattedName(text4)",
+          "default": "{t9}"
+        },
+        {
+          "index": 10,
+          "type": "historykit-token",
+          "raw": "<spice.instancesOf.dearOnes.!random>",
+          "default": "{t10}"
+        },
+        {
+          "index": 11,
+          "type": "historykit-token",
+          "raw": "<spice.instancesOf.criedOut.!random>",
+          "default": "{t11}"
+        },
+        {
+          "index": 12,
+          "type": "historykit-token",
+          "raw": "<spice.commonPhrases.woe.!random>",
+          "default": "{t12}"
+        }
+      ],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:90d50965c2991229309a68587042e31b935ab59ba936a5ef7df55cb1744fd06e"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/expected_local_ternary_string_format.json
+++ b/scripts/tests/fixtures/annals/expected_local_ternary_string_format.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "1",
+  "candidates": [
+    {
+      "id": "local_ternary_string_format#tombInscription#if:else",
+      "source_file": "local_ternary_string_format.cs",
+      "annal_class": "local_ternary_string_format",
+      "switch_case": "default",
+      "event_property": "tombInscription",
+      "sample_source": "Remember the Battle of Bethesda Susa in woe.",
+      "extracted_pattern": "^Remember\\ the\\ Battle\\ of\\ Bethesda\\ Susa\\ in\\ woe\\.$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:2d37b10a9b1d40c645e1ec92d9e7066dec38ec458f4f7dea34887a0388e12ba3"
+    },
+    {
+      "id": "local_ternary_string_format#tombInscription#if:then",
+      "source_file": "local_ternary_string_format.cs",
+      "annal_class": "local_ternary_string_format",
+      "switch_case": "default",
+      "event_property": "tombInscription",
+      "sample_source": "Remember the Battle of Bethesda Susa in celebration.",
+      "extracted_pattern": "^Remember\\ the\\ Battle\\ of\\ Bethesda\\ Susa\\ in\\ celebration\\.$",
+      "slots": [],
+      "status": "pending",
+      "reason": "",
+      "ja_template": "",
+      "review_notes": "",
+      "route": "annals",
+      "en_template_hash": "sha256:367c4ed724a0dca25fdbccec8971d45b7ededa19f4a87bce9c494337205fac24"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/annals/local_ternary_string_format.cs
+++ b/scripts/tests/fixtures/annals/local_ternary_string_format.cs
@@ -1,0 +1,11 @@
+public class local_ternary_string_format
+{
+    public void Generate()
+    {
+        var place = "Bethesda Susa";
+        var value = flag
+            ? string.Format("Remember the Battle of {0} in celebration.", place)
+            : string.Format("Remember the Battle of {0} in woe.", place);
+        SetEventProperty("tombInscription", value);
+    }
+}

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -84,7 +84,8 @@ class TestProjectManifest:
         """Release setup does not require a preview image asset yet."""
         manifest = PROJECT_ROOT / "Mods" / "QudJP" / "manifest.json"
         data = json.loads(manifest.read_text(encoding="utf-8"))
-        assert data.get("PreviewImage", "") == ""
+        assert "PreviewImage" in data
+        assert data["PreviewImage"] == ""
 
 
 class TestCollectLocalizationFiles:
@@ -402,6 +403,7 @@ class TestBuildReleaseImport:
         ):
             build_release()
 
+        create_zip_mock.assert_called_once()
         assert create_zip_mock.call_args.args[0] == tmp_path / "dist" / "QudJP-v1.2.3.zip"
 
     def test_build_dll_raises_on_missing_dll(self, tmp_path: Path) -> None:

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -16,6 +16,8 @@ from scripts.build_release import (
     read_version,
 )
 
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
 
 class TestReadVersion:
     """Tests for read_version."""
@@ -26,11 +28,19 @@ class TestReadVersion:
         manifest.write_text(json.dumps({"Version": "1.2.3"}), encoding="utf-8")
         assert read_version(manifest) == "1.2.3"
 
-    def test_reads_dev_version(self, tmp_path: Path) -> None:
-        """Dev version strings like '0.1.0-dev' are returned as-is."""
+    def test_rejects_dev_version_suffix(self, tmp_path: Path) -> None:
+        """Version strings must be simple semver accepted by the game."""
         manifest = tmp_path / "manifest.json"
         manifest.write_text(json.dumps({"Version": "0.1.0-dev"}), encoding="utf-8")
-        assert read_version(manifest) == "0.1.0-dev"
+        with pytest.raises(ValueError, match="simple semver"):
+            read_version(manifest)
+
+    def test_rejects_non_semver_version(self, tmp_path: Path) -> None:
+        """Non-semver version strings are rejected before release packaging."""
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(json.dumps({"Version": "v1"}), encoding="utf-8")
+        with pytest.raises(ValueError, match="simple semver"):
+            read_version(manifest)
 
     def test_missing_manifest_raises(self, tmp_path: Path) -> None:
         """FileNotFoundError is raised when manifest.json does not exist."""
@@ -50,6 +60,21 @@ class TestReadVersion:
         manifest.write_text(json.dumps({"Version": ""}), encoding="utf-8")
         with pytest.raises(ValueError, match="Version field is empty"):
             read_version(manifest)
+
+
+class TestProjectManifest:
+    """Tests for the checked-in release manifest."""
+
+    def test_manifest_version_is_release_semver(self) -> None:
+        """Checked-in manifest uses the current release setup version."""
+        manifest = PROJECT_ROOT / "Mods" / "QudJP" / "manifest.json"
+        assert read_version(manifest) == "0.2.0"
+
+    def test_preview_image_can_remain_pending(self) -> None:
+        """Release setup does not require a preview image asset yet."""
+        manifest = PROJECT_ROOT / "Mods" / "QudJP" / "manifest.json"
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        assert data.get("PreviewImage", "") == ""
 
 
 class TestCollectLocalizationFiles:
@@ -342,6 +367,32 @@ class TestBuildReleaseImport:
             mock_root.side_effect = FileNotFoundError("no root")
             with pytest.raises(FileNotFoundError):
                 build_release()
+
+    def test_build_release_names_zip_from_manifest_version(self, tmp_path: Path) -> None:
+        """Release ZIP output path includes the manifest version."""
+        mod_dir = tmp_path / "Mods" / "QudJP"
+        loc_dir = mod_dir / "Localization"
+        mod_dir.mkdir(parents=True)
+        loc_dir.mkdir()
+        manifest = mod_dir / "manifest.json"
+        manifest.write_text(json.dumps({"Version": "1.2.3"}), encoding="utf-8")
+        dll = mod_dir / "Assemblies" / "QudJP.dll"
+        dll.parent.mkdir()
+        dll.write_bytes(b"dll")
+        license_file = tmp_path / "LICENSE"
+        license_file.write_text("license", encoding="utf-8")
+        notice_file = tmp_path / "NOTICE.md"
+        notice_file.write_text("notice", encoding="utf-8")
+
+        with (
+            patch("scripts.build_release._find_project_root", return_value=tmp_path),
+            patch("scripts.build_release.build_dll", return_value=dll),
+            patch("scripts.build_release.collect_localization_files", return_value=[]),
+            patch("scripts.build_release.create_zip", return_value=[]) as create_zip_mock,
+        ):
+            build_release()
+
+        assert create_zip_mock.call_args.args[0] == tmp_path / "dist" / "QudJP-v1.2.3.zip"
 
     def test_build_dll_raises_on_missing_dll(self, tmp_path: Path) -> None:
         """build_dll raises FileNotFoundError when DLL is absent after build."""

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -33,8 +33,10 @@ class TestReadVersion:
         """Version strings must be simple semver accepted by the game."""
         manifest = tmp_path / "manifest.json"
         manifest.write_text(json.dumps({"Version": "0.1.0-dev"}), encoding="utf-8")
-        with pytest.raises(ValueError, match="simple semver"):
+        with pytest.raises(ValueError, match="simple semver") as exc_info:
             read_version(manifest)
+        assert str(manifest) in str(exc_info.value)
+        assert "0.1.0-dev" in str(exc_info.value)
 
     def test_rejects_non_semver_version(self, tmp_path: Path) -> None:
         """Non-semver version strings are rejected before release packaging."""

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from scripts.build_release import (
+    RELEASE_VERSION,
     build_dll,
     build_release,
     collect_localization_files,
@@ -68,7 +69,7 @@ class TestProjectManifest:
     def test_manifest_version_is_release_semver(self) -> None:
         """Checked-in manifest uses the current release setup version."""
         manifest = PROJECT_ROOT / "Mods" / "QudJP" / "manifest.json"
-        assert read_version(manifest) == "0.2.0"
+        assert read_version(manifest) == RELEASE_VERSION
 
     def test_preview_image_can_remain_pending(self) -> None:
         """Release setup does not require a preview image asset yet."""

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -48,10 +48,10 @@ class TestReadVersion:
             read_version(tmp_path / "nonexistent.json")
 
     def test_missing_version_key_raises(self, tmp_path: Path) -> None:
-        """KeyError is raised when the Version key is absent."""
+        """ValueError is raised when the Version key is absent."""
         manifest = tmp_path / "manifest.json"
         manifest.write_text(json.dumps({"Id": "QudJP"}), encoding="utf-8")
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError, match="Version field is missing"):
             read_version(manifest)
 
     def test_empty_version_raises(self, tmp_path: Path) -> None:

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -64,6 +64,13 @@ class TestReadVersion:
         with pytest.raises(ValueError, match="Version field is empty"):
             read_version(manifest)
 
+    def test_whitespace_only_version_raises(self, tmp_path: Path) -> None:
+        """Whitespace-only Version is treated as empty."""
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(json.dumps({"Version": "   "}), encoding="utf-8")
+        with pytest.raises(ValueError, match="Version field is empty"):
+            read_version(manifest)
+
 
 class TestProjectManifest:
     """Tests for the checked-in release manifest."""

--- a/scripts/tools/AnnalsPatternExtractor/Extractor.cs
+++ b/scripts/tools/AnnalsPatternExtractor/Extractor.cs
@@ -105,36 +105,44 @@ internal sealed class Extractor
             foreach (var (branchLabel, setterLocals) in setterLocalsBranches)
             {
                 var branchedIdPrefix = branchLabel is null ? idPrefix : idPrefix + CandidateIdSuffix.BranchedLocal + branchLabel;
-                var armings = ExpandSwitchExpressionArms(valueExpr, setterLocals);
-                foreach (var (armLabel, armLocals) in armings)
+                var conditionalArmings = ExpandConditionalExpressionArms(valueExpr, setterLocals);
+                foreach (var (conditionalArmLabel, conditionalArmLocals) in conditionalArmings)
                 {
-                    var armSwitchCase = armLabel is null ? switchLabel : armLabel;
-                    var armId = armLabel is null ? branchedIdPrefix : branchedIdPrefix + CandidateIdSuffix.Arm + armLabel;
+                    var conditionalId = conditionalArmLabel is null
+                        ? branchedIdPrefix
+                        : branchedIdPrefix + CandidateIdSuffix.If + conditionalArmLabel;
 
-                    var optExpansions = ExpandOptionalAppends(valueExpr, armLocals, FilterAppendsToLocals(armLocals, setterScopedAppends));
-                    foreach (var (optLabel, optLocals) in optExpansions)
+                    var armings = ExpandSwitchExpressionArms(valueExpr, conditionalArmLocals);
+                    foreach (var (armLabel, armLocals) in armings)
                     {
-                        var optId = optLabel is null ? armId : armId + CandidateIdSuffix.Opt + optLabel;
-                        var resolution = ResolveValueExpression(valueExpr, optLocals);
-                        if (!resolution.Resolved)
+                        var armSwitchCase = armLabel is null ? switchLabel : armLabel;
+                        var armId = armLabel is null ? conditionalId : conditionalId + CandidateIdSuffix.Arm + armLabel;
+
+                        var optExpansions = ExpandOptionalAppends(valueExpr, armLocals, FilterAppendsToLocals(armLocals, setterScopedAppends));
+                        foreach (var (optLabel, optLocals) in optExpansions)
                         {
-                            candidates.Add(NeedsManual(
+                            var optId = optLabel is null ? armId : armId + CandidateIdSuffix.Opt + optLabel;
+                            var resolution = ResolveValueExpression(valueExpr, optLocals);
+                            if (!resolution.Resolved)
+                            {
+                                candidates.Add(NeedsManual(
+                                    id: optId,
+                                    sourceFile: fileName,
+                                    annalClass: className,
+                                    switchCase: armSwitchCase,
+                                    eventProperty: eventProperty,
+                                    reason: resolution.Reason));
+                                continue;
+                            }
+
+                            candidates.Add(BuildCandidate(
                                 id: optId,
                                 sourceFile: fileName,
                                 annalClass: className,
                                 switchCase: armSwitchCase,
                                 eventProperty: eventProperty,
-                                reason: resolution.Reason));
-                            continue;
+                                resolved: resolution));
                         }
-
-                        candidates.Add(BuildCandidate(
-                            id: optId,
-                            sourceFile: fileName,
-                            annalClass: className,
-                            switchCase: armSwitchCase,
-                            eventProperty: eventProperty,
-                            resolved: resolution));
                     }
                 }
             }
@@ -989,6 +997,69 @@ internal sealed class Extractor
             if (nested.name is not null) return nested;
         }
         return (null, null);
+    }
+
+    /// <summary>
+    /// If the value expression depends on a local whose initializer is a ternary expression,
+    /// fan out the local into `then` and `else` overrides. This covers decompiled annal shapes
+    /// like `var value = cond ? string.Format(...) : string.Format(...); SetEventProperty(...,
+    /// value);` without requiring control-flow analysis.
+    /// </summary>
+    private static List<(string? armLabel, IReadOnlyDictionary<string, ExpressionSyntax> locals)>
+        ExpandConditionalExpressionArms(
+            ExpressionSyntax valueExpr,
+            IReadOnlyDictionary<string, ExpressionSyntax> locals)
+    {
+        var result = new List<(string?, IReadOnlyDictionary<string, ExpressionSyntax>)>();
+        var (conditionalLocalName, conditionalExpr) =
+            FindConditionalExpressionLocal(valueExpr, locals, new HashSet<string>(StringComparer.Ordinal));
+        if (conditionalLocalName is null || conditionalExpr is null)
+        {
+            result.Add((null, locals));
+            return result;
+        }
+
+        var thenLocals = new Dictionary<string, ExpressionSyntax>(locals, StringComparer.Ordinal)
+        {
+            [conditionalLocalName] = conditionalExpr.WhenTrue,
+        };
+        result.Add(("then", thenLocals));
+
+        var elseLocals = new Dictionary<string, ExpressionSyntax>(locals, StringComparer.Ordinal)
+        {
+            [conditionalLocalName] = conditionalExpr.WhenFalse,
+        };
+        result.Add(("else", elseLocals));
+
+        return result;
+    }
+
+    private static (string? name, ConditionalExpressionSyntax? expr) FindConditionalExpressionLocal(
+        ExpressionSyntax expr,
+        IReadOnlyDictionary<string, ExpressionSyntax> locals,
+        HashSet<string> visited)
+    {
+        foreach (var id in expr.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+        {
+            var name = id.Identifier.ValueText;
+            if (visited.Contains(name)) continue;
+            if (!locals.TryGetValue(name, out var init)) continue;
+            init = UnwrapParentheses(init);
+            if (init is ConditionalExpressionSyntax conditional) return (name, conditional);
+            visited.Add(name);
+            var nested = FindConditionalExpressionLocal(init, locals, visited);
+            if (nested.name is not null) return nested;
+        }
+        return (null, null);
+    }
+
+    private static ExpressionSyntax UnwrapParentheses(ExpressionSyntax expr)
+    {
+        while (expr is ParenthesizedExpressionSyntax parenthesized)
+        {
+            expr = parenthesized.Expression;
+        }
+        return expr;
     }
 
     private static string SwitchExpressionArmLabel(SwitchExpressionArmSyntax arm)


### PR DESCRIPTION
## Summary

- Advances release-readiness localization work across mutations, popup text, glossary promotion, and release metadata validation.
- Adds the #422 Annals batch: five accepted Annals translations plus extractor support for local ternary `string.Format` patterns, including parenthesized BattleItem-shaped ternaries.
- Records release slice evidence and closes out #370 evidence locally; `BattleItem#tombInscription` remains unpromoted to dictionary/L2 because the broad fallback is superseded and requires a later translation slice.

## Details

- Adds/updates focused L1/L2 coverage for mutation wording, popup tooltip text, and Annals samples.
- Updates `annals-patterns.ja.json` and `candidates_pending.json` for accepted Annals candidates and rejected/superseded cases.
- Adds Annals extractor golden fixtures for direct and parenthesized local ternary `string.Format` fan-out.
- Updates release packaging checks to validate simple semver while keeping preview image pending.
- Promotes selected glossary terms and adds release/issue evidence reports.

## Validation

- `git diff --check`
- `python3 scripts/validate_candidate_schema.py scripts/_artifacts/annals/candidates_pending.json`
- Annals merge determinism: regenerated `annals-patterns.ja.json` to temp and diffed cleanly
- `uv run pytest scripts/tests/test_extract_annals_patterns.py scripts/tests/test_roslyn_extractor_smoke.py scripts/tests/test_build_release.py -q` -> `111 passed`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~ReshephHistoryTranslationTests|FullyQualifiedName~SultanShrineWrapperTranslatorTests|FullyQualifiedName~AnnalsPatternsCollisionTests|FullyQualifiedName~AnnalsPatternsMarkupInvariantTests|FullyQualifiedName~AnnalsPatternsAssetReachabilityTests'` -> `422 passed`

## Notes

- `ChariotDrivesOffCliff#gospel#bl:else` was intentionally not promoted after review found unstable spice-phrase boundary handling.
- `BattleItem#tombInscription` dictionary/L2 translation is intentionally not included in this PR; this PR only improves extractor handling and marks the broad fallback superseded.
- Open release blockers remain for preview image/workshop docs/runtime smoke and other issue-specific work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * プレイヤー自己表示ポップアップに日本語翻訳を追加（「あなた自身だ。」）

* **文章更新 / バグ修正**
  * 複数ミューテーション説明の日本語表現を改善・整合化（用語・回復表現・挙動記述の更新）
  * 特定アビリティの攻撃／帰還タイミング表記を修正

* **テスト**
  * ローカライゼーションとAnnals抽出に関する多数の単体テストを追加・強化

* **ドキュメント**
  * リリース／検証レポートを追加

* **その他**
  * パターン＆サンプルデータ追加、モジュール版を0.2.0へ更新、ビルド検証のバージョン確認強化、抽出ツールの条件分岐対応を改善
<!-- end of auto-generated comment: release notes by coderabbit.ai -->