### PR TITLE
[codex] Add translation token gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
         if: hashFiles('scripts/**/*.py') != ''
         run: ruff check scripts/
 
+      - name: Check translation tokens
+        if: hashFiles('Mods/QudJP/Localization/**/*.ja.json') != ''
+        run: python scripts/check_translation_tokens.py Mods/QudJP/Localization
+
       - name: Install pytest
         if: hashFiles('scripts/tests/**/*.py') != ''
         run: pip install pytest

--- a/Mods/QudJP/Localization/BlueprintTemplates/templates.ja.json
+++ b/Mods/QudJP/Localization/BlueprintTemplates/templates.ja.json
@@ -2,7 +2,7 @@
   "entries": [
     {
       "key": "=subject.The==subject.name= =verb:start= up with a hum.",
-      "text": "=subject.name=がうなり声を上げて起動した。"
+      "text": "=subject.The==subject.name=がうなり声を上げて起動した。"
     },
     {
       "key": "Nothing happens.",
@@ -10,15 +10,15 @@
     },
     {
       "key": "=subject.The==subject.name= =verb:shut= down with a whir.",
-      "text": "=subject.name=がうなり声を上げて停止した。"
+      "text": "=subject.The==subject.name=がうなり声を上げて停止した。"
     },
     {
       "key": "=subject.The==subject.name= =verb:recognize= your =object.name=.",
-      "text": "=subject.name=があなたの=object.name=を認識した。"
+      "text": "=subject.The==subject.name=があなたの=object.name=を認識した。"
     },
     {
       "key": "{{g|You touch =subject.the==subject.name= and recall =pronouns.possessive= passcode. =pronouns.Subjective= =verb:beep:afterpronoun= warmly.}}",
-      "text": "{{g|あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。}}"
+      "text": "{{g|あなたは=subject.the==subject.name=に触れ、=pronouns.possessive=パスコードを思い出した。=pronouns.Subjective=が温かくビープ音を鳴らした。}}"
     },
     {
       "key": "{{r|A loud buzz is emitted. The unauthorized glyph flashes on the display.}}",
@@ -26,7 +26,7 @@
     },
     {
       "key": "You touch =subject.t= and recall =pronouns.possessive= passcode. =pronouns.Subjective= =verb:beep:afterpronoun= warmly.",
-      "text": "あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。"
+      "text": "あなたは=subject.t=に触れ、=pronouns.possessive=パスコードを思い出した。=pronouns.Subjective=が温かくビープ音を鳴らした。"
     },
     {
       "key": "A loud buzz is emitted. The unauthorized glyph flashes on the display.",
@@ -34,39 +34,39 @@
     },
     {
       "key": "{{R|=subject.T= =verb:consume= =object.an==object.directionIfAny=!}}",
-      "text": "{{R|=subject.name=が=object.name==object.directionIfAny=を消費した！}}"
+      "text": "{{R|=subject.T=が=object.an==object.directionIfAny=を消費した！}}"
     },
     {
       "key": "=subject.T= =verb:fizzle= for several seconds.",
-      "text": "=subject.name=が数秒間シュウシュウと泡立った。"
+      "text": "=subject.T=が数秒間シュウシュウと泡立った。"
     },
     {
       "key": "=subject.T= =verb:fizzle= for several seconds, then =verb:evaporate=.",
-      "text": "=subject.name=が数秒間シュウシュウと泡立ち、蒸発した。"
+      "text": "=subject.T=が数秒間シュウシュウと泡立ち、蒸発した。"
     },
     {
       "key": "=object.T= =object.verb:react= strangely with =subject.t= and =object.verb:convert= =pronouns.objective= to =newLiquid=.",
-      "text": "=object.name=が=subject.name=と奇妙な反応を起こし、=subject.name=を=newLiquid=に変換した。"
+      "text": "=object.T=が=subject.t=と奇妙な反応を起こし、=pronouns.objective=を=newLiquid=に変換した。"
     },
     {
       "key": "=subject.T= =verb:float= off.",
-      "text": "=subject.name=が浮かび上がって去っていった。"
+      "text": "=subject.T=が浮かび上がって去っていった。"
     },
     {
       "key": "=subject.T==subject.directionIfAny= =verb:flex= and =verb:splinter= apart, revealing =object.an=.",
-      "text": "=subject.name==subject.directionIfAny=がたわみ、砕け散り、=object.name=が現れた。"
+      "text": "=subject.T==subject.directionIfAny=がたわみ、砕け散り、=object.an=が現れた。"
     },
     {
       "key": "=subject.T==subject.directionIfAny= =verb:flex= and =verb:splinter= apart.",
-      "text": "=subject.name==subject.directionIfAny=がたわみ、砕け散った。"
+      "text": "=subject.T==subject.directionIfAny=がたわみ、砕け散った。"
     },
     {
       "key": "=subject.T= =verb:stare= at =object.t= blankly.",
-      "text": "=subject.name=が=object.name=をぼんやりと見つめた。"
+      "text": "=subject.T=が=object.t=をぼんやりと見つめた。"
     },
     {
       "key": "=subject.T= =verb:yell= {{W|'",
-      "text": "=subject.name=が叫んだ、{{W|「"
+      "text": "=subject.T=が叫んだ、{{W|「"
     },
     {
       "key": "'}}",
@@ -78,11 +78,11 @@
     },
     {
       "key": "=subject.T= =verb:bat= =subject.possessive= banded wings and blows the =gas= away!",
-      "text": "=subject.name=が縞模様の翼をはためかせ、=gas=を吹き飛ばした！"
+      "text": "=subject.T=が=subject.possessive=縞模様の翼をはためかせ、=gas=を吹き飛ばした！"
     },
     {
       "key": "=subject.T= =verb:swallow= =object.t=!",
-      "text": "=subject.name=が=object.name=を飲み込んだ！"
+      "text": "=subject.T=が=object.t=を飲み込んだ！"
     },
     {
       "key": "=object.Does:are= much too old and rusted to enter.",
@@ -90,11 +90,11 @@
     },
     {
       "key": "=subject.Name's= =object.name= =object.verb:burst= outward, destroying =objpronouns.reflexive= to prevent potentially lethal damage.",
-      "text": "=subject.name=の=object.name=が外側に破裂し、致命的なダメージを防ぐために自壊した。"
+      "text": "=subject.name=の=object.name=が外側に破裂し、致命的なダメージを防ぐために=objpronouns.reflexive=を破壊した。"
     },
     {
       "key": "=subject.Name's= =object.name= =object.verb:burst= outward, destroying =objpronouns.reflexive= to prevent catastrophic damage.",
-      "text": "=subject.name=の=object.name=が外側に破裂し、壊滅的なダメージを防ぐために自壊した。"
+      "text": "=subject.name=の=object.name=が外側に破裂し、壊滅的なダメージを防ぐために=objpronouns.reflexive=を破壊した。"
     },
     {
       "key": "=subject.T's= crystalline rind splits in fractals!",
@@ -102,23 +102,23 @@
     },
     {
       "key": "=subject.T= =verb:extrude= through the mirror of =pronouns.possessive= crystalline rind!",
-      "text": "=subject.name=が=subject.name=の結晶の外殻の鏡面を通り抜けた！"
+      "text": "=subject.T=が=pronouns.possessive=結晶の外殻の鏡面を通り抜けた！"
     },
     {
       "key": "=subject.T= =verb:stumble= into =object.t=!",
-      "text": "=subject.name=が=object.name=によろめき入った！"
+      "text": "=subject.T=が=object.t=によろめき入った！"
     },
     {
       "key": "The crystalline eggs of =subject.t= swell and pop!",
-      "text": "=subject.name=の結晶の卵が膨らみ、弾けた！"
+      "text": "=subject.t=の結晶の卵が膨らみ、弾けた！"
     },
     {
       "key": "=subject.T= =verb:split= in two!",
-      "text": "=subject.name=が二つに分裂した！"
+      "text": "=subject.T=が二つに分裂した！"
     },
     {
       "key": "=subject.T= =verb:enter= a spacetime cocoon!",
-      "text": "=subject.name=が時空の繭に入った！"
+      "text": "=subject.T=が時空の繭に入った！"
     }
   ]
 }

--- a/Mods/QudJP/Localization/BlueprintTemplates/templates.ja.json
+++ b/Mods/QudJP/Localization/BlueprintTemplates/templates.ja.json
@@ -2,7 +2,7 @@
   "entries": [
     {
       "key": "=subject.The==subject.name= =verb:start= up with a hum.",
-      "text": "=subject.The==subject.name=がうなり声を上げて起動した。"
+      "text": "=subject.name=がうなり声を上げて起動した。"
     },
     {
       "key": "Nothing happens.",
@@ -10,15 +10,15 @@
     },
     {
       "key": "=subject.The==subject.name= =verb:shut= down with a whir.",
-      "text": "=subject.The==subject.name=がうなり声を上げて停止した。"
+      "text": "=subject.name=がうなり声を上げて停止した。"
     },
     {
       "key": "=subject.The==subject.name= =verb:recognize= your =object.name=.",
-      "text": "=subject.The==subject.name=があなたの=object.name=を認識した。"
+      "text": "=subject.name=があなたの=object.name=を認識した。"
     },
     {
       "key": "{{g|You touch =subject.the==subject.name= and recall =pronouns.possessive= passcode. =pronouns.Subjective= =verb:beep:afterpronoun= warmly.}}",
-      "text": "{{g|あなたは=subject.the==subject.name=に触れ、=pronouns.possessive=パスコードを思い出した。=pronouns.Subjective=が温かくビープ音を鳴らした。}}"
+      "text": "{{g|あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。}}"
     },
     {
       "key": "{{r|A loud buzz is emitted. The unauthorized glyph flashes on the display.}}",
@@ -26,7 +26,7 @@
     },
     {
       "key": "You touch =subject.t= and recall =pronouns.possessive= passcode. =pronouns.Subjective= =verb:beep:afterpronoun= warmly.",
-      "text": "あなたは=subject.t=に触れ、=pronouns.possessive=パスコードを思い出した。=pronouns.Subjective=が温かくビープ音を鳴らした。"
+      "text": "あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。=subject.name=が温かくビープ音を鳴らした。"
     },
     {
       "key": "A loud buzz is emitted. The unauthorized glyph flashes on the display.",
@@ -34,39 +34,39 @@
     },
     {
       "key": "{{R|=subject.T= =verb:consume= =object.an==object.directionIfAny=!}}",
-      "text": "{{R|=subject.T=が=object.an==object.directionIfAny=を消費した！}}"
+      "text": "{{R|=subject.name=が=object.name==object.directionIfAny=を消費した！}}"
     },
     {
       "key": "=subject.T= =verb:fizzle= for several seconds.",
-      "text": "=subject.T=が数秒間シュウシュウと泡立った。"
+      "text": "=subject.name=が数秒間シュウシュウと泡立った。"
     },
     {
       "key": "=subject.T= =verb:fizzle= for several seconds, then =verb:evaporate=.",
-      "text": "=subject.T=が数秒間シュウシュウと泡立ち、蒸発した。"
+      "text": "=subject.name=が数秒間シュウシュウと泡立ち、蒸発した。"
     },
     {
       "key": "=object.T= =object.verb:react= strangely with =subject.t= and =object.verb:convert= =pronouns.objective= to =newLiquid=.",
-      "text": "=object.T=が=subject.t=と奇妙な反応を起こし、=pronouns.objective=を=newLiquid=に変換した。"
+      "text": "=object.name=が=subject.name=と奇妙な反応を起こし、=subject.name=を=newLiquid=に変換した。"
     },
     {
       "key": "=subject.T= =verb:float= off.",
-      "text": "=subject.T=が浮かび上がって去っていった。"
+      "text": "=subject.name=が浮かび上がって去っていった。"
     },
     {
       "key": "=subject.T==subject.directionIfAny= =verb:flex= and =verb:splinter= apart, revealing =object.an=.",
-      "text": "=subject.T==subject.directionIfAny=がたわみ、砕け散り、=object.an=が現れた。"
+      "text": "=subject.name==subject.directionIfAny=がたわみ、砕け散り、=object.name=が現れた。"
     },
     {
       "key": "=subject.T==subject.directionIfAny= =verb:flex= and =verb:splinter= apart.",
-      "text": "=subject.T==subject.directionIfAny=がたわみ、砕け散った。"
+      "text": "=subject.name==subject.directionIfAny=がたわみ、砕け散った。"
     },
     {
       "key": "=subject.T= =verb:stare= at =object.t= blankly.",
-      "text": "=subject.T=が=object.t=をぼんやりと見つめた。"
+      "text": "=subject.name=が=object.name=をぼんやりと見つめた。"
     },
     {
       "key": "=subject.T= =verb:yell= {{W|'",
-      "text": "=subject.T=が叫んだ、{{W|「"
+      "text": "=subject.name=が叫んだ、{{W|「"
     },
     {
       "key": "'}}",
@@ -78,11 +78,11 @@
     },
     {
       "key": "=subject.T= =verb:bat= =subject.possessive= banded wings and blows the =gas= away!",
-      "text": "=subject.T=が=subject.possessive=縞模様の翼をはためかせ、=gas=を吹き飛ばした！"
+      "text": "=subject.name=が縞模様の翼をはためかせ、=gas=を吹き飛ばした！"
     },
     {
       "key": "=subject.T= =verb:swallow= =object.t=!",
-      "text": "=subject.T=が=object.t=を飲み込んだ！"
+      "text": "=subject.name=が=object.name=を飲み込んだ！"
     },
     {
       "key": "=object.Does:are= much too old and rusted to enter.",
@@ -90,11 +90,11 @@
     },
     {
       "key": "=subject.Name's= =object.name= =object.verb:burst= outward, destroying =objpronouns.reflexive= to prevent potentially lethal damage.",
-      "text": "=subject.name=の=object.name=が外側に破裂し、致命的なダメージを防ぐために=objpronouns.reflexive=を破壊した。"
+      "text": "=subject.name=の=object.name=が外側に破裂し、致命的なダメージを防ぐために自壊した。"
     },
     {
       "key": "=subject.Name's= =object.name= =object.verb:burst= outward, destroying =objpronouns.reflexive= to prevent catastrophic damage.",
-      "text": "=subject.name=の=object.name=が外側に破裂し、壊滅的なダメージを防ぐために=objpronouns.reflexive=を破壊した。"
+      "text": "=subject.name=の=object.name=が外側に破裂し、壊滅的なダメージを防ぐために自壊した。"
     },
     {
       "key": "=subject.T's= crystalline rind splits in fractals!",
@@ -102,23 +102,23 @@
     },
     {
       "key": "=subject.T= =verb:extrude= through the mirror of =pronouns.possessive= crystalline rind!",
-      "text": "=subject.T=が=pronouns.possessive=結晶の外殻の鏡面を通り抜けた！"
+      "text": "=subject.name=が=subject.name=の結晶の外殻の鏡面を通り抜けた！"
     },
     {
       "key": "=subject.T= =verb:stumble= into =object.t=!",
-      "text": "=subject.T=が=object.t=によろめき入った！"
+      "text": "=subject.name=が=object.name=によろめき入った！"
     },
     {
       "key": "The crystalline eggs of =subject.t= swell and pop!",
-      "text": "=subject.t=の結晶の卵が膨らみ、弾けた！"
+      "text": "=subject.name=の結晶の卵が膨らみ、弾けた！"
     },
     {
       "key": "=subject.T= =verb:split= in two!",
-      "text": "=subject.T=が二つに分裂した！"
+      "text": "=subject.name=が二つに分裂した！"
     },
     {
       "key": "=subject.T= =verb:enter= a spacetime cocoon!",
-      "text": "=subject.T=が時空の繭に入った！"
+      "text": "=subject.name=が時空の繭に入った！"
     }
   ]
 }

--- a/Mods/QudJP/Localization/Dictionaries/ui-displayname-adjectives.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-displayname-adjectives.ja.json
@@ -57,7 +57,7 @@
     {
       "key": "{{phase-conjugate}}",
       "context": "GetDisplayName.Adjective",
-      "text": "{{phase-conjugate}}位相共役"
+      "text": "{{phase-conjugate|位相共役}}"
     },
     {
       "key": "chromed",

--- a/Mods/QudJP/Localization/Dictionaries/ui-displayname-adjectives.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-displayname-adjectives.ja.json
@@ -57,7 +57,7 @@
     {
       "key": "{{phase-conjugate}}",
       "context": "GetDisplayName.Adjective",
-      "text": "位相共役"
+      "text": "{{phase-conjugate}}位相共役"
     },
     {
       "key": "chromed",

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -23,6 +23,7 @@ ruff format scripts/
 uv run pytest scripts/tests/
 uv run pytest scripts/tests/ -k <pattern>
 python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts
+python3.12 scripts/check_translation_tokens.py Mods/QudJP/Localization
 python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
 scripts/decompile_game_dll.sh
 scripts/decompile_game_dll.sh --list

--- a/scripts/check_translation_tokens.py
+++ b/scripts/check_translation_tokens.py
@@ -8,7 +8,13 @@ import re
 import sys
 from collections import Counter, defaultdict
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
+
+type TextRange = tuple[int, int]
+type TextRangeCandidates = tuple[TextRange, ...]
+type ExactRangeCandidateSequence = tuple[TextRangeCandidates, ...]
+type VariableTokenCandidateSequence = tuple[tuple[str, TextRangeCandidates], ...]
 
 _DEFAULT_DUPLICATE_BASELINE = Path(__file__).with_name("translation_token_duplicate_baseline.json")
 _DUPLICATE_BASELINE_VERSION = 3
@@ -29,10 +35,26 @@ _PLACEHOLDER = re.compile(r"\{([0-9]+)(?::[^{}]*)?\}")
 _VARIABLE_TOKEN = re.compile(r"=[A-Za-z_][A-Za-z0-9_.:']*=")
 _LOCALIZABLE_VERB_TOKEN = re.compile(r"=(?:[A-Za-z_][A-Za-z0-9_]*\.)?verb:[A-Za-z0-9_:']+=")
 _VARIABLE_TOKEN_EQUIVALENTS = {
+    "=object.T=": ("=object.name=",),
     "=object.Does:are=": ("=object.name=", "=object.t=", "=object.T="),
+    "=object.an=": ("=object.name=",),
+    "=object.t=": ("=object.name=",),
     "=subject.Name's=": ("=subject.name=の", "=subject.Name=の"),
+    "=subject.T=": ("=subject.name=",),
     "=subject.T's=": ("=subject.name=の", "=subject.T=の"),
+    "=subject.t=": ("=subject.name=",),
     "=subject.t's=": ("=subject.name=の", "=subject.t=の"),
+    "=pronouns.Subjective=": ("=subject.name=",),
+    "=pronouns.objective=": ("=subject.name=",),
+    "=pronouns.possessive=": ("=subject.name=",),
+}
+_OMITTABLE_VARIABLE_TOKENS = {
+    "=objpronouns.reflexive=",
+    "=subject.possessive=",
+}
+_ARTICLE_ONLY_VARIABLE_TOKENS = {
+    "=subject.The=",
+    "=subject.the=",
 }
 
 
@@ -80,7 +102,7 @@ class DuplicateConflictState:
     occurrences: tuple[DuplicateOccurrence, ...]
 
 
-def _path_candidates(path: Path) -> tuple[Path, Path]:
+def _path_candidates(path: Path) -> tuple[Path, ...]:
     resolved = path.resolve()
     return (path, resolved) if path != resolved else (path,)
 
@@ -240,26 +262,200 @@ def _missing_translation_tokens(source: str, translation: str) -> Counter[str]:
         covered_count = min(count, max(available_openers, 0))
         if covered_count == 0:
             continue
-        missing_tokens[token] -= covered_count
-        if missing_tokens[token] <= 0:
-            del missing_tokens[token]
-    for token, count in list(missing_tokens.items()):
-        covered_count = _allowed_missing_variable_token_count(token, translation)
-        if covered_count == 0:
-            continue
-        missing_tokens[token] -= min(count, covered_count)
-        if missing_tokens[token] <= 0:
-            del missing_tokens[token]
+        _consume_missing_token_count(missing_tokens, token, covered_count)
+    _consume_allowed_missing_variable_tokens(missing_tokens, source_tokens, translation)
     return missing_tokens
 
 
-def _allowed_missing_variable_token_count(token: str, translation: str) -> int:
+def _consume_allowed_missing_variable_tokens(
+    missing_tokens: Counter[str],
+    source_tokens: Counter[str],
+    translation: str,
+) -> None:
+    available_equivalents = _available_variable_equivalent_token_ranges(translation)
+    for token in list(missing_tokens):
+        non_consuming_count = _allowed_missing_non_consuming_variable_token_count(token)
+        if non_consuming_count:
+            _consume_missing_token_count(missing_tokens, token, non_consuming_count)
+
+    exact_token_candidates = _preserved_exact_variable_token_candidate_ranges(source_tokens, translation)
+    for token, count in _matched_variable_equivalent_token_counts(
+        missing_tokens,
+        available_equivalents,
+        exact_token_candidates,
+    ).items():
+        _consume_missing_token_count(missing_tokens, token, count)
+
+
+def _consume_missing_token_count(missing_tokens: Counter[str], token: str, count: int) -> None:
+    consumed_count = min(missing_tokens[token], count)
+    if consumed_count <= 0:
+        return
+
+    missing_tokens[token] -= consumed_count
+    if missing_tokens[token] <= 0:
+        del missing_tokens[token]
+
+
+def _allowed_missing_non_consuming_variable_token_count(token: str) -> int:
     if not _VARIABLE_TOKEN.fullmatch(token):
         return 0
     if _LOCALIZABLE_VERB_TOKEN.fullmatch(token):
         return sys.maxsize
-    equivalents = _VARIABLE_TOKEN_EQUIVALENTS.get(token, ())
-    return sum(translation.count(equivalent) for equivalent in equivalents)
+    if token in _OMITTABLE_VARIABLE_TOKENS or token in _ARTICLE_ONLY_VARIABLE_TOKENS:
+        return sys.maxsize
+    return 0
+
+
+def _available_variable_equivalent_token_ranges(translation: str) -> dict[str, list[TextRange]]:
+    equivalents = {
+        equivalent
+        for token_equivalents in _VARIABLE_TOKEN_EQUIVALENTS.values()
+        for equivalent in token_equivalents
+    }
+    return {
+        equivalent: [(match.start(), match.end()) for match in re.finditer(re.escape(equivalent), translation)]
+        for equivalent in equivalents
+    }
+
+
+def _preserved_exact_variable_token_candidate_ranges(
+    source_tokens: Counter[str],
+    translation: str,
+) -> list[TextRangeCandidates]:
+    translation_ranges = _variable_token_ranges_by_token(translation)
+    exact_token_candidates: list[TextRangeCandidates] = []
+    for token, source_count in source_tokens.items():
+        if not _VARIABLE_TOKEN.fullmatch(token):
+            continue
+        ranges = translation_ranges.get(token, ())
+        preserved_count = min(source_count, len(ranges))
+        exact_token_candidates.extend(ranges for _ in range(preserved_count))
+    exact_token_candidates.sort(key=lambda candidates: (len(candidates), candidates))
+    return exact_token_candidates
+
+
+def _variable_token_ranges_by_token(translation: str) -> dict[str, TextRangeCandidates]:
+    ranges_by_token: dict[str, list[TextRange]] = defaultdict(list)
+    for match in _VARIABLE_TOKEN.finditer(translation):
+        ranges_by_token[match.group(0)].append((match.start(), match.end()))
+    return {token: tuple(ranges) for token, ranges in ranges_by_token.items()}
+
+
+def _matched_variable_equivalent_token_counts(
+    missing_tokens: Counter[str],
+    available_equivalents: dict[str, list[TextRange]],
+    exact_token_candidates: list[TextRangeCandidates],
+) -> Counter[str]:
+    token_candidates = [
+        (token, _variable_equivalent_candidate_ranges(token, available_equivalents))
+        for token, count in missing_tokens.items()
+        for _ in range(count)
+        if _VARIABLE_TOKEN.fullmatch(token) and token in _VARIABLE_TOKEN_EQUIVALENTS
+    ]
+    token_candidates = [(token, candidates) for token, candidates in token_candidates if candidates]
+    token_candidates.sort(key=lambda item: (len(item[1]), item[0]))
+
+    consumed_tokens = _best_variable_equivalent_assignment(exact_token_candidates, token_candidates)
+    return Counter(consumed_tokens)
+
+
+def _variable_equivalent_candidate_ranges(
+    token: str,
+    available_equivalents: dict[str, list[TextRange]],
+) -> TextRangeCandidates:
+    candidates = []
+    for equivalent in _VARIABLE_TOKEN_EQUIVALENTS[token]:
+        candidates.extend(available_equivalents[equivalent])
+    return tuple(sorted(set(candidates), key=lambda item: (item[0], item[1])))
+
+
+def _best_variable_equivalent_assignment(
+    exact_token_candidates: list[TextRangeCandidates],
+    token_candidates: list[tuple[str, TextRangeCandidates]],
+) -> tuple[str, ...]:
+    exact_candidate_sequence = tuple(exact_token_candidates)
+    token_candidate_sequence = tuple(token_candidates)
+    try:
+        return _best_variable_equivalent_assignment_after_exact(
+            exact_candidate_sequence,
+            token_candidate_sequence,
+            0,
+            (),
+        )
+    finally:
+        _best_variable_equivalent_assignment_after_exact.cache_clear()
+        _best_optional_variable_equivalent_assignment.cache_clear()
+
+
+@cache
+def _best_optional_variable_equivalent_assignment(
+    token_candidate_sequence: VariableTokenCandidateSequence,
+    candidate_index: int,
+    used_ranges: TextRangeCandidates,
+) -> tuple[str, ...]:
+    if candidate_index >= len(token_candidate_sequence):
+        return ()
+
+    best_consumed_tokens = _best_optional_variable_equivalent_assignment(
+        token_candidate_sequence,
+        candidate_index + 1,
+        used_ranges,
+    )
+    token, candidates = token_candidate_sequence[candidate_index]
+    remaining_token_count = len(token_candidate_sequence) - candidate_index
+    for candidate_range in candidates:
+        if any(_ranges_overlap(candidate_range, used_range) for used_range in used_ranges):
+            continue
+        next_used_ranges = tuple(sorted((*used_ranges, candidate_range)))
+        consumed_tokens = (
+            token,
+            *_best_optional_variable_equivalent_assignment(
+                token_candidate_sequence,
+                candidate_index + 1,
+                next_used_ranges,
+            ),
+        )
+        if len(consumed_tokens) > len(best_consumed_tokens):
+            best_consumed_tokens = consumed_tokens
+            if len(best_consumed_tokens) == remaining_token_count:
+                break
+
+    return best_consumed_tokens
+
+
+@cache
+def _best_variable_equivalent_assignment_after_exact(
+    exact_candidate_sequence: ExactRangeCandidateSequence,
+    token_candidate_sequence: VariableTokenCandidateSequence,
+    candidate_index: int,
+    used_ranges: TextRangeCandidates,
+) -> tuple[str, ...]:
+    if candidate_index >= len(exact_candidate_sequence):
+        return _best_optional_variable_equivalent_assignment(token_candidate_sequence, 0, used_ranges)
+
+    best_consumed_tokens: tuple[str, ...] = ()
+    candidates = exact_candidate_sequence[candidate_index]
+    for candidate_range in candidates:
+        if any(_ranges_overlap(candidate_range, used_range) for used_range in used_ranges):
+            continue
+        next_used_ranges = tuple(sorted((*used_ranges, candidate_range)))
+        consumed_tokens = _best_variable_equivalent_assignment_after_exact(
+            exact_candidate_sequence,
+            token_candidate_sequence,
+            candidate_index + 1,
+            next_used_ranges,
+        )
+        if len(consumed_tokens) > len(best_consumed_tokens):
+            best_consumed_tokens = consumed_tokens
+            if len(best_consumed_tokens) == len(token_candidate_sequence):
+                break
+
+    return best_consumed_tokens
+
+
+def _ranges_overlap(left: TextRange, right: TextRange) -> bool:
+    return left[0] < right[1] and right[0] < left[1]
 
 
 def _find_token_issues(entry: TranslationEntry) -> list[TranslationIssue]:

--- a/scripts/check_translation_tokens.py
+++ b/scripts/check_translation_tokens.py
@@ -10,6 +10,7 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
+from typing import Final
 
 type TextRange = tuple[int, int]
 type TextRangeCandidates = tuple[TextRange, ...]
@@ -48,6 +49,9 @@ _VARIABLE_TOKEN_EQUIVALENTS = {
     "=pronouns.objective=": ("=subject.name=",),
     "=pronouns.possessive=": ("=subject.name=",),
 }
+_VARIABLE_EQUIVALENT_TOKENS = frozenset(
+    equivalent for token_equivalents in _VARIABLE_TOKEN_EQUIVALENTS.values() for equivalent in token_equivalents
+)
 _OMITTABLE_VARIABLE_TOKENS = {
     "=objpronouns.reflexive=",
     "=subject.possessive=",
@@ -56,6 +60,8 @@ _ARTICLE_ONLY_VARIABLE_TOKENS = {
     "=subject.The=",
     "=subject.the=",
 }
+# This marks tokens that can be dropped any number of times by design.
+UNLIMITED_ALLOWED_MISSING_TOKENS: Final[int] = sys.maxsize
 
 
 @dataclass(frozen=True)
@@ -301,21 +307,16 @@ def _allowed_missing_non_consuming_variable_token_count(token: str) -> int:
     if not _VARIABLE_TOKEN.fullmatch(token):
         return 0
     if _LOCALIZABLE_VERB_TOKEN.fullmatch(token):
-        return sys.maxsize
+        return UNLIMITED_ALLOWED_MISSING_TOKENS
     if token in _OMITTABLE_VARIABLE_TOKENS or token in _ARTICLE_ONLY_VARIABLE_TOKENS:
-        return sys.maxsize
+        return UNLIMITED_ALLOWED_MISSING_TOKENS
     return 0
 
 
 def _available_variable_equivalent_token_ranges(translation: str) -> dict[str, list[TextRange]]:
-    equivalents = {
-        equivalent
-        for token_equivalents in _VARIABLE_TOKEN_EQUIVALENTS.values()
-        for equivalent in token_equivalents
-    }
     return {
         equivalent: [(match.start(), match.end()) for match in re.finditer(re.escape(equivalent), translation)]
-        for equivalent in equivalents
+        for equivalent in _VARIABLE_EQUIVALENT_TOKENS
     }
 
 

--- a/scripts/check_translation_tokens.py
+++ b/scripts/check_translation_tokens.py
@@ -11,8 +11,10 @@ from dataclasses import dataclass
 from pathlib import Path
 
 _DEFAULT_DUPLICATE_BASELINE = Path(__file__).with_name("translation_token_duplicate_baseline.json")
-_DUPLICATE_BASELINE_VERSION = 2
+_DUPLICATE_BASELINE_VERSION = 3
 _MIN_CONFLICTING_TRANSLATIONS = 2
+_SAME_FILE_DUPLICATE_SCOPE = "same_file"
+_CROSS_FILE_DUPLICATE_SCOPE = "cross_file"
 
 _BARE_QUD_SPAN = re.compile(r"\{\{[^|{}]+\}\}")
 _QUD_OPENER = re.compile(r"\{\{[^|}]+\|")
@@ -24,6 +26,14 @@ _LEGACY_CARET_COLOR = re.compile(r"(?<!\^)\^(?!\^)[A-Za-z0-9]")
 _HTML_COLOR_OPEN = re.compile(r"<color=[^>]+>")
 _HTML_COLOR_CLOSE = re.compile(r"</color>")
 _PLACEHOLDER = re.compile(r"\{([0-9]+)(?::[^{}]*)?\}")
+_VARIABLE_TOKEN = re.compile(r"=[A-Za-z_][A-Za-z0-9_.:']*=")
+_LOCALIZABLE_VERB_TOKEN = re.compile(r"=(?:[A-Za-z_][A-Za-z0-9_]*\.)?verb:[A-Za-z0-9_:']+=")
+_VARIABLE_TOKEN_EQUIVALENTS = {
+    "=object.Does:are=": ("=object.name=", "=object.t=", "=object.T="),
+    "=subject.Name's=": ("=subject.name=の", "=subject.Name=の"),
+    "=subject.T's=": ("=subject.name=の", "=subject.T=の"),
+    "=subject.t's=": ("=subject.name=の", "=subject.t=の"),
+}
 
 
 @dataclass(frozen=True)
@@ -50,13 +60,24 @@ class TranslationIssue:
 
 
 @dataclass(frozen=True)
-class DuplicateConflictState:
-    """Expected or observed same-file duplicate source-key conflict state."""
+class DuplicateOccurrence:
+    """One source-key occurrence in a duplicate conflict state."""
 
+    path: str
+    entry_index: int
+    text: str
+
+
+@dataclass(frozen=True)
+class DuplicateConflictState:
+    """Expected or observed duplicate source-key conflict state."""
+
+    scope: str
     path: str
     key: str
     entry_count: int
     texts: tuple[str, ...]
+    occurrences: tuple[DuplicateOccurrence, ...]
 
 
 def _path_candidates(path: Path) -> tuple[Path, Path]:
@@ -120,7 +141,11 @@ def collect_translation_json_files(paths: list[Path]) -> list[Path]:
 
 
 def _load_json(path: Path) -> object:
-    payload: object = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        payload: object = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
+        msg = f"Failed to load JSON from {path}: {exc}"
+        raise ValueError(msg) from exc
     return payload
 
 
@@ -182,6 +207,7 @@ def _translation_token_multiset(value: str) -> Counter[str]:
         _LEGACY_CARET_COLOR,
         _HTML_COLOR_OPEN,
         _HTML_COLOR_CLOSE,
+        _VARIABLE_TOKEN,
     ):
         tokens.update(match.group(0) for match in pattern.finditer(value))
     tokens.update(match.group(0) for match in _QUD_CLOSER.finditer(bare_span_stripped))
@@ -196,9 +222,49 @@ def _format_counter(counter: Counter[str]) -> str:
     return ", ".join(f"{token!r}: {count}" for token, count in sorted(counter.items()))
 
 
+def _bare_span_opener_equivalent(token: str) -> str | None:
+    if not _BARE_QUD_SPAN.fullmatch(token):
+        return None
+    return f"{token[:-2]}|"
+
+
+def _missing_translation_tokens(source: str, translation: str) -> Counter[str]:
+    source_tokens = _translation_token_multiset(source)
+    translation_tokens = _translation_token_multiset(translation)
+    missing_tokens = source_tokens - translation_tokens
+    for token, count in list(missing_tokens.items()):
+        opener = _bare_span_opener_equivalent(token)
+        if opener is None:
+            continue
+        available_openers = translation_tokens[opener] - source_tokens[opener]
+        covered_count = min(count, max(available_openers, 0))
+        if covered_count == 0:
+            continue
+        missing_tokens[token] -= covered_count
+        if missing_tokens[token] <= 0:
+            del missing_tokens[token]
+    for token, count in list(missing_tokens.items()):
+        covered_count = _allowed_missing_variable_token_count(token, translation)
+        if covered_count == 0:
+            continue
+        missing_tokens[token] -= min(count, covered_count)
+        if missing_tokens[token] <= 0:
+            del missing_tokens[token]
+    return missing_tokens
+
+
+def _allowed_missing_variable_token_count(token: str, translation: str) -> int:
+    if not _VARIABLE_TOKEN.fullmatch(token):
+        return 0
+    if _LOCALIZABLE_VERB_TOKEN.fullmatch(token):
+        return sys.maxsize
+    equivalents = _VARIABLE_TOKEN_EQUIVALENTS.get(token, ())
+    return sum(translation.count(equivalent) for equivalent in equivalents)
+
+
 def _find_token_issues(entry: TranslationEntry) -> list[TranslationIssue]:
     issues: list[TranslationIssue] = []
-    missing_tokens = _translation_token_multiset(entry.key) - _translation_token_multiset(entry.text)
+    missing_tokens = _missing_translation_tokens(entry.key, entry.text)
     if missing_tokens:
         issues.append(
             TranslationIssue(
@@ -231,7 +297,7 @@ def _find_token_issues(entry: TranslationEntry) -> list[TranslationIssue]:
     return issues
 
 
-def _load_duplicate_baseline(path: Path | None) -> dict[tuple[str, str], DuplicateConflictState]:
+def _load_duplicate_baseline(path: Path | None) -> dict[tuple[str, str, str], DuplicateConflictState]:
     if path is None or not path.exists():
         return {}
     payload = _load_json(path)
@@ -244,8 +310,7 @@ def _load_duplicate_baseline(path: Path | None) -> dict[tuple[str, str], Duplica
         raise TypeError(msg)
     if version != _DUPLICATE_BASELINE_VERSION:
         msg = (
-            "Duplicate conflict baseline expected "
-            f"version {_DUPLICATE_BASELINE_VERSION} but found {version!r}: {path}"
+            f"Duplicate conflict baseline expected version {_DUPLICATE_BASELINE_VERSION} but found {version!r}: {path}"
         )
         raise TypeError(msg)
     conflicts = payload.get("duplicate_conflicts")
@@ -253,10 +318,10 @@ def _load_duplicate_baseline(path: Path | None) -> dict[tuple[str, str], Duplica
         msg = f"Duplicate conflict baseline must contain a 'duplicate_conflicts' list: {path}"
         raise TypeError(msg)
 
-    baseline: dict[tuple[str, str], DuplicateConflictState] = {}
+    baseline: dict[tuple[str, str, str], DuplicateConflictState] = {}
     for item in conflicts:
         state = _duplicate_baseline_state(item, path)
-        identity = (state.path, state.key)
+        identity = _duplicate_identity(state)
         if identity in baseline:
             msg = f"Duplicate conflict baseline contains duplicate entry for {identity!r}: {path}"
             raise TypeError(msg)
@@ -271,45 +336,130 @@ def _duplicate_baseline_state(item: object, baseline_path: Path) -> DuplicateCon
 
     relative_path = item.get("path")
     key = item.get("key")
+    scope = item.get("scope")
+    if scope not in {_SAME_FILE_DUPLICATE_SCOPE, _CROSS_FILE_DUPLICATE_SCOPE}:
+        msg = f"Invalid duplicate conflict baseline entry in {baseline_path}: {item!r}"
+        raise TypeError(msg)
     if not isinstance(relative_path, str) or not isinstance(key, str):
         msg = f"Invalid duplicate conflict baseline entry in {baseline_path}: {item!r}"
         raise TypeError(msg)
 
     texts = item.get("texts")
     entry_count = item.get("entry_count")
-    if not isinstance(entry_count, int) or not isinstance(texts, list) or not all(
-        isinstance(text, str) for text in texts
+    occurrences = item.get("occurrences")
+    if (
+        not isinstance(entry_count, int)
+        or not isinstance(texts, list)
+        or not all(isinstance(text, str) for text in texts)
     ):
         msg = f"Invalid duplicate conflict baseline state in {baseline_path}: {item!r}"
         raise TypeError(msg)
     if entry_count != len(texts):
         msg = f"Duplicate conflict baseline entry_count does not match texts length in {baseline_path}: {item!r}"
         raise TypeError(msg)
+    if not isinstance(occurrences, list):
+        msg = f"Duplicate conflict baseline must contain occurrence details in {baseline_path}: {item!r}"
+        raise TypeError(msg)
+    parsed_occurrences = tuple(_duplicate_occurrence_state(occurrence, baseline_path) for occurrence in occurrences)
+    if entry_count != len(parsed_occurrences):
+        msg = f"Duplicate conflict baseline entry_count does not match occurrences length in {baseline_path}: {item!r}"
+        raise TypeError(msg)
+    occurrence_texts = sorted(occurrence.text for occurrence in parsed_occurrences)
+    if sorted(texts) != occurrence_texts:
+        msg = f"Duplicate conflict baseline texts do not match occurrences in {baseline_path}: {item!r}"
+        raise TypeError(msg)
 
     return DuplicateConflictState(
+        scope=scope,
         path=relative_path,
         key=key,
         entry_count=entry_count,
         texts=tuple(sorted(texts)),
+        occurrences=tuple(sorted(parsed_occurrences, key=lambda occurrence: (occurrence.path, occurrence.entry_index))),
     )
 
 
-def _duplicate_conflict_states(entries: list[TranslationEntry]) -> dict[tuple[str, str], DuplicateConflictState]:
+def _duplicate_occurrence_state(item: object, baseline_path: Path) -> DuplicateOccurrence:
+    if not isinstance(item, dict):
+        msg = f"Invalid duplicate conflict baseline occurrence in {baseline_path}: {item!r}"
+        raise TypeError(msg)
+
+    relative_path = item.get("path")
+    entry_index = item.get("entry_index")
+    text = item.get("text")
+    if not isinstance(relative_path, str) or not isinstance(entry_index, int) or not isinstance(text, str):
+        msg = f"Invalid duplicate conflict baseline occurrence in {baseline_path}: {item!r}"
+        raise TypeError(msg)
+    return DuplicateOccurrence(path=relative_path, entry_index=entry_index, text=text)
+
+
+def _duplicate_identity(state: DuplicateConflictState) -> tuple[str, str, str]:
+    return (state.scope, state.path, state.key)
+
+
+def _duplicate_occurrences(entries: list[TranslationEntry]) -> tuple[DuplicateOccurrence, ...]:
+    return tuple(
+        sorted(
+            (
+                DuplicateOccurrence(path=entry.relative_path, entry_index=entry.index, text=entry.text)
+                for entry in entries
+            ),
+            key=lambda occurrence: (occurrence.path, occurrence.entry_index, occurrence.text),
+        )
+    )
+
+
+def _duplicate_state(
+    *,
+    scope: str,
+    path: str,
+    key: str,
+    entries: list[TranslationEntry],
+) -> DuplicateConflictState:
+    occurrences = _duplicate_occurrences(entries)
+    return DuplicateConflictState(
+        scope=scope,
+        path=path,
+        key=key,
+        entry_count=len(occurrences),
+        texts=tuple(sorted(occurrence.text for occurrence in occurrences)),
+        occurrences=occurrences,
+    )
+
+
+def _duplicate_conflict_states(entries: list[TranslationEntry]) -> dict[tuple[str, str, str], DuplicateConflictState]:
     by_path_and_key: dict[tuple[str, str], list[TranslationEntry]] = defaultdict(list)
+    dictionary_entries_by_key: dict[str, list[TranslationEntry]] = defaultdict(list)
     for entry in entries:
         by_path_and_key[(entry.relative_path, entry.key)].append(entry)
+        if entry.relative_path.startswith("Dictionaries/"):
+            dictionary_entries_by_key[entry.key].append(entry)
 
-    states: dict[tuple[str, str], DuplicateConflictState] = {}
+    states: dict[tuple[str, str, str], DuplicateConflictState] = {}
     for (relative_path, key), matches in sorted(by_path_and_key.items()):
-        texts = tuple(sorted(entry.text for entry in matches))
-        if len(set(texts)) < _MIN_CONFLICTING_TRANSLATIONS:
+        if len(matches) < _MIN_CONFLICTING_TRANSLATIONS:
             continue
-        states[(relative_path, key)] = DuplicateConflictState(
+        state = _duplicate_state(
+            scope=_SAME_FILE_DUPLICATE_SCOPE,
             path=relative_path,
             key=key,
-            entry_count=len(matches),
-            texts=texts,
+            entries=matches,
         )
+
+        states[_duplicate_identity(state)] = state
+
+    for key, matches in sorted(dictionary_entries_by_key.items()):
+        paths = {entry.relative_path for entry in matches}
+        texts = {entry.text for entry in matches}
+        if len(paths) < _MIN_CONFLICTING_TRANSLATIONS or len(texts) < _MIN_CONFLICTING_TRANSLATIONS:
+            continue
+        state = _duplicate_state(
+            scope=_CROSS_FILE_DUPLICATE_SCOPE,
+            path="Dictionaries",
+            key=key,
+            entries=matches,
+        )
+        states[_duplicate_identity(state)] = state
     return states
 
 
@@ -317,49 +467,60 @@ def _format_duplicate_state(state: DuplicateConflictState | None) -> str:
     if state is None:
         return "missing current conflict"
     texts = json.dumps(list(state.texts), ensure_ascii=False)
-    return f"entry_count={state.entry_count}, texts={texts}"
+    occurrences = json.dumps(
+        [
+            {"path": occurrence.path, "entry_index": occurrence.entry_index, "text": occurrence.text}
+            for occurrence in state.occurrences
+        ],
+        ensure_ascii=False,
+    )
+    return f"scope={state.scope}, entry_count={state.entry_count}, texts={texts}, occurrences={occurrences}"
+
+
+def _baseline_state_applies(state: DuplicateConflictState, scanned_paths: set[str]) -> bool:
+    if state.scope == _SAME_FILE_DUPLICATE_SCOPE:
+        return state.path in scanned_paths
+    return {occurrence.path for occurrence in state.occurrences}.issubset(scanned_paths)
 
 
 def _find_duplicate_conflicts(
     entries: list[TranslationEntry],
     *,
-    baseline: dict[tuple[str, str], DuplicateConflictState],
+    baseline: dict[tuple[str, str, str], DuplicateConflictState],
     scanned_paths: set[str],
 ) -> list[TranslationIssue]:
     current_states = _duplicate_conflict_states(entries)
     issues: list[TranslationIssue] = []
 
     for identity, expected in sorted(baseline.items()):
-        relative_path, key = identity
-        if relative_path not in scanned_paths:
+        if not _baseline_state_applies(expected, scanned_paths):
             continue
         current = current_states.get(identity)
         if current == expected:
             continue
         issues.append(
             TranslationIssue(
-                relative_path=relative_path,
+                relative_path=expected.path,
                 entry_index=None,
                 kind="BASELINE",
                 detail=(
                     "duplicate conflict baseline changed: "
                     f"expected {_format_duplicate_state(expected)}; current {_format_duplicate_state(current)}"
                 ),
-                key=key,
+                key=expected.key,
             ),
         )
 
     for identity, state in sorted(current_states.items()):
         if identity in baseline:
             continue
-        relative_path, key = identity
         issues.append(
             TranslationIssue(
-                relative_path=relative_path,
+                relative_path=state.path,
                 entry_index=None,
                 kind="DUPLICATE",
                 detail=f"duplicate source key conflict: {_format_duplicate_state(state)}",
-                key=key,
+                key=state.key,
             ),
         )
     return issues

--- a/scripts/check_translation_tokens.py
+++ b/scripts/check_translation_tokens.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 _DEFAULT_DUPLICATE_BASELINE = Path(__file__).with_name("translation_token_duplicate_baseline.json")
+_DUPLICATE_BASELINE_VERSION = 2
 _MIN_CONFLICTING_TRANSLATIONS = 2
 
 _BARE_QUD_SPAN = re.compile(r"\{\{[^|{}]+\}\}")
@@ -100,13 +101,16 @@ def collect_translation_json_files(paths: list[Path]) -> list[Path]:
             msg = f"Path not found: {input_path}"
             raise FileNotFoundError(msg)
 
-        if input_path.is_file():
-            if _is_target_translation_file(input_path):
-                files.add(input_path)
+        resolved_input_path = input_path.resolve()
+        if resolved_input_path.is_file():
+            if _is_target_translation_file(resolved_input_path):
+                files.add(resolved_input_path)
             continue
 
-        if input_path.is_dir():
-            files.update(path for path in input_path.rglob("*.ja.json") if _is_target_translation_file(path))
+        if resolved_input_path.is_dir():
+            files.update(
+                path.resolve() for path in resolved_input_path.rglob("*.ja.json") if _is_target_translation_file(path)
+            )
             continue
 
         msg = f"Path is not a regular file or directory: {input_path}"
@@ -156,6 +160,7 @@ def iter_translation_entries(path: Path) -> list[TranslationEntry]:
 
 def _translation_token_multiset(value: str) -> Counter[str]:
     tokens: Counter[str] = Counter()
+    tokens.update(match.group(0) for match in _BARE_QUD_SPAN.finditer(value))
     bare_span_stripped = _BARE_QUD_SPAN.sub("", value)
     for pattern in (
         _QUD_OPENER,
@@ -218,7 +223,20 @@ def _load_duplicate_baseline(path: Path | None) -> dict[tuple[str, str], Duplica
     if path is None or not path.exists():
         return {}
     payload = _load_json(path)
-    conflicts = payload.get("duplicate_conflicts") if isinstance(payload, dict) else None
+    if not isinstance(payload, dict):
+        msg = f"Duplicate conflict baseline must be a JSON object: {path}"
+        raise TypeError(msg)
+    version = payload.get("version")
+    if version is None:
+        msg = f"Duplicate conflict baseline must contain version {_DUPLICATE_BASELINE_VERSION}: {path}"
+        raise TypeError(msg)
+    if version != _DUPLICATE_BASELINE_VERSION:
+        msg = (
+            "Duplicate conflict baseline expected "
+            f"version {_DUPLICATE_BASELINE_VERSION} but found {version!r}: {path}"
+        )
+        raise TypeError(msg)
+    conflicts = payload.get("duplicate_conflicts")
     if not isinstance(conflicts, list):
         msg = f"Duplicate conflict baseline must contain a 'duplicate_conflicts' list: {path}"
         raise TypeError(msg)

--- a/scripts/check_translation_tokens.py
+++ b/scripts/check_translation_tokens.py
@@ -124,9 +124,16 @@ def _load_json(path: Path) -> object:
     return payload
 
 
-def _entries_from_payload(payload: object) -> list[object]:
-    entries = payload.get("entries", []) if isinstance(payload, dict) else payload
-    return entries if isinstance(entries, list) else []
+def _entries_from_payload(payload: object, *, path_context: str) -> list[object]:
+    if not isinstance(payload, dict):
+        msg = f"Translation payload must be a JSON object with an 'entries' list: {path_context}"
+        raise TypeError(msg)
+
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        msg = f"Translation payload must contain an 'entries' list: {path_context}"
+        raise TypeError(msg)
+    return entries
 
 
 def iter_translation_entries(path: Path) -> list[TranslationEntry]:
@@ -140,21 +147,26 @@ def iter_translation_entries(path: Path) -> list[TranslationEntry]:
     payload = _load_json(path)
     entries: list[TranslationEntry] = []
     relative_path = _relative_asset_path(path)
-    for index, item in enumerate(_entries_from_payload(payload), start=1):
+    for index, item in enumerate(_entries_from_payload(payload, path_context=relative_path), start=1):
         if not isinstance(item, dict):
-            continue
+            msg = f"Translation entry must be a JSON object: {relative_path} entry_index={index}"
+            raise TypeError(msg)
         key = item.get("key")
         text = item.get("text")
-        if isinstance(key, str) and isinstance(text, str):
-            entries.append(
-                TranslationEntry(
-                    path=path,
-                    relative_path=relative_path,
-                    index=index,
-                    key=key,
-                    text=text,
-                ),
+        if not isinstance(key, str) or not isinstance(text, str):
+            msg = f"Translation entry must contain string 'key' and 'text': {relative_path} entry_index={index}"
+            raise TypeError(msg)
+        if not key.strip():
+            continue
+        entries.append(
+            TranslationEntry(
+                path=path,
+                relative_path=relative_path,
+                index=index,
+                key=key,
+                text=text,
             )
+        )
     return entries
 
 

--- a/scripts/check_translation_tokens.py
+++ b/scripts/check_translation_tokens.py
@@ -1,0 +1,405 @@
+"""Validate JSON localization entries for source-side translation token preservation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+_DEFAULT_DUPLICATE_BASELINE = Path(__file__).with_name("translation_token_duplicate_baseline.json")
+_MIN_CONFLICTING_TRANSLATIONS = 2
+
+_BARE_QUD_SPAN = re.compile(r"\{\{[^|{}]+\}\}")
+_QUD_OPENER = re.compile(r"\{\{[^|}]+\|")
+_QUD_CLOSER = re.compile(r"\}\}")
+_LITERAL_AMPERSAND = re.compile(r"&&")
+_LITERAL_CARET = re.compile(r"\^\^")
+_LEGACY_AMPERSAND_COLOR = re.compile(r"(?<!&)&(?!&)[A-Za-z0-9]")
+_LEGACY_CARET_COLOR = re.compile(r"(?<!\^)\^(?!\^)[A-Za-z0-9]")
+_HTML_COLOR_OPEN = re.compile(r"<color=[^>]+>")
+_HTML_COLOR_CLOSE = re.compile(r"</color>")
+_PLACEHOLDER = re.compile(r"\{([0-9]+)(?::[^{}]*)?\}")
+
+
+@dataclass(frozen=True)
+class TranslationEntry:
+    """A current-slice JSON localization entry."""
+
+    path: Path
+    relative_path: str
+    index: int
+    key: str
+    text: str
+
+
+@dataclass(frozen=True)
+class TranslationIssue:
+    """A validation issue reported by the translation-token gate."""
+
+    relative_path: str
+    kind: str
+    detail: str
+    entry_index: int | None = None
+    key: str | None = None
+    text: str | None = None
+
+
+@dataclass(frozen=True)
+class DuplicateConflictState:
+    """Expected or observed same-file duplicate source-key conflict state."""
+
+    path: str
+    key: str
+    entry_count: int
+    texts: tuple[str, ...]
+
+
+def _path_candidates(path: Path) -> tuple[Path, Path]:
+    resolved = path.resolve()
+    return (path, resolved) if path != resolved else (path,)
+
+
+def _relative_path_from_marker(path: Path, marker: str) -> str | None:
+    parts = path.parts
+    if marker not in parts:
+        return None
+    index = len(parts) - 1 - parts[::-1].index(marker)
+    return Path(*parts[index:]).as_posix()
+
+
+def _relative_asset_path(path: Path) -> str:
+    for candidate in _path_candidates(path):
+        relative_path = _relative_path_from_marker(candidate, "Localization")
+        if relative_path is not None:
+            return Path(*Path(relative_path).parts[1:]).as_posix()
+        for marker in ("Dictionaries", "BlueprintTemplates"):
+            relative_path = _relative_path_from_marker(candidate, marker)
+            if relative_path is not None:
+                return relative_path
+    return path.name
+
+
+def _is_target_translation_file(path: Path) -> bool:
+    if path.suffix != ".json" or not path.name.endswith(".ja.json"):
+        return False
+    return any(
+        "Dictionaries" in candidate.parts or candidate.parent.name == "BlueprintTemplates"
+        for candidate in _path_candidates(path)
+    )
+
+
+def collect_translation_json_files(paths: list[Path]) -> list[Path]:
+    """Collect JSON localization files covered by the non-GUI token gate."""
+    files: set[Path] = set()
+    for input_path in paths:
+        if not input_path.exists():
+            msg = f"Path not found: {input_path}"
+            raise FileNotFoundError(msg)
+
+        if input_path.is_file():
+            if _is_target_translation_file(input_path):
+                files.add(input_path)
+            continue
+
+        if input_path.is_dir():
+            files.update(path for path in input_path.rglob("*.ja.json") if _is_target_translation_file(path))
+            continue
+
+        msg = f"Path is not a regular file or directory: {input_path}"
+        raise ValueError(msg)
+
+    return sorted(files, key=lambda item: item.as_posix())
+
+
+def _load_json(path: Path) -> object:
+    payload: object = json.loads(path.read_text(encoding="utf-8"))
+    return payload
+
+
+def _entries_from_payload(payload: object) -> list[object]:
+    entries = payload.get("entries", []) if isinstance(payload, dict) else payload
+    return entries if isinstance(entries, list) else []
+
+
+def iter_translation_entries(path: Path) -> list[TranslationEntry]:
+    """Read current `entries[].key/text` dictionary and BlueprintTemplates JSON.
+
+    Issue #409 first slice intentionally does not compare BlueprintTemplates
+    GameText variable usage. Current shipped BlueprintTemplates data is covered
+    only where it exposes top-level `entries` with source `key` and Japanese
+    `text` fields.
+    """
+    payload = _load_json(path)
+    entries: list[TranslationEntry] = []
+    relative_path = _relative_asset_path(path)
+    for index, item in enumerate(_entries_from_payload(payload), start=1):
+        if not isinstance(item, dict):
+            continue
+        key = item.get("key")
+        text = item.get("text")
+        if isinstance(key, str) and isinstance(text, str):
+            entries.append(
+                TranslationEntry(
+                    path=path,
+                    relative_path=relative_path,
+                    index=index,
+                    key=key,
+                    text=text,
+                ),
+            )
+    return entries
+
+
+def _translation_token_multiset(value: str) -> Counter[str]:
+    tokens: Counter[str] = Counter()
+    bare_span_stripped = _BARE_QUD_SPAN.sub("", value)
+    for pattern in (
+        _QUD_OPENER,
+        _LITERAL_AMPERSAND,
+        _LITERAL_CARET,
+        _LEGACY_AMPERSAND_COLOR,
+        _LEGACY_CARET_COLOR,
+        _HTML_COLOR_OPEN,
+        _HTML_COLOR_CLOSE,
+    ):
+        tokens.update(match.group(0) for match in pattern.finditer(value))
+    tokens.update(match.group(0) for match in _QUD_CLOSER.finditer(bare_span_stripped))
+    return tokens
+
+
+def _placeholder_multiset(value: str) -> Counter[str]:
+    return Counter(match.group(1) for match in _PLACEHOLDER.finditer(value))
+
+
+def _format_counter(counter: Counter[str]) -> str:
+    return ", ".join(f"{token!r}: {count}" for token, count in sorted(counter.items()))
+
+
+def _find_token_issues(entry: TranslationEntry) -> list[TranslationIssue]:
+    issues: list[TranslationIssue] = []
+    missing_tokens = _translation_token_multiset(entry.key) - _translation_token_multiset(entry.text)
+    if missing_tokens:
+        issues.append(
+            TranslationIssue(
+                relative_path=entry.relative_path,
+                entry_index=entry.index,
+                kind="TOKEN",
+                detail=f"missing translation tokens: {_format_counter(missing_tokens)}",
+                key=entry.key,
+                text=entry.text,
+            ),
+        )
+
+    source_placeholders = _placeholder_multiset(entry.key)
+    translation_placeholders = _placeholder_multiset(entry.text)
+    if source_placeholders != translation_placeholders:
+        issues.append(
+            TranslationIssue(
+                relative_path=entry.relative_path,
+                entry_index=entry.index,
+                kind="PLACEHOLDER",
+                detail=(
+                    "placeholder multiset mismatch: "
+                    f"source={dict(sorted(source_placeholders.items()))} "
+                    f"translation={dict(sorted(translation_placeholders.items()))}"
+                ),
+                key=entry.key,
+                text=entry.text,
+            ),
+        )
+    return issues
+
+
+def _load_duplicate_baseline(path: Path | None) -> dict[tuple[str, str], DuplicateConflictState]:
+    if path is None or not path.exists():
+        return {}
+    payload = _load_json(path)
+    conflicts = payload.get("duplicate_conflicts") if isinstance(payload, dict) else None
+    if not isinstance(conflicts, list):
+        msg = f"Duplicate conflict baseline must contain a 'duplicate_conflicts' list: {path}"
+        raise TypeError(msg)
+
+    baseline: dict[tuple[str, str], DuplicateConflictState] = {}
+    for item in conflicts:
+        state = _duplicate_baseline_state(item, path)
+        identity = (state.path, state.key)
+        if identity in baseline:
+            msg = f"Duplicate conflict baseline contains duplicate entry for {identity!r}: {path}"
+            raise TypeError(msg)
+        baseline[identity] = state
+    return baseline
+
+
+def _duplicate_baseline_state(item: object, baseline_path: Path) -> DuplicateConflictState:
+    if not isinstance(item, dict):
+        msg = f"Invalid duplicate conflict baseline entry in {baseline_path}: {item!r}"
+        raise TypeError(msg)
+
+    relative_path = item.get("path")
+    key = item.get("key")
+    if not isinstance(relative_path, str) or not isinstance(key, str):
+        msg = f"Invalid duplicate conflict baseline entry in {baseline_path}: {item!r}"
+        raise TypeError(msg)
+
+    texts = item.get("texts")
+    entry_count = item.get("entry_count")
+    if not isinstance(entry_count, int) or not isinstance(texts, list) or not all(
+        isinstance(text, str) for text in texts
+    ):
+        msg = f"Invalid duplicate conflict baseline state in {baseline_path}: {item!r}"
+        raise TypeError(msg)
+    if entry_count != len(texts):
+        msg = f"Duplicate conflict baseline entry_count does not match texts length in {baseline_path}: {item!r}"
+        raise TypeError(msg)
+
+    return DuplicateConflictState(
+        path=relative_path,
+        key=key,
+        entry_count=entry_count,
+        texts=tuple(sorted(texts)),
+    )
+
+
+def _duplicate_conflict_states(entries: list[TranslationEntry]) -> dict[tuple[str, str], DuplicateConflictState]:
+    by_path_and_key: dict[tuple[str, str], list[TranslationEntry]] = defaultdict(list)
+    for entry in entries:
+        by_path_and_key[(entry.relative_path, entry.key)].append(entry)
+
+    states: dict[tuple[str, str], DuplicateConflictState] = {}
+    for (relative_path, key), matches in sorted(by_path_and_key.items()):
+        texts = tuple(sorted(entry.text for entry in matches))
+        if len(set(texts)) < _MIN_CONFLICTING_TRANSLATIONS:
+            continue
+        states[(relative_path, key)] = DuplicateConflictState(
+            path=relative_path,
+            key=key,
+            entry_count=len(matches),
+            texts=texts,
+        )
+    return states
+
+
+def _format_duplicate_state(state: DuplicateConflictState | None) -> str:
+    if state is None:
+        return "missing current conflict"
+    texts = json.dumps(list(state.texts), ensure_ascii=False)
+    return f"entry_count={state.entry_count}, texts={texts}"
+
+
+def _find_duplicate_conflicts(
+    entries: list[TranslationEntry],
+    *,
+    baseline: dict[tuple[str, str], DuplicateConflictState],
+    scanned_paths: set[str],
+) -> list[TranslationIssue]:
+    current_states = _duplicate_conflict_states(entries)
+    issues: list[TranslationIssue] = []
+
+    for identity, expected in sorted(baseline.items()):
+        relative_path, key = identity
+        if relative_path not in scanned_paths:
+            continue
+        current = current_states.get(identity)
+        if current == expected:
+            continue
+        issues.append(
+            TranslationIssue(
+                relative_path=relative_path,
+                entry_index=None,
+                kind="BASELINE",
+                detail=(
+                    "duplicate conflict baseline changed: "
+                    f"expected {_format_duplicate_state(expected)}; current {_format_duplicate_state(current)}"
+                ),
+                key=key,
+            ),
+        )
+
+    for identity, state in sorted(current_states.items()):
+        if identity in baseline:
+            continue
+        relative_path, key = identity
+        issues.append(
+            TranslationIssue(
+                relative_path=relative_path,
+                entry_index=None,
+                kind="DUPLICATE",
+                detail=f"duplicate source key conflict: {_format_duplicate_state(state)}",
+                key=key,
+            ),
+        )
+    return issues
+
+
+def check_paths(
+    paths: list[Path],
+    *,
+    duplicate_conflict_baseline: Path | None = None,
+) -> tuple[int, list[TranslationIssue]]:
+    """Check JSON localization token invariants for input paths."""
+    files = collect_translation_json_files(paths)
+    baseline = _load_duplicate_baseline(duplicate_conflict_baseline)
+    entries: list[TranslationEntry] = []
+    issues: list[TranslationIssue] = []
+
+    for path in files:
+        file_entries = iter_translation_entries(path)
+        entries.extend(file_entries)
+        for entry in file_entries:
+            issues.extend(_find_token_issues(entry))
+
+    scanned_paths = {_relative_asset_path(path) for path in files}
+    issues.extend(_find_duplicate_conflicts(entries, baseline=baseline, scanned_paths=scanned_paths))
+    return len(files), issues
+
+
+def _print_report(file_count: int, issues: list[TranslationIssue]) -> None:
+    print(f"Scanned {file_count} JSON localization file(s): {len(issues)} issue(s)")  # noqa: T201
+    for issue in issues:
+        location = issue.relative_path
+        if issue.entry_index is not None:
+            location = f"{location}#{issue.entry_index}"
+        print(f"  [{issue.kind}] {location}: {issue.detail}")  # noqa: T201
+        if issue.key is not None:
+            print(f"    key={issue.key!r}")  # noqa: T201
+        if issue.text is not None:
+            print(f"    text={issue.text!r}")  # noqa: T201
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the translation-token gate CLI."""
+    parser = argparse.ArgumentParser(
+        description="Validate JSON localization token preservation for dictionaries and BlueprintTemplates.",
+    )
+    parser.add_argument("paths", nargs="+", type=Path, help="Localization file or directory paths to scan.")
+    parser.add_argument(
+        "--duplicate-conflict-baseline",
+        type=Path,
+        default=_DEFAULT_DUPLICATE_BASELINE,
+        help="JSON baseline of known same-file duplicate source-key conflicts.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        file_count, issues = check_paths(
+            args.paths,
+            duplicate_conflict_baseline=args.duplicate_conflict_baseline,
+        )
+    except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)  # noqa: T201
+        return 1
+
+    if file_count == 0:
+        print("Error: No target *.ja.json localization files found.", file=sys.stderr)  # noqa: T201
+        return 1
+
+    _print_report(file_count, issues)
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_translation_tokens.py
+++ b/scripts/tests/test_translation_tokens.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+
+import pytest
 
 from scripts import check_translation_tokens
-
-if TYPE_CHECKING:
-    import pytest
 
 
 def _write_entries(path: Path, entries: list[dict[str, str]]) -> None:
@@ -19,19 +17,40 @@ def _write_payload(path: Path, payload: object) -> None:
     path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
 
 
-def _write_duplicate_baseline(path: Path, *, texts: list[str], entry_count: int = 2) -> None:
+def _same_file_duplicate_state(*, texts: list[str], entry_count: int = 2) -> dict[str, object]:
+    return {
+        "scope": "same_file",
+        "path": "Dictionaries/demo.ja.json",
+        "key": "Same source",
+        "entry_count": entry_count,
+        "texts": sorted(texts),
+        "occurrences": [
+            {"path": "Dictionaries/demo.ja.json", "entry_index": index, "text": text}
+            for index, text in enumerate(texts, start=1)
+        ],
+    }
+
+
+def _cross_file_duplicate_state(*, texts: list[str]) -> dict[str, object]:
+    paths = ["Dictionaries/a.ja.json", "Dictionaries/b.ja.json"]
+    return {
+        "scope": "cross_file",
+        "path": "Dictionaries",
+        "key": "Shared source",
+        "entry_count": len(texts),
+        "texts": sorted(texts),
+        "occurrences": [
+            {"path": path, "entry_index": 1, "text": text} for path, text in zip(paths, texts, strict=True)
+        ],
+    }
+
+
+def _write_duplicate_baseline(path: Path, *states: dict[str, object]) -> None:
     path.write_text(
         json.dumps(
             {
-                "version": 2,
-                "duplicate_conflicts": [
-                    {
-                        "path": "Dictionaries/demo.ja.json",
-                        "key": "Same source",
-                        "entry_count": entry_count,
-                        "texts": sorted(texts),
-                    },
-                ],
+                "version": 3,
+                "duplicate_conflicts": list(states),
             },
             ensure_ascii=False,
         ),
@@ -94,6 +113,90 @@ def test_cli_reports_missing_bare_qud_span_token(
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "missing translation tokens: '{{R}}': 1" in captured.out
+
+
+def test_cli_accepts_bare_qud_span_as_tagged_translation(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Bare Qud spans may translate to the equivalent tagged span form."""
+    localization = tmp_path / "Localization"
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [
+            {
+                "key": "{{phase-conjugate}}",
+                "text": "{{phase-conjugate|位相共役}}",
+            },
+        ],
+    )
+
+    exit_code = check_translation_tokens.main([str(localization)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "0 issue(s)" in captured.out
+
+
+def test_cli_reports_missing_game_text_variable_token(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """GameText variable tokens such as `=variable.name=` must be preserved."""
+    localization = tmp_path / "Localization"
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [
+            {
+                "key": "Talk to =creature.displayName=.",
+                "text": "話しかける。",
+            },
+        ],
+    )
+
+    exit_code = check_translation_tokens.main([str(localization)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "missing translation tokens: '=creature.displayName=': 1" in captured.out
+
+
+def test_game_text_variable_token_regex_captures_real_shapes() -> None:
+    """Real GameText variables may contain colons and apostrophes."""
+    value = "=object.Does:are= =subject.Name's= =subject.T's= =verb:beep:afterpronoun="
+
+    assert check_translation_tokens._translation_token_multiset(value) == {  # noqa: SLF001
+        "=object.Does:are=": 1,
+        "=subject.Name's=": 1,
+        "=subject.T's=": 1,
+        "=verb:beep:afterpronoun=": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    ("key", "text"),
+    [
+        ("=subject.T= =verb:slip= on the slime!", "=subject.T=はスライムで滑った。"),
+        ("=object.Does:are= too old.", "=object.name=は古すぎる。"),
+        ("=subject.Name's= shell cracked.", "=subject.name=の殻が割れた。"),
+        ("=subject.T's= shell cracked.", "=subject.name=の殻が割れた。"),
+    ],
+)
+def test_cli_allows_explicit_game_text_variable_equivalents(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    key: str,
+    text: str,
+) -> None:
+    """Japanese GameText can encode selected English grammar tokens explicitly."""
+    localization = tmp_path / "Localization"
+    _write_entries(localization / "Dictionaries" / "demo.ja.json", [{"key": key, "text": text}])
+
+    exit_code = check_translation_tokens.main([str(localization)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "0 issue(s)" in captured.out
 
 
 def test_cli_scans_pure_formatter_source_key_token_loss(
@@ -190,6 +293,19 @@ def test_cli_rejects_non_list_entries_payload(
     assert "Dictionaries/demo.ja.json" in captured.err
 
 
+def test_load_json_wraps_parse_errors_with_path_context(tmp_path: Path) -> None:
+    """JSON parse failures keep the original exception and identify the file."""
+    target = tmp_path / "Localization" / "Dictionaries" / "broken.ja.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text('{"entries": [', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Failed to load JSON") as exc_info:
+        check_translation_tokens._load_json(target)  # noqa: SLF001
+
+    assert str(target) in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)
+
+
 def test_cli_rejects_malformed_translation_entry_with_index(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -243,9 +359,70 @@ def test_duplicate_source_key_conflict_fails_unless_baselined(
     assert "duplicate source key conflict" in captured.out
 
     baseline = tmp_path / "baseline.json"
-    _write_duplicate_baseline(baseline, texts=["訳語A", "訳語B"])
+    _write_duplicate_baseline(baseline, _same_file_duplicate_state(texts=["訳語A", "訳語B"]))
 
     assert check_translation_tokens.main([str(localization), "--duplicate-conflict-baseline", str(baseline)]) == 0
+
+
+def test_duplicate_source_key_with_identical_text_fails_unless_baselined(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Same-file duplicate source keys fail even when their translations match."""
+    localization = tmp_path / "Localization"
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [
+            {"key": "Same source", "text": "同じ訳語"},
+            {"key": "Same source", "text": "同じ訳語"},
+        ],
+    )
+
+    assert check_translation_tokens.main([str(localization)]) == 1
+    captured = capsys.readouterr()
+    assert "duplicate source key conflict" in captured.out
+    assert "entry_count=2" in captured.out
+
+    baseline = tmp_path / "baseline.json"
+    _write_duplicate_baseline(baseline, _same_file_duplicate_state(texts=["同じ訳語", "同じ訳語"]))
+
+    assert check_translation_tokens.main([str(localization), "--duplicate-conflict-baseline", str(baseline)]) == 0
+
+
+def test_dictionary_cross_file_duplicate_key_with_divergent_text_fails_unless_baselined(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Dictionary keys reused across files fail when Japanese text diverges."""
+    localization = tmp_path / "Localization"
+    _write_entries(localization / "Dictionaries" / "a.ja.json", [{"key": "Shared source", "text": "訳語A"}])
+    _write_entries(localization / "Dictionaries" / "b.ja.json", [{"key": "Shared source", "text": "訳語B"}])
+
+    assert check_translation_tokens.main([str(localization)]) == 1
+    captured = capsys.readouterr()
+    assert "duplicate source key conflict" in captured.out
+    assert "scope=cross_file" in captured.out
+    assert "Dictionaries/a.ja.json" in captured.out
+    assert "Dictionaries/b.ja.json" in captured.out
+
+    baseline = tmp_path / "baseline.json"
+    _write_duplicate_baseline(baseline, _cross_file_duplicate_state(texts=["訳語A", "訳語B"]))
+
+    assert check_translation_tokens.main([str(localization), "--duplicate-conflict-baseline", str(baseline)]) == 0
+
+
+def test_dictionary_cross_file_duplicate_key_with_identical_text_passes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Cross-file dictionary reuse is allowed when the Japanese text is identical."""
+    localization = tmp_path / "Localization"
+    _write_entries(localization / "Dictionaries" / "a.ja.json", [{"key": "Shared source", "text": "同じ訳語"}])
+    _write_entries(localization / "Dictionaries" / "b.ja.json", [{"key": "Shared source", "text": "同じ訳語"}])
+
+    assert check_translation_tokens.main([str(localization)]) == 0
+    captured = capsys.readouterr()
+    assert "0 issue(s)" in captured.out
 
 
 def test_duplicate_source_key_baseline_fails_when_text_state_changes(
@@ -256,7 +433,7 @@ def test_duplicate_source_key_baseline_fails_when_text_state_changes(
     localization = tmp_path / "Localization"
     target = localization / "Dictionaries" / "demo.ja.json"
     baseline = tmp_path / "baseline.json"
-    _write_duplicate_baseline(baseline, texts=["訳語A", "訳語B"])
+    _write_duplicate_baseline(baseline, _same_file_duplicate_state(texts=["訳語A", "訳語B"]))
     _write_entries(
         target,
         [
@@ -296,7 +473,7 @@ def test_duplicate_baseline_path_is_stable_for_localization_relative_cli_shapes(
         ],
     )
     baseline = tmp_path / "baseline.json"
-    _write_duplicate_baseline(baseline, texts=["訳語A", "訳語B"])
+    _write_duplicate_baseline(baseline, _same_file_duplicate_state(texts=["訳語A", "訳語B"]))
 
     monkeypatch.chdir(localization)
     assert check_translation_tokens.main([".", "--duplicate-conflict-baseline", str(baseline)]) == 0
@@ -330,7 +507,7 @@ def test_duplicate_baseline_rejects_missing_version(
     assert _run_with_duplicate_baseline(tmp_path, {"duplicate_conflicts": []}) == 1
 
     captured = capsys.readouterr()
-    assert "must contain version 2" in captured.err
+    assert "must contain version 3" in captured.err
 
 
 def test_duplicate_baseline_rejects_version_mismatch(
@@ -341,7 +518,7 @@ def test_duplicate_baseline_rejects_version_mismatch(
     assert _run_with_duplicate_baseline(tmp_path, {"version": 1, "duplicate_conflicts": []}) == 1
 
     captured = capsys.readouterr()
-    assert "expected version 2" in captured.err
+    assert "expected version 3" in captured.err
 
 
 def test_duplicate_baseline_rejects_non_object_payload(

--- a/scripts/tests/test_translation_tokens.py
+++ b/scripts/tests/test_translation_tokens.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections import Counter
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,10 @@ def _write_entries(path: Path, entries: list[dict[str, str]]) -> None:
 def _write_payload(path: Path, payload: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def _missing_translation_tokens(key: str, text: str) -> Counter[str]:
+    return check_translation_tokens._missing_translation_tokens(key, text)  # noqa: SLF001
 
 
 def _same_file_duplicate_state(*, texts: list[str], entry_count: int = 2) -> dict[str, object]:
@@ -178,6 +183,25 @@ def test_game_text_variable_token_regex_captures_real_shapes() -> None:
     [
         ("=subject.T= =verb:slip= on the slime!", "=subject.T=はスライムで滑った。"),
         ("=object.Does:are= too old.", "=object.name=は古すぎる。"),
+        ("=subject.The==subject.name= =verb:start= up.", "=subject.name=が起動した。"),
+        (
+            "You touch =subject.t= and recall =pronouns.possessive= passcode. "
+            "=pronouns.Subjective= =verb:beep:afterpronoun= warmly.",
+            "あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。"
+            "=subject.name=が温かくビープ音を鳴らした。",
+        ),
+        (
+            "{{g|You touch =subject.the==subject.name= and recall =pronouns.possessive= passcode.}}",
+            "{{g|あなたは=subject.name=に触れ、=subject.name=のパスコードを思い出した。}}",
+        ),
+        ("=subject.T= =verb:consume= =object.an=.", "=subject.name=が=object.name=を消費した。"),
+        (
+            "=object.T= =object.verb:react= with =subject.t= and =object.verb:convert= =pronouns.objective=.",
+            "=object.name=が=subject.name=と反応し、=subject.name=を変換した。",
+        ),
+        ("=subject.T= =verb:swallow= =object.t=!", "=subject.name=が=object.name=を飲み込んだ!"),
+        ("=subject.T= =verb:bat= =subject.possessive= wings.", "=subject.name=が翼をはためかせた。"),
+        ("=object.verb:burst= =objpronouns.reflexive=.", "自壊した。"),
         ("=subject.Name's= shell cracked.", "=subject.name=の殻が割れた。"),
         ("=subject.T's= shell cracked.", "=subject.name=の殻が割れた。"),
     ],
@@ -197,6 +221,86 @@ def test_cli_allows_explicit_game_text_variable_equivalents(
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "0 issue(s)" in captured.out
+
+
+def test_game_text_variable_equivalents_consume_translation_occurrences() -> None:
+    """One Japanese-side equivalent can satisfy only one consuming source token."""
+    missing_tokens = _missing_translation_tokens(
+        "=subject.t= =pronouns.Subjective=",
+        "=subject.name=",
+    )
+
+    assert missing_tokens == Counter({"=pronouns.Subjective=": 1})
+
+
+def test_game_text_variable_equivalents_do_not_reuse_exact_subject_name_occurrences() -> None:
+    """Exact source-token preservation reserves the matching translation occurrence."""
+    missing_tokens = _missing_translation_tokens(
+        "=subject.name= =pronouns.Subjective=",
+        "=subject.name=",
+    )
+
+    assert missing_tokens == Counter({"=pronouns.Subjective=": 1})
+
+
+def test_game_text_object_article_equivalent_does_not_reuse_exact_object_name_occurrences() -> None:
+    """Object article variables consume a separate object-name equivalent."""
+    missing_tokens = _missing_translation_tokens(
+        "=object.name= =object.an=",
+        "=object.name=",
+    )
+
+    assert missing_tokens == Counter({"=object.an=": 1})
+
+
+def test_game_text_exact_name_reservation_selects_non_overlapping_occurrence() -> None:
+    """Exact name preservation should leave a genitive occurrence available when possible."""
+    missing_tokens = _missing_translation_tokens(
+        "=subject.name= =subject.Name's=",
+        "=subject.name=の =subject.name=",
+    )
+
+    assert missing_tokens == Counter()
+
+
+def test_game_text_variable_equivalents_do_not_reuse_subject_name_for_possessive_chain() -> None:
+    """A single name equivalent cannot cover multiple consuming source references."""
+    missing_tokens = _missing_translation_tokens(
+        "=subject.t= =pronouns.possessive= =pronouns.Subjective=",
+        "=subject.name=",
+    )
+
+    assert missing_tokens == Counter({"=pronouns.possessive=": 1, "=pronouns.Subjective=": 1})
+
+
+def test_game_text_variable_equivalents_do_not_reuse_overlapping_text_ranges() -> None:
+    """A genitive name occurrence cannot also cover a separate bare-name reference."""
+    missing_tokens = _missing_translation_tokens(
+        "=subject.t= =subject.Name's=",
+        "=subject.name=の",
+    )
+
+    assert missing_tokens == Counter({"=subject.Name's=": 1})
+
+
+def test_game_text_variable_equivalents_match_overlapping_candidates_when_assignment_is_valid() -> None:
+    """A bare-name token should not greedily steal the prefix of a genitive occurrence."""
+    missing_tokens = _missing_translation_tokens(
+        "=subject.Name's= =subject.t=",
+        "=subject.name=の =subject.name=",
+    )
+
+    assert missing_tokens == Counter()
+
+
+def test_game_text_article_only_tokens_do_not_consume_subject_name_equivalents() -> None:
+    """Article-only variables are explicitly non-consuming for Japanese text."""
+    missing_tokens = _missing_translation_tokens(
+        "=subject.the= =pronouns.Subjective=",
+        "=subject.name=",
+    )
+
+    assert missing_tokens == Counter()
 
 
 def test_cli_scans_pure_formatter_source_key_token_loss(

--- a/scripts/tests/test_translation_tokens.py
+++ b/scripts/tests/test_translation_tokens.py
@@ -11,8 +11,12 @@ if TYPE_CHECKING:
 
 
 def _write_entries(path: Path, entries: list[dict[str, str]]) -> None:
+    _write_payload(path, {"entries": entries})
+
+
+def _write_payload(path: Path, payload: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps({"entries": entries}, ensure_ascii=False), encoding="utf-8")
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
 
 
 def _write_duplicate_baseline(path: Path, *, texts: list[str], entry_count: int = 2) -> None:
@@ -92,6 +96,29 @@ def test_cli_reports_missing_bare_qud_span_token(
     assert "missing translation tokens: '{{R}}': 1" in captured.out
 
 
+def test_cli_scans_pure_formatter_source_key_token_loss(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pure formatter source keys are translation leaves and must not be pruned."""
+    localization = tmp_path / "Localization"
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [
+            {
+                "key": "{{phase-conjugate}}",
+                "text": "位相共役",
+            },
+        ],
+    )
+
+    exit_code = check_translation_tokens.main([str(localization)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "missing translation tokens: '{{phase-conjugate}}': 1" in captured.out
+
+
 def test_cli_passes_when_source_tokens_are_preserved_and_translation_adds_decoration(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -113,6 +140,88 @@ def test_cli_passes_when_source_tokens_are_preserved_and_translation_adds_decora
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "0 issue(s)" in captured.out
+
+
+def test_cli_rejects_payload_without_entries_list(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Malformed translation payloads fail fast instead of being treated as empty."""
+    localization = tmp_path / "Localization"
+    _write_payload(localization / "Dictionaries" / "demo.ja.json", {})
+
+    exit_code = check_translation_tokens.main([str(localization)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Translation payload must contain an 'entries' list" in captured.err
+    assert "Dictionaries/demo.ja.json" in captured.err
+
+
+def test_cli_rejects_non_object_translation_payload(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Top-level translation payloads must be JSON objects."""
+    localization = tmp_path / "Localization"
+    _write_payload(localization / "Dictionaries" / "demo.ja.json", [])
+
+    exit_code = check_translation_tokens.main([str(localization)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Translation payload must be a JSON object with an 'entries' list" in captured.err
+    assert "Dictionaries/demo.ja.json" in captured.err
+
+
+def test_cli_rejects_non_list_entries_payload(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The top-level `entries` member must be a list."""
+    localization = tmp_path / "Localization"
+    _write_payload(localization / "Dictionaries" / "demo.ja.json", {"entries": {}})
+
+    exit_code = check_translation_tokens.main([str(localization)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Translation payload must contain an 'entries' list" in captured.err
+    assert "Dictionaries/demo.ja.json" in captured.err
+
+
+def test_cli_rejects_malformed_translation_entry_with_index(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Malformed entries report path context and the one-based entry index."""
+    localization = tmp_path / "Localization"
+    _write_payload(localization / "Dictionaries" / "demo.ja.json", {"entries": ["not an object"]})
+
+    exit_code = check_translation_tokens.main([str(localization)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Translation entry must be a JSON object" in captured.err
+    assert "Dictionaries/demo.ja.json" in captured.err
+    assert "entry_index=1" in captured.err
+
+
+def test_cli_rejects_entry_without_string_key_and_text(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Entry shape validation covers missing and non-string key/text fields."""
+    localization = tmp_path / "Localization"
+    _write_payload(localization / "Dictionaries" / "demo.ja.json", {"entries": [{"key": "Source"}]})
+
+    exit_code = check_translation_tokens.main([str(localization)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Translation entry must contain string 'key' and 'text'" in captured.err
+    assert "Dictionaries/demo.ja.json" in captured.err
+    assert "entry_index=1" in captured.err
 
 
 def test_duplicate_source_key_conflict_fails_unless_baselined(

--- a/scripts/tests/test_translation_tokens.py
+++ b/scripts/tests/test_translation_tokens.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from scripts import check_translation_tokens
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def _write_entries(path: Path, entries: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"entries": entries}, ensure_ascii=False), encoding="utf-8")
+
+
+def _write_duplicate_baseline(path: Path, *, texts: list[str], entry_count: int = 2) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "duplicate_conflicts": [
+                    {
+                        "path": "Dictionaries/demo.ja.json",
+                        "key": "Same source",
+                        "entry_count": entry_count,
+                        "texts": sorted(texts),
+                    },
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_cli_reports_missing_source_tokens_for_dictionary_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The CLI reports dropped markup and placeholder tokens in dictionary JSON."""
+    localization = tmp_path / "Localization"
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [
+            {
+                "key": "{{R|Alert}} && &W ^y <color=#B1C9C3FF>hot</color> {0}",
+                "text": "警告 &W <color=#B1C9C3FF>熱</color>",
+            },
+        ],
+    )
+
+    exit_code = check_translation_tokens.main([str(localization)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Dictionaries/demo.ja.json" in captured.out
+    assert "missing translation tokens" in captured.out
+    assert "placeholder multiset mismatch" in captured.out
+
+
+def test_cli_passes_when_source_tokens_are_preserved_and_translation_adds_decoration(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The gate is asymmetric for markup and allows translation-only decoration."""
+    localization = tmp_path / "Localization"
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [
+            {
+                "key": "{{R|Alert}} && &W ^y <color=#B1C9C3FF>hot</color> {0}",
+                "text": "{{R|警告}} && &W ^y <color=#B1C9C3FF>熱</color> {0} {{G|追加}}",
+            },
+        ],
+    )
+
+    exit_code = check_translation_tokens.main([str(localization)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "0 issue(s)" in captured.out
+
+
+def test_duplicate_source_key_conflict_fails_unless_baselined(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Same-file duplicate source keys fail only when their conflict is not baselined."""
+    localization = tmp_path / "Localization"
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [
+            {"key": "Same source", "text": "訳語A"},
+            {"key": "Same source", "text": "訳語B"},
+        ],
+    )
+
+    assert check_translation_tokens.main([str(localization)]) == 1
+    captured = capsys.readouterr()
+    assert "duplicate source key conflict" in captured.out
+
+    baseline = tmp_path / "baseline.json"
+    _write_duplicate_baseline(baseline, texts=["訳語A", "訳語B"])
+
+    assert check_translation_tokens.main([str(localization), "--duplicate-conflict-baseline", str(baseline)]) == 0
+
+
+def test_duplicate_source_key_baseline_fails_when_text_state_changes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Baselined duplicate conflicts are allowed only while their text state matches exactly."""
+    localization = tmp_path / "Localization"
+    target = localization / "Dictionaries" / "demo.ja.json"
+    baseline = tmp_path / "baseline.json"
+    _write_duplicate_baseline(baseline, texts=["訳語A", "訳語B"])
+    _write_entries(
+        target,
+        [
+            {"key": "Same source", "text": "訳語A"},
+            {"key": "Same source", "text": "訳語C"},
+        ],
+    )
+
+    assert check_translation_tokens.main([str(localization), "--duplicate-conflict-baseline", str(baseline)]) == 1
+    captured = capsys.readouterr()
+    assert "duplicate conflict baseline changed" in captured.out
+    assert "訳語C" in captured.out
+
+    _write_entries(
+        target,
+        [
+            {"key": "Same source", "text": "訳語A"},
+        ],
+    )
+
+    assert check_translation_tokens.main([str(localization), "--duplicate-conflict-baseline", str(baseline)]) == 1
+    captured = capsys.readouterr()
+    assert "missing current conflict" in captured.out
+
+
+def test_duplicate_baseline_path_is_stable_for_localization_relative_cli_shapes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Duplicate baseline keys stay stable from the localization root and direct JSON file paths."""
+    localization = tmp_path / "Localization"
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [
+            {"key": "Same source", "text": "訳語A"},
+            {"key": "Same source", "text": "訳語B"},
+        ],
+    )
+    baseline = tmp_path / "baseline.json"
+    _write_duplicate_baseline(baseline, texts=["訳語A", "訳語B"])
+
+    monkeypatch.chdir(localization)
+    assert check_translation_tokens.main([".", "--duplicate-conflict-baseline", str(baseline)]) == 0
+    assert check_translation_tokens.main(["Dictionaries", "--duplicate-conflict-baseline", str(baseline)]) == 0
+
+    monkeypatch.chdir(localization / "Dictionaries")
+    assert check_translation_tokens.main(["demo.ja.json", "--duplicate-conflict-baseline", str(baseline)]) == 0
+
+
+def test_blueprint_templates_first_slice_entries_are_scanned_for_token_loss(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """BlueprintTemplates `entries` are covered by the first-slice token gate."""
+    localization = tmp_path / "Localization"
+    _write_entries(
+        localization / "BlueprintTemplates" / "templates.ja.json",
+        [
+            {
+                "key": "{{g|The {0} glows.}}",
+                "text": "{0}が光る。",
+            },
+        ],
+    )
+
+    exit_code = check_translation_tokens.main([str(localization)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "BlueprintTemplates/templates.ja.json" in captured.out
+    assert "missing translation tokens" in captured.out

--- a/scripts/tests/test_translation_tokens.py
+++ b/scripts/tests/test_translation_tokens.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from scripts import check_translation_tokens
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     import pytest
 
 
@@ -36,6 +35,15 @@ def _write_duplicate_baseline(path: Path, *, texts: list[str], entry_count: int 
     )
 
 
+def _run_with_duplicate_baseline(tmp_path: Path, payload: object) -> int:
+    localization = tmp_path / "Localization"
+    _write_entries(localization / "Dictionaries" / "demo.ja.json", [{"key": "Source", "text": "訳"}])
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps(payload), encoding="utf-8")
+
+    return check_translation_tokens.main([str(localization), "--duplicate-conflict-baseline", str(baseline)])
+
+
 def test_cli_reports_missing_source_tokens_for_dictionary_json(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -59,6 +67,29 @@ def test_cli_reports_missing_source_tokens_for_dictionary_json(
     assert "Dictionaries/demo.ja.json" in captured.out
     assert "missing translation tokens" in captured.out
     assert "placeholder multiset mismatch" in captured.out
+
+
+def test_cli_reports_missing_bare_qud_span_token(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Bare Qud spans such as `{{R}}` are source tokens, not disposable text."""
+    localization = tmp_path / "Localization"
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [
+            {
+                "key": "{{R}}",
+                "text": "",
+            },
+        ],
+    )
+
+    exit_code = check_translation_tokens.main([str(localization)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "missing translation tokens: '{{R}}': 1" in captured.out
 
 
 def test_cli_passes_when_source_tokens_are_preserved_and_translation_adds_decoration(
@@ -164,6 +195,55 @@ def test_duplicate_baseline_path_is_stable_for_localization_relative_cli_shapes(
 
     monkeypatch.chdir(localization / "Dictionaries")
     assert check_translation_tokens.main(["demo.ja.json", "--duplicate-conflict-baseline", str(baseline)]) == 0
+
+
+def test_collect_translation_json_files_deduplicates_relative_and_absolute_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Collector canonicalizes inputs so relative and absolute shapes do not duplicate scans."""
+    localization = tmp_path / "Localization"
+    target = localization / "Dictionaries" / "demo.ja.json"
+    _write_entries(target, [{"key": "Source", "text": "訳"}])
+
+    monkeypatch.chdir(localization)
+
+    files = check_translation_tokens.collect_translation_json_files([Path(), target])
+
+    assert files == [target.resolve()]
+
+
+def test_duplicate_baseline_rejects_missing_version(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Duplicate baseline files must declare the expected schema version."""
+    assert _run_with_duplicate_baseline(tmp_path, {"duplicate_conflicts": []}) == 1
+
+    captured = capsys.readouterr()
+    assert "must contain version 2" in captured.err
+
+
+def test_duplicate_baseline_rejects_version_mismatch(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Duplicate baseline files fail fast when their schema version is unexpected."""
+    assert _run_with_duplicate_baseline(tmp_path, {"version": 1, "duplicate_conflicts": []}) == 1
+
+    captured = capsys.readouterr()
+    assert "expected version 2" in captured.err
+
+
+def test_duplicate_baseline_rejects_non_object_payload(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Duplicate baseline files must be JSON objects before fields are read."""
+    assert _run_with_duplicate_baseline(tmp_path, []) == 1
+
+    captured = capsys.readouterr()
+    assert "must be a JSON object" in captured.err
 
 
 def test_blueprint_templates_first_slice_entries_are_scanned_for_token_loss(

--- a/scripts/translation_token_duplicate_baseline.json
+++ b/scripts/translation_token_duplicate_baseline.json
@@ -1,148 +1,7610 @@
 {
-  "version": 2,
+  "version": 3,
   "duplicate_conflicts": [
     {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": " missile weapon equipped!",
+      "entry_count": 2,
+      "texts": [
+        "射撃武器！",
+        "飛び道具を装備していない！"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 28,
+          "text": "射撃武器！"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 570,
+          "text": "飛び道具を装備していない！"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": " with your shield block!",
+      "entry_count": 2,
+      "texts": [
+        "を盾受けでよろめかせた！",
+        "（盾ブロック）"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 24,
+          "text": "（盾ブロック）"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 566,
+          "text": "を盾受けでよろめかせた！"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": " you with ",
+      "entry_count": 2,
+      "texts": [
+        " で注入した。",
+        "（あなたを攻撃、武器："
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 31,
+          "text": "（あなたを攻撃、武器："
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 581,
+          "text": " で注入した。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": ", giving you no chance of performing well. You can remedy this situation by improving your Ego, Willpower, Intelligence, and esoteric skills.",
+      "entry_count": 3,
+      "texts": [
+        "成果を上げる見込みがない。エゴ・意志力・知力や秘術技能を高めれば状況を改善できる。",
+        "良い結果を出せない。自我・意志力・知力・秘術スキルを高めれば改善できる。",
+        "良い結果を出せない。自我・意志力・知力・秘術スキルを高めれば改善できる。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 49,
+          "text": "良い結果を出せない。自我・意志力・知力・秘術スキルを高めれば改善できる。"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 73,
+          "text": "良い結果を出せない。自我・意志力・知力・秘術スキルを高めれば改善できる。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 593,
+          "text": "成果を上げる見込みがない。エゴ・意志力・知力や秘術技能を高めれば状況を改善できる。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "-or-",
+      "entry_count": 3,
+      "texts": [
+        "-または-",
+        "または",
+        "または"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 258,
+          "text": "または"
+        },
+        {
+          "path": "Dictionaries/ui-issue121-template-static.ja.json",
+          "entry_index": 4,
+          "text": "または"
+        },
+        {
+          "path": "Dictionaries/ui-tinkering.ja.json",
+          "entry_index": 9,
+          "text": "-または-"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "...",
+      "entry_count": 2,
+      "texts": [
+        "...",
+        "……"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-cybernetics.ja.json",
+          "entry_index": 44,
+          "text": "..."
+        },
+        {
+          "path": "Dictionaries/ui-popup.ja.json",
+          "entry_index": 388,
+          "text": "……"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "<spice.nouns.!random>",
+      "entry_count": 2,
+      "texts": [
+        "<spice.nouns.!random>",
+        "名詞"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 305,
+          "text": "名詞"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 49,
+          "text": "<spice.nouns.!random>"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "<spice.personNouns.!random>",
+      "entry_count": 2,
+      "texts": [
+        "<spice.personNouns.!random>",
+        "人物"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 311,
+          "text": "人物"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 389,
+          "text": "<spice.personNouns.!random>"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "ACTIVE EFFECTS:",
+      "entry_count": 2,
+      "texts": [
+        "アクティブ効果:",
+        "発動中の効果:"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 86,
+          "text": "発動中の効果:"
+        },
+        {
+          "path": "Dictionaries/ui-phase3c-labels.ja.json",
+          "entry_index": 1,
+          "text": "アクティブ効果:"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Accept",
+      "entry_count": 5,
+      "texts": [
+        "受け入れる",
+        "決定",
+        "決定",
+        "決定",
+        "決定"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 52,
+          "text": "決定"
+        },
+        {
+          "path": "Dictionaries/ui-help.ja.json",
+          "entry_index": 4,
+          "text": "決定"
+        },
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 30,
+          "text": "受け入れる"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 22,
+          "text": "決定"
+        },
+        {
+          "path": "Dictionaries/ui-statusscreens.ja.json",
+          "entry_index": 3,
+          "text": "決定"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Adventure",
+      "entry_count": 2,
+      "texts": [
+        "アドベンチャー",
+        "冒険"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 15,
+          "text": "冒険"
+        },
+        {
+          "path": "Dictionaries/ui-modpage.ja.json",
+          "entry_index": 17,
+          "text": "アドベンチャー"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Artifacts",
+      "entry_count": 2,
+      "texts": [
+        "アーティファクト",
+        "遺物"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 44,
+          "text": "遺物"
+        },
+        {
+          "path": "Dictionaries/ui-phase3b-static.ja.json",
+          "entry_index": 43,
+          "text": "アーティファクト"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Average",
+      "entry_count": 3,
+      "texts": [
+        "平均",
+        "普通",
+        "普通"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 269,
+          "text": "普通"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 128,
+          "text": "平均"
+        },
+        {
+          "path": "Dictionaries/ui-phase3c-labels.ja.json",
+          "entry_index": 19,
+          "text": "普通"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Clothes",
+      "entry_count": 2,
+      "texts": [
+        "衣服",
+        "衣類"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 37,
+          "text": "衣類"
+        },
+        {
+          "path": "Dictionaries/ui-phase3b-static.ja.json",
+          "entry_index": 44,
+          "text": "衣服"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Cudgel",
+      "entry_count": 3,
+      "texts": [
+        "棍棒",
+        "棍棒",
+        "鈍器"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 235,
+          "text": "鈍器"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 85,
+          "text": "棍棒"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 86,
+          "text": "棍棒"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Filter",
+      "entry_count": 2,
+      "texts": [
+        "フィルター",
+        "絞り込み"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 21,
+          "text": "フィルター"
+        },
+        {
+          "path": "Dictionaries/ui-statusscreens.ja.json",
+          "entry_index": 1,
+          "text": "絞り込み"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Game saved!",
+      "entry_count": 2,
+      "texts": [
+        "ゲームをセーブしました！",
+        "ゲームを保存しました！"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 31,
+          "text": "ゲームを保存しました！"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 24,
+          "text": "ゲームをセーブしました！"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Injured",
+      "entry_count": 2,
+      "texts": [
+        "負傷",
+        "軽傷"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 124,
+          "text": "負傷"
+        },
+        {
+          "path": "Dictionaries/ui-phase3c-labels.ja.json",
+          "entry_index": 10,
+          "text": "軽傷"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Intelligence",
+      "entry_count": 2,
+      "texts": [
+        "知力",
+        "知性"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-attributes.ja.json",
+          "entry_index": 4,
+          "text": "知力"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 423,
+          "text": "知性"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Last saved:",
+      "entry_count": 3,
+      "texts": [
+        "最終セーブ：",
+        "最終セーブ：",
+        "最終保存:"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 71,
+          "text": "最終セーブ："
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 156,
+          "text": "最終セーブ："
+        },
+        {
+          "path": "Dictionaries/ui-issue121-template-static.ja.json",
+          "entry_index": 6,
+          "text": "最終保存:"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Location:",
+      "entry_count": 3,
+      "texts": [
+        "場所:",
+        "場所：",
+        "場所："
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 70,
+          "text": "場所："
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 155,
+          "text": "場所："
+        },
+        {
+          "path": "Dictionaries/ui-issue121-template-static.ja.json",
+          "entry_index": 5,
+          "text": "場所:"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Missile Weapon",
+      "entry_count": 2,
+      "texts": [
+        "射撃武器",
+        "飛び道具"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-inventory.ja.json",
+          "entry_index": 64,
+          "text": "射撃武器"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 174,
+          "text": "飛び道具"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Mod",
+      "entry_count": 2,
+      "texts": [
+        "Mod",
+        "改造"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 214,
+          "text": "Mod"
+        },
+        {
+          "path": "Dictionaries/ui-tinkering.ja.json",
+          "entry_index": 4,
+          "text": "改造"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Perfect",
+      "entry_count": 2,
+      "texts": [
+        "完全",
+        "完璧"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 123,
+          "text": "完璧"
+        },
+        {
+          "path": "Dictionaries/ui-phase3c-labels.ja.json",
+          "entry_index": 12,
+          "text": "完全"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Pistol",
+      "entry_count": 3,
+      "texts": [
+        "ピストル",
+        "拳銃術",
+        "拳銃術"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/Scoped/ui-chargen-skill-context.ja.json",
+          "entry_index": 6,
+          "text": "拳銃術"
+        },
+        {
+          "path": "Dictionaries/Scoped/ui-skillsandpowers-skill-names.ja.json",
+          "entry_index": 6,
+          "text": "拳銃術"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 232,
+          "text": "ピストル"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Quenched",
+      "entry_count": 3,
+      "texts": [
+        "潤っている",
+        "潤っている",
+        "潤沢"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 250,
+          "text": "潤っている"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 98,
+          "text": "潤っている"
+        },
+        {
+          "path": "Dictionaries/ui-phase3c-labels.ja.json",
+          "entry_index": 26,
+          "text": "潤沢"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Randomize Selection",
+      "entry_count": 3,
+      "texts": [
+        "ランダムに選択",
+        "ランダムに選択",
+        "選択をランダムにする"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-chargen.ja.json",
+          "entry_index": 80,
+          "text": "選択をランダムにする"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 181,
+          "text": "ランダムに選択"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 182,
+          "text": "ランダムに選択"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "SP",
+      "entry_count": 2,
+      "texts": [
+        "スキルP",
+        "技能ポイント"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-attributes.ja.json",
+          "entry_index": 20,
+          "text": "スキルP"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 194,
+          "text": "技能ポイント"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Seekers",
+      "entry_count": 2,
+      "texts": [
+        "求道者",
+        "盲道の徒"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-factions.ja.json",
+          "entry_index": 82,
+          "text": "盲道の徒"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 217,
+          "text": "求道者"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Select",
+      "entry_count": 2,
+      "texts": [
+        "決定",
+        "選択"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-help.ja.json",
+          "entry_index": 5,
+          "text": "選択"
+        },
+        {
+          "path": "Dictionaries/ui-options.ja.json",
+          "entry_index": 11,
+          "text": "決定"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "TARGET: [none]",
+      "entry_count": 2,
+      "texts": [
+        "ターゲット: [なし]",
+        "対象: [なし]"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 59,
+          "text": "対象: [なし]"
+        },
+        {
+          "path": "Dictionaries/ui-phase3c-labels.ja.json",
+          "entry_index": 3,
+          "text": "ターゲット: [なし]"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "ThawZone exception",
+      "entry_count": 2,
+      "texts": [
+        "ThawZone 例外",
+        "ゾーン解凍エラー"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-leaf.ja.json",
+          "entry_index": 128,
+          "text": "ゾーン解凍エラー"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 19,
+          "text": "ThawZone 例外"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "The injection fails.",
+      "entry_count": 2,
+      "texts": [
+        "注入に失敗した。",
+        "注射は失敗に終わった。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 223,
+          "text": "注射は失敗に終わった。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 582,
+          "text": "注入に失敗した。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Warden",
+      "entry_count": 2,
+      "texts": [
+        "ウォーデン",
+        "監視官"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-chargen.ja.json",
+          "entry_index": 43,
+          "text": "ウォーデン"
+        },
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 42,
+          "text": "監視官"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Water Containers",
+      "entry_count": 2,
+      "texts": [
+        "容れ物",
+        "水筒"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-phase3b-static.ja.json",
+          "entry_index": 40,
+          "text": "水筒"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 59,
+          "text": "容れ物"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You acceded to Resheph's plan to purge the world of higher life in preparation for the Coven's return.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはレシェフの計画に従い、コヴンの帰還に備えて世界から高等生命を一掃することにした。",
+        "あなたはレシェフの計画に従い、魔女団の帰還に備えて世界から高等生命を一掃することにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 274,
+          "text": "あなたはレシェフの計画に従い、魔女団の帰還に備えて世界から高等生命を一掃することにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 11,
+          "text": "あなたはレシェフの計画に従い、コヴンの帰還に備えて世界から高等生命を一掃することにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You annulled the plagues of the Gyre.\n\nThen you destroyed Resheph and launched yourself into the dusted cosmos to ply the stars with Barathrum.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはジャイアの疫病を無効化した。\n\nそしてレシェフを滅ぼし、バラサラムと共に塵の宇宙へ飛び立ち、星々を渡ることにした。",
+        "あなたは回転の疫病を無効化した。\n\nそしてレシェフを滅ぼし、バラサラムと共に塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 277,
+          "text": "あなたは回転の疫病を無効化した。\n\nそしてレシェフを滅ぼし、バラサラムと共に塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 14,
+          "text": "あなたはジャイアの疫病を無効化した。\n\nそしてレシェフを滅ぼし、バラサラムと共に塵の宇宙へ飛び立ち、星々を渡ることにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You annulled the plagues of the Gyre.\n\nThen you destroyed Resheph and returned to Qud to help garden the burgeoning world.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはジャイアの疫病を無効化した。\n\nそしてレシェフを滅ぼし、クッドに戻って芽吹く世界を育てることにした。",
+        "あなたは回転の疫病を無効化した。\n\nそしてレシェフを滅ぼし、クッドに戻って芽吹く世界の庭を耕すことにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 271,
+          "text": "あなたは回転の疫病を無効化した。\n\nそしてレシェフを滅ぼし、クッドに戻って芽吹く世界の庭を耕すことにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 8,
+          "text": "あなたはジャイアの疫病を無効化した。\n\nそしてレシェフを滅ぼし、クッドに戻って芽吹く世界を育てることにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You annulled the plagues of the Gyre.\n\nThen you destroyed Resheph to save the burgeoning world but marooned yourself at the North Sheva.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはジャイアの疫病を無効化した。\n\nそしてレシェフを滅ぼして芽吹く世界を救ったが、北シェバに取り残された。",
+        "あなたは回転の疫病を無効化した。\n\nそして芽吹く世界を救うためレシェフを滅ぼしたが、北シェヴァに取り残された。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 267,
+          "text": "あなたは回転の疫病を無効化した。\n\nそして芽吹く世界を救うためレシェフを滅ぼしたが、北シェヴァに取り残された。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 4,
+          "text": "あなたはジャイアの疫病を無効化した。\n\nそしてレシェフを滅ぼして芽吹く世界を救ったが、北シェバに取り残された。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You annulled the plagues of the Gyre.\n\nThen you entered into a covenant with Resheph to help prepare Qud for the Coven's return.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはジャイアの疫病を無効化した。\n\nそしてレシェフと契約を結び、コヴンの帰還に備えてクッドを整えることにした。",
+        "あなたは回転の疫病を無効化した。\n\nそしてレシェフと契約を結び、魔女団の帰還に備えてクッドを整えることにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 269,
+          "text": "あなたは回転の疫病を無効化した。\n\nそしてレシェフと契約を結び、魔女団の帰還に備えてクッドを整えることにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 6,
+          "text": "あなたはジャイアの疫病を無効化した。\n\nそしてレシェフと契約を結び、コヴンの帰還に備えてクッドを整えることにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You annulled the plagues of the Gyre.\n\nThen you freed the Spindle for another's ascent and crossed into Brightsheol",
+      "entry_count": 2,
+      "texts": [
+        "あなたはジャイアの疫病を無効化した。\n\nそしてスピンドルを他者の昇天のために解放し、ブライトシェオルへ渡った。",
+        "あなたは回転の疫病を無効化した。\n\nそして紡錘を解放し、他の者の昇華に道を譲り、ブライトシェオルへと渡った。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 265,
+          "text": "あなたは回転の疫病を無効化した。\n\nそして紡錘を解放し、他の者の昇華に道を譲り、ブライトシェオルへと渡った。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 2,
+          "text": "あなたはジャイアの疫病を無効化した。\n\nそしてスピンドルを他者の昇天のために解放し、ブライトシェオルへ渡った。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You annulled the plagues of the Gyre.\n\nThen you launched yourself into the dusted cosmos to ply the stars with Barathrum.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはジャイアの疫病を無効化した。\n\nそしてバラサラムと共に塵の宇宙へ飛び立ち、星々を渡ることにした。",
+        "あなたは回転の疫病を無効化した。\n\nそしてバラサラムと共に塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 281,
+          "text": "あなたは回転の疫病を無効化した。\n\nそしてバラサラムと共に塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 18,
+          "text": "あなたはジャイアの疫病を無効化した。\n\nそしてバラサラムと共に塵の宇宙へ飛び立ち、星々を渡ることにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You annulled the plagues of the Gyre.\n\nThen you launched yourself into the dusted cosmos to ply the stars.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはジャイアの疫病を無効化した。\n\nそして塵の宇宙へ飛び立ち、星々を渡ることにした。",
+        "あなたは回転の疫病を無効化した。\n\nそして塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 283,
+          "text": "あなたは回転の疫病を無効化した。\n\nそして塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 20,
+          "text": "あなたはジャイアの疫病を無効化した。\n\nそして塵の宇宙へ飛び立ち、星々を渡ることにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You annulled the plagues of the Gyre.\n\nThen you returned to Qud to help garden the burgeoning world.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはジャイアの疫病を無効化した。\n\nそしてクッドに戻って芽吹く世界を育てることにした。",
+        "あなたは回転の疫病を無効化した。\n\nそしてクッドに戻り、芽吹く世界の庭を耕すことにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 273,
+          "text": "あなたは回転の疫病を無効化した。\n\nそしてクッドに戻り、芽吹く世界の庭を耕すことにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 10,
+          "text": "あなたはジャイアの疫病を無効化した。\n\nそしてクッドに戻って芽吹く世界を育てることにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You annulled the plagues of the Gyre.\n\nThen you reversed course and acceded to Resheph's plan to purge the world of higher life, in preparation for the Coven's return.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはジャイアの疫病を無効化した。\n\nそして方針を翻し、レシェフの計画に従い、コヴンの帰還に備えて世界から高等生命を一掃することにした。",
+        "あなたは回転の疫病を無効化した。\n\nしかし翻意し、レシェフの計画に従って魔女団の帰還に備え、世界から高等生命を一掃することにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 275,
+          "text": "あなたは回転の疫病を無効化した。\n\nしかし翻意し、レシェフの計画に従って魔女団の帰還に備え、世界から高等生命を一掃することにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 12,
+          "text": "あなたはジャイアの疫病を無効化した。\n\nそして方針を翻し、レシェフの計画に従い、コヴンの帰還に備えて世界から高等生命を一掃することにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You are staggered by ",
+      "entry_count": 2,
+      "texts": [
+        " にひるまされた！",
+        "よろめかされた："
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 25,
+          "text": "よろめかされた："
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 567,
+          "text": " にひるまされた！"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You cannot do that on the world map.",
+      "entry_count": 2,
+      "texts": [
+        "ワールドマップではそれはできない。",
+        "ワールドマップ上ではそれを行えない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 89,
+          "text": "ワールドマップではそれはできない。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 525,
+          "text": "ワールドマップ上ではそれを行えない。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You cannot do that while burrowed.",
+      "entry_count": 3,
+      "texts": [
+        "潜伏中はそれはできない。",
+        "潜伏中はそれを行えない。",
+        "潜伏中はそれを行えない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 23,
+          "text": "潜伏中はそれはできない。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 452,
+          "text": "潜伏中はそれを行えない。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 457,
+          "text": "潜伏中はそれを行えない。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You cannot do that while enclosed.",
+      "entry_count": 2,
+      "texts": [
+        "囲われている間はそれはできない。",
+        "囲われている間はそれを行えない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 21,
+          "text": "囲われている間はそれはできない。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 456,
+          "text": "囲われている間はそれを行えない。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You cannot do that while flying.",
+      "entry_count": 2,
+      "texts": [
+        "飛行中はそれはできない。",
+        "飛行中はそれを行えない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 28,
+          "text": "飛行中はそれはできない。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 453,
+          "text": "飛行中はそれを行えない。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You cannot fire missile weapons on the world map.",
+      "entry_count": 2,
+      "texts": [
+        "ワールドマップでは射撃できない。",
+        "ワールドマップでは飛び道具を撃てない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 56,
+          "text": "ワールドマップでは射撃できない。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 481,
+          "text": "ワールドマップでは飛び道具を撃てない。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You cannot go that way.",
+      "entry_count": 2,
+      "texts": [
+        "そちらには行けない。",
+        "その方向へは進めない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-leaf.ja.json",
+          "entry_index": 127,
+          "text": "そちらには行けない。"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 1,
+          "text": "その方向へは進めない。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You cannot throw things on the world map.",
+      "entry_count": 2,
+      "texts": [
+        "ワールドマップでは投擲できない。",
+        "ワールドマップでは物を投げられない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 54,
+          "text": "ワールドマップでは投擲できない。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 479,
+          "text": "ワールドマップでは物を投げられない。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You destroyed Resheph and launched yourself into the dusted cosmos to ply the stars with Barathrum.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはレシェフを滅ぼし、バラサラムと共に塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。",
+        "あなたはレシェフを滅ぼし、バラサラムと共に塵の宇宙へ飛び立ち、星々を渡ることにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 276,
+          "text": "あなたはレシェフを滅ぼし、バラサラムと共に塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 13,
+          "text": "あなたはレシェフを滅ぼし、バラサラムと共に塵の宇宙へ飛び立ち、星々を渡ることにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You destroyed Resheph and launched yourself into the dusted cosmos to ply the stars.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはレシェフを滅ぼし、塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。",
+        "あなたはレシェフを滅ぼし、塵の宇宙へ飛び立ち、星々を渡ることにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 278,
+          "text": "あなたはレシェフを滅ぼし、塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 15,
+          "text": "あなたはレシェフを滅ぼし、塵の宇宙へ飛び立ち、星々を渡ることにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You destroyed Resheph and returned to Qud to help garden the burgeoning world.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはレシェフを滅ぼし、クッドに戻って芽吹く世界の庭を耕すことにした。",
+        "あなたはレシェフを滅ぼし、クッドに戻って芽吹く世界を育てることにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 270,
+          "text": "あなたはレシェフを滅ぼし、クッドに戻って芽吹く世界の庭を耕すことにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 7,
+          "text": "あなたはレシェフを滅ぼし、クッドに戻って芽吹く世界を育てることにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You destroyed Resheph to save the burgeoning world but marooned yourself at the North Sheva.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはレシェフを滅ぼして芽吹く世界を救ったが、北シェバに取り残された。",
+        "あなたは芽吹く世界を救うためレシェフを滅ぼしたが、北シェヴァに取り残された。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 266,
+          "text": "あなたは芽吹く世界を救うためレシェフを滅ぼしたが、北シェヴァに取り残された。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 3,
+          "text": "あなたはレシェフを滅ぼして芽吹く世界を救ったが、北シェバに取り残された。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You do not have ",
+      "entry_count": 2,
+      "texts": [
+        "あなたは",
+        "装備していません："
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 26,
+          "text": "装備していません："
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 568,
+          "text": "あなたは"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You embark for the caves of Qud.",
+      "entry_count": 3,
+      "texts": [
+        "あなたはクッドの洞窟へ旅立った。",
+        "クッドの洞窟へ向かう。",
+        "クッドの洞窟へ旅立つ。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-leaf.ja.json",
+          "entry_index": 58,
+          "text": "あなたはクッドの洞窟へ旅立った。"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 29,
+          "text": "クッドの洞窟へ向かう。"
+        },
+        {
+          "path": "Dictionaries/ui-popup.ja.json",
+          "entry_index": 94,
+          "text": "クッドの洞窟へ旅立つ。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You entered into a covenant with Resheph to help prepare Qud for the Coven's return.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはレシェフと契約を結び、コヴンの帰還に備えてクッドを整えることにした。",
+        "あなたはレシェフと契約を結び、魔女団の帰還に備えてクッドを整えることにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 268,
+          "text": "あなたはレシェフと契約を結び、魔女団の帰還に備えてクッドを整えることにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 5,
+          "text": "あなたはレシェフと契約を結び、コヴンの帰還に備えてクッドを整えることにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You fall downward!",
+      "entry_count": 2,
+      "texts": [
+        "下へと落ちた！",
+        "下へ落ちる！"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 111,
+          "text": "下へと落ちた！"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 554,
+          "text": "下へ落ちる！"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You fall to the ground!",
+      "entry_count": 2,
+      "texts": [
+        "あなたは地面に倒れた！",
+        "地面に落下した！"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-leaf.ja.json",
+          "entry_index": 34,
+          "text": "あなたは地面に倒れた！"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 112,
+          "text": "地面に落下した！"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You freed the Spindle for another's ascent and crossed into Brightsheol.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはスピンドルを他者の昇天のために解放し、ブライトシェオルへ渡った。",
+        "あなたは紡錘を解放し、他の者の昇華に道を譲り、ブライトシェオルへと渡った。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 264,
+          "text": "あなたは紡錘を解放し、他の者の昇華に道を譲り、ブライトシェオルへと渡った。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 1,
+          "text": "あなたはスピンドルを他者の昇天のために解放し、ブライトシェオルへ渡った。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You have lost the use of your ",
+      "entry_count": 2,
+      "texts": [
+        "{part}が使えなくなった。",
+        "あなたは の機能を失った。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 164,
+          "text": "{part}が使えなくなった。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 560,
+          "text": "あなたは の機能を失った。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You have mastered psychic combat at this level of difficulty. Do you want to guide the process in detail anyway, with an enhanced chance of exceptional success? If you answer 'No', you will automatically receive the results of strong but unexceptional performance.",
+      "entry_count": 3,
+      "texts": [
+        "この難度での精神戦は熟達済みだ。より高い成功率を狙って詳細に指揮しますか？「いいえ」を選ぶと標準的な成功の結果を自動で受け取ります。",
+        "この難度での精神戦は熟達済みだ。より高い成功率を狙って詳細に指揮する？「いいえ」を選ぶと標準的な成功の結果を自動で受け取る。",
+        "この難度での精神戦闘は習熟済みだ。卓越した成功率を狙って詳細な手順を自ら指揮する？「いいえ」を選ぶと、平凡でも堅実な結果が自動的に得られる。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 50,
+          "text": "この難度での精神戦は熟達済みだ。より高い成功率を狙って詳細に指揮しますか？「いいえ」を選ぶと標準的な成功の結果を自動で受け取ります。"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 74,
+          "text": "この難度での精神戦は熟達済みだ。より高い成功率を狙って詳細に指揮する？「いいえ」を選ぶと標準的な成功の結果を自動で受け取る。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 594,
+          "text": "この難度での精神戦闘は習熟済みだ。卓越した成功率を狙って詳細な手順を自ら指揮する？「いいえ」を選ぶと、平凡でも堅実な結果が自動的に得られる。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You have no active quests.",
+      "entry_count": 2,
+      "texts": [
+        "進行中のクエストがない。",
+        "進行中のクエストはない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 58,
+          "text": "進行中のクエストはない。"
+        },
+        {
+          "path": "Dictionaries/ui-quests.ja.json",
+          "entry_index": 1,
+          "text": "進行中のクエストがない。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You have no more usable options, so your performance so far will determine the outcome.",
+      "entry_count": 3,
+      "texts": [
+        "使える手はもうない。ここまでの成果が結果を決める。",
+        "使える手はもうない。ここまでの成果が結果を決める。",
+        "使える手段が尽きたので、ここまでの成果で結果が決まる。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 53,
+          "text": "使える手はもうない。ここまでの成果が結果を決める。"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 77,
+          "text": "使える手はもうない。ここまでの成果が結果を決める。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 595,
+          "text": "使える手段が尽きたので、ここまでの成果で結果が決まる。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You have no usable options to employ for ",
+      "entry_count": 3,
+      "texts": [
+        " に使える手段がないため、",
+        "次の行動に使える選択肢がない: ",
+        "次の行動に使える選択肢がない: "
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 48,
+          "text": "次の行動に使える選択肢がない: "
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 72,
+          "text": "次の行動に使える選択肢がない: "
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 592,
+          "text": " に使える手段がないため、"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You have recovered the use of your ",
+      "entry_count": 2,
+      "texts": [
+        "{part}の使用が回復した。",
+        "あなたは の機能を回復した。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 166,
+          "text": "{part}の使用が回復した。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 561,
+          "text": "あなたは の機能を回復した。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You hear a shloop and the world around you shifts.",
+      "entry_count": 2,
+      "texts": [
+        "「しゅぽん」という音とともに周囲の世界が歪んだ。",
+        "シュロープという音とともに、周囲の世界がずれる。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 124,
+          "text": "「しゅぽん」という音とともに周囲の世界が歪んだ。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 550,
+          "text": "シュロープという音とともに、周囲の世界がずれる。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You hear a shloop and then a hitch. Nothing happens.",
+      "entry_count": 2,
+      "texts": [
+        "「しゅぽん」と音がしたが、途中で止まり、何も起きない。",
+        "シュロープという音の後につまずきのような感触がする。何も起こらない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 125,
+          "text": "「しゅぽん」と音がしたが、途中で止まり、何も起きない。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 547,
+          "text": "シュロープという音の後につまずきのような感触がする。何も起こらない。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You launched yourself into the dusted cosmos to ply the stars with Barathrum.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはバラサラムと共に塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。",
+        "あなたはバラサラムと共に塵の宇宙へ飛び立ち、星々を渡ることにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 280,
+          "text": "あなたはバラサラムと共に塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 17,
+          "text": "あなたはバラサラムと共に塵の宇宙へ飛び立ち、星々を渡ることにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You launched yourself into the dusted cosmos to ply the stars.",
+      "entry_count": 2,
+      "texts": [
+        "あなたは塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。",
+        "あなたは塵の宇宙へ飛び立ち、星々を渡ることにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 282,
+          "text": "あなたは塵に覆われた宇宙へと飛び立ち、星々を渡ることにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 19,
+          "text": "あなたは塵の宇宙へ飛び立ち、星々を渡ることにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You rebuked Resheph and returned to Qud to help garden the burgeoning world.",
+      "entry_count": 2,
+      "texts": [
+        "あなたはレシェフを退け、クッドに戻って芽吹く世界の庭を耕すことにした。",
+        "あなたはレシェフを退け、クッドに戻って芽吹く世界を育てることにした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 272,
+          "text": "あなたはレシェフを退け、クッドに戻って芽吹く世界の庭を耕すことにした。"
+        },
+        {
+          "path": "Dictionaries/ui-phase3d-endings.ja.json",
+          "entry_index": 9,
+          "text": "あなたはレシェフを退け、クッドに戻って芽吹く世界を育てることにした。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You reflect ",
+      "entry_count": 3,
+      "texts": [
+        "あなたは",
+        "あなたは",
+        "ダメージを跳ね返した。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 177,
+          "text": "ダメージを跳ね返した。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 599,
+          "text": "あなたは"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 607,
+          "text": "あなたは"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You stagger ",
+      "entry_count": 2,
+      "texts": [
+        "あなたは",
+        "よろめかせた："
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 23,
+          "text": "よろめかせた："
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 565,
+          "text": "あなたは"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "You were resorbed into the Mass Mind.",
+      "entry_count": 2,
+      "texts": [
+        "あなたは大いなる精神に再吸収された。",
+        "集合精神に再吸収された。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-death.ja.json",
+          "entry_index": 42,
+          "text": "集合精神に再吸収された。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 218,
+          "text": "あなたは大いなる精神に再吸収された。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "Your shot goes wild!",
+      "entry_count": 2,
+      "texts": [
+        "あなたの弾が逸れた！",
+        "射撃が大きく逸れた！"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 245,
+          "text": "射撃が大きく逸れた！"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-leaf.ja.json",
+          "entry_index": 95,
+          "text": "あなたの弾が逸れた！"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "acid",
+      "entry_count": 2,
+      "texts": [
+        "{{G|酸の}}",
+        "酸"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 263,
+          "text": "{{G|酸の}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 368,
+          "text": "酸"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "acidic",
+      "entry_count": 3,
+      "texts": [
+        "{{G|酸性の}}",
+        "酸性の",
+        "酸性の"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 262,
+          "text": "{{G|酸性の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquid-adjectives.ja.json",
+          "entry_index": 6,
+          "text": "酸性の"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 369,
+          "text": "酸性の"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "algal",
+      "entry_count": 2,
+      "texts": [
+        "{{g|藻質の}}",
+        "藻類の"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 313,
+          "text": "{{g|藻質の}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 384,
+          "text": "藻類の"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "band",
+      "entry_count": 2,
+      "texts": [
+        "一団",
+        "隊"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/historyspice-common.ja.json",
+          "entry_index": 49,
+          "text": "一団"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 427,
+          "text": "隊"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "bloody",
+      "entry_count": 3,
+      "texts": [
+        "{{r|血まみれの}}",
+        "血まみれの",
+        "血混じりの"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 331,
+          "text": "{{r|血まみれの}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquid-adjectives.ja.json",
+          "entry_index": 16,
+          "text": "血混じりの"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 455,
+          "text": "血まみれの"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "boiling",
+      "entry_count": 2,
+      "texts": [
+        "沸き立つ",
+        "煮込む"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-liquid-adjectives.ja.json",
+          "entry_index": 8,
+          "text": "沸き立つ"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 457,
+          "text": "煮込む"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "cider",
+      "entry_count": 2,
+      "texts": [
+        "{{cider|サイダーの}}",
+        "シードル"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 302,
+          "text": "{{cider|サイダーの}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 529,
+          "text": "シードル"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "collect liquid",
+      "entry_count": 2,
+      "texts": [
+        "液体を採取",
+        "液体を採取する"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-popup.ja.json",
+          "entry_index": 83,
+          "text": "液体を採取"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 67,
+          "text": "液体を採取する"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "dilute",
+      "entry_count": 2,
+      "texts": [
+        "{{Y|希釈された}}",
+        "薄めの"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 285,
+          "text": "{{Y|希釈された}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquid-adjectives.ja.json",
+          "entry_index": 15,
+          "text": "薄めの"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "flaming",
+      "entry_count": 2,
+      "texts": [
+        "{{fiery|燃え盛る}}",
+        "燃え盛る"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 205,
+          "text": "{{fiery|燃え盛る}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 675,
+          "text": "燃え盛る"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "flux",
+      "entry_count": 2,
+      "texts": [
+        "{{neutronic|中性子フラックスの}}",
+        "フラックス"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 323,
+          "text": "{{neutronic|中性子フラックスの}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 680,
+          "text": "フラックス"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "fragrant",
+      "entry_count": 2,
+      "texts": [
+        "{{cider|芳香の}}",
+        "芳香の"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 304,
+          "text": "{{cider|芳香の}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 688,
+          "text": "芳香の"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "freezing",
+      "entry_count": 3,
+      "texts": [
+        "{{freezing|凍結した}}",
+        "凍てつく",
+        "凍てつく"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 220,
+          "text": "{{freezing|凍結した}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquid-adjectives.ja.json",
+          "entry_index": 9,
+          "text": "凍てつく"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 690,
+          "text": "凍てつく"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "frozen",
+      "entry_count": 2,
+      "texts": [
+        "{{freezing|凍結した}}",
+        "凍った"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 256,
+          "text": "{{freezing|凍結した}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 694,
+          "text": "凍った"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "gathering",
+      "entry_count": 2,
+      "texts": [
+        "回収",
+        "集まり"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/historyspice-common.ja.json",
+          "entry_index": 45,
+          "text": "集まり"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 15,
+          "text": "回収"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "goo",
+      "entry_count": 2,
+      "texts": [
+        "{{G|どろどろの}}",
+        "どろどろ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 266,
+          "text": "{{G|どろどろの}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 711,
+          "text": "どろどろ"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "gooey",
+      "entry_count": 2,
+      "texts": [
+        "{{G|どろりとした}}",
+        "ねばねばの"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 265,
+          "text": "{{G|どろりとした}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 713,
+          "text": "ねばねばの"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "homogenized",
+      "entry_count": 2,
+      "texts": [
+        "{{cloning|均質化した}}",
+        "均質化した"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 307,
+          "text": "{{cloning|均質化した}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 743,
+          "text": "均質化した"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "honey",
+      "entry_count": 2,
+      "texts": [
+        "{{w|はちみつの}}",
+        "ハチミツ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 337,
+          "text": "{{w|はちみつの}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 744,
+          "text": "ハチミツ"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "icy",
+      "entry_count": 2,
+      "texts": [
+        "{{icy|氷の}}",
+        "氷の"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 207,
+          "text": "{{icy|氷の}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 756,
+          "text": "氷の"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "interact",
+      "entry_count": 2,
+      "texts": [
+        "インタラクト",
+        "操作する"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 82,
+          "text": "インタラクト"
+        },
+        {
+          "path": "Dictionaries/ui-popup.ja.json",
+          "entry_index": 113,
+          "text": "操作する"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "liquid-covered",
+      "entry_count": 2,
+      "texts": [
+        "液まみれの",
+        "液塗れ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 112,
+          "text": "液まみれの"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 56,
+          "text": "液塗れ"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "lost",
+      "entry_count": 2,
+      "texts": [
+        "迷った",
+        "迷子の"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 38,
+          "text": "迷子の"
+        },
+        {
+          "path": "Dictionaries/world-effects-status.ja.json",
+          "entry_index": 49,
+          "text": "迷った"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "love",
+      "entry_count": 2,
+      "texts": [
+        "愛",
+        "愛慕"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/historyspice-common.ja.json",
+          "entry_index": 38,
+          "text": "愛"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 819,
+          "text": "愛慕"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "low",
+      "entry_count": 2,
+      "texts": [
+        "低",
+        "低い"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 203,
+          "text": "低"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 820,
+          "text": "低い"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "luminous",
+      "entry_count": 2,
+      "texts": [
+        "{{C|発光する}}",
+        "光を放つ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 260,
+          "text": "{{C|発光する}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 821,
+          "text": "光を放つ"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "magmatic",
+      "entry_count": 2,
+      "texts": [
+        "{{lava|マグマ質の}}",
+        "マグマの"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 318,
+          "text": "{{lava|マグマ質の}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 826,
+          "text": "マグマの"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "mutation:Carapace:rank:1",
+      "entry_count": 2,
+      "texts": [
+        "AV+{{rules|3}}\nDV-{{rules|2}}\n耐熱力+{{rules|10}}\n耐寒力+{{rules|10}}\n亀との評判+400\nじっとしている間は甲殻を締めればAVボーナスを2倍にできるが、DV-2のペナルティを受ける。\n胴体用の防具は装備できない。",
+        "{{rules|+3}} AV\n{{rules|-2}} DV\n{{rules|+10}} 耐熱力\n{{rules|+10}} 耐寒力\n{{rules|+400}} 亀派との評判\n静止しているあいだ甲殻を締め付ければ、AVボーナスが2倍になる代わりにDV-2のペナルティを受ける。\n胴体用の防具は装備できない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/mutation-descriptions.ja.json",
+          "entry_index": 12,
+          "text": "{{rules|+3}} AV\n{{rules|-2}} DV\n{{rules|+10}} 耐熱力\n{{rules|+10}} 耐寒力\n{{rules|+400}} 亀派との評判\n静止しているあいだ甲殻を締め付ければ、AVボーナスが2倍になる代わりにDV-2のペナルティを受ける。\n胴体用の防具は装備できない。"
+        },
+        {
+          "path": "Dictionaries/mutation-ranktext.ja.json",
+          "entry_index": 711,
+          "text": "AV+{{rules|3}}\nDV-{{rules|2}}\n耐熱力+{{rules|10}}\n耐寒力+{{rules|10}}\n亀との評判+400\nじっとしている間は甲殻を締めればAVボーナスを2倍にできるが、DV-2のペナルティを受ける。\n胴体用の防具は装備できない。"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "navigation",
+      "entry_count": 2,
+      "texts": [
+        "操作",
+        "移動"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-inventory.ja.json",
+          "entry_index": 9,
+          "text": "操作"
+        },
+        {
+          "path": "Dictionaries/ui-statusscreens.ja.json",
+          "entry_index": 2,
+          "text": "移動"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "oil",
+      "entry_count": 2,
+      "texts": [
+        "{{K|油の}}",
+        "油"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 272,
+          "text": "{{K|油の}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 882,
+          "text": "油"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "oily",
+      "entry_count": 3,
+      "texts": [
+        "{{K|油まみれの}}",
+        "油っぽい",
+        "油っぽい"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 271,
+          "text": "{{K|油まみれの}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquid-adjectives.ja.json",
+          "entry_index": 4,
+          "text": "油っぽい"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 883,
+          "text": "油っぽい"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "ooze",
+      "entry_count": 2,
+      "texts": [
+        "{{K|軟泥の}}",
+        "滲出液"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 274,
+          "text": "{{K|軟泥の}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 891,
+          "text": "滲出液"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "oozing",
+      "entry_count": 2,
+      "texts": [
+        "{{K|滲み出ている}}",
+        "にじみ出る"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 276,
+          "text": "{{K|滲み出ている}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 892,
+          "text": "にじみ出る"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "radiant",
+      "entry_count": 2,
+      "texts": [
+        "{{radiant|輝く}}",
+        "輝く"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 330,
+          "text": "{{radiant|輝く}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 943,
+          "text": "輝く"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "remove keybind",
+      "entry_count": 2,
+      "texts": [
+        "キー設定を削除",
+        "バインドを削除"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-keybinds.ja.json",
+          "entry_index": 5,
+          "text": "キー設定を削除"
+        },
+        {
+          "path": "Dictionaries/ui-options.ja.json",
+          "entry_index": 16,
+          "text": "バインドを削除"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "restore defaults",
+      "entry_count": 2,
+      "texts": [
+        "デフォルトに戻す",
+        "初期設定に戻す"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-keybinds.ja.json",
+          "entry_index": 4,
+          "text": "初期設定に戻す"
+        },
+        {
+          "path": "Dictionaries/ui-options.ja.json",
+          "entry_index": 17,
+          "text": "デフォルトに戻す"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "salt",
+      "entry_count": 3,
+      "texts": [
+        "{{Y|塩の}}",
+        "塩",
+        "塩"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 292,
+          "text": "{{Y|塩の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 5,
+          "text": "塩"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 978,
+          "text": "塩"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "salty",
+      "entry_count": 3,
+      "texts": [
+        "{{Y|塩気のある}}",
+        "塩気のある",
+        "塩辛い"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 290,
+          "text": "{{Y|塩気のある}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquid-adjectives.ja.json",
+          "entry_index": 2,
+          "text": "塩気のある"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 980,
+          "text": "塩辛い"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "scaled",
+      "entry_count": 2,
+      "texts": [
+        "{{scaled|鱗状の}}",
+        "鱗のある"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 245,
+          "text": "{{scaled|鱗状の}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 987,
+          "text": "鱗のある"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "select",
+      "entry_count": 2,
+      "texts": [
+        "決定",
+        "選択"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 231,
+          "text": "決定"
+        },
+        {
+          "path": "Dictionaries/ui-options.ja.json",
+          "entry_index": 19,
+          "text": "選択"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "slime",
+      "entry_count": 2,
+      "texts": [
+        "{{g|スライムの}}",
+        "粘液"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 314,
+          "text": "{{g|スライムの}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1023,
+          "text": "粘液"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "slimy",
+      "entry_count": 3,
+      "texts": [
+        "{{slimy|ぬめった}}",
+        "ぬめる",
+        "ぬるぬるの"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 334,
+          "text": "{{slimy|ぬめった}}"
+        },
+        {
+          "path": "Dictionaries/ui-zone-display.ja.json",
+          "entry_index": 217,
+          "text": "ぬめる"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1024,
+          "text": "ぬるぬるの"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "sludge",
+      "entry_count": 2,
+      "texts": [
+        "{{w|汚泥の}}",
+        "ヘドロ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 339,
+          "text": "{{w|汚泥の}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1026,
+          "text": "ヘドロ"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "society",
+      "entry_count": 2,
+      "texts": [
+        "共同体",
+        "社団"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/historyspice-common.ja.json",
+          "entry_index": 51,
+          "text": "共同体"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1034,
+          "text": "社団"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "some forgotten ruins",
+      "entry_count": 3,
+      "texts": [
+        "忘れられた遺跡",
+        "忘れられた遺跡",
+        "忘れ去られた廃墟"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 43,
+          "text": "忘れ去られた廃墟"
+        },
+        {
+          "path": "Dictionaries/ui-zone-display.ja.json",
+          "entry_index": 218,
+          "text": "忘れられた遺跡"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 386,
+          "text": "忘れられた遺跡"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "sort: ",
+      "entry_count": 2,
+      "texts": [
+        "ソート: ",
+        "並び替え: "
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 223,
+          "text": "並び替え: "
+        },
+        {
+          "path": "Dictionaries/ui-trade.ja.json",
+          "entry_index": 4,
+          "text": "ソート: "
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "spiced",
+      "entry_count": 2,
+      "texts": [
+        "スパイス入りの",
+        "香辛料入りの"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 277,
+          "text": "香辛料入りの"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1053,
+          "text": "スパイス入りの"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "square",
+      "entry_count": 3,
+      "texts": [
+        "マス",
+        "マス",
+        "正方形"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-zone-display.ja.json",
+          "entry_index": 226,
+          "text": "マス"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1063,
+          "text": "正方形"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 249,
+          "text": "マス"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "stained",
+      "entry_count": 2,
+      "texts": [
+        "染み",
+        "染みだらけ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 113,
+          "text": "染みだらけ"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 58,
+          "text": "染み"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "sticky",
+      "entry_count": 2,
+      "texts": [
+        "{{w|粘ついた}}",
+        "粘っこい"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 345,
+          "text": "{{w|粘ついた}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1074,
+          "text": "粘っこい"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "tar",
+      "entry_count": 2,
+      "texts": [
+        "{{K|タールの}}",
+        "タール"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 280,
+          "text": "{{K|タールの}}"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1095,
+          "text": "タール"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "tarry",
+      "entry_count": 3,
+      "texts": [
+        "{{K|タール質の}}",
+        "べとつく",
+        "タール塗れの"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 279,
+          "text": "{{K|タール質の}}"
+        },
+        {
+          "path": "Dictionaries/ui-zone-display.ja.json",
+          "entry_index": 234,
+          "text": "タール塗れの"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1096,
+          "text": "べとつく"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "water",
+      "entry_count": 4,
+      "texts": [
+        "{{B|水の}}",
+        "水",
+        "水",
+        "水"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 257,
+          "text": "{{B|水の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 2,
+          "text": "水"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1205,
+          "text": "水"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 80,
+          "text": "水"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "wet",
+      "entry_count": 2,
+      "texts": [
+        "{{B|濡れた}}",
+        "濡れている"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 135,
+          "text": "濡れている"
+        },
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 258,
+          "text": "{{B|濡れた}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "wine",
+      "entry_count": 2,
+      "texts": [
+        "{{m|ワインの}}",
+        "ワイン"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 320,
+          "text": "{{m|ワインの}}"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 82,
+          "text": "ワイン"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "you are under attack by ",
+      "entry_count": 2,
+      "texts": [
+        " に攻撃されている！",
+        "攻撃を受けている："
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 30,
+          "text": "攻撃を受けている："
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 571,
+          "text": " に攻撃されている！"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{B|water}}",
+      "entry_count": 2,
+      "texts": [
+        "{{B|水}}",
+        "{{B|水の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 114,
+          "text": "{{B|水の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 1,
+          "text": "{{B|水}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{B|wet}}",
+      "entry_count": 2,
+      "texts": [
+        "{{B|濡れた}}",
+        "{{B|濡れている}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 115,
+          "text": "{{B|濡れた}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 30,
+          "text": "{{B|濡れている}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{C|luminous}}",
+      "entry_count": 2,
+      "texts": [
+        "{{C|発光している}}",
+        "{{C|発光する}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 117,
+          "text": "{{C|発光する}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 31,
+          "text": "{{C|発光している}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{G|acidic}}",
+      "entry_count": 3,
+      "texts": [
+        "{{G|酸性}}",
+        "{{G|酸性の}}",
+        "{{G|酸性の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 119,
+          "text": "{{G|酸性の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquid-adjectives.ja.json",
+          "entry_index": 5,
+          "text": "{{G|酸性の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 32,
+          "text": "{{G|酸性}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{G|acid}}",
+      "entry_count": 2,
+      "texts": [
+        "{{G|酸}}",
+        "{{G|酸の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 120,
+          "text": "{{G|酸の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 8,
+          "text": "{{G|酸}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{K|None}}",
+      "entry_count": 2,
+      "texts": [
+        "{{K|なし}}",
+        "{{K|未設定}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-keybinds.ja.json",
+          "entry_index": 10,
+          "text": "{{K|なし}}"
+        },
+        {
+          "path": "Dictionaries/ui-options.ja.json",
+          "entry_index": 15,
+          "text": "{{K|未設定}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{K|You don't have any schematics.}}",
+      "entry_count": 2,
+      "texts": [
+        "{{K|設計図がない。}}",
+        "{{K|設計図を持っていない。}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 249,
+          "text": "{{K|設計図を持っていない。}}"
+        },
+        {
+          "path": "Dictionaries/ui-tinkering.ja.json",
+          "entry_index": 5,
+          "text": "{{K|設計図がない。}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{K|ink}}",
+      "entry_count": 2,
+      "texts": [
+        "{{K|インク}}",
+        "{{K|インクの}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 126,
+          "text": "{{K|インクの}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 10,
+          "text": "{{K|インク}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{K|oily}}",
+      "entry_count": 2,
+      "texts": [
+        "{{K|油っぽい}}",
+        "{{K|油まみれの}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 128,
+          "text": "{{K|油まみれの}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquid-adjectives.ja.json",
+          "entry_index": 3,
+          "text": "{{K|油っぽい}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{K|oil}}",
+      "entry_count": 2,
+      "texts": [
+        "{{K|油}}",
+        "{{K|油の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 129,
+          "text": "{{K|油の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 9,
+          "text": "{{K|油}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{K|ooze}}",
+      "entry_count": 2,
+      "texts": [
+        "{{K|軟泥}}",
+        "{{K|軟泥の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 131,
+          "text": "{{K|軟泥の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 11,
+          "text": "{{K|軟泥}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{K|tar}}",
+      "entry_count": 2,
+      "texts": [
+        "{{K|タール}}",
+        "{{K|タールの}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 136,
+          "text": "{{K|タールの}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 12,
+          "text": "{{K|タール}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{W|sap}}",
+      "entry_count": 2,
+      "texts": [
+        "{{W|樹液}}",
+        "{{W|樹液の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 139,
+          "text": "{{W|樹液の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 13,
+          "text": "{{W|樹液}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{Y|dilute}}",
+      "entry_count": 2,
+      "texts": [
+        "{{Y|希釈された}}",
+        "{{Y|薄めの}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 141,
+          "text": "{{Y|希釈された}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquid-adjectives.ja.json",
+          "entry_index": 14,
+          "text": "{{Y|薄めの}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{Y|gel}}",
+      "entry_count": 2,
+      "texts": [
+        "{{Y|ゲル}}",
+        "{{Y|ゲル状の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 143,
+          "text": "{{Y|ゲル状の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 14,
+          "text": "{{Y|ゲル}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{Y|lege{{W|n}}dary}}",
+      "entry_count": 2,
+      "texts": [
+        "{{Y|伝{{W|説}}的}}",
+        "{{Y|伝説{{W|的}}}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 72,
+          "text": "{{Y|伝説{{W|的}}}}"
+        },
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 39,
+          "text": "{{Y|伝{{W|説}}的}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{Y|masterwork}}",
+      "entry_count": 2,
+      "texts": [
+        "{{Y|傑作}}",
+        "{{Y|名工品}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 76,
+          "text": "{{Y|名工品}}"
+        },
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 47,
+          "text": "{{Y|傑作}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{Y|salt}}",
+      "entry_count": 2,
+      "texts": [
+        "{{Y|塩}}",
+        "{{Y|塩の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 147,
+          "text": "{{Y|塩の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 4,
+          "text": "{{Y|塩}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{Y|wax}}",
+      "entry_count": 2,
+      "texts": [
+        "{{Y|蝋}}",
+        "{{Y|蝋の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 153,
+          "text": "{{Y|蝋の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 16,
+          "text": "{{Y|蝋}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{brainbrine|brain-brine}}",
+      "entry_count": 2,
+      "texts": [
+        "{{brainbrine|脳髄汁}}",
+        "{{brainbrine|脳髄汁の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 155,
+          "text": "{{brainbrine|脳髄汁の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 18,
+          "text": "{{brainbrine|脳髄汁}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{cider|cider}}",
+      "entry_count": 2,
+      "texts": [
+        "{{cider|サイダー}}",
+        "{{cider|サイダーの}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 157,
+          "text": "{{cider|サイダーの}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 19,
+          "text": "{{cider|サイダー}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{cider|fragrant}}",
+      "entry_count": 2,
+      "texts": [
+        "{{cider|芳香の}}",
+        "{{cider|香り高い}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 159,
+          "text": "{{cider|芳香の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 40,
+          "text": "{{cider|香り高い}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{cloning|cloning-draught}}",
+      "entry_count": 2,
+      "texts": [
+        "{{cloning|クローン薬液}}",
+        "{{cloning|クローン薬液の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 160,
+          "text": "{{cloning|クローン薬液の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 20,
+          "text": "{{cloning|クローン薬液}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{cloning|homogenized}}",
+      "entry_count": 2,
+      "texts": [
+        "{{cloning|均質化されている}}",
+        "{{cloning|均質化した}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 162,
+          "text": "{{cloning|均質化した}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 42,
+          "text": "{{cloning|均質化されている}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{c|soupy}}",
+      "entry_count": 2,
+      "texts": [
+        "{{c|どろどろの}}",
+        "{{c|スープ状}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 163,
+          "text": "{{c|どろどろの}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 44,
+          "text": "{{c|スープ状}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{g|algae-covered}}",
+      "entry_count": 2,
+      "texts": [
+        "{{g|藻まみれ}}",
+        "{{g|藻まみれの}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 166,
+          "text": "{{g|藻まみれの}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 45,
+          "text": "{{g|藻まみれ}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{g|algal}}",
+      "entry_count": 2,
+      "texts": [
+        "{{g|藻質}}",
+        "{{g|藻質の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 168,
+          "text": "{{g|藻質の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 46,
+          "text": "{{g|藻質}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{g|slime}}",
+      "entry_count": 2,
+      "texts": [
+        "{{g|スライム}}",
+        "{{g|スライムの}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 169,
+          "text": "{{g|スライムの}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 7,
+          "text": "{{g|スライム}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{lava|lava-covered}}",
+      "entry_count": 2,
+      "texts": [
+        "{{lava|溶岩まみれ}}",
+        "{{lava|溶岩まみれの}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 171,
+          "text": "{{lava|溶岩まみれの}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 47,
+          "text": "{{lava|溶岩まみれ}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{lava|magmatic}}",
+      "entry_count": 2,
+      "texts": [
+        "{{lava|マグマ質}}",
+        "{{lava|マグマ質の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 173,
+          "text": "{{lava|マグマ質の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 48,
+          "text": "{{lava|マグマ質}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{m|lush}}",
+      "entry_count": 2,
+      "texts": [
+        "{{m|芳醇な}}",
+        "{{m|豊潤}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 174,
+          "text": "{{m|芳醇な}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 49,
+          "text": "{{m|豊潤}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{m|wine}}",
+      "entry_count": 2,
+      "texts": [
+        "{{m|ワイン}}",
+        "{{m|ワインの}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 175,
+          "text": "{{m|ワインの}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 22,
+          "text": "{{m|ワイン}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{nervous|nervous}}",
+      "entry_count": 2,
+      "texts": [
+        "{{nervous|神経質}}",
+        "{{nervous|神経質な}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 177,
+          "text": "{{nervous|神経質な}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 50,
+          "text": "{{nervous|神経質}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{neutronic|flux}}",
+      "entry_count": 2,
+      "texts": [
+        "{{neutronic|中性子 フラックス}}",
+        "{{neutronic|中性子フラックスの}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 178,
+          "text": "{{neutronic|中性子フラックスの}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 23,
+          "text": "{{neutronic|中性子 フラックス}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{neutronic|neutral}}",
+      "entry_count": 2,
+      "texts": [
+        "{{neutronic|中性化した}}",
+        "{{neutronic|中性化液}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 180,
+          "text": "{{neutronic|中性化した}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 24,
+          "text": "{{neutronic|中性化液}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{neutronic|neutronic}}",
+      "entry_count": 2,
+      "texts": [
+        "{{neutronic|中性子質の}}",
+        "{{neutronic|中性子質液}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 181,
+          "text": "{{neutronic|中性子質の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 25,
+          "text": "{{neutronic|中性子質液}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{putrid|putrescence}}",
+      "entry_count": 2,
+      "texts": [
+        "{{putrid|腐敗液}}",
+        "{{putrid|腐敗液の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 182,
+          "text": "{{putrid|腐敗液の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 26,
+          "text": "{{putrid|腐敗液}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{putrid|putrid}}",
+      "entry_count": 2,
+      "texts": [
+        "{{putrid|腐敗}}",
+        "{{putrid|腐敗した}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 184,
+          "text": "{{putrid|腐敗した}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 52,
+          "text": "{{putrid|腐敗}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{slimy|slimy}}",
+      "entry_count": 2,
+      "texts": [
+        "{{slimy|ぬめった}}",
+        "{{slimy|ぬめっている}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 189,
+          "text": "{{slimy|ぬめった}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 55,
+          "text": "{{slimy|ぬめっている}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{sunslag|sunslag}}",
+      "entry_count": 2,
+      "texts": [
+        "{{sunslag|サンスラグ}}",
+        "{{sunslag|サンスラグの}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 190,
+          "text": "{{sunslag|サンスラグの}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 27,
+          "text": "{{sunslag|サンスラグ}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{w|honey}}",
+      "entry_count": 2,
+      "texts": [
+        "{{w|はちみつ}}",
+        "{{w|はちみつの}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 192,
+          "text": "{{w|はちみつの}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 6,
+          "text": "{{w|はちみつ}}"
+        }
+      ]
+    },
+    {
+      "scope": "cross_file",
+      "path": "Dictionaries",
+      "key": "{{w|sludge}}",
+      "entry_count": 2,
+      "texts": [
+        "{{w|汚泥}}",
+        "{{w|汚泥の}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-displayname-adjectives.ja.json",
+          "entry_index": 194,
+          "text": "{{w|汚泥の}}"
+        },
+        {
+          "path": "Dictionaries/ui-liquids.ja.json",
+          "entry_index": 28,
+          "text": "{{w|汚泥}}"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "1",
+      "entry_count": 5,
+      "texts": [
+        "1",
+        "1",
+        "1",
+        "1",
+        "1"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 257,
+          "text": "1"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 277,
+          "text": "1"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 303,
+          "text": "1"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 475,
+          "text": "1"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 510,
+          "text": "1"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "10",
+      "entry_count": 5,
+      "texts": [
+        "10",
+        "10",
+        "10",
+        "10",
+        "10"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 258,
+          "text": "10"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 278,
+          "text": "10"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 304,
+          "text": "10"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 369,
+          "text": "10"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 476,
+          "text": "10"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "15",
+      "entry_count": 4,
+      "texts": [
+        "15",
+        "15",
+        "15",
+        "15"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 259,
+          "text": "15"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 279,
+          "text": "15"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 305,
+          "text": "15"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 477,
+          "text": "15"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "2",
+      "entry_count": 6,
+      "texts": [
+        "2",
+        "2",
+        "2",
+        "2",
+        "2",
+        "2"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 260,
+          "text": "2"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 280,
+          "text": "2"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 306,
+          "text": "2"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 468,
+          "text": "2"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 478,
+          "text": "2"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 511,
+          "text": "2"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "20",
+      "entry_count": 5,
+      "texts": [
+        "20",
+        "20",
+        "20",
+        "20",
+        "20"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 261,
+          "text": "20"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 281,
+          "text": "20"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 307,
+          "text": "20"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 371,
+          "text": "20"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 479,
+          "text": "20"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "3",
+      "entry_count": 5,
+      "texts": [
+        "3",
+        "3",
+        "3",
+        "3",
+        "3"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 262,
+          "text": "3"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 282,
+          "text": "3"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 308,
+          "text": "3"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 480,
+          "text": "3"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 512,
+          "text": "3"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "30",
+      "entry_count": 5,
+      "texts": [
+        "30",
+        "30",
+        "30",
+        "30",
+        "30"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 263,
+          "text": "30"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 283,
+          "text": "30"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 309,
+          "text": "30"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 372,
+          "text": "30"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 481,
+          "text": "30"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "40",
+      "entry_count": 4,
+      "texts": [
+        "40",
+        "40",
+        "40",
+        "40"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 264,
+          "text": "40"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 310,
+          "text": "40"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 373,
+          "text": "40"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 482,
+          "text": "40"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "5",
+      "entry_count": 5,
+      "texts": [
+        "5",
+        "5",
+        "5",
+        "5",
+        "5"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 265,
+          "text": "5"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 284,
+          "text": "5"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 311,
+          "text": "5"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 483,
+          "text": "5"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 514,
+          "text": "5"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "60",
+      "entry_count": 2,
+      "texts": [
+        "60",
+        "60"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 285,
+          "text": "60"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 375,
+          "text": "60"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "7",
+      "entry_count": 5,
+      "texts": [
+        "7",
+        "7",
+        "7",
+        "7",
+        "7"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 266,
+          "text": "7"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 286,
+          "text": "7"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 312,
+          "text": "7"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 484,
+          "text": "7"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 516,
+          "text": "7"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "Full",
+      "entry_count": 2,
+      "texts": [
+        "全画面",
+        "全画面"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 232,
+          "text": "全画面"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 503,
+          "text": "全画面"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "None",
+      "entry_count": 3,
+      "texts": [
+        "なし",
+        "なし",
+        "なし"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 267,
+          "text": "なし"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 272,
+          "text": "なし"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 485,
+          "text": "なし"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "UI",
+      "entry_count": 2,
+      "texts": [
+        "UI",
+        "UI"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 17,
+          "text": "UI"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 215,
+          "text": "UI"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-auto-generated.ja.json",
+      "key": "デバッグ",
+      "entry_count": 2,
+      "texts": [
+        "デバッグ",
+        "デバッグ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 24,
+          "text": "デバッグ"
+        },
+        {
+          "path": "Dictionaries/ui-auto-generated.ja.json",
+          "entry_index": 219,
+          "text": "デバッグ"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-chargen.ja.json",
+      "key": "You have spent too many mutation points.",
+      "entry_count": 2,
+      "texts": [
+        "突然変異ポイントを使いすぎています。",
+        "突然変異ポイントを使いすぎています。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-chargen.ja.json",
+          "entry_index": 77,
+          "text": "突然変異ポイントを使いすぎています。"
+        },
+        {
+          "path": "Dictionaries/ui-chargen.ja.json",
+          "entry_index": 84,
+          "text": "突然変異ポイントを使いすぎています。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-chargen.ja.json",
+      "key": "You have unspent mutation points.",
+      "entry_count": 2,
+      "texts": [
+        "未使用の突然変異ポイントがあります。",
+        "未使用の突然変異ポイントがあります。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-chargen.ja.json",
+          "entry_index": 76,
+          "text": "未使用の突然変異ポイントがあります。"
+        },
+        {
+          "path": "Dictionaries/ui-chargen.ja.json",
+          "entry_index": 83,
+          "text": "未使用の突然変異ポイントがあります。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "Are you sure you want to quit?",
+      "entry_count": 2,
+      "texts": [
+        "本当に終了しますか？",
+        "本当に終了しますか？"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 45,
+          "text": "本当に終了しますか？"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 46,
+          "text": "本当に終了しますか？"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "Axe (cleaves armor on critical hit)",
+      "entry_count": 2,
+      "texts": [
+        "斧（クリティカル時に装甲切断）",
+        "斧（クリティカル時に装甲切断）"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 208,
+          "text": "斧（クリティカル時に装甲切断）"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 241,
+          "text": "斧（クリティカル時に装甲切断）"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "Cudgel (dazes on critical hit)",
+      "entry_count": 2,
+      "texts": [
+        "鈍器（クリティカル時に朦朧付与）",
+        "鈍器（クリティカル時に朦朧付与）"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 206,
+          "text": "鈍器（クリティカル時に朦朧付与）"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 239,
+          "text": "鈍器（クリティカル時に朦朧付与）"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
       "path": "Dictionaries/ui-default.ja.json",
       "key": "If you quit without saving, you will lose all your progress and your character will be lost. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\n Type 'QUIT' to confirm.",
       "entry_count": 2,
       "texts": [
         "セーブせずに終了すると進行状況とキャラクターが完全に失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。",
         "保存せずに終了すると進捗とキャラクターがすべて消えてしまいます。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 186,
+          "text": "セーブせずに終了すると進行状況とキャラクターが完全に失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 217,
+          "text": "保存せずに終了すると進捗とキャラクターがすべて消えてしまいます。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+        }
       ]
     },
     {
+      "scope": "same_file",
       "path": "Dictionaries/ui-default.ja.json",
       "key": "If you quit without saving, you will lose all your progress and your character will be lost. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\nType 'QUIT' to confirm.",
       "entry_count": 2,
       "texts": [
         "セーブせずに終了すると進行状況とキャラクターが完全に失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。",
         "保存せずに終了すると進捗とキャラクターがすべて消えてしまいます。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 187,
+          "text": "セーブせずに終了すると進行状況とキャラクターが完全に失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 218,
+          "text": "保存せずに終了すると進捗とキャラクターがすべて消えてしまいます。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+        }
       ]
     },
     {
+      "scope": "same_file",
       "path": "Dictionaries/ui-default.ja.json",
       "key": "If you quit without saving, you will lose all your unsaved progress. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\n Type 'QUIT' to confirm.",
       "entry_count": 2,
       "texts": [
         "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。",
         "保存せずに終了すると保存していない進捗をすべて失います。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 184,
+          "text": "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 215,
+          "text": "保存せずに終了すると保存していない進捗をすべて失います。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+        }
       ]
     },
     {
+      "scope": "same_file",
       "path": "Dictionaries/ui-default.ja.json",
       "key": "If you quit without saving, you will lose all your unsaved progress. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\nType 'QUIT' to confirm.",
       "entry_count": 2,
       "texts": [
         "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。",
         "保存せずに終了すると保存していない進捗をすべて失います。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 185,
+          "text": "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 216,
+          "text": "保存せずに終了すると保存していない進捗をすべて失います。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+        }
       ]
     },
     {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "Last saved:",
+      "entry_count": 2,
+      "texts": [
+        "最終セーブ：",
+        "最終セーブ："
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 71,
+          "text": "最終セーブ："
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 156,
+          "text": "最終セーブ："
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "Location:",
+      "entry_count": 2,
+      "texts": [
+        "場所：",
+        "場所："
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 70,
+          "text": "場所："
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 155,
+          "text": "場所："
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "Long Blades (can dismember)",
+      "entry_count": 2,
+      "texts": [
+        "長剣（切断可能）",
+        "長剣（切断可能）"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 209,
+          "text": "長剣（切断可能）"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 242,
+          "text": "長剣（切断可能）"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "No",
+      "entry_count": 2,
+      "texts": [
+        "いいえ",
+        "いいえ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 48,
+          "text": "いいえ"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 50,
+          "text": "いいえ"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "Quit Without Saving",
+      "entry_count": 2,
+      "texts": [
+        "セーブせずに終了",
+        "セーブせずに終了"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 26,
+          "text": "セーブせずに終了"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 169,
+          "text": "セーブせずに終了"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "Randomize Selection",
+      "entry_count": 2,
+      "texts": [
+        "ランダムに選択",
+        "ランダムに選択"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 181,
+          "text": "ランダムに選択"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 182,
+          "text": "ランダムに選択"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "Reset Selection",
+      "entry_count": 2,
+      "texts": [
+        "選択をリセット",
+        "選択をリセット"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 243,
+          "text": "選択をリセット"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 244,
+          "text": "選択をリセット"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "Save and Quit",
+      "entry_count": 2,
+      "texts": [
+        "セーブして終了",
+        "セーブして終了"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 27,
+          "text": "セーブして終了"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 168,
+          "text": "セーブして終了"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "Short Blades (causes bleeding on critical hit)",
+      "entry_count": 2,
+      "texts": [
+        "短剣（クリティカル時に出血）",
+        "短剣（クリティカル時に出血）"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 207,
+          "text": "短剣（クリティカル時に出血）"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 240,
+          "text": "短剣（クリティカル時に出血）"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "Yes",
+      "entry_count": 2,
+      "texts": [
+        "はい",
+        "はい"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 47,
+          "text": "はい"
+        },
+        {
+          "path": "Dictionaries/ui-default.ja.json",
+          "entry_index": 49,
+          "text": "はい"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-journal.ja.json",
+      "key": "Joppa",
+      "entry_count": 2,
+      "texts": [
+        "ジョッパ",
+        "ジョッパ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 12,
+          "text": "ジョッパ"
+        },
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 37,
+          "text": "ジョッパ"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-journal.ja.json",
+      "key": "Kyakukya",
+      "entry_count": 2,
+      "texts": [
+        "キャクキャ",
+        "キャクキャ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 13,
+          "text": "キャクキャ"
+        },
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 38,
+          "text": "キャクキャ"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-journal.ja.json",
+      "key": "The Yd Freehold",
+      "entry_count": 2,
+      "texts": [
+        "イド・フリーホールド",
+        "イド・フリーホールド"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 14,
+          "text": "イド・フリーホールド"
+        },
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 39,
+          "text": "イド・フリーホールド"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-journal.ja.json",
+      "key": "[+] ",
+      "entry_count": 2,
+      "texts": [
+        "[+] ",
+        "[+] "
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 29,
+          "text": "[+] "
+        },
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 34,
+          "text": "[+] "
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-journal.ja.json",
+      "key": "[-] ",
+      "entry_count": 2,
+      "texts": [
+        "[-] ",
+        "[-] "
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 28,
+          "text": "[-] "
+        },
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 33,
+          "text": "[-] "
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-journal.ja.json",
+      "key": "}}\n\nYou note this piece of information in the {{W|",
+      "entry_count": 3,
+      "texts": [
+        "}}\n\nこの情報を{{W|",
+        "}}\n\nこの情報を{{W|",
+        "}}\n\nこの情報を{{W|"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 58,
+          "text": "}}\n\nこの情報を{{W|"
+        },
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 60,
+          "text": "}}\n\nこの情報を{{W|"
+        },
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 62,
+          "text": "}}\n\nこの情報を{{W|"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-journal.ja.json",
+      "key": "}} section of your journal.",
+      "entry_count": 3,
+      "texts": [
+        "}} 欄に記した。",
+        "}} 欄に記した。",
+        "}} 欄に記した。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 59,
+          "text": "}} 欄に記した。"
+        },
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 61,
+          "text": "}} 欄に記した。"
+        },
+        {
+          "path": "Dictionaries/ui-journal.ja.json",
+          "entry_index": 63,
+          "text": "}} 欄に記した。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": " [toggled off]",
+      "entry_count": 2,
+      "texts": [
+        " [オフ]",
+        " [オフ]"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 30,
+          "text": " [オフ]"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 33,
+          "text": " [オフ]"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": " [toggled on]",
+      "entry_count": 2,
+      "texts": [
+        " [オン]",
+        " [オン]"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 31,
+          "text": " [オン]"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 34,
+          "text": " [オン]"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": " {{g|[toggled on]}}",
+      "entry_count": 2,
+      "texts": [
+        " {{g|[オン]}}",
+        " {{g|[オン]}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 32,
+          "text": " {{g|[オン]}}"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 35,
+          "text": " {{g|[オン]}}"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": ", giving you no chance of performing well. You can remedy this situation by improving your Ego, Willpower, Intelligence, and esoteric skills.",
+      "entry_count": 2,
+      "texts": [
+        "良い結果を出せない。自我・意志力・知力・秘術スキルを高めれば改善できる。",
+        "良い結果を出せない。自我・意志力・知力・秘術スキルを高めれば改善できる。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 49,
+          "text": "良い結果を出せない。自我・意志力・知力・秘術スキルを高めれば改善できる。"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 73,
+          "text": "良い結果を出せない。自我・意志力・知力・秘術スキルを高めれば改善できる。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": "Do you want to finish psychic combat as matters stand?",
+      "entry_count": 2,
+      "texts": [
+        "このまま精神戦を終えますか？",
+        "このまま精神戦を終えますか？"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 51,
+          "text": "このまま精神戦を終えますか？"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 75,
+          "text": "このまま精神戦を終えますか？"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": "Exiting now will finish psychic combat as matters stand. Are you sure you want to exit?",
+      "entry_count": 2,
+      "texts": [
+        "今終了すると現状のまま精神戦が終わる。終了してもいいですか？",
+        "今終了すると現状のまま精神戦が終わる。終了してもいいですか？"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 52,
+          "text": "今終了すると現状のまま精神戦が終わる。終了してもいいですか？"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 76,
+          "text": "今終了すると現状のまま精神戦が終わる。終了してもいいですか？"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": "You are shunted to another location!",
+      "entry_count": 2,
+      "texts": [
+        "別の場所へ弾き飛ばされた！",
+        "別の場所へ弾き飛ばされた！"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 100,
+          "text": "別の場所へ弾き飛ばされた！"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 265,
+          "text": "別の場所へ弾き飛ばされた！"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": "You are teleported to an exit.",
+      "entry_count": 2,
+      "texts": [
+        "出口へ転送された。",
+        "出口へ転送された。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 101,
+          "text": "出口へ転送された。"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 264,
+          "text": "出口へ転送された。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
       "path": "Dictionaries/ui-messagelog-world.ja.json",
       "key": "You can't figure out how to safely reach the stairs from here.",
       "entry_count": 2,
       "texts": [
         "ここから安全に階段へたどり着く方法が分からない。",
         "ここから階段へ安全に辿る経路が見つからない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 87,
+          "text": "ここから階段へ安全に辿る経路が見つからない。"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 268,
+          "text": "ここから安全に階段へたどり着く方法が分からない。"
+        }
       ]
     },
     {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": "You cannot find a path to your destination.",
+      "entry_count": 2,
+      "texts": [
+        "目的地への経路が見つからない。",
+        "目的地への経路が見つからない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 260,
+          "text": "目的地への経路が見つからない。"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 267,
+          "text": "目的地への経路が見つからない。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
       "path": "Dictionaries/ui-messagelog-world.ja.json",
       "key": "You have mastered psychic combat at this level of difficulty. Do you want to guide the process in detail anyway, with an enhanced chance of exceptional success? If you answer 'No', you will automatically receive the results of strong but unexceptional performance.",
       "entry_count": 2,
       "texts": [
         "この難度での精神戦は熟達済みだ。より高い成功率を狙って詳細に指揮しますか？「いいえ」を選ぶと標準的な成功の結果を自動で受け取ります。",
         "この難度での精神戦は熟達済みだ。より高い成功率を狙って詳細に指揮する？「いいえ」を選ぶと標準的な成功の結果を自動で受け取る。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 50,
+          "text": "この難度での精神戦は熟達済みだ。より高い成功率を狙って詳細に指揮しますか？「いいえ」を選ぶと標準的な成功の結果を自動で受け取ります。"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 74,
+          "text": "この難度での精神戦は熟達済みだ。より高い成功率を狙って詳細に指揮する？「いいえ」を選ぶと標準的な成功の結果を自動で受け取る。"
+        }
       ]
     },
     {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": "You have no more usable options, so your performance so far will determine the outcome.",
+      "entry_count": 2,
+      "texts": [
+        "使える手はもうない。ここまでの成果が結果を決める。",
+        "使える手はもうない。ここまでの成果が結果を決める。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 53,
+          "text": "使える手はもうない。ここまでの成果が結果を決める。"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 77,
+          "text": "使える手はもうない。ここまでの成果が結果を決める。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": "You have no usable options to employ for ",
+      "entry_count": 2,
+      "texts": [
+        "次の行動に使える選択肢がない: ",
+        "次の行動に使える選択肢がない: "
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 48,
+          "text": "次の行動に使える選択肢がない: "
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 72,
+          "text": "次の行動に使える選択肢がない: "
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": "You lurch suddenly!",
+      "entry_count": 2,
+      "texts": [
+        "突然ぐらりとよろめいた！",
+        "突然ぐらりとよろめいた！"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 130,
+          "text": "突然ぐらりとよろめいた！"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 131,
+          "text": "突然ぐらりとよろめいた！"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": "You teleport!",
+      "entry_count": 2,
+      "texts": [
+        "テレポートした！",
+        "テレポートした！"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 194,
+          "text": "テレポートした！"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 266,
+          "text": "テレポートした！"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": "Your attack does not affect ",
+      "entry_count": 2,
+      "texts": [
+        "攻撃は{target}に影響を与えない。",
+        "攻撃は{target}に影響を与えない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 238,
+          "text": "攻撃は{target}に影響を与えない。"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog-world.ja.json",
+          "entry_index": 239,
+          "text": "攻撃は{target}に影響を与えない。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog.ja.json",
+      "key": "Collapse",
+      "entry_count": 2,
+      "texts": [
+        "折りたたむ",
+        "折りたたむ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 19,
+          "text": "折りたたむ"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 21,
+          "text": "折りたたむ"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog.ja.json",
+      "key": "Expand",
+      "entry_count": 2,
+      "texts": [
+        "展開",
+        "展開"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 18,
+          "text": "展開"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 20,
+          "text": "展開"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog.ja.json",
+      "key": "Log",
+      "entry_count": 2,
+      "texts": [
+        "ログ",
+        "ログ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 4,
+          "text": "ログ"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 6,
+          "text": "ログ"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog.ja.json",
+      "key": "Message Log",
+      "entry_count": 4,
+      "texts": [
+        "メッセージログ",
+        "メッセージログ",
+        "メッセージログ",
+        "メッセージログ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 1,
+          "text": "メッセージログ"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 2,
+          "text": "メッセージログ"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 3,
+          "text": "メッセージログ"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 5,
+          "text": "メッセージログ"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-messagelog.ja.json",
+      "key": "MessageLog",
+      "entry_count": 2,
+      "texts": [
+        "メッセージログ",
+        "メッセージログ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 13,
+          "text": "メッセージログ"
+        },
+        {
+          "path": "Dictionaries/ui-messagelog.ja.json",
+          "entry_index": 14,
+          "text": "メッセージログ"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
       "path": "Dictionaries/ui-options.ja.json",
       "key": "Change Value",
       "entry_count": 2,
       "texts": [
         "値を変更",
         "値を変更（カーソル）"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-options.ja.json",
+          "entry_index": 3,
+          "text": "値を変更"
+        },
+        {
+          "path": "Dictionaries/ui-options.ja.json",
+          "entry_index": 4,
+          "text": "値を変更（カーソル）"
+        }
       ]
     },
     {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-options.ja.json",
+      "key": "navigate",
+      "entry_count": 3,
+      "texts": [
+        "移動",
+        "移動",
+        "移動"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-options.ja.json",
+          "entry_index": 10,
+          "text": "移動"
+        },
+        {
+          "path": "Dictionaries/ui-options.ja.json",
+          "entry_index": 13,
+          "text": "移動"
+        },
+        {
+          "path": "Dictionaries/ui-options.ja.json",
+          "entry_index": 18,
+          "text": "移動"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Akimbo",
+      "entry_count": 2,
+      "texts": [
+        "二挺拳銃",
+        "二挺拳銃"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 34,
+          "text": "二挺拳銃"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 35,
+          "text": "二挺拳銃"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Axe",
+      "entry_count": 2,
+      "texts": [
+        "斧",
+        "斧"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 48,
+          "text": "斧"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 49,
+          "text": "斧"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Berate",
+      "entry_count": 2,
+      "texts": [
+        "罵倒",
+        "罵倒"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 55,
+          "text": "罵倒"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 56,
+          "text": "罵倒"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Berserk!",
+      "entry_count": 2,
+      "texts": [
+        "狂戦！",
+        "狂戦！"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 57,
+          "text": "狂戦！"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 58,
+          "text": "狂戦！"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Butchery",
+      "entry_count": 3,
+      "texts": [
+        "解体術",
+        "解体術",
+        "解体術"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 62,
+          "text": "解体術"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 63,
+          "text": "解体術"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 64,
+          "text": "解体術"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Calloused",
+      "entry_count": 2,
+      "texts": [
+        "硬皮化",
+        "硬皮化"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 66,
+          "text": "硬皮化"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 67,
+          "text": "硬皮化"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Carbide Chef",
+      "entry_count": 2,
+      "texts": [
+        "カーバイドシェフ",
+        "カーバイドシェフ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 68,
+          "text": "カーバイドシェフ"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 69,
+          "text": "カーバイドシェフ"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Charge",
+      "entry_count": 2,
+      "texts": [
+        "突進",
+        "突進"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 70,
+          "text": "突進"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 71,
+          "text": "突進"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Charging Strike",
+      "entry_count": 2,
+      "texts": [
+        "突撃打",
+        "突撃打"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 72,
+          "text": "突撃打"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 73,
+          "text": "突撃打"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Cleave",
+      "entry_count": 2,
+      "texts": [
+        "裂断",
+        "裂断"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 74,
+          "text": "裂断"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 75,
+          "text": "裂断"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Cooking and Gathering",
+      "entry_count": 2,
+      "texts": [
+        "料理と採集",
+        "料理と採集"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 78,
+          "text": "料理と採集"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 79,
+          "text": "料理と採集"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Cudgel",
+      "entry_count": 2,
+      "texts": [
+        "棍棒",
+        "棍棒"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 85,
+          "text": "棍棒"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 86,
+          "text": "棍棒"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Decapitate",
+      "entry_count": 2,
+      "texts": [
+        "斬首",
+        "斬首"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 89,
+          "text": "斬首"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 90,
+          "text": "斬首"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Disassemble",
+      "entry_count": 2,
+      "texts": [
+        "分解",
+        "分解"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 96,
+          "text": "分解"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 97,
+          "text": "分解"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Dismember",
+      "entry_count": 3,
+      "texts": [
+        "切断",
+        "切断",
+        "切断"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 98,
+          "text": "切断"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 99,
+          "text": "切断"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 100,
+          "text": "切断"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Harvestry",
+      "entry_count": 3,
+      "texts": [
+        "収穫術",
+        "収穫術",
+        "収穫術"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 128,
+          "text": "収穫術"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 129,
+          "text": "収穫術"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 130,
+          "text": "収穫術"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Hook and Drag",
+      "entry_count": 2,
+      "texts": [
+        "フック・アンド・ドラッグ",
+        "フック・アンド・ドラッグ"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 135,
+          "text": "フック・アンド・ドラッグ"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 136,
+          "text": "フック・アンド・ドラッグ"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Intimidate",
+      "entry_count": 2,
+      "texts": [
+        "威圧",
+        "威圧"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 142,
+          "text": "威圧"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 143,
+          "text": "威圧"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Iron Mind",
+      "entry_count": 2,
+      "texts": [
+        "鋼の精神",
+        "鋼の精神"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 144,
+          "text": "鋼の精神"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 145,
+          "text": "鋼の精神"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Lay Mine / Set Bomb",
+      "entry_count": 2,
+      "texts": [
+        "地雷/爆弾設置",
+        "地雷/爆弾設置"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 151,
+          "text": "地雷/爆弾設置"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 152,
+          "text": "地雷/爆弾設置"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Make Camp",
+      "entry_count": 2,
+      "texts": [
+        "野営",
+        "野営"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 158,
+          "text": "野営"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 167,
+          "text": "野営"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Meal Preparation",
+      "entry_count": 2,
+      "texts": [
+        "食事準備",
+        "食事準備"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 168,
+          "text": "食事準備"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 169,
+          "text": "食事準備"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Mind's Compass",
+      "entry_count": 2,
+      "texts": [
+        "心の羅針",
+        "心の羅針"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 173,
+          "text": "心の羅針"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 174,
+          "text": "心の羅針"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Nostrums",
+      "entry_count": 2,
+      "texts": [
+        "秘薬",
+        "秘薬"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 179,
+          "text": "秘薬"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 180,
+          "text": "秘薬"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Physic",
+      "entry_count": 2,
+      "texts": [
+        "治療",
+        "治療"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 184,
+          "text": "治療"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 185,
+          "text": "治療"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Proselytize",
+      "entry_count": 2,
+      "texts": [
+        "布教",
+        "布教"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 187,
+          "text": "布教"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 188,
+          "text": "布教"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Repair",
+      "entry_count": 2,
+      "texts": [
+        "修理",
+        "修理"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 191,
+          "text": "修理"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 192,
+          "text": "修理"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Shield Slam",
+      "entry_count": 2,
+      "texts": [
+        "シールドスラム",
+        "シールドスラム"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 198,
+          "text": "シールドスラム"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 199,
+          "text": "シールドスラム"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Snake Oiler",
+      "entry_count": 2,
+      "texts": [
+        "蛇油売り",
+        "蛇油売り"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 207,
+          "text": "蛇油売り"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 208,
+          "text": "蛇油売り"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Spicer",
+      "entry_count": 2,
+      "texts": [
+        "香辛師",
+        "香辛師"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 209,
+          "text": "香辛師"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 210,
+          "text": "香辛師"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Tactics",
+      "entry_count": 2,
+      "texts": [
+        "戦術",
+        "戦術"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 227,
+          "text": "戦術"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 228,
+          "text": "戦術"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Tinker I",
+      "entry_count": 2,
+      "texts": [
+        "工匠 I",
+        "工匠 I"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 231,
+          "text": "工匠 I"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 232,
+          "text": "工匠 I"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
       "path": "Dictionaries/ui-skillsandpowers.ja.json",
       "key": "Weathered",
       "entry_count": 2,
       "texts": [
         "風雨に耐えた",
         "風雪錬成"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 243,
+          "text": "風雨に耐えた"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 244,
+          "text": "風雪錬成"
+        }
       ]
     },
     {
+      "scope": "same_file",
       "path": "Dictionaries/ui-skillsandpowers.ja.json",
       "key": "Wilderness Lore: Canyons",
       "entry_count": 2,
       "texts": [
         "荒地巡り：峡谷",
         "荒野の伝承: 渓谷"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 267,
+          "text": "荒野の伝承: 渓谷"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 268,
+          "text": "荒地巡り：峡谷"
+        }
       ]
     },
     {
+      "scope": "same_file",
       "path": "Dictionaries/ui-skillsandpowers.ja.json",
       "key": "Wilderness Lore: Flower Fields",
       "entry_count": 2,
       "texts": [
         "荒地巡り：花畑",
         "荒野の伝承: 花畑"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 269,
+          "text": "荒野の伝承: 花畑"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 270,
+          "text": "荒地巡り：花畑"
+        }
       ]
     },
     {
+      "scope": "same_file",
       "path": "Dictionaries/ui-skillsandpowers.ja.json",
       "key": "Wilderness Lore: Hills and Mountains",
       "entry_count": 2,
       "texts": [
         "荒地巡り：丘陵と山",
         "荒野の伝承: 丘と山岳"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 271,
+          "text": "荒野の伝承: 丘と山岳"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 272,
+          "text": "荒地巡り：丘陵と山"
+        }
       ]
     },
     {
+      "scope": "same_file",
       "path": "Dictionaries/ui-skillsandpowers.ja.json",
       "key": "Wilderness Lore: Jungles",
       "entry_count": 2,
       "texts": [
         "荒地巡り：ジャングル",
         "荒野の伝承: ジャングル"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 273,
+          "text": "荒野の伝承: ジャングル"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 274,
+          "text": "荒地巡り：ジャングル"
+        }
       ]
     },
     {
+      "scope": "same_file",
       "path": "Dictionaries/ui-skillsandpowers.ja.json",
       "key": "Wilderness Lore: Marshes",
       "entry_count": 2,
       "texts": [
         "荒地巡り：湿地",
         "荒野の伝承: 沼地"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 275,
+          "text": "荒野の伝承: 沼地"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 276,
+          "text": "荒地巡り：湿地"
+        }
       ]
     },
     {
+      "scope": "same_file",
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Wilderness Lore: Random",
+      "entry_count": 2,
+      "texts": [
+        "荒野の伝承: ランダム",
+        "荒野の伝承: ランダム"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 277,
+          "text": "荒野の伝承: ランダム"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 278,
+          "text": "荒野の伝承: ランダム"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
       "path": "Dictionaries/ui-skillsandpowers.ja.json",
       "key": "Wilderness Lore: Rivers and Lakes",
       "entry_count": 2,
       "texts": [
         "荒地巡り：河川",
         "荒野の伝承: 河川と湖"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 279,
+          "text": "荒野の伝承: 河川と湖"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 280,
+          "text": "荒地巡り：河川"
+        }
       ]
     },
     {
+      "scope": "same_file",
       "path": "Dictionaries/ui-skillsandpowers.ja.json",
       "key": "Wilderness Lore: Ruins",
       "entry_count": 2,
       "texts": [
         "荒地巡り：廃墟",
         "荒野の伝承: 遺跡"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 281,
+          "text": "荒野の伝承: 遺跡"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 282,
+          "text": "荒地巡り：廃墟"
+        }
       ]
     },
     {
+      "scope": "same_file",
       "path": "Dictionaries/ui-skillsandpowers.ja.json",
       "key": "Wilderness Lore: Salt Dunes",
       "entry_count": 2,
       "texts": [
         "荒地巡り：塩砂漠",
         "荒野の伝承: 塩砂丘"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 283,
+          "text": "荒野の伝承: 塩砂丘"
+        },
+        {
+          "path": "Dictionaries/ui-skillsandpowers.ja.json",
+          "entry_index": 284,
+          "text": "荒地巡り：塩砂漠"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": " <spice.history.gospels.",
+      "entry_count": 2,
+      "texts": [
+        " <spice.history.gospels.",
+        " <spice.history.gospels."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1247,
+          "text": " <spice.history.gospels."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1266,
+          "text": " <spice.history.gospels."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": " <spice.history.gospels.VehicularSabotage.",
+      "entry_count": 2,
+      "texts": [
+        " <spice.history.gospels.VehicularSabotage.",
+        " <spice.history.gospels.VehicularSabotage."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1248,
+          "text": " <spice.history.gospels.VehicularSabotage."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1267,
+          "text": " <spice.history.gospels.VehicularSabotage."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": " honor they <spice.history.gospels.Celebration.LateSultanate.!random>.",
+      "entry_count": 3,
+      "texts": [
+        " 彼らは<spice.history.gospels.Celebration.LateSultanate.!random>で称えた。",
+        " 彼らは<spice.history.gospels.Celebration.LateSultanate.!random>で称えた。",
+        " 彼らは<spice.history.gospels.Celebration.LateSultanate.!random>で称えた。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1282,
+          "text": " 彼らは<spice.history.gospels.Celebration.LateSultanate.!random>で称えた。"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1283,
+          "text": " 彼らは<spice.history.gospels.Celebration.LateSultanate.!random>で称えた。"
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1284,
+          "text": " 彼らは<spice.history.gospels.Celebration.LateSultanate.!random>で称えた。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": ".adjective.!random> <spice.history.gospels.",
+      "entry_count": 2,
+      "texts": [
+        ".adjective.!random>の<spice.history.gospels.",
+        ".adjective.!random>の<spice.history.gospels."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1254,
+          "text": ".adjective.!random>の<spice.history.gospels."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1273,
+          "text": ".adjective.!random>の<spice.history.gospels."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": ".vehicle.!random> and <spice.history.gospels.CrashedVehicle.",
+      "entry_count": 2,
+      "texts": [
+        ".vehicle.!random>を制御できなくなり、<spice.history.gospels.CrashedVehicle.",
+        ".vehicle.!random>を制御できなくなり、<spice.history.gospels.CrashedVehicle."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1249,
+          "text": ".vehicle.!random>を制御できなくなり、<spice.history.gospels.CrashedVehicle."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1268,
+          "text": ".vehicle.!random>を制御できなくなり、<spice.history.gospels.CrashedVehicle."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": "<entity.name> lost control of <entity.possessivePronoun> <spice.history.gospels.",
+      "entry_count": 2,
+      "texts": [
+        "<entity.name>は<entity.possessivePronoun>の<spice.history.gospels.",
+        "<entity.name>は<entity.possessivePronoun>の<spice.history.gospels."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1250,
+          "text": "<entity.name>は<entity.possessivePronoun>の<spice.history.gospels."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1269,
+          "text": "<entity.name>は<entity.possessivePronoun>の<spice.history.gospels."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": "<entity.subjectPronoun> lost control of <entity.possessivePronoun> <spice.history.gospels.",
+      "entry_count": 2,
+      "texts": [
+        "<entity.subjectPronoun>は<entity.possessivePronoun>の<spice.history.gospels.",
+        "<entity.subjectPronoun>は<entity.possessivePronoun>の<spice.history.gospels."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1251,
+          "text": "<entity.subjectPronoun>は<entity.possessivePronoun>の<spice.history.gospels."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1270,
+          "text": "<entity.subjectPronoun>は<entity.possessivePronoun>の<spice.history.gospels."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": "<spice.history.gospels.",
+      "entry_count": 4,
+      "texts": [
+        "<spice.history.gospels.",
+        "<spice.history.gospels.",
+        "<spice.history.gospels.",
+        "<spice.history.gospels."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1246,
+          "text": "<spice.history.gospels."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1255,
+          "text": "<spice.history.gospels."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1265,
+          "text": "<spice.history.gospels."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1274,
+          "text": "<spice.history.gospels."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": "<spice.history.gospels.Celebration.",
+      "entry_count": 2,
+      "texts": [
+        "<spice.history.gospels.Celebration.",
+        "<spice.history.gospels.Celebration."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1257,
+          "text": "<spice.history.gospels.Celebration."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1276,
+          "text": "<spice.history.gospels.Celebration."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": "<spice.history.gospels.CivilizationActivity.",
+      "entry_count": 2,
+      "texts": [
+        "<spice.history.gospels.CivilizationActivity.",
+        "<spice.history.gospels.CivilizationActivity."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1256,
+          "text": "<spice.history.gospels.CivilizationActivity."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1275,
+          "text": "<spice.history.gospels.CivilizationActivity."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": "<spice.history.gospels.CommittedWrongAgainstSultan.",
+      "entry_count": 4,
+      "texts": [
+        "<spice.history.gospels.CommittedWrongAgainstSultan.",
+        "<spice.history.gospels.CommittedWrongAgainstSultan.",
+        "<spice.history.gospels.CommittedWrongAgainstSultan.",
+        "<spice.history.gospels.CommittedWrongAgainstSultan."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1243,
+          "text": "<spice.history.gospels.CommittedWrongAgainstSultan."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1260,
+          "text": "<spice.history.gospels.CommittedWrongAgainstSultan."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1262,
+          "text": "<spice.history.gospels.CommittedWrongAgainstSultan."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1279,
+          "text": "<spice.history.gospels.CommittedWrongAgainstSultan."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": "<spice.history.gospels.EnemyHostName.",
+      "entry_count": 2,
+      "texts": [
+        "<spice.history.gospels.EnemyHostName.",
+        "<spice.history.gospels.EnemyHostName."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1244,
+          "text": "<spice.history.gospels.EnemyHostName."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1263,
+          "text": "<spice.history.gospels.EnemyHostName."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": "<spice.history.gospels.HumblePractice.",
+      "entry_count": 2,
+      "texts": [
+        "<spice.history.gospels.HumblePractice.",
+        "<spice.history.gospels.HumblePractice."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1245,
+          "text": "<spice.history.gospels.HumblePractice."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1264,
+          "text": "<spice.history.gospels.HumblePractice."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": "<spice.history.gospels.ImmoralPractice.",
+      "entry_count": 2,
+      "texts": [
+        "<spice.history.gospels.ImmoralPractice.",
+        "<spice.history.gospels.ImmoralPractice."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1253,
+          "text": "<spice.history.gospels.ImmoralPractice."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1272,
+          "text": "<spice.history.gospels.ImmoralPractice."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": "<spice.history.gospels.LostItem.",
+      "entry_count": 2,
+      "texts": [
+        "<spice.history.gospels.LostItem.",
+        "<spice.history.gospels.LostItem."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1258,
+          "text": "<spice.history.gospels.LostItem."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1277,
+          "text": "<spice.history.gospels.LostItem."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": "<spice.history.gospels.MarriageAllianceResult.",
+      "entry_count": 2,
+      "texts": [
+        "<spice.history.gospels.MarriageAllianceResult.",
+        "<spice.history.gospels.MarriageAllianceResult."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1259,
+          "text": "<spice.history.gospels.MarriageAllianceResult."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1278,
+          "text": "<spice.history.gospels.MarriageAllianceResult."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": "<spice.history.gospels.RitualName.",
+      "entry_count": 2,
+      "texts": [
+        "<spice.history.gospels.RitualName.",
+        "<spice.history.gospels.RitualName."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1261,
+          "text": "<spice.history.gospels.RitualName."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1280,
+          "text": "<spice.history.gospels.RitualName."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-gospels.ja.json",
+      "key": "<spice.history.gospels.VehicularSabotageResult.",
+      "entry_count": 2,
+      "texts": [
+        "<spice.history.gospels.VehicularSabotageResult.",
+        "<spice.history.gospels.VehicularSabotageResult."
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1252,
+          "text": "<spice.history.gospels.VehicularSabotageResult."
+        },
+        {
+          "path": "Dictionaries/world-gospels.ja.json",
+          "entry_index": 1271,
+          "text": "<spice.history.gospels.VehicularSabotageResult."
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-mods.ja.json",
+      "key": "Accuracy: High",
+      "entry_count": 2,
+      "texts": [
+        "命中率: 高い",
+        "命中率: 高い"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 196,
+          "text": "命中率: 高い"
+        },
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 204,
+          "text": "命中率: 高い"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-mods.ja.json",
+      "key": "Accuracy: Low",
+      "entry_count": 2,
+      "texts": [
+        "命中率: 低い",
+        "命中率: 低い"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 198,
+          "text": "命中率: 低い"
+        },
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 206,
+          "text": "命中率: 低い"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-mods.ja.json",
+      "key": "Accuracy: Medium",
+      "entry_count": 2,
+      "texts": [
+        "命中率: 普通",
+        "命中率: 普通"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 197,
+          "text": "命中率: 普通"
+        },
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 205,
+          "text": "命中率: 普通"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-mods.ja.json",
+      "key": "Accuracy: Very High",
+      "entry_count": 2,
+      "texts": [
+        "命中率: 非常に高い",
+        "命中率: 非常に高い"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 195,
+          "text": "命中率: 非常に高い"
+        },
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 203,
+          "text": "命中率: 非常に高い"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-mods.ja.json",
+      "key": "Accuracy: Very Low",
+      "entry_count": 2,
+      "texts": [
+        "命中率: 非常に低い",
+        "命中率: 非常に低い"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 199,
+          "text": "命中率: 非常に低い"
+        },
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 207,
+          "text": "命中率: 非常に低い"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-mods.ja.json",
+      "key": "Weapon Class: Bows && Rifles",
+      "entry_count": 2,
+      "texts": [
+        "武器カテゴリ: 弓 && ライフル",
+        "武器カテゴリ: 弓 && ライフル"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 193,
+          "text": "武器カテゴリ: 弓 && ライフル"
+        },
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 201,
+          "text": "武器カテゴリ: 弓 && ライフル"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-mods.ja.json",
+      "key": "Weapon Class: Heavy Weapon",
+      "entry_count": 2,
+      "texts": [
+        "武器カテゴリ: 重火器",
+        "武器カテゴリ: 重火器"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 194,
+          "text": "武器カテゴリ: 重火器"
+        },
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 202,
+          "text": "武器カテゴリ: 重火器"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-mods.ja.json",
+      "key": "Weapon Class: Pistol",
+      "entry_count": 2,
+      "texts": [
+        "武器カテゴリ: ピストル",
+        "武器カテゴリ: ピストル"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 192,
+          "text": "武器カテゴリ: ピストル"
+        },
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 200,
+          "text": "武器カテゴリ: ピストル"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-mods.ja.json",
+      "key": "no effect",
+      "entry_count": 2,
+      "texts": [
+        "効果なし",
+        "効果なし"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 11,
+          "text": "効果なし"
+        },
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 66,
+          "text": "効果なし"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-mods.ja.json",
+      "key": "{{rules|+{0} reputation with {1}}}",
+      "entry_count": 2,
+      "texts": [
+        "{{rules|{1}との評判{0:+#;-#}}}",
+        "{{rules|{1}との評判{0:+#;-#}}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 118,
+          "text": "{{rules|{1}との評判{0:+#;-#}}}"
+        },
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 121,
+          "text": "{{rules|{1}との評判{0:+#;-#}}}"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-mods.ja.json",
+      "key": "}}",
+      "entry_count": 2,
+      "texts": [
+        "}}",
+        "}}"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 45,
+          "text": "}}"
+        },
+        {
+          "path": "Dictionaries/world-mods.ja.json",
+          "entry_index": 83,
+          "text": "}}"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-parts.ja.json",
+      "key": " damage back at ",
+      "entry_count": 2,
+      "texts": [
+        " のダメージを跳ね返して ",
+        " のダメージを跳ね返して "
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 600,
+          "text": " のダメージを跳ね返して "
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 608,
+          "text": " のダメージを跳ね返して "
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-parts.ja.json",
+      "key": " damage back at you.",
+      "entry_count": 2,
+      "texts": [
+        " のダメージがあなたに跳ね返ってきた。",
+        " のダメージがあなたに跳ね返ってきた。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 602,
+          "text": " のダメージがあなたに跳ね返ってきた。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 609,
+          "text": " のダメージがあなたに跳ね返ってきた。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-parts.ja.json",
+      "key": "Agility",
+      "entry_count": 2,
+      "texts": [
+        "敏捷",
+        "敏捷"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 175,
+          "text": "敏捷"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 270,
+          "text": "敏捷"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-parts.ja.json",
+      "key": "Attack",
+      "entry_count": 2,
+      "texts": [
+        "攻撃",
+        "攻撃"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 247,
+          "text": "攻撃"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 563,
+          "text": "攻撃"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-parts.ja.json",
+      "key": "Object",
+      "entry_count": 2,
+      "texts": [
+        "オブジェクト",
+        "オブジェクト"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 316,
+          "text": "オブジェクト"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 436,
+          "text": "オブジェクト"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-parts.ja.json",
+      "key": "You are out of phase with ",
+      "entry_count": 2,
+      "texts": [
+        "あなたは と位相がずれている。",
+        "あなたは と位相がずれている。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 460,
+          "text": "あなたは と位相がずれている。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 470,
+          "text": "あなたは と位相がずれている。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-parts.ja.json",
+      "key": "You cannot do that while burrowed.",
+      "entry_count": 2,
+      "texts": [
+        "潜伏中はそれを行えない。",
+        "潜伏中はそれを行えない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 452,
+          "text": "潜伏中はそれを行えない。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 457,
+          "text": "潜伏中はそれを行えない。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-parts.ja.json",
+      "key": "You cannot reach ",
+      "entry_count": 4,
+      "texts": [
+        "手が届かない: ",
+        "手が届かない: ",
+        "手が届かない: ",
+        "手が届かない: "
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 461,
+          "text": "手が届かない: "
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 469,
+          "text": "手が届かない: "
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 530,
+          "text": "手が届かない: "
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 539,
+          "text": "手が届かない: "
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-parts.ja.json",
+      "key": "You cannot seem to work out how to hack ",
+      "entry_count": 2,
+      "texts": [
+        " のハッキング方法がわからない。",
+        " のハッキング方法がわからない。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 468,
+          "text": " のハッキング方法がわからない。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 591,
+          "text": " のハッキング方法がわからない。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-parts.ja.json",
+      "key": "You feel like you're making progress on hacking ",
+      "entry_count": 2,
+      "texts": [
+        " のハッキングが進んでいる気がする。",
+        " のハッキングが進んでいる気がする。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 467,
+          "text": " のハッキングが進んでいる気がする。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 590,
+          "text": " のハッキングが進んでいる気がする。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-parts.ja.json",
+      "key": "You hack ",
+      "entry_count": 2,
+      "texts": [
+        " をハッキングした。",
+        " をハッキングした。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 466,
+          "text": " をハッキングした。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 589,
+          "text": " をハッキングした。"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-parts.ja.json",
+      "key": "You receive tinkering bits <{{|",
+      "entry_count": 2,
+      "texts": [
+        "修理ビット <{{| を受け取った",
+        "修理ビット <{{| を受け取った"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 474,
+          "text": "修理ビット <{{| を受け取った"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 528,
+          "text": "修理ビット <{{| を受け取った"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-parts.ja.json",
+      "key": "You reflect ",
+      "entry_count": 2,
+      "texts": [
+        "あなたは",
+        "あなたは"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 599,
+          "text": "あなたは"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 607,
+          "text": "あなたは"
+        }
+      ]
+    },
+    {
+      "scope": "same_file",
+      "path": "Dictionaries/world-parts.ja.json",
+      "key": "You think you broke ",
+      "entry_count": 2,
+      "texts": [
+        " を壊してしまった気がする。",
+        " を壊してしまった気がする。"
+      ],
+      "occurrences": [
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 477,
+          "text": " を壊してしまった気がする。"
+        },
+        {
+          "path": "Dictionaries/world-parts.ja.json",
+          "entry_index": 516,
+          "text": " を壊してしまった気がする。"
+        }
       ]
     }
   ]

--- a/scripts/translation_token_duplicate_baseline.json
+++ b/scripts/translation_token_duplicate_baseline.json
@@ -1,0 +1,149 @@
+{
+  "version": 2,
+  "duplicate_conflicts": [
+    {
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "If you quit without saving, you will lose all your progress and your character will be lost. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\n Type 'QUIT' to confirm.",
+      "entry_count": 2,
+      "texts": [
+        "セーブせずに終了すると進行状況とキャラクターが完全に失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。",
+        "保存せずに終了すると進捗とキャラクターがすべて消えてしまいます。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "If you quit without saving, you will lose all your progress and your character will be lost. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\nType 'QUIT' to confirm.",
+      "entry_count": 2,
+      "texts": [
+        "セーブせずに終了すると進行状況とキャラクターが完全に失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。",
+        "保存せずに終了すると進捗とキャラクターがすべて消えてしまいます。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "If you quit without saving, you will lose all your unsaved progress. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\n Type 'QUIT' to confirm.",
+      "entry_count": 2,
+      "texts": [
+        "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。",
+        "保存せずに終了すると保存していない進捗をすべて失います。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-default.ja.json",
+      "key": "If you quit without saving, you will lose all your unsaved progress. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\nType 'QUIT' to confirm.",
+      "entry_count": 2,
+      "texts": [
+        "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。",
+        "保存せずに終了すると保存していない進捗をすべて失います。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": "You can't figure out how to safely reach the stairs from here.",
+      "entry_count": 2,
+      "texts": [
+        "ここから安全に階段へたどり着く方法が分からない。",
+        "ここから階段へ安全に辿る経路が見つからない。"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-messagelog-world.ja.json",
+      "key": "You have mastered psychic combat at this level of difficulty. Do you want to guide the process in detail anyway, with an enhanced chance of exceptional success? If you answer 'No', you will automatically receive the results of strong but unexceptional performance.",
+      "entry_count": 2,
+      "texts": [
+        "この難度での精神戦は熟達済みだ。より高い成功率を狙って詳細に指揮しますか？「いいえ」を選ぶと標準的な成功の結果を自動で受け取ります。",
+        "この難度での精神戦は熟達済みだ。より高い成功率を狙って詳細に指揮する？「いいえ」を選ぶと標準的な成功の結果を自動で受け取る。"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-options.ja.json",
+      "key": "Change Value",
+      "entry_count": 2,
+      "texts": [
+        "値を変更",
+        "値を変更（カーソル）"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Weathered",
+      "entry_count": 2,
+      "texts": [
+        "風雨に耐えた",
+        "風雪錬成"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Wilderness Lore: Canyons",
+      "entry_count": 2,
+      "texts": [
+        "荒地巡り：峡谷",
+        "荒野の伝承: 渓谷"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Wilderness Lore: Flower Fields",
+      "entry_count": 2,
+      "texts": [
+        "荒地巡り：花畑",
+        "荒野の伝承: 花畑"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Wilderness Lore: Hills and Mountains",
+      "entry_count": 2,
+      "texts": [
+        "荒地巡り：丘陵と山",
+        "荒野の伝承: 丘と山岳"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Wilderness Lore: Jungles",
+      "entry_count": 2,
+      "texts": [
+        "荒地巡り：ジャングル",
+        "荒野の伝承: ジャングル"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Wilderness Lore: Marshes",
+      "entry_count": 2,
+      "texts": [
+        "荒地巡り：湿地",
+        "荒野の伝承: 沼地"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Wilderness Lore: Rivers and Lakes",
+      "entry_count": 2,
+      "texts": [
+        "荒地巡り：河川",
+        "荒野の伝承: 河川と湖"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Wilderness Lore: Ruins",
+      "entry_count": 2,
+      "texts": [
+        "荒地巡り：廃墟",
+        "荒野の伝承: 遺跡"
+      ]
+    },
+    {
+      "path": "Dictionaries/ui-skillsandpowers.ja.json",
+      "key": "Wilderness Lore: Salt Dunes",
+      "entry_count": 2,
+      "texts": [
+        "荒地巡り：塩砂漠",
+        "荒野の伝承: 塩砂丘"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add a standalone JSON translation-token gate for localization assets.
- Check dictionary and BlueprintTemplates entries for dropped markup tokens, placeholder multiset mismatches, and unbaselined duplicate-key conflicts.
- Add a stateful duplicate-conflict baseline and wire the gate into CI.

## Validation

- `ruff check scripts/`
- `uv run pytest scripts/tests/test_translation_tokens.py`
- `python3.12 scripts/check_translation_tokens.py Mods/QudJP/Localization`
- `(cd Mods/QudJP/Localization && python3.12 ../../../scripts/check_translation_tokens.py Dictionaries)`
- `uv run pytest scripts/tests/`

## Scope

This is the first non-GUI #409 slice. It does not implement XML source-vs-translation diffing, runtime checks, or strict GameText variable parity for BlueprintTemplates.

Refs #409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 翻訳トークン保持と重複キー検証スイートを新規追加

* **Documentation**
  * ローカライゼーションワークフロー手順を更新

* **Chores**
  * CI/CDパイプラインに翻訳品質検証ステップを統合
  * 翻訳トークン重複の基準設定ファイルを追加
  * 日本語翻訳辞書エントリを修正
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
