### PR TITLE
[codex] Add color route static closeout tests

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -1,110 +1,714 @@
-namespace QudJP.Tests.L1;
+using System.Text.Json;
+using System.Text.RegularExpressions;
 
-// issue-376: color tag application/restoration static analysis — L1 supplement.
-//
-// Catalog-level allowlist tests that would have caught past color-tag drops once
-// the static-analysis layer is wired up. They are NUnit `[Test, Ignore(...)]` (the
-// project does not use xUnit; see ColorTagStaticAnalysisTests.cs for rationale).
-//
-// Layer rationale per docs/test-architecture.md:
-//   Both this file and ColorTagStaticAnalysisTests.cs sit at L1 (no HarmonyLib,
-//   no Assembly-CSharp.dll, no Unity). This file is the static catalog scan
-//   layer; ColorTagStaticAnalysisTests.cs is the translator-surface drop-scenario
-//   layer. Catalog-1/-2/-3 here scan `Mods/QudJP/Assemblies/src/`; Catalog-4
-//   scans `Mods/QudJP/Localization/Dictionaries/*.json`.
+namespace QudJP.Tests.L1;
 
 [TestFixture]
 [Category("L1")]
 public sealed class ColorTagAllowlistCoverageTests
 {
-    // Common prefix `"issue-376 — production code pending"` is shared with
-    // ColorTagStaticAnalysisTests.SkipReason so a single grep surfaces every
-    // scaffold the production PR must address.
-    private const string SkipReason = "issue-376 — production code pending; catalog allowlist not yet defined";
+    private static readonly Regex FileScopedNamespacePattern =
+        new("^namespace\\s+.+?;$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
-    // Catalog-1: every Patches/*.cs that calls ColorAwareTranslationComposer.Strip
-    // must also reach a paired Restore site (RestoreCapture / RestoreSpans /
-    // TranslatePreservingColors). The check is per-call-site, NOT a count match:
-    // one Strip can fan out to multiple RestoreCapture calls (one per capture
-    // group), and TranslatePreservingColors performs Strip+Restore internally
-    // and shouldn't be paired with a sibling Strip at all.
+    private static readonly Regex MethodSignaturePattern =
+        new(
+            "^\\s*(?:private|internal|public|protected|static|sealed|override|async|unsafe|extern|readonly|virtual|new|partial|\\s)+[^=;]*?\\b(?<name>[A-Za-z_]\\w*)\\s*\\(",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex StripDeconstructionPattern =
+        new(
+            "\\bvar\\s*\\(\\s*(?:[A-Za-z_]\\w*|_)\\s*,\\s*(?<spans>[A-Za-z_]\\w*|_)\\s*\\)\\s*=\\s*(?:ColorAwareTranslationComposer|ColorCodePreserver)\\.Strip\\(",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly string[] RestoreRoundTripSymbols =
+    {
+        "ColorAwareTranslationComposer.Restore(",
+        "ColorAwareTranslationComposer.RestoreRelative(",
+        "ColorAwareTranslationComposer.RestoreCapture(",
+        "ColorAwareTranslationComposer.MarkupAwareRestoreCapture(",
+        "ColorAwareTranslationComposer.RestoreSlice(",
+        "ColorAwareTranslationComposer.RestoreMatchBoundaries(",
+        "ColorAwareTranslationComposer.TranslatePreservingColors(",
+        "GetDisplayNameRouteTranslator.TranslatePreservingColors(",
+        "UITextSkinTranslationPatch.TranslatePreservingColors(",
+        "RestoreBalancedCapture(",
+        "RestoreCaptureAtOffset(",
+    };
+
+    private static readonly string[] StripRoundTripSymbols =
+    {
+        "ColorAwareTranslationComposer.Strip(",
+        "ColorCodePreserver.Strip(",
+    };
+
+    private static readonly string[] NameLikeCaptureGroups =
+    {
+        "killer",
+        "item",
+        "name",
+        "owner",
+        "subject",
+        "target",
+    };
+
+    private static readonly string NameLikeCaptureAlternation = string.Join("|", NameLikeCaptureGroups);
+
+    private static readonly Regex DirectNameLikeRestoreCapturePattern =
+        new(
+            "ColorAwareTranslationComposer\\.RestoreCapture\\((?<value>.*?),\\s*[^,]+,\\s*(?<group>[^;]*?\\.Groups\\[\"(?<name>"
+            + NameLikeCaptureAlternation
+            + ")\"\\])",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.Singleline);
+
+    private static readonly Regex AliasAssignmentPattern =
+        new(
+            "\\b(?:var|Group)\\s+(?<alias>[A-Za-z_]\\w*)\\s*=\\s*[^;]*?\\.Groups\\[\"(?<name>"
+            + NameLikeCaptureAlternation
+            + ")\"\\]",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex AliasedNameLikeRestoreCapturePattern =
+        new(
+            "ColorAwareTranslationComposer\\.RestoreCapture\\((?<value>.*?),\\s*[^,]+,\\s*(?<alias>[A-Za-z_]\\w*)\\s*\\)",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.Singleline);
+
+    private static readonly Regex SourceHelperNameLikeRestoreCapturePattern =
+        new(
+            "\\bRestoreCapture\\(\\s*match\\s*,\\s*spans\\s*,\\s*\"(?<name>"
+            + NameLikeCaptureAlternation
+            + ")\"\\s*\\)",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex SourceCaptureValuePattern =
+        new(
+            "^(?:[^;]*?\\.Groups\\[\"(?<name>"
+            + NameLikeCaptureAlternation
+            + ")\"\\]\\.Value|(?<alias>[A-Za-z_]\\w*))$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly string[] NameLikeRestoreCaptureGuardSymbols =
+    {
+        "HasColorMarkup(",
+        "IsAlreadyLocalized",
+        "MarkupAwareRestoreCapture(",
+    };
+
+    private static readonly SortedDictionary<string, string> StripWithoutLocalRestoreAllowlist =
+        new(StringComparer.Ordinal)
+        {
+            ["Mods/QudJP/Assemblies/src/Observability/FinalOutputObservability.cs:108:RecordDirectMarker"] = "Observation-only final sink marker check.",
+            ["Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs:238:HasColorMarkup"] = "Predicate only; it compares stripped and original text.",
+            ["Mods/QudJP/Assemblies/src/Patches/ActiveEffectTextTranslator.cs:69:TryTranslateTemplate"] = "Delegates restoration to the template helper selected by the matched rule.",
+            ["Mods/QudJP/Assemblies/src/Patches/BedChairFragmentTranslator.cs:120:TryTranslate"] = "Delegates capture restoration to rule builders through RestoreVisible.",
+            ["Mods/QudJP/Assemblies/src/Patches/ClonelingVehicleFragmentTranslator.cs:56:TryTranslate"] = "Delegates capture restoration to the build function.",
+            ["Mods/QudJP/Assemblies/src/Patches/CombatGetDefenderHitDiceTranslationPatch.cs:82:TryTranslateQueuedMessage"] = "Uses stripped text only for owner-route detection; queued message text is replaced wholesale.",
+            ["Mods/QudJP/Assemblies/src/Patches/CombatMeleeAttackTranslationPatch.cs:100:TryTranslateQueuedMessage"] = "Uses stripped text only for owner-route detection; queued message text is replaced wholesale.",
+            ["Mods/QudJP/Assemblies/src/Patches/CookingEffectFragmentTranslator.cs:72:TryTranslate"] = "Delegates capture restoration to RestoreVisible.",
+            ["Mods/QudJP/Assemblies/src/Patches/DescriptionTextTranslator.cs:97:TryTranslateSultanShrineWrapperPreservingColors"] = "Passes stripped text and spans to SultanShrineWrapperTranslator.",
+            ["Mods/QudJP/Assemblies/src/Patches/EnclosingFragmentTranslator.cs:22:TryTranslatePopupMessage"] = "Delegates capture restoration to RestoreVisible.",
+            ["Mods/QudJP/Assemblies/src/Patches/FactionsLineTranslationPatch.cs:84:TranslateTextField"] = "Strips only to detect whether the already-localized field contains visible text.",
+            ["Mods/QudJP/Assemblies/src/Patches/FactionsStatusScreenTranslationPatch.cs:895:AddLocalizedSearchFragment"] = "Strips only to add searchable plain text beside the colored display text.",
+            ["Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs:877:TranslateDisplayNameModifier"] = "Strips only to classify display-name modifier text before composing a translated modifier.",
+            ["Mods/QudJP/Assemblies/src/Patches/LiquidVolumeFragmentTranslator.cs:118:TryTranslate"] = "Delegates capture restoration to helper calls in the matched branch.",
+            ["Mods/QudJP/Assemblies/src/Patches/MainMenuLocalizationPatch.cs:174:TranslateProducerText"] = "Strips only for already-localized/direct-route checks before TranslatePreservingColors owns restoration.",
+            ["Mods/QudJP/Assemblies/src/Patches/MessageLogPatch.cs:44:Prefix"] = "Observation-only direct marker check before MessagePatternTranslator owns restoration.",
+            ["Mods/QudJP/Assemblies/src/Patches/MutationsApiTranslationPatch.cs:85:TryTranslatePopupMessage"] = "Delegates capture restoration to term-specific branch helpers.",
+            ["Mods/QudJP/Assemblies/src/Patches/OptionsLocalizationPatch.cs:106:TranslateProducerText"] = "Strips only for already-localized/direct-route checks before TranslatePreservingColors owns restoration.",
+            ["Mods/QudJP/Assemblies/src/Patches/PickGameObjectScreenTranslationPatch.cs:115:TranslateProducerText"] = "Strips only for already-localized/direct-route checks before TranslatePreservingColors owns restoration.",
+            ["Mods/QudJP/Assemblies/src/Patches/PlayerStatusBarProducerTranslationHelpers.cs:84:TryTranslateFoodWaterPart"] = "Strips only to choose an exact visible-text translation before TranslatePreservingColors owns restoration.",
+            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:1081:IsAlreadyLocalizedPopupText"] = "Predicate only; it compares stripped and original text.",
+            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:245:TranslatePopupTextForRoute"] = "Strips only for direct-marker and already-localized detection before producer routes own restoration.",
+            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:291:TranslatePopupMenuItemTextForRoute"] = "Strips only for direct-marker and already-localized detection before producer routes own restoration.",
+            ["Mods/QudJP/Assemblies/src/Patches/SkillsAndPowersLineTranslationPatch.cs:229:TranslateSkillRightText"] = "Strips only for skill right-text detection before a non-colored exact replacement.",
+            ["Mods/QudJP/Assemblies/src/Patches/TradeUiPopupTranslationPatch.cs:239:TryTranslateTradeUiPopupText"] = "Delegates capture restoration to branch-specific RestoreCapture helpers.",
+            ["Mods/QudJP/Assemblies/src/Patches/UITextSkinTranslationPatch.cs:100:TranslatePreservingColors"] = "Sink fallback uses stripped text only for already-localized/direct-route checks.",
+            ["Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs:490:TryTranslateCoProcessorTemplate"] = "Delegates restoration to the template helper.",
+            ["Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs:526:TryTranslateCounterweightedTemplate"] = "Delegates restoration to the template helper.",
+            ["Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs:560:TryTranslateElementalDamageTemplate"] = "Delegates restoration to the template helper.",
+            ["Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs:593:TryTranslateTemplate"] = "Delegates restoration to the template helper.",
+            ["Mods/QudJP/Assemblies/src/Translation/ColorAwareTranslationComposer.cs:30:Strip"] = "Wrapper method exposes the Strip API; callers are checked where they consume the returned spans.",
+            ["Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs:70:Translate"] = "Passes stripped text and spans to TranslateStripped, where template application restores colors.",
+            ["Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs:79:Translate"] = "Passes stripped text and spans to TranslateStripped, where template application restores colors.",
+            ["Mods/QudJP/Assemblies/src/UI/FontManager.cs:174:TryWarmPrimaryFontCharactersForUi"] = "UI glyph warmup intentionally strips markup only to add visible characters to the font atlas.",
+        };
+
+    private static readonly SortedDictionary<string, string> NameLikeRestoreCaptureWithoutGuardAllowlist =
+        new(StringComparer.Ordinal)
+        {
+            ["Mods/QudJP/Assemblies/src/Patches/ChargenStructuredTextTranslator.cs:339:TryTranslateCyberneticsSlot:name"] =
+                "Cybernetics slot names are exact static labels, not display-name owner captures.",
+        };
+
+    private static readonly string[] DisplayNameOwnerRouteFiles =
+    {
+        "Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs",
+        "Mods/QudJP/Assemblies/src/Patches/AbilityBarButtonTextTranslationPatch.cs",
+        "Mods/QudJP/Assemblies/src/Patches/DeathWrapperFamilyTranslator.cs",
+        "Mods/QudJP/Assemblies/src/Patches/GameManagerUpdateSelectedAbilityPatch.cs",
+        "Mods/QudJP/Assemblies/src/Patches/GetDisplayNamePatch.cs",
+        "Mods/QudJP/Assemblies/src/Patches/GetDisplayNameProcessPatch.cs",
+        "Mods/QudJP/Assemblies/src/Patches/InventoryLocalizationPatch.cs",
+        "Mods/QudJP/Assemblies/src/Patches/XDidYTranslationPatch.cs",
+    };
+
+    private static readonly string[] MarkupAwareCaptureOwnerFiles =
+    {
+        "Mods/QudJP/Assemblies/src/Patches/DeathWrapperFamilyTranslator.cs",
+        "Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs",
+        "Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs",
+    };
+
     [Test]
-    [Ignore(SkipReason)]
     public void EveryStripCallSite_HasMatchingRestoreCallSite()
     {
-        // Production rule (to encode here):
-        //   for each *.cs under Mods/QudJP/Assemblies/src/ that actually calls
-        //   ColorAwareTranslationComposer.Strip / RestoreCapture (i.e. NOT limited to
-        //   src/Patches/ — translator-layer files like
-        //   Translation/MessagePatternTranslator.cs are equally subject to the rule):
-        //     each `Strip(` call site must have at least one Restore* / TranslatePreservingColors
-        //     reachable in the same control-flow path (function or method). Files where
-        //     `TranslatePreservingColors(` already encapsulates the round-trip do NOT need
-        //     an explicit sibling Restore. Exemptions live in an explicit allowlist
-        //     (path -> reason) that this test reads.
-        // Implementation hint: extend `ColorRouteCatalog.RouteSymbols` with
-        // `"ColorAwareTranslationComposer.Strip("` and `"ColorAwareTranslationComposer.RestoreCapture("`,
-        // then reuse `ColorRouteCatalogTests.ScanSymbolOccurrences` for the per-file
-        // symbol map; the pairing logic is what's new (counts alone are not the contract).
-        Assert.Pass("Scaffold; replace with per-call-site reachability scan when production lands.");
+        var actual = FindStripCallSitesWithoutLocalRestore();
+
+        Assert.That(
+            actual.Keys,
+            Is.EquivalentTo(StripWithoutLocalRestoreAllowlist.Keys),
+            "Each Strip call site must restore colors in the same local forward block or be explicitly allowlisted.\n"
+            + string.Join("\n", actual.Keys));
     }
 
-    // Catalog-2: routes that call GetDisplayNameRouteTranslator.TranslatePreservingColors
-    // from inside a wrapper translator must be in the wrapper-owner allowlist —
-    // observation-only / sink routes must NOT call it.
-    // This guards the "ownership at producer / mid-pipeline, not sink" rule from
-    // docs/RULES.md.
     [Test]
-    [Ignore(SkipReason)]
     public void DisplayNameTranslate_OnlyCalled_FromOwnerRouteAllowlist()
     {
-        // Production rule:
-        //   the set of files calling GetDisplayNameRouteTranslator.TranslatePreservingColors
-        //   must be a subset of OwnerRouteAllowlist (defined in this test file or a
-        //   shared catalog).
-        // Implementation hint: `ColorRouteCatalog.ExpectedSymbolOccurrences` already
-        // tracks per-file counts of `GetDisplayNameRouteTranslator.TranslatePreservingColors(`
-        // — the allowlist is just the keys of that map filtered by owner-vs-observation
-        // classification.
-        Assert.Pass("Scaffold; pair with ColorRouteCatalog OwnerRouteAllowlist when production lands.");
+        var actual = FindFilesContaining("GetDisplayNameRouteTranslator.TranslatePreservingColors(");
+
+        Assert.That(actual, Is.EquivalentTo(DisplayNameOwnerRouteFiles));
     }
 
-    // Catalog-3: every owner route that performs RestoreCapture on a capture group
-    // whose value can carry pre-existing markup must branch on a markup-aware guard
-    // (mirroring DeathWrapperFamilyTranslator.cs:326-328 which uses HasColorMarkup).
-    // Static check: any file that contains both "RestoreCapture(" and a name-like
-    // capture group ("killer" / "name" / "subject" / "target") must also reference
-    // an equivalent guard or markup-aware abstraction.
     [Test]
-    [Ignore(SkipReason)]
     public void RestoreCapture_OnNameLikeCapture_HasMarkupGuard()
     {
-        // Production rule (the GUARD side is intentionally an OPEN set, not a literal):
-        //   trigger: file contains `RestoreCapture(` against any name-like capture group
-        //            (current corpus uses killer / name / subject / target — extend as
-        //            new owner routes appear).
-        //   guard:   file must also contain a call into ANY symbol from
-        //            `static readonly string[] AllowedGuardSymbols` defined in this test.
-        //            Initial set: { "HasColorMarkup(", "MarkupAwareRestoreCapture(",
-        //            "IsAlreadyLocalized" }. Renames or new abstractions land as one-line
-        //            additions to that constant; the test must NOT pin to a single
-        //            literal like `HasColorMarkup\(`.
-        //   exempt:  pre-rendered sinks listed in an explicit (path -> reason) allowlist
-        //            this test reads.
-        Assert.Pass("Scaffold; replace with regex-based catalog scan when production lands.");
+        var unguarded = FindNameLikeRestoreCaptureCallSitesWithoutMarkupGuard();
+        var markupAwareOwnerFiles = FindFilesContaining("ColorAwareTranslationComposer.MarkupAwareRestoreCapture(");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                unguarded.Keys,
+                Is.EquivalentTo(NameLikeRestoreCaptureWithoutGuardAllowlist.Keys),
+                "RestoreCapture on name-like captures must use a markup-aware guard or be a documented non-display-name exception.\n"
+                + string.Join("\n", unguarded.Keys));
+            Assert.That(markupAwareOwnerFiles, Is.EquivalentTo(MarkupAwareCaptureOwnerFiles));
+        });
     }
 
-    // Catalog-4: the dictionary corpus must not contain unbalanced markup tokens.
-    // (Closely related to issue #404 but distinct: #404 was about a single XML
-    // entry; this catalog enforces the invariant repository-wide.)
     [Test]
-    [Ignore(SkipReason)]
     public void DictionaryCorpus_HasBalancedMarkupTokens()
     {
-        // Production rule:
-        //   for every translated value in Mods/QudJP/Localization/Dictionaries/*.json
-        //   the multiset of `{{`, `}}`, `&<letter>` opening/closing markers must be
-        //   token-balanced. Mirrors scripts/validate_xml.py's invariant for JSON.
-        Assert.Pass("Scaffold; defer to issue #409 if a CI gate already covers this.");
+        var failures = new List<string>();
+        foreach (var value in EnumerateDictionaryTranslatedValues())
+        {
+            var (stripped, spans) = ColorAwareTranslationComposer.Strip(value.Value);
+            var restored = ColorAwareTranslationComposer.Restore(stripped, spans);
+            if (!string.Equals(value.Value, restored, StringComparison.Ordinal))
+            {
+                failures.Add($"{value.RelativePath}:{value.ArrayName}.{value.PropertyName}[{value.Index}]");
+            }
+        }
+
+        Assert.That(failures, Is.Empty);
     }
+
+    private static SortedDictionary<string, string> FindStripCallSitesWithoutLocalRestore()
+    {
+        var result = new SortedDictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var file in GetSourceFiles())
+        {
+            var relativePath = ToRepositoryRelativePath(file);
+            var lines = File.ReadAllLines(file);
+            for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+            {
+                if (!ContainsAny(lines[lineIndex], StripRoundTripSymbols))
+                {
+                    continue;
+                }
+
+                var methodStart = FindContainingMethodStart(lines, lineIndex);
+                var methodName = methodStart < 0 ? "<unknown>" : ExtractMethodName(lines[methodStart]);
+                var localText = methodStart < 0
+                    ? lines[lineIndex]
+                    : string.Join("\n", ExtractLocalForwardBlock(lines, methodStart, lineIndex));
+
+                if (TryGetStripSpansVariable(lines[lineIndex], out var spansVariable)
+                    && ContainsRestoreUsingSpansVariable(localText, spansVariable))
+                {
+                    continue;
+                }
+
+                var key = $"{relativePath}:{lineIndex + 1}:{methodName}";
+                result[key] = lines[lineIndex].Trim();
+            }
+        }
+
+        return result;
+    }
+
+    private static SortedDictionary<string, string> FindNameLikeRestoreCaptureCallSitesWithoutMarkupGuard()
+    {
+        var result = new SortedDictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var file in GetSourceFiles())
+        {
+            var relativePath = ToRepositoryRelativePath(file);
+            var lines = File.ReadAllLines(file);
+            foreach (var invocation in EnumerateRestoreCaptureInvocations(lines))
+            {
+                var methodStart = FindContainingMethodStart(lines, invocation.StartLineIndex);
+                var methodName = methodStart < 0 ? "<unknown>" : ExtractMethodName(lines[methodStart]);
+                var methodLines = methodStart < 0
+                    ? new[] { invocation.Text }
+                    : ExtractMethodBlock(lines, methodStart);
+                var aliases = FindNameLikeGroupAliases(methodLines);
+                if (!TryGetUnsafeNameLikeRestoreCapture(invocation.Text, aliases, out var groupName))
+                {
+                    continue;
+                }
+
+                var guardText = methodStart < 0
+                    ? invocation.Text
+                    : string.Join("\n", ExtractLocalGuardBlock(lines, methodStart, invocation.StartLineIndex));
+                if (ContainsAny(guardText, NameLikeRestoreCaptureGuardSymbols))
+                {
+                    continue;
+                }
+
+                var key = $"{relativePath}:{invocation.StartLineIndex + 1}:{methodName}:{groupName}";
+                result[key] = invocation.Text.Trim();
+            }
+        }
+
+        return result;
+    }
+
+    private static string[] FindFilesContaining(string symbol)
+    {
+        var matches = new List<string>();
+
+        foreach (var file in GetSourceFiles())
+        {
+            var text = File.ReadAllText(file);
+            if (text.Contains(symbol, StringComparison.Ordinal))
+            {
+                matches.Add(ToRepositoryRelativePath(file));
+            }
+        }
+
+        return matches.ToArray();
+    }
+
+    private static IEnumerable<DictionaryValue> EnumerateDictionaryTranslatedValues()
+    {
+        var root = TestProjectPaths.GetRepositoryRoot();
+        var dictionariesRoot = Path.Combine(root, "Mods", "QudJP", "Localization", "Dictionaries");
+
+        foreach (var file in GetSortedFiles(dictionariesRoot, "*.json"))
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(file));
+            var rootElement = document.RootElement;
+            foreach (var value in EnumerateTranslatedTextArrays(rootElement, file))
+            {
+                yield return value;
+            }
+        }
+    }
+
+    private static IEnumerable<DictionaryValue> EnumerateTranslatedTextArrays(JsonElement rootElement, string file)
+    {
+        foreach (var property in rootElement.EnumerateObject())
+        {
+            if (property.Value.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var value in EnumerateStringPropertyArray(rootElement, file, property.Name, "text"))
+            {
+                yield return value;
+            }
+
+            foreach (var value in EnumerateStringPropertyArray(rootElement, file, property.Name, "template"))
+            {
+                yield return value;
+            }
+        }
+    }
+
+    private static IEnumerable<DictionaryValue> EnumerateStringPropertyArray(
+        JsonElement rootElement,
+        string file,
+        string arrayName,
+        string propertyName)
+    {
+        if (!rootElement.TryGetProperty(arrayName, out var array) || array.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        var index = 0;
+        foreach (var element in array.EnumerateArray())
+        {
+            if (element.ValueKind == JsonValueKind.Object
+                && element.TryGetProperty(propertyName, out var property)
+                && property.ValueKind == JsonValueKind.String
+                && property.GetString() is { } value)
+            {
+                yield return new DictionaryValue(ToRepositoryRelativePath(file), arrayName, propertyName, index, value);
+            }
+
+            index++;
+        }
+    }
+
+    private static int FindContainingMethodStart(string[] lines, int callLineIndex)
+    {
+        for (var index = callLineIndex; index >= 0; index--)
+        {
+            var line = lines[index].Trim();
+            if (line.Length == 0
+                || line.StartsWith("[", StringComparison.Ordinal)
+                || FileScopedNamespacePattern.IsMatch(line))
+            {
+                continue;
+            }
+
+            if (IsMethodSignature(line))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static string ExtractMethodName(string line)
+    {
+        var match = MethodSignaturePattern.Match(line);
+        return match.Success ? match.Groups["name"].Value : "<unknown>";
+    }
+
+    private static IReadOnlyList<string> ExtractMethodBlock(string[] lines, int methodStart)
+    {
+        var end = methodStart;
+        var depth = 0;
+        var sawOpeningBrace = false;
+        for (var index = methodStart; index < lines.Length; index++)
+        {
+            var line = lines[index];
+            for (var charIndex = 0; charIndex < line.Length; charIndex++)
+            {
+                if (line[charIndex] == '{')
+                {
+                    depth++;
+                    sawOpeningBrace = true;
+                }
+                else if (line[charIndex] == '}')
+                {
+                    depth--;
+                }
+            }
+
+            end = index;
+            if (sawOpeningBrace && depth <= 0)
+            {
+                break;
+            }
+        }
+
+        return lines[methodStart..(end + 1)];
+    }
+
+    private static IReadOnlyList<string> ExtractLocalForwardBlock(string[] lines, int methodStart, int callLineIndex)
+    {
+        var methodBlock = ExtractMethodBlock(lines, methodStart);
+        var methodEnd = methodStart + methodBlock.Count - 1;
+        var regionEnd = Math.Min(methodEnd, callLineIndex + 80);
+        return lines[callLineIndex..(regionEnd + 1)];
+    }
+
+    private static IReadOnlyList<string> ExtractLocalGuardBlock(string[] lines, int methodStart, int callLineIndex)
+    {
+        var methodBlock = ExtractMethodBlock(lines, methodStart);
+        var methodEnd = methodStart + methodBlock.Count - 1;
+        var regionStart = Math.Max(methodStart, callLineIndex - 80);
+        var regionEnd = Math.Min(methodEnd, callLineIndex + 80);
+        return lines[regionStart..(regionEnd + 1)];
+    }
+
+    private static bool TryGetStripSpansVariable(string line, out string spansVariable)
+    {
+        var match = StripDeconstructionPattern.Match(line);
+        if (match.Success && match.Groups["spans"].Value != "_")
+        {
+            spansVariable = match.Groups["spans"].Value;
+            return true;
+        }
+
+        spansVariable = string.Empty;
+        return false;
+    }
+
+    private static bool ContainsRestoreUsingSpansVariable(string source, string spansVariable)
+    {
+        for (var symbolIndex = 0; symbolIndex < RestoreRoundTripSymbols.Length; symbolIndex++)
+        {
+            var symbol = RestoreRoundTripSymbols[symbolIndex];
+            var searchStart = 0;
+            while (searchStart < source.Length)
+            {
+                var occurrence = source.IndexOf(symbol, searchStart, StringComparison.Ordinal);
+                if (occurrence < 0)
+                {
+                    break;
+                }
+
+                var invocation = TryExtractInvocation(source, occurrence, out var extracted)
+                    ? extracted
+                    : source[occurrence..];
+                if (ContainsIdentifier(invocation, spansVariable))
+                {
+                    return true;
+                }
+
+                searchStart = occurrence + symbol.Length;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<InvocationText> EnumerateRestoreCaptureInvocations(string[] lines)
+    {
+        for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+        {
+            var searchStart = 0;
+            while (searchStart < lines[lineIndex].Length)
+            {
+                var occurrence = lines[lineIndex].IndexOf("RestoreCapture(", searchStart, StringComparison.Ordinal);
+                if (occurrence < 0)
+                {
+                    break;
+                }
+
+                if (TryExtractInvocation(lines, lineIndex, occurrence, out var invocation))
+                {
+                    yield return invocation;
+                }
+                else
+                {
+                    yield return new InvocationText(lines[lineIndex][occurrence..], lineIndex);
+                }
+
+                searchStart = occurrence + "RestoreCapture(".Length;
+            }
+        }
+    }
+
+    private static bool TryExtractInvocation(string[] lines, int lineIndex, int invocationNameIndex, out InvocationText invocation)
+    {
+        var source = string.Join("\n", lines[lineIndex..]);
+        var start = GetInvocationTextStart(lines[lineIndex], invocationNameIndex);
+        if (!TryExtractInvocation(source, start, out var invocationText))
+        {
+            invocation = new InvocationText(string.Empty, lineIndex);
+            return false;
+        }
+
+        invocation = new InvocationText(invocationText, lineIndex);
+        return true;
+    }
+
+    private static bool TryExtractInvocation(string source, int invocationStart, out string invocationText)
+    {
+        var openParen = source.IndexOf('(', invocationStart);
+        if (openParen < 0)
+        {
+            invocationText = string.Empty;
+            return false;
+        }
+
+        var depth = 0;
+        for (var index = openParen; index < source.Length; index++)
+        {
+            if (source[index] == '(')
+            {
+                depth++;
+            }
+            else if (source[index] == ')')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    invocationText = source[invocationStart..(index + 1)];
+                    return true;
+                }
+            }
+        }
+
+        invocationText = string.Empty;
+        return false;
+    }
+
+    private static int GetInvocationTextStart(string line, int invocationNameIndex)
+    {
+        var index = invocationNameIndex;
+        while (index > 0 && IsInvocationQualifierCharacter(line[index - 1]))
+        {
+            index--;
+        }
+
+        return index;
+    }
+
+    private static bool IsInvocationQualifierCharacter(char value)
+    {
+        return value == '.' || value == '_' || char.IsAsciiLetterOrDigit(value);
+    }
+
+    private static bool ContainsIdentifier(string source, string identifier)
+    {
+        var searchStart = 0;
+        while (searchStart < source.Length)
+        {
+            var index = source.IndexOf(identifier, searchStart, StringComparison.Ordinal);
+            if (index < 0)
+            {
+                return false;
+            }
+
+            var before = index == 0 ? '\0' : source[index - 1];
+            var afterIndex = index + identifier.Length;
+            var after = afterIndex >= source.Length ? '\0' : source[afterIndex];
+            if (!IsIdentifierCharacter(before) && !IsIdentifierCharacter(after))
+            {
+                return true;
+            }
+
+            searchStart = index + identifier.Length;
+        }
+
+        return false;
+    }
+
+    private static bool IsIdentifierCharacter(char value)
+    {
+        return value == '_' || char.IsAsciiLetterOrDigit(value);
+    }
+
+    private static Dictionary<string, string> FindNameLikeGroupAliases(IReadOnlyList<string> methodLines)
+    {
+        var aliases = new Dictionary<string, string>(StringComparer.Ordinal);
+        for (var index = 0; index < methodLines.Count; index++)
+        {
+            var match = AliasAssignmentPattern.Match(methodLines[index]);
+            if (match.Success)
+            {
+                aliases[match.Groups["alias"].Value] = match.Groups["name"].Value;
+            }
+        }
+
+        return aliases;
+    }
+
+    private static bool TryGetUnsafeNameLikeRestoreCapture(
+        string line,
+        IReadOnlyDictionary<string, string> aliases,
+        out string groupName)
+    {
+        var directMatch = DirectNameLikeRestoreCapturePattern.Match(line);
+        if (directMatch.Success)
+        {
+            groupName = directMatch.Groups["name"].Value;
+            return !IsSourceCaptureRestore(directMatch.Groups["value"].Value, groupName, aliases);
+        }
+
+        var aliasMatch = AliasedNameLikeRestoreCapturePattern.Match(line);
+        if (aliasMatch.Success && aliases.TryGetValue(aliasMatch.Groups["alias"].Value, out var aliasedGroupName))
+        {
+            groupName = aliasedGroupName;
+            return !IsSourceCaptureRestore(aliasMatch.Groups["value"].Value, groupName, aliases);
+        }
+
+        var helperMatch = SourceHelperNameLikeRestoreCapturePattern.Match(line);
+        if (helperMatch.Success)
+        {
+            groupName = helperMatch.Groups["name"].Value;
+            return false;
+        }
+
+        groupName = string.Empty;
+        return false;
+    }
+
+    private static bool IsSourceCaptureRestore(string valueExpression, string groupName, IReadOnlyDictionary<string, string> aliases)
+    {
+        var normalized = valueExpression.Trim();
+        var sourceMatch = SourceCaptureValuePattern.Match(normalized);
+        if (!sourceMatch.Success)
+        {
+            return false;
+        }
+
+        if (sourceMatch.Groups["name"].Success)
+        {
+            return string.Equals(sourceMatch.Groups["name"].Value, groupName, StringComparison.Ordinal);
+        }
+
+        return aliases.TryGetValue(sourceMatch.Groups["alias"].Value, out var aliasedGroup)
+            && string.Equals(aliasedGroup, groupName, StringComparison.Ordinal);
+    }
+
+    private static bool IsMethodSignature(string line)
+    {
+        if (!MethodSignaturePattern.IsMatch(line))
+        {
+            return false;
+        }
+
+        return !line.StartsWith("if ", StringComparison.Ordinal)
+            && !line.StartsWith("for ", StringComparison.Ordinal)
+            && !line.StartsWith("foreach ", StringComparison.Ordinal)
+            && !line.StartsWith("while ", StringComparison.Ordinal)
+            && !line.StartsWith("switch ", StringComparison.Ordinal)
+            && !line.StartsWith("catch ", StringComparison.Ordinal);
+    }
+
+    private static bool ContainsAny(string source, IReadOnlyList<string> symbols)
+    {
+        for (var index = 0; index < symbols.Count; index++)
+        {
+            if (source.Contains(symbols[index], StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string ToRepositoryRelativePath(string path)
+    {
+        return Path.GetRelativePath(TestProjectPaths.GetRepositoryRoot(), path)
+            .Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    private static string[] GetSourceFiles()
+    {
+        var sourceRoot = Path.Combine(TestProjectPaths.GetRepositoryRoot(), "Mods", "QudJP", "Assemblies", "src");
+        return GetSortedFiles(sourceRoot, "*.cs");
+    }
+
+    private static string[] GetSortedFiles(string root, string searchPattern)
+    {
+        var files = Directory.GetFiles(root, searchPattern, SearchOption.AllDirectories);
+        Array.Sort(files, StringComparer.Ordinal);
+        return files;
+    }
+
+    private sealed record DictionaryValue(string RelativePath, string ArrayName, string PropertyName, int Index, string Value);
+
+    private sealed record InvocationText(string Text, int StartLineIndex);
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagStaticAnalysisTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagStaticAnalysisTests.cs
@@ -8,8 +8,8 @@ namespace QudJP.Tests.L1;
 [NonParallelizable]
 public sealed class ColorTagStaticAnalysisTests
 {
-    private const string LocalizedKillerKey = "bloody Tam, dromad merchant [sitting]";
-    private const string LocalizedKillerText = "{{r|血まみれの}}タム、ドロマド商団 [座っている]";
+    private const string ColorTaggedDisplayNameKey = "bloody Tam, dromad merchant [sitting]";
+    private const string ColorTaggedDisplayNameText = "{{r|血まみれの}}タム、ドロマド商団 [座っている]";
 
     private static readonly UTF8Encoding Utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
@@ -135,17 +135,17 @@ public sealed class ColorTagStaticAnalysisTests
     [Test]
     public void MessagePattern_CaptureRestoration_DoesNotDoubleWrapMarkupCarryingCapture()
     {
-        WritePatternDictionary(("^You were killed by (.+?)[.!]?$", "{t0}に殺された。"));
-        WriteDeathDictionaryWithLocalizedKiller();
+        WritePatternDictionary(("^You see (.+?)[.!]?$", "{t0}が見える。"));
+        WriteExactDictionary((ColorTaggedDisplayNameKey, ColorTaggedDisplayNameText));
 
         var translated = MessagePatternTranslator.Translate(
-            "You were killed by {{r|bloody}} Tam, dromad merchant [sitting].");
+            "You see {{r|bloody}} Tam, dromad merchant [sitting].");
 
         Assert.Multiple(() =>
         {
             Assert.That(
                 translated,
-                Is.EqualTo("{{r|血まみれの}}タム、ドロマド商団 [座っている]に殺された。"));
+                Is.EqualTo("{{r|血まみれの}}タム、ドロマド商団 [座っている]が見える。"));
             Assert.That(translated, Does.Not.Contain("{{r|{{r|"));
             Assert.That(translated, Does.Not.Match("\\[座ってい}}る\\]"));
         });
@@ -176,7 +176,7 @@ public sealed class ColorTagStaticAnalysisTests
 
     private void WriteDeathDictionaryWithLocalizedKiller()
     {
-        WriteExactDictionary(CommonDeathEntries().Append((LocalizedKillerKey, LocalizedKillerText)));
+        WriteExactDictionary(CommonDeathEntries().Append((ColorTaggedDisplayNameKey, ColorTaggedDisplayNameText)));
     }
 
     private void WritePatternDictionary(params (string pattern, string template)[] patterns)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagStaticAnalysisTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagStaticAnalysisTests.cs
@@ -1,163 +1,123 @@
+using System.Text;
 using QudJP.Patches;
 
 namespace QudJP.Tests.L1;
 
-// issue-376: color tag application/restoration static analysis.
-//
-// These tests pin the post-translation behavior we expect once the static-analysis-
-// driven detection layer lands. They sit in L1 (no HarmonyLib, no Assembly-CSharp.dll,
-// no UnityEngine — see docs/test-architecture.md): every translator path they touch
-// is pure C# string logic. Tests are intentionally skipped (NUnit Ignore) so CI stays
-// green; they become discoverable failures the moment a production fix is wired up
-// that flips them to passing.
-//
-// Skip pattern note:
-//   The umbrella prompt asked for `[Fact(Skip = "...")]` (xUnit). The QudJP test
-//   project is NUnit (see QudJP.Tests.csproj `<Using Include="NUnit.Framework" />`),
-//   so we use the NUnit-equivalent `[Test, Ignore("issue-376 — production code pending")]`.
-//   Behavior contract is identical: the test is discoverable but does not run.
-//
-// Each scenario below corresponds to a concrete drop pattern documented in the issue
-// body and in `docs/superpowers/plans/2026-04-27-issue-376-color-static-analysis.md`.
-// The tests are written in arrange/act/assert form with comments describing the
-// expected post-fix behavior. Implementation hooks are deliberately sketched
-// (commented out) — wiring them up is the responsibility of the future production PR.
-
-// NonParallelizable: the un-ignored production tests will mutate shared static
-// state on MessagePatternTranslator, Translator, DynamicTextObservability, and
-// SinkObservation. The scaffold itself is read-only, but flipping any Ignore
-// must not require remembering to add the attribute.
-//
-// When un-ignoring, the production PR must add a SetUp/TearDown pair modeled on
-// PopupPickOptionTranslationPatchTests — SetUp seeds the dictionary directory
-// and any pattern fixtures via the *ForTests entry points; TearDown calls the
-// matching ResetForTests on each translator surface. Without that pair, the
-// translator surfaces see uninitialized dictionary state and either throw or
-// pass through the input unchanged.
 [TestFixture]
 [Category("L1")]
 [NonParallelizable]
 public sealed class ColorTagStaticAnalysisTests
 {
-    // Common prefix `"issue-376 — production code pending"` is shared with
-    // ColorTagAllowlistCoverageTests.SkipReason so a single grep surfaces every
-    // scaffold the production PR must address.
-    private const string SkipReason = "issue-376 — production code pending; static analysis layer not yet implemented";
+    private const string LocalizedKillerKey = "bloody Tam, dromad merchant [sitting]";
+    private const string LocalizedKillerText = "{{r|血まみれの}}タム、ドロマド商団 [座っている]";
 
-    // Scenario 1: triple-nested {{r|...}} accumulation reproduced in Player.log
-    //   "{{r|{{r|{{r|血ま}}みれの}}タム、ドロマド商団 [座ってい}}る]}}"
-    // Expectation post-fix: outer wrapper restoration must NOT reapply on already-
-    // localized killer fragments that already carry markup.
+    private static readonly UTF8Encoding Utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    private string tempDirectory = null!;
+    private string dictionaryDirectory = null!;
+    private string patternFilePath = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempDirectory = Path.Combine(Path.GetTempPath(), "qudjp-color-tag-static-l1", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        dictionaryDirectory = Path.Combine(tempDirectory, "dict");
+        Directory.CreateDirectory(dictionaryDirectory);
+        patternFilePath = Path.Combine(tempDirectory, "messages.ja.json");
+
+        Translator.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(dictionaryDirectory);
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
+        MessagePatternTranslator.ResetForTests();
+        MessagePatternTranslator.SetPatternFileForTests(patternFilePath);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+
+        WritePatternDictionary();
+        WriteExactDictionary(CommonDeathEntries());
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
+        MessagePatternTranslator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+
+        if (Directory.Exists(tempDirectory))
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
     [Test]
-    [Ignore(SkipReason)]
     public void DeathPopup_DoesNotAccumulateNestedRedWrappers_OnAlreadyLocalizedKiller()
     {
-        // Arrange: source carries one outer {{r|...}} and the localized killer
-        // already injects its own {{r|血まみれの}} via dictionary lookup.
-        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
-            "You died.\n\nYou were killed by {{r|bloody Tam, dromad merchant [sitting]}}.");
+        WriteDeathDictionaryWithLocalizedKiller();
 
-        // Act
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
+            "You died.\n\nYou were killed by {{r|bloody}} Tam, dromad merchant [sitting].");
+
         var translated = DeathWrapperFamilyTranslator.TryTranslatePopup(
             stripped,
             spans,
             nameof(PopupTranslationPatch),
             out var popupTranslated);
 
-        // Assert: the killer's own injected markup must remain singly-wrapped and
-        // the outer span must not bleed into the trailing "[座っている]" bracket.
         Assert.Multiple(() =>
         {
             Assert.That(translated, Is.True);
-            // Positive: the actual death-popup translation must contain the
-            // Japanese localizations the production PR is responsible for emitting.
-            // Without these positive anchors, an English pass-through would also
-            // satisfy the negative assertions vacuously.
             Assert.That(
                 popupTranslated,
-                Does.Contain("血まみれの").And.Contain("殺された"),
-                "Expected the localized killer fragment and the death-verb in the output.");
-            Assert.That(
-                popupTranslated,
-                Does.Not.Contain("{{r|{{r|"),
-                "Detected {{r|{{r|... — wrapper double-restoration regressed.");
-            Assert.That(
-                popupTranslated,
-                Does.Not.Match("\\[座ってい}}る\\]"),
-                "Closing }} must not land mid-bracket.");
+                Is.EqualTo("あなたは死んだ。\n\n{{r|血まみれの}}タム、ドロマド商団 [座っている]に殺された。"));
+            Assert.That(popupTranslated, Does.Not.Contain("{{r|{{r|"));
+            Assert.That(popupTranslated, Does.Not.Match("\\[座ってい}}る\\]"));
         });
     }
 
-    // Scenario 2: ampersand color code {&y} eats into a Japanese bracketed token.
-    //   "&r血まみれのタム、ドロマド商団 [座ってい&yる]に殺された。"
     [Test]
-    [Ignore(SkipReason)]
     public void DeathReason_AmpersandCode_DoesNotSplitBracketedJapaneseToken()
     {
-        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
-            "&rbloody Tam, dromad merchant [sitting]&y was killed by you.");
+        WriteDeathDictionaryWithLocalizedKiller();
 
-        var translated = DeathWrapperFamilyTranslator.TryTranslateMessage(
-            stripped,
-            spans,
-            out var messageTranslated);
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(
+            "You were killed by &rbloody Tam, dromad merchant [sitting]&y.");
+
+        var translated = DeathWrapperFamilyTranslator.TryTranslateMessage(stripped, spans, out var messageTranslated);
 
         Assert.Multiple(() =>
         {
             Assert.That(translated, Is.True);
-            // Positive: the localized death-message body must be present so a
-            // pass-through (English or partial) cannot satisfy the negative below.
-            Assert.That(
-                messageTranslated,
-                Does.Contain("血まみれの").And.Contain("殺された"),
-                "Expected localized killer fragment and death verb.");
-            Assert.That(
-                messageTranslated,
-                Does.Not.Match("\\[座ってい&[a-zA-Z]る\\]"),
-                "Ampersand color code must not split bracketed Japanese token.");
+            Assert.That(messageTranslated, Does.Contain("血まみれの").And.Contain("殺された"));
+            Assert.That(messageTranslated, Does.Not.Match("\\[座ってい&[a-zA-Z]る\\]"));
         });
     }
 
-    // Scenario 3: capture-group RestoreCapture must not insert close tags into
-    // already-translated display name internals (issue body "double restoration").
     [Test]
-    [Ignore(SkipReason)]
     public void RestoreCapture_DoesNotInjectCloseTagInsideTranslatedDisplayName()
     {
-        // Source has a {{C|...whole...}} wrapper around an English display name.
+        WriteDeathDictionaryWithLocalizedKiller();
+
         var (stripped, spans) = ColorAwareTranslationComposer.Strip(
             "You were killed by {{C|bloody Tam, dromad merchant [sitting]}}.");
 
-        var translated = DeathWrapperFamilyTranslator.TryTranslateMessage(
-            stripped,
-            spans,
-            out var messageTranslated);
+        var translated = DeathWrapperFamilyTranslator.TryTranslateMessage(stripped, spans, out var messageTranslated);
 
         Assert.Multiple(() =>
         {
             Assert.That(translated, Is.True);
-            // Positive: the localized killer phrase must be present so a pass-through
-            // can't satisfy the negative regex vacuously.
             Assert.That(
                 messageTranslated,
-                Does.Contain("血まみれの").And.Contain("殺された"),
-                "Expected localized killer phrase and death verb.");
-            // No stray "}}" inside the Japanese display name body. The right-hand
-            // anchor is the localized display name `タム`, NOT the source-side `Tam` —
-            // pinning to English here would make the assertion vacuously true on a
-            // pass-through.
-            Assert.That(
-                messageTranslated,
-                Does.Not.Match("血まみれの.*}}.*タム"),
-                "RestoreCapture inserted close tag into translated display-name body.");
+                Is.EqualTo("{{C|{{r|血まみれの}}タム、ドロマド商団 [座っている]}}に殺された。"));
+            Assert.That(messageTranslated, Does.Not.Contain("{{C|{{C|"));
+            Assert.That(messageTranslated, Does.Not.Match("\\[座ってい}}る\\]"));
         });
     }
 
-    // Scenario 4: pre-rendered string passed through the translator twice.
-    // When a sink receives an already-translated and already-color-restored string,
-    // the second pass must be a no-op (idempotency contract).
     [Test]
-    [Ignore(SkipReason)]
     public void Translator_IsIdempotent_OnAlreadyLocalizedColoredDisplayName()
     {
         const string preLocalized = "{{r|血まみれの}}タム、ドロマド商人 [座っている]";
@@ -167,61 +127,117 @@ public sealed class ColorTagStaticAnalysisTests
 
         Assert.Multiple(() =>
         {
-            // Positive: the first pass must keep the Japanese form intact (no
-            // English fragments leaking back in) — otherwise idempotency could
-            // hold on a damaged-but-stable string.
-            Assert.That(
-                first,
-                Does.Contain("血まみれの").And.Contain("タム").And.Contain("座っている"),
-                "Localized fragments must survive the first pass unchanged.");
-            Assert.That(
-                second,
-                Is.EqualTo(first),
-                "Second pass through TranslatePreservingColors must be identity on already-localized text.");
+            Assert.That(first, Is.EqualTo(preLocalized));
+            Assert.That(second, Is.EqualTo(first));
         });
     }
 
-    // Scenario 5: MessagePatternTranslator capture restoration must not duplicate
-    // wrapper spans when the captured group already carries its own markup.
-    // Mirrors the DeathWrapperFamilyTranslator HasColorMarkup branch but at the
-    // generic message-pattern layer (decompiled-source families using {0}/{1}).
     [Test]
-    [Ignore(SkipReason)]
     public void MessagePattern_CaptureRestoration_DoesNotDoubleWrapMarkupCarryingCapture()
     {
-        // Production PR prerequisites (replace this body — model on
-        // `PopupPickOptionTranslationPatchTests` SetUp/TearDown):
-        //   1. Use `MessagePatternTranslator.SetPatternFileForTests(path)` to load a fixture
-        //      pattern whose template wraps a capture (e.g. `{{r|{0}}}`).
-        //   2. Pick a `source` whose Strip+pattern-match path actually fires that template,
-        //      and whose capture value already carries its own `{{r|...}}` markup.
-        //   3. Translate; assert exact output equals the markup-aware expectation, AND
-        //      `Does.Not.Contain("{{r|{{r|")`. The exact-output assertion catches the case
-        //      where the translator silently passes through and the negative assertion
-        //      becomes vacuously true.
-        // Reset state in `[TearDown]` via `MessagePatternTranslator.ResetForTests()`,
-        // `Translator.ResetForTests()`, `DynamicTextObservability.ResetForTests()`,
-        // `SinkObservation.ResetForTests()`.
-        Assert.Pass("Scaffold; production PR replaces with pattern-fixture-driven exact-output test.");
+        WritePatternDictionary(("^You were killed by (.+?)[.!]?$", "{t0}に殺された。"));
+        WriteDeathDictionaryWithLocalizedKiller();
+
+        var translated = MessagePatternTranslator.Translate(
+            "You were killed by {{r|bloody}} Tam, dromad merchant [sitting].");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                translated,
+                Is.EqualTo("{{r|血まみれの}}タム、ドロマド商団 [座っている]に殺された。"));
+            Assert.That(translated, Does.Not.Contain("{{r|{{r|"));
+            Assert.That(translated, Does.Not.Match("\\[座ってい}}る\\]"));
+        });
     }
 
-    // Scenario 6: sentence-specific owner route (DescriptionTextTranslator) must
-    // not splice color tags across sentence boundaries during balanced-capture.
     [Test]
-    [Ignore(SkipReason)]
     public void DescriptionText_BalancedCapture_DoesNotSpliceColorAcrossSentences()
     {
-        // Production PR prerequisites (replace this body):
-        //   1. Pick an input that actually engages a `DescriptionTextTranslator`
-        //      regex route (FactionDispositionPattern / LabeledListPattern /
-        //      VillageDispositionTargetPattern), e.g. multiline
-        //      `"{{W|Hated by the bandits for stealing.}}\nIt is dangerous."`
-        //      and inject a matching dictionary entry via the test scope.
-        //   2. Call `TranslateLongDescription`; assert exact output equals the
-        //      translated-with-confined-wrapper expectation (e.g. line 1 fully
-        //      Japanese-translated and re-wrapped, line 2 left alone) AND that
-        //      no `{{W|` survives onto line 2.
-        //   3. Reset dictionary scope in `[TearDown]`.
-        Assert.Pass("Scaffold; production PR replaces with regex-fixture-driven exact-output test.");
+        WriteExactDictionary(("stealing", "盗み"));
+
+        var translated = DescriptionTextTranslator.TranslateLongDescription(
+            "{{W|Hated by the bandits for stealing.}}\nIt is dangerous.",
+            nameof(DescriptionLongDescriptionPatch));
+
+        Assert.That(
+            translated,
+            Is.EqualTo("{{W|the banditsに憎まれている。理由: 盗み。}}\nIt is dangerous."));
+    }
+
+    private static IEnumerable<(string key, string text)> CommonDeathEntries()
+    {
+        return
+        [
+            ("QudJP.DeathWrapper.Generic.Wrapped", "あなたは死んだ。\n\n{body}"),
+            ("QudJP.DeathWrapper.KilledBy.Bare", "{killer}に殺された。"),
+        ];
+    }
+
+    private void WriteDeathDictionaryWithLocalizedKiller()
+    {
+        WriteExactDictionary(CommonDeathEntries().Append((LocalizedKillerKey, LocalizedKillerText)));
+    }
+
+    private void WritePatternDictionary(params (string pattern, string template)[] patterns)
+    {
+        var builder = new StringBuilder();
+        builder.Append("{\"patterns\":[");
+        for (var index = 0; index < patterns.Length; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append("{\"pattern\":\"");
+            builder.Append(EscapeJson(patterns[index].pattern));
+            builder.Append("\",\"template\":\"");
+            builder.Append(EscapeJson(patterns[index].template));
+            builder.Append("\"}");
+        }
+
+        builder.AppendLine("]}");
+        File.WriteAllText(patternFilePath, builder.ToString(), Utf8WithoutBom);
+        MessagePatternTranslator.SetPatternFileForTests(patternFilePath);
+    }
+
+    private void WriteExactDictionary(IEnumerable<(string key, string text)> entries)
+    {
+        var builder = new StringBuilder();
+        builder.Append("{\"entries\":[");
+        var first = true;
+        foreach (var (key, text) in entries)
+        {
+            if (!first)
+            {
+                builder.Append(',');
+            }
+
+            first = false;
+            builder.Append("{\"key\":\"");
+            builder.Append(EscapeJson(key));
+            builder.Append("\",\"text\":\"");
+            builder.Append(EscapeJson(text));
+            builder.Append("\"}");
+        }
+
+        builder.AppendLine("]}");
+        File.WriteAllText(Path.Combine(dictionaryDirectory, "color-static-l1.ja.json"), builder.ToString(), Utf8WithoutBom);
+    }
+
+    private void WriteExactDictionary(params (string key, string text)[] entries)
+    {
+        WriteExactDictionary((IEnumerable<(string key, string text)>)entries);
+    }
+
+    private static string EscapeJson(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\t", "\\t", StringComparison.Ordinal);
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagStaticAnalysisTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagStaticAnalysisTests.cs
@@ -120,14 +120,12 @@ public sealed class ColorTagStaticAnalysisTests
     [Test]
     public void Translator_IsIdempotent_OnAlreadyLocalizedColoredDisplayName()
     {
-        const string preLocalized = "{{r|血まみれの}}タム、ドロマド商人 [座っている]";
-
-        var first = ColorAwareTranslationComposer.TranslatePreservingColors(preLocalized);
+        var first = ColorAwareTranslationComposer.TranslatePreservingColors(ColorTaggedDisplayNameText);
         var second = ColorAwareTranslationComposer.TranslatePreservingColors(first);
 
         Assert.Multiple(() =>
         {
-            Assert.That(first, Is.EqualTo(preLocalized));
+            Assert.That(first, Is.EqualTo(ColorTaggedDisplayNameText));
             Assert.That(second, Is.EqualTo(first));
         });
     }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagStaticAnalysisTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagStaticAnalysisTests.cs
@@ -91,7 +91,9 @@ public sealed class ColorTagStaticAnalysisTests
         Assert.Multiple(() =>
         {
             Assert.That(translated, Is.True);
-            Assert.That(messageTranslated, Does.Contain("血まみれの").And.Contain("殺された"));
+            Assert.That(
+                messageTranslated,
+                Is.EqualTo("&r{{r|血まみれの}}タム、ドロマド商団 [座っている]&yに殺された。"));
             Assert.That(messageTranslated, Does.Not.Match("\\[座ってい&[a-zA-Z]る\\]"));
         });
     }


### PR DESCRIPTION
## Summary

- Replace the remaining skipped #376 color-tag scaffolds with executable L1 regression tests.
- Add deterministic static gates for color-preserving route invariants, including strip/restore pairing, name-like capture restore safety, display-name route coverage, and dictionary markup balance.
- Reduce #376 non-GUI work to runtime final-smoke evidence pending.

## Validation

- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~ColorTag"`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1`
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- `git diff --check`

## Review Cycle

- Initial codex-review found static gate false negatives around unsafe `RestoreCapture`, strip/restore pairing, and dictionary tier arrays.
- Follow-up review found multiline invocation and unrelated restore-window gaps.
- Fixes added full invocation scanning, same-spans strip/restore checks, tier-array dictionary scanning, and narrow explicit allowlists.
- Post-simplify and final P3 review were approved.

Refs #376


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * カラータグとローカライゼーション関連のテストを無視状態から実行状態へ移行し、カバレッジを強化しました。
  * ストリップ／復元の呼び出し整合性、表示名翻訳の呼び出し元制約、名前様キャプチャのマークアップ保護を検証する追加検査を導入。
  * ローカライズ辞書の翻訳文字列が復元で元に戻ることをバイト単位で検証。
  * 各テストで隔離された一時環境と生成済みフィクスチャを使用して等価性と回帰防止を確立しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
