### PR TITLE
[codex] Fix check_encoding generated artifact scan

### DIFF
--- a/scripts/check_encoding.py
+++ b/scripts/check_encoding.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 _BOM = b"\xef\xbb\xbf"
 _MOJIBAKE_PATTERNS = ("繧", "縺", "蜒", "驕ｿ")
-_SKIPPED_DIR_NAMES = frozenset({"__pycache__"})
+_SKIPPED_DIR_NAMES = frozenset({"__pycache__", "bin", "obj"})
 _SKIPPED_SUFFIXES = frozenset({".pyc", ".pyo"})
 _MOJIBAKE_SKIP_SUFFIXES = frozenset({".md", ".py"})
 

--- a/scripts/tests/test_check_encoding.py
+++ b/scripts/tests/test_check_encoding.py
@@ -116,6 +116,18 @@ class TestCheckDirectory:
 
         assert check_directory(tmp_path) == []
 
+    def test_recursive_scan_skips_generated_build_directories(self, tmp_path: Path) -> None:
+        """Generated build outputs are ignored during recursive scans."""
+        extractor = tmp_path / "scripts" / "tools" / "AnnalsPatternExtractor"
+        bin_dir = extractor / "bin" / "Debug" / "net10.0"
+        obj_dir = extractor / "obj" / "Debug" / "net10.0"
+        bin_dir.mkdir(parents=True)
+        obj_dir.mkdir(parents=True)
+        (bin_dir / "AnnalsPatternExtractor.dll").write_bytes(b"\x80\r\n")
+        (obj_dir / "AnnalsPatternExtractor.assets.cache").write_bytes(b"\x81\r\n")
+
+        assert check_directory(tmp_path) == []
+
     def test_python_files_skip_mojibake_check(self, tmp_path: Path) -> None:
         """Python fixtures may contain mojibake sentinels without failing the scan."""
         script = tmp_path / "fixture.py"


### PR DESCRIPTION
## Summary
- Skip generated `bin/` and `obj/` directories during recursive encoding checks.
- Add a regression test for generated AnnalsPatternExtractor artifacts with invalid bytes.

## Validation
- `uv run pytest scripts/tests/test_check_encoding.py`: 24 passed
- `ruff check scripts/check_encoding.py scripts/tests/test_check_encoding.py`: passed
- `python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts`: 290 OK, 0 issues
- `git diff --check`: passed

## Review cycle
- codex-review: APPROVE
- simplify: no behavior changes needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * エンコーディングチェッカーがビルド出力ディレクトリを除外対象として処理するよう改善。スキャン範囲が削減され、不要なエンコーディング問題の報告が減少します。

* **テスト**
  * ビルド出力フォルダを正しく除外することを検証するテストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->