### PR TITLE
Add XML source markup validation

### DIFF
--- a/scripts/tests/test_validate_xml.py
+++ b/scripts/tests/test_validate_xml.py
@@ -298,3 +298,233 @@ def test_empty_object_stub_not_flagged(tmp_path: Path, capsys: pytest.CaptureFix
 
     assert result == 0
     assert "Empty text" not in captured.out
+
+
+def test_source_root_reports_markup_drift_in_element_text_and_attributes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--source-root`` compares source and localized XML markup tokens."""
+    localization = tmp_path / "Localization"
+    source_root = tmp_path / "Base"
+    localized_xml = localization / "Conversations.jp.xml"
+    source_xml = source_root / "Conversations.xml"
+    _write_xml(
+        source_xml,
+        (
+            '<conversations><node ID="Greet" Name="{{Y|Joppa}}">'
+            "<text>{{R|Alert}} &amp;W =player.name=</text></node></conversations>"
+        ),
+    )
+    _write_xml(
+        localized_xml,
+        '<conversations><node ID="Greet" Name="Joppa"><text>{{R|警告}} =player.name=</text></node></conversations>',
+    )
+
+    result = main(["--source-root", str(source_root), str(localized_xml)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "Markup token drift" in captured.out
+    assert "@Name" in captured.out
+    assert "text()" in captured.out
+    assert "'&W': 1" in captured.out
+    assert "'{{Y|': 1" in captured.out
+
+
+def test_source_root_maps_nested_jp_xml_to_base_xml(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Nested ``ObjectBlueprints/Foo.jp.xml`` maps to ``ObjectBlueprints/Foo.xml``."""
+    localization = tmp_path / "Localization"
+    source_root = tmp_path / "Base"
+    localized_xml = localization / "ObjectBlueprints" / "Creatures.jp.xml"
+    source_xml = source_root / "ObjectBlueprints" / "Creatures.xml"
+    _write_xml(
+        source_xml,
+        '<objects><object Name="Glowfish" Description="A &amp;Cglowing&amp;y fish."/></objects>',
+    )
+    _write_xml(
+        localized_xml,
+        '<objects><object Name="Glowfish" Description="光る魚。"/></objects>',
+    )
+
+    result = main(["--source-root", str(source_root), str(localization)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "Creatures.jp.xml" in captured.out
+    assert "ObjectBlueprints/Creatures.xml" in captured.out
+    assert "@Description" in captured.out
+    assert "'&C': 1" in captured.out
+    assert "'&y': 1" in captured.out
+
+
+def test_source_root_comparison_is_opt_in(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Source-vs-localized markup comparison is not run without ``--source-root``."""
+    localized_xml = tmp_path / "Conversations.jp.xml"
+    _write_xml(localized_xml, "<conversations><text>警告</text></conversations>")
+
+    result = main([str(localized_xml)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "Markup token drift" not in captured.out
+
+
+def test_source_root_does_not_report_source_only_overlay_values(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Source-only values are inherited by merge overlays, so they are not drift."""
+    localization = tmp_path / "Localization"
+    source_root = tmp_path / "Base"
+    localized_xml = localization / "Skills.jp.xml"
+    source_xml = source_root / "Skills.xml"
+    _write_xml(
+        source_xml,
+        '<skills><skill Name="Acrobatics" Description="{{G|Jump}}"/></skills>',
+    )
+    _write_xml(localized_xml, '<skills><skill Name="Acrobatics"/></skills>')
+
+    result = main(["--source-root", str(source_root), str(localized_xml)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "Markup token drift" not in captured.out
+
+
+def test_source_root_matches_keyed_elements_when_sibling_order_differs(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Element matching prefers stable IDs over sibling position."""
+    localization = tmp_path / "Localization"
+    source_root = tmp_path / "Base"
+    localized_xml = localization / "Conversations.jp.xml"
+    source_xml = source_root / "Conversations.xml"
+    _write_xml(
+        source_xml,
+        (
+            '<conversations><conversation ID="A"><node ID="Start"><text>{{R|Alert}}</text></node></conversation>'
+            '<conversation ID="B"><node ID="Start"><text>{{G|Safe}}</text></node></conversation></conversations>'
+        ),
+    )
+    _write_xml(
+        localized_xml,
+        (
+            '<conversations><conversation ID="B"><node ID="Start"><text>{{G|安全}}</text></node></conversation>'
+            '<conversation ID="A"><node ID="Start"><text>警告</text></node></conversation></conversations>'
+        ),
+    )
+
+    result = main(["--source-root", str(source_root), str(localized_xml)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert captured.out.count("Markup token drift") == 1
+    assert "conversation[@ID='A'][1]" in captured.out
+    assert "'{{R|': 1" in captured.out
+    assert "'{{G|': 1" not in captured.out
+
+
+def test_source_root_matches_duplicate_keyed_conditionals_when_sibling_order_differs(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Duplicate keyed conditional siblings use stable attributes before position."""
+    localization = tmp_path / "Localization"
+    source_root = tmp_path / "Base"
+    localized_xml = localization / "Conversations.jp.xml"
+    source_xml = source_root / "Conversations.xml"
+    _write_xml(
+        source_xml,
+        (
+            '<conversations><conversation ID="Village">'
+            '<node ID="Ask" IfHaveState="met"><text>{{G|Met}}</text></node>'
+            '<node ID="Ask" IfHaveState="new"><text>{{R|New}}</text></node>'
+            "</conversation></conversations>"
+        ),
+    )
+    _write_xml(
+        localized_xml,
+        (
+            '<conversations><conversation ID="Village">'
+            '<node ID="Ask" IfHaveState="new"><text>{{R|新規}}</text></node>'
+            '<node ID="Ask" IfHaveState="met"><text>{{G|既知}}</text></node>'
+            "</conversation></conversations>"
+        ),
+    )
+
+    result = main(["--source-root", str(source_root), str(localized_xml)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "Markup token drift" not in captured.out
+
+
+def test_source_root_reports_name_attribute_drift_when_name_is_translated(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """ID-less elements still compare ``@Name`` when the name itself is translated."""
+    localization = tmp_path / "Localization"
+    source_root = tmp_path / "Base"
+    localized_xml = localization / "ObjectBlueprints.jp.xml"
+    source_xml = source_root / "ObjectBlueprints.xml"
+    _write_xml(source_xml, '<objects><object Name="{{R|Alert}}"/></objects>')
+    _write_xml(localized_xml, '<objects><object Name="警告"/></objects>')
+
+    result = main(["--source-root", str(source_root), str(localized_xml)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "Markup token drift" in captured.out
+    assert "@Name" in captured.out
+    assert "'{{R|': 1" in captured.out
+
+
+def test_source_root_uses_translated_name_fallback_for_description_without_false_positive(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Translated ID-less ``@Name`` still maps sibling attributes to the source element."""
+    localization = tmp_path / "Localization"
+    source_root = tmp_path / "Base"
+    localized_xml = localization / "ObjectBlueprints.jp.xml"
+    source_xml = source_root / "ObjectBlueprints.xml"
+    _write_xml(
+        source_xml,
+        '<objects><object Name="{{R|Alert}}" Description="{{G|Important}}"/></objects>',
+    )
+    _write_xml(
+        localized_xml,
+        '<objects><object Name="警告" Description="{{G|重要}}"/></objects>',
+    )
+
+    result = main(["--source-root", str(source_root), str(localized_xml)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "Markup token drift" in captured.out
+    assert "@Name" in captured.out
+    assert "@Description" not in captured.out
+
+
+def test_source_root_reports_description_drift_when_name_is_translated(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Translated ID-less ``@Name`` fallback applies to all units on that element."""
+    localization = tmp_path / "Localization"
+    source_root = tmp_path / "Base"
+    localized_xml = localization / "ObjectBlueprints.jp.xml"
+    source_xml = source_root / "ObjectBlueprints.xml"
+    _write_xml(
+        source_xml,
+        '<objects><object Name="{{R|Alert}}" Description="{{G|Important}}"/></objects>',
+    )
+    _write_xml(localized_xml, '<objects><object Name="警告" Description="重要"/></objects>')
+
+    result = main(["--source-root", str(source_root), str(localized_xml)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert captured.out.count("Markup token drift") == 2
+    assert "@Name" in captured.out
+    assert "@Description" in captured.out
+    assert "'{{R|': 1" in captured.out
+    assert "'{{G|': 1" in captured.out

--- a/scripts/tests/test_validate_xml.py
+++ b/scripts/tests/test_validate_xml.py
@@ -641,7 +641,7 @@ def test_source_root_parse_os_error_reports_deterministic_warning(
 
     original_parse = ET.parse
 
-    def fail_source_parse(path: Path) -> "ET.ElementTree[ET.Element[str]]":
+    def fail_source_parse(path: Path) -> "ET.ElementTree[ET.Element]":
         if Path(path) == source_xml:
             message = "permission denied"
             raise OSError(message)

--- a/scripts/tests/test_validate_xml.py
+++ b/scripts/tests/test_validate_xml.py
@@ -1,3 +1,4 @@
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
@@ -551,3 +552,72 @@ def test_source_root_reports_description_drift_when_name_is_translated(
     assert "@Description" in captured.out
     assert "'{{R|': 1" in captured.out
     assert "'{{G|': 1" in captured.out
+
+
+def test_source_root_rematches_translated_name_siblings_by_stable_attributes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Translated ID-less ``@Name`` siblings rematch by stable attrs before position."""
+    localization = tmp_path / "Localization"
+    source_root = tmp_path / "Base"
+    localized_xml = localization / "Worlds.jp.xml"
+    source_xml = source_root / "Worlds.xml"
+    _write_xml(
+        source_xml,
+        (
+            '<worlds><world Name="JoppaWorld">'
+            '<zone Name="North" Level="10" x="0" y="0" Description="{{G|Safe}}"/>'
+            '<zone Name="South" Level="11" x="0" y="0" Description="{{R|Danger}}"/>'
+            "</world></worlds>"
+        ),
+    )
+    _write_xml(
+        localized_xml,
+        (
+            '<worlds><world Name="JoppaWorld">'
+            '<zone Name="南" Level="11" x="0" y="0" Description="危険"/>'
+            '<zone Name="北" Level="10" x="0" y="0" Description="{{G|安全}}"/>'
+            "</world></worlds>"
+        ),
+    )
+
+    result = main(["--source-root", str(source_root), str(localized_xml)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert captured.out.count("Markup token drift") == 1
+    assert "zone[@Name='South'][1] @Description" in captured.out
+    assert "'{{R|': 1" in captured.out
+    assert "'{{G|': 1" not in captured.out
+
+
+def test_source_root_parse_os_error_reports_deterministic_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Source XML read failures report a stable source-relative warning."""
+    localization = tmp_path / "Localization"
+    source_root = tmp_path / "Base"
+    localized_xml = localization / "ObjectBlueprints" / "Creatures.jp.xml"
+    source_xml = source_root / "ObjectBlueprints" / "Creatures.xml"
+    _write_xml(localized_xml, '<objects><object Name="Glowfish"/></objects>')
+    _write_xml(source_xml, '<objects><object Name="Glowfish"/></objects>')
+
+    original_parse = ET.parse
+
+    def fail_source_parse(path: Path) -> "ET.ElementTree[ET.Element[str]]":
+        if Path(path) == source_xml:
+            message = "permission denied"
+            raise OSError(message)
+        return original_parse(path)
+
+    monkeypatch.setattr(ET, "parse", fail_source_parse)
+
+    result = validate_xml_file(
+        localized_xml,
+        source_root=source_root,
+        validation_roots=[localization],
+    )
+
+    assert result.warnings == [
+        "Source XML read failed for ObjectBlueprints/Creatures.xml: permission denied",
+    ]

--- a/scripts/tests/test_validate_xml.py
+++ b/scripts/tests/test_validate_xml.py
@@ -359,6 +359,29 @@ def test_source_root_maps_nested_jp_xml_to_base_xml(
     assert "'&y': 1" in captured.out
 
 
+def test_source_root_missing_source_warning_uses_relative_path(tmp_path: Path) -> None:
+    """Missing source XML warning is stable across source-root spelling."""
+    localization = tmp_path / "Localization"
+    source_root = tmp_path / "Base"
+    localized_xml = localization / "ObjectBlueprints" / "Creatures.jp.xml"
+    _write_xml(localized_xml, '<objects><object Name="Glowfish"/></objects>')
+
+    absolute_result = validate_xml_file(
+        localized_xml,
+        source_root=source_root,
+        validation_roots=[localization],
+    )
+    relative_result = validate_xml_file(
+        localized_xml,
+        source_root=Path("Base"),
+        validation_roots=[localization],
+    )
+
+    expected_warning = "Source XML not found for Creatures.jp.xml: ObjectBlueprints/Creatures.xml"
+    assert absolute_result.warnings == [expected_warning]
+    assert relative_result.warnings == [expected_warning]
+
+
 def test_source_root_comparison_is_opt_in(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """Source-vs-localized markup comparison is not run without ``--source-root``."""
     localized_xml = tmp_path / "Conversations.jp.xml"

--- a/scripts/tests/test_validate_xml.py
+++ b/scripts/tests/test_validate_xml.py
@@ -591,6 +591,43 @@ def test_source_root_rematches_translated_name_siblings_by_stable_attributes(
     assert "'{{G|': 1" not in captured.out
 
 
+def test_source_root_maps_reordered_keyed_children_under_positional_parent(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Children inherit a positionally matched translated parent source path."""
+    localization = tmp_path / "Localization"
+    source_root = tmp_path / "Base"
+    localized_xml = localization / "Conversations.jp.xml"
+    source_xml = source_root / "Conversations.xml"
+    _write_xml(
+        source_xml,
+        (
+            '<conversations><conversation Name="Village">'
+            '<node ID="Keep"><text>{{G|Keep}}</text></node>'
+            '<node ID="Drop"><text>{{R|Drop}}</text></node>'
+            "</conversation></conversations>"
+        ),
+    )
+    _write_xml(
+        localized_xml,
+        (
+            '<conversations><conversation Name="村">'
+            '<node ID="Drop"><text>削除</text></node>'
+            '<node ID="Keep"><text>{{G|維持}}</text></node>'
+            "</conversation></conversations>"
+        ),
+    )
+
+    result = main(["--source-root", str(source_root), str(localized_xml)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert captured.out.count("Markup token drift") == 1
+    assert "conversation[@Name='Village'][1]/node[@ID='Drop'][1]/text[1] text()" in captured.out
+    assert "'{{R|': 1" in captured.out
+    assert "'{{G|': 1" not in captured.out
+
+
 def test_source_root_parse_os_error_reports_deterministic_warning(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/scripts/validate_xml.py
+++ b/scripts/validate_xml.py
@@ -635,8 +635,6 @@ def _find_markup_token_drift(
 
         missing_tokens = source_tokens - localized_tokens
         extra_tokens = localized_tokens - source_tokens
-        if not missing_tokens and not extra_tokens:
-            continue
 
         details: list[str] = []
         if missing_tokens:

--- a/scripts/validate_xml.py
+++ b/scripts/validate_xml.py
@@ -2,8 +2,10 @@
 
 import argparse
 import json
+import re
 import sys
 import xml.etree.ElementTree as ET
+from collections import Counter, defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -33,6 +35,71 @@ on schema-legitimate repetition (Naming weights, Conversations conditional
 branches, Worlds zone differentiation, etc.).
 """
 
+_BARE_QUD_SPAN = re.compile(r"\{\{[^|{}]+\}\}")
+_QUD_OPENER = re.compile(r"\{\{[^|}]+\|")
+_QUD_CLOSER = re.compile(r"\}\}")
+_LITERAL_AMPERSAND = re.compile(r"&&")
+_LITERAL_CARET = re.compile(r"\^\^")
+_LEGACY_AMPERSAND_COLOR = re.compile(r"(?<!&)&(?!&)[A-Za-z0-9]")
+_LEGACY_CARET_COLOR = re.compile(r"(?<!\^)\^(?!\^)[A-Za-z0-9]")
+_HTML_COLOR_OPEN = re.compile(r"<color=[^>]+>")
+_HTML_COLOR_CLOSE = re.compile(r"</color>")
+_VARIABLE_TOKEN = re.compile(r"=[A-Za-z_][A-Za-z0-9_.:']*=")
+_MARKUP_TOKEN_PATTERNS = (
+    _QUD_OPENER,
+    _LITERAL_AMPERSAND,
+    _LITERAL_CARET,
+    _LEGACY_AMPERSAND_COLOR,
+    _LEGACY_CARET_COLOR,
+    _HTML_COLOR_OPEN,
+    _HTML_COLOR_CLOSE,
+    _VARIABLE_TOKEN,
+)
+
+type _MarkupUnitKey = tuple[str, str]
+type _ElementPathRecord = tuple[str, str, ET.Element, bool]
+
+_MARKUP_COMPARISON_ATTRIBUTES = frozenset(
+    {
+        "ChargedName",
+        "ChargenDescription",
+        "ColdName",
+        "Description",
+        "DisplayName",
+        "Gospel",
+        "Hagiograph",
+        "HeatName",
+        "LethalMessage",
+        "Long",
+        "MaxHitpointsThresholdMessage",
+        "Message",
+        "Messages",
+        "Name",
+        "Ordinary",
+        "PhaseMessage",
+        "Postfix",
+        "Prefix",
+        "PrepMessageOther",
+        "PrepMessageSelf",
+        "Short",
+        "Snippet",
+        "SpawnMessage",
+        "Text",
+        "Title",
+        "Value",
+        "message",
+        "text",
+    }
+)
+_PATH_KEY_ATTRIBUTES = ("ID", "Name")
+_PREFERRED_PATH_DISCRIMINATOR_ATTRIBUTES = (
+    "IfHaveState",
+    "IfNotHaveState",
+    "If",
+    "Speaker",
+    "GotoID",
+)
+
 
 def _collect_xml_files(paths: list[Path]) -> list[Path]:
     xml_files: set[Path] = set()
@@ -53,6 +120,14 @@ def _collect_xml_files(paths: list[Path]) -> list[Path]:
         raise ValueError(msg)
 
     return sorted(xml_files, key=str)
+
+
+def _ensure_source_root_is_directory(source_root: Path | None) -> None:
+    if source_root is None or source_root.is_dir():
+        return
+
+    msg = f"source root is not a directory: {source_root}"
+    raise ValueError(msg)
 
 
 def _warning_path(path: Path, *, root: Path) -> str:
@@ -167,11 +242,239 @@ def _find_empty_text_elements(root: ET.Element) -> list[str]:
     return warnings
 
 
-def validate_xml_file(path: Path) -> ValidationResult:
+def _markup_token_multiset(value: str) -> Counter[str]:
+    tokens: Counter[str] = Counter()
+    tokens.update(match.group(0) for match in _BARE_QUD_SPAN.finditer(value))
+    bare_span_stripped = _BARE_QUD_SPAN.sub("", value)
+    for pattern in _MARKUP_TOKEN_PATTERNS:
+        tokens.update(match.group(0) for match in pattern.finditer(value))
+    tokens.update(match.group(0) for match in _QUD_CLOSER.finditer(bare_span_stripped))
+    return tokens
+
+
+def _format_counter(counter: Counter[str]) -> str:
+    return ", ".join(f"{token!r}: {count}" for token, count in sorted(counter.items()))
+
+
+def _source_xml_relative_path(relative_path: Path) -> Path:
+    source_name = relative_path.name.removesuffix(".jp.xml") + ".xml"
+    return relative_path.with_name(source_name)
+
+
+def _source_relative_path(path: Path, *, validation_roots: list[Path]) -> Path | None:
+    if not path.name.endswith(".jp.xml"):
+        return None
+
+    for candidate in (path, path.resolve()):
+        if "Localization" in candidate.parts:
+            index = len(candidate.parts) - 1 - candidate.parts[::-1].index("Localization")
+            relative_path = Path(*candidate.parts[index + 1 :])
+            return _source_xml_relative_path(relative_path)
+
+    resolved_path = path.resolve()
+    for validation_root in validation_roots:
+        if not validation_root.is_dir():
+            continue
+        try:
+            relative_path = resolved_path.relative_to(validation_root.resolve())
+        except ValueError:
+            continue
+        return _source_xml_relative_path(relative_path)
+
+    return _source_xml_relative_path(Path(path.name))
+
+
+def _quote_path_value(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _element_path_key_base(element: ET.Element) -> str:
+    for key_attribute in _PATH_KEY_ATTRIBUTES:
+        if value := element.attrib.get(key_attribute):
+            return f"{element.tag}[@{key_attribute}='{_quote_path_value(value)}']"
+    return element.tag
+
+
+def _attribute_signature(element: ET.Element, attribute_names: Iterable[str]) -> tuple[str, ...]:
+    return tuple(element.attrib.get(attribute_name, "") for attribute_name in attribute_names)
+
+
+def _signature_is_unique(elements: list[ET.Element], attribute_names: Iterable[str]) -> bool:
+    attribute_names = tuple(attribute_names)
+    signatures = [_attribute_signature(element, attribute_names) for element in elements]
+    return len(signatures) == len(set(signatures))
+
+
+def _varying_attributes(elements: list[ET.Element], attribute_names: Iterable[str]) -> list[str]:
+    varying_attributes: list[str] = []
+    for attribute_name in attribute_names:
+        values = {element.attrib.get(attribute_name, "") for element in elements}
+        if len(values) > 1 and any(values):
+            varying_attributes.append(attribute_name)
+    return varying_attributes
+
+
+def _path_discriminator_attributes(elements: list[ET.Element]) -> tuple[str, ...]:
+    discriminator_attributes = _varying_attributes(elements, _PREFERRED_PATH_DISCRIMINATOR_ATTRIBUTES)
+    if discriminator_attributes and _signature_is_unique(elements, discriminator_attributes):
+        return tuple(discriminator_attributes)
+
+    fallback_attribute_names = sorted(
+        {
+            attribute_name
+            for element in elements
+            for attribute_name in element.attrib
+            if attribute_name not in _PATH_KEY_ATTRIBUTES
+            and attribute_name not in _MARKUP_COMPARISON_ATTRIBUTES
+            and attribute_name not in discriminator_attributes
+        }
+    )
+    for attribute_name in _varying_attributes(elements, fallback_attribute_names):
+        discriminator_attributes.append(attribute_name)
+        if _signature_is_unique(elements, discriminator_attributes):
+            break
+    return tuple(discriminator_attributes)
+
+
+def _element_path_base(element: ET.Element, discriminator_attributes: Iterable[str]) -> str:
+    path_base = _element_path_key_base(element)
+    for attribute_name in discriminator_attributes:
+        value = element.attrib.get(attribute_name, "")
+        path_base += f"[@{attribute_name}='{_quote_path_value(value)}']"
+    return path_base
+
+
+def _element_path_records(root: ET.Element) -> list[_ElementPathRecord]:
+    records: list[_ElementPathRecord] = []
+
+    def walk(
+        element: ET.Element,
+        keyed_path: str,
+        positional_path: str,
+        *,
+        uses_idless_name_fallback: bool,
+    ) -> None:
+        uses_idless_name_fallback = uses_idless_name_fallback or (
+            "ID" not in element.attrib and "Name" in element.attrib
+        )
+        records.append((keyed_path, positional_path, element, uses_idless_name_fallback))
+        keyed_groups: defaultdict[str, list[ET.Element]] = defaultdict(list)
+        for child in element:
+            keyed_groups[_element_path_key_base(child)].append(child)
+        group_discriminator_attributes = {
+            key_base: _path_discriminator_attributes(group)
+            for key_base, group in keyed_groups.items()
+            if len(group) > 1
+        }
+        sibling_counts: defaultdict[str, int] = defaultdict(int)
+        tag_counts: defaultdict[str, int] = defaultdict(int)
+        for child in element:
+            key_base = _element_path_key_base(child)
+            path_base = _element_path_base(child, group_discriminator_attributes.get(key_base, ()))
+            sibling_counts[path_base] += 1
+            tag_counts[child.tag] += 1
+            walk(
+                child,
+                f"{keyed_path}/{path_base}[{sibling_counts[path_base]}]",
+                f"{positional_path}/{child.tag}[{tag_counts[child.tag]}]",
+                uses_idless_name_fallback=uses_idless_name_fallback,
+            )
+
+    walk(root, f"/{root.tag}[1]", f"/{root.tag}[1]", uses_idless_name_fallback=False)
+    return records
+
+
+def _markup_unit_values(root: ET.Element, *, use_positional_paths: bool = False) -> dict[_MarkupUnitKey, str]:
+    values: dict[_MarkupUnitKey, str] = {}
+    for keyed_path, positional_path, element, _uses_idless_name_fallback in _element_path_records(root):
+        element_path = positional_path if use_positional_paths else keyed_path
+        values[(element_path, "text()")] = element.text or ""
+        for attribute_name, attribute_value in element.attrib.items():
+            if attribute_name not in _MARKUP_COMPARISON_ATTRIBUTES:
+                continue
+            values[(element_path, f"@{attribute_name}")] = attribute_value
+    return values
+
+
+def _idless_name_element_fallback_paths(root: ET.Element) -> dict[str, str]:
+    return {
+        keyed_path: positional_path
+        for keyed_path, positional_path, _element, uses_idless_name_fallback in _element_path_records(root)
+        if uses_idless_name_fallback
+    }
+
+
+def _find_markup_token_drift(
+    localized_root: ET.Element,
+    source_root: ET.Element,
+    *,
+    source_relative_path: Path,
+) -> list[str]:
+    warnings: list[str] = []
+    localized_values = _markup_unit_values(localized_root)
+    source_values = _markup_unit_values(source_root)
+    localized_fallback_paths = _idless_name_element_fallback_paths(localized_root)
+    source_positional_values = _markup_unit_values(source_root, use_positional_paths=True)
+    for unit_key, localized_value in sorted(localized_values.items()):
+        element_path, unit_name = unit_key
+        source_value = source_values.get(unit_key)
+        warning_key = unit_key
+        if source_value is None and (fallback_path := localized_fallback_paths.get(element_path)) is not None:
+            fallback_key = (fallback_path, unit_name)
+            source_value = source_positional_values.get(fallback_key, "")
+            warning_key = fallback_key
+        source_tokens = _markup_token_multiset(source_value or "")
+        localized_tokens = _markup_token_multiset(localized_value)
+        if source_tokens == localized_tokens:
+            continue
+
+        missing_tokens = source_tokens - localized_tokens
+        extra_tokens = localized_tokens - source_tokens
+        if not missing_tokens and not extra_tokens:
+            continue
+
+        details: list[str] = []
+        if missing_tokens:
+            details.append(f"missing {_format_counter(missing_tokens)}")
+        if extra_tokens:
+            details.append(f"extra {_format_counter(extra_tokens)}")
+        element_path, unit_name = warning_key
+        warnings.append(
+            f"Markup token drift vs {source_relative_path.as_posix()} at {element_path} {unit_name}: "
+            + "; ".join(details)
+        )
+    return warnings
+
+
+def _find_source_markup_token_drift(
+    path: Path,
+    root: ET.Element,
+    source_path: Path,
+    source_relative_path: Path,
+) -> list[str]:
+    if not source_path.exists():
+        return [f"Source XML not found for {path.name}: {source_path}"]
+
+    try:
+        source_root = ET.parse(source_path).getroot()  # noqa: S314 -- local repository XML validation tool
+    except ET.ParseError as exc:
+        return [f"Source XML parse failed for {source_relative_path.as_posix()}: {exc}"]
+
+    return _find_markup_token_drift(root, source_root, source_relative_path=source_relative_path)
+
+
+def validate_xml_file(
+    path: Path,
+    *,
+    source_root: Path | None = None,
+    validation_roots: list[Path] | None = None,
+) -> ValidationResult:
     """Validate one XML file and return its findings.
 
     Args:
         path: XML file path.
+        source_root: Optional base XML root for source-vs-localized markup comparison.
+        validation_roots: Original validation inputs used to map file paths to source-relative paths.
 
     Returns:
         Validation result with errors and warnings.
@@ -195,6 +498,17 @@ def validate_xml_file(path: Path) -> ValidationResult:
 
     warnings.extend(_find_duplicate_siblings(root))
     warnings.extend(_find_empty_text_elements(root))
+    if source_root is not None:
+        source_relative_path = _source_relative_path(path, validation_roots=validation_roots or [])
+        if source_relative_path is not None:
+            warnings.extend(
+                _find_source_markup_token_drift(
+                    path,
+                    root,
+                    source_root / source_relative_path,
+                    source_relative_path,
+                )
+            )
     return ValidationResult(path=path, errors=errors, warnings=warnings)
 
 
@@ -222,6 +536,7 @@ def run_validation(
     strict: bool,
     warning_baseline: Path | None = None,
     write_warning_baseline: Path | None = None,
+    source_root: Path | None = None,
 ) -> int:
     """Run validation for input paths.
 
@@ -230,12 +545,14 @@ def run_validation(
         strict: Treat non-baselined warnings as failures.
         warning_baseline: Existing warning baseline to subtract from strict failures.
         write_warning_baseline: Optional path to write current warnings as a baseline.
+        source_root: Optional base XML root for source-vs-localized markup comparison.
 
     Returns:
         Exit code (0 on success, 1 on failure).
     """
     try:
         xml_files = _collect_xml_files(paths)
+        _ensure_source_root_is_directory(source_root)
     except (FileNotFoundError, ValueError) as exc:
         print(f"Error: {exc}", file=sys.stderr)  # noqa: T201
         return 1
@@ -253,7 +570,7 @@ def run_validation(
 
     results: list[ValidationResult] = []
     for file_path in xml_files:
-        result = validate_xml_file(file_path)
+        result = validate_xml_file(file_path, source_root=source_root, validation_roots=paths)
         results.append(result)
         _print_result(result)
 
@@ -311,6 +628,11 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         help="Write current warnings to a JSON baseline file.",
     )
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        help="Optional base XML directory used to compare markup tokens in corresponding *.jp.xml files.",
+    )
 
     args = parser.parse_args(argv)
     return run_validation(
@@ -318,6 +640,7 @@ def main(argv: list[str] | None = None) -> int:
         strict=args.strict,
         warning_baseline=args.warning_baseline,
         write_warning_baseline=args.write_warning_baseline,
+        source_root=args.source_root,
     )
 
 

--- a/scripts/validate_xml.py
+++ b/scripts/validate_xml.py
@@ -509,11 +509,30 @@ def _is_translated_idless_name_record(record: _ElementPathRecord) -> bool:
     return "ID" not in record.element.attrib and "Name" in record.element.attrib
 
 
+def _relative_keyed_path(record: _ElementPathRecord) -> str:
+    if record.parent_keyed_path is None:
+        return record.keyed_path
+    return record.keyed_path.removeprefix(f"{record.parent_keyed_path}/")
+
+
+def _source_child_by_relative_keyed_path(
+    localized_record: _ElementPathRecord,
+    source_candidates: list[_ElementPathRecord],
+) -> _ElementPathRecord | None:
+    localized_relative_path = _relative_keyed_path(localized_record)
+    for candidate in source_candidates:
+        if (
+            candidate.element.tag == localized_record.element.tag
+            and _relative_keyed_path(candidate) == localized_relative_path
+        ):
+            return candidate
+    return None
+
+
 def _source_record_for_localized_record(
     localized_record: _ElementPathRecord,
     *,
     source_parent_path: str,
-    rematch_paths: dict[str, str],
     source_record_by_keyed_path: dict[str, _ElementPathRecord],
     source_children_by_parent: defaultdict[str, list[_ElementPathRecord]],
     source_child_by_relative_position: dict[tuple[str, str, int], _ElementPathRecord],
@@ -523,29 +542,39 @@ def _source_record_for_localized_record(
         if source_record is not None:
             return source_record
 
+    source_candidates = source_children_by_parent[source_parent_path]
+    source_record = _source_child_by_relative_keyed_path(localized_record, source_candidates)
+    if source_record is not None:
+        return source_record
+
     if _is_translated_idless_name_record(localized_record):
         source_record = _stable_source_rematch(
             localized_record,
             [
                 candidate
-                for candidate in source_children_by_parent[source_parent_path]
+                for candidate in source_candidates
                 if candidate.element.tag == localized_record.element.tag
             ],
         )
         if source_record is not None:
             return source_record
 
-    if localized_record.parent_keyed_path in rematch_paths:
-        return source_child_by_relative_position.get(
-            (source_parent_path, localized_record.element.tag, localized_record.sibling_tag_index)
-        )
-    return None
+    return source_child_by_relative_position.get(
+        (source_parent_path, localized_record.element.tag, localized_record.sibling_tag_index)
+    )
 
 
-def _source_stable_rematch_paths(localized_root: ET.Element, source_root: ET.Element) -> dict[str, str]:
+def _source_stable_rematch_paths(
+    localized_root: ET.Element,
+    source_root: ET.Element,
+) -> dict[str, str]:
     localized_records = _element_path_records(localized_root)
     source_records = _element_path_records(source_root)
-    if not localized_records or not source_records or localized_records[0].element.tag != source_records[0].element.tag:
+    if (
+        not localized_records
+        or not source_records
+        or localized_records[0].element.tag != source_records[0].element.tag
+    ):
         return {}
 
     source_record_by_keyed_path, source_children_by_parent, source_child_by_relative_position = (
@@ -553,7 +582,6 @@ def _source_stable_rematch_paths(localized_root: ET.Element, source_root: ET.Ele
     )
 
     localized_to_source_paths = {localized_records[0].keyed_path: source_records[0].keyed_path}
-    rematch_paths: dict[str, str] = {}
     for localized_record in localized_records[1:]:
         if localized_record.parent_keyed_path is None:
             continue
@@ -564,7 +592,6 @@ def _source_stable_rematch_paths(localized_root: ET.Element, source_root: ET.Ele
         source_record = _source_record_for_localized_record(
             localized_record,
             source_parent_path=source_parent_path,
-            rematch_paths=rematch_paths,
             source_record_by_keyed_path=source_record_by_keyed_path,
             source_children_by_parent=source_children_by_parent,
             source_child_by_relative_position=source_child_by_relative_position,
@@ -574,9 +601,7 @@ def _source_stable_rematch_paths(localized_root: ET.Element, source_root: ET.Ele
             continue
 
         localized_to_source_paths[localized_record.keyed_path] = source_record.keyed_path
-        if source_record.keyed_path != localized_record.keyed_path:
-            rematch_paths[localized_record.keyed_path] = source_record.keyed_path
-    return rematch_paths
+    return localized_to_source_paths
 
 
 def _find_markup_token_drift(
@@ -589,16 +614,16 @@ def _find_markup_token_drift(
     localized_values = _markup_unit_values(localized_root)
     source_values = _markup_unit_values(source_root)
     localized_fallback_paths = _idless_name_element_fallback_paths(localized_root)
-    localized_rematch_paths = _source_stable_rematch_paths(localized_root, source_root)
+    source_paths = _source_stable_rematch_paths(localized_root, source_root)
     source_positional_values = _markup_unit_values(source_root, use_positional_paths=True)
     for unit_key, localized_value in sorted(localized_values.items()):
         element_path, unit_name = unit_key
         source_value = source_values.get(unit_key)
         warning_key = unit_key
-        if source_value is None and (rematch_path := localized_rematch_paths.get(element_path)) is not None:
-            rematch_key = (rematch_path, unit_name)
-            source_value = source_values.get(rematch_key, "")
-            warning_key = rematch_key
+        if source_value is None and (source_path := source_paths.get(element_path)) is not None:
+            source_key = (source_path, unit_name)
+            source_value = source_values.get(source_key, "")
+            warning_key = source_key
         if source_value is None and (fallback_path := localized_fallback_paths.get(element_path)) is not None:
             fallback_key = (fallback_path, unit_name)
             source_value = source_positional_values.get(fallback_key, "")

--- a/scripts/validate_xml.py
+++ b/scripts/validate_xml.py
@@ -456,7 +456,7 @@ def _find_source_markup_token_drift(
     source_relative_path: Path,
 ) -> list[str]:
     if not source_path.exists():
-        return [f"Source XML not found for {path.name}: {source_path}"]
+        return [f"Source XML not found for {path.name}: {source_relative_path.as_posix()}"]
 
     try:
         source_root = ET.parse(source_path).getroot()  # noqa: S314 -- local repository XML validation tool

--- a/scripts/validate_xml.py
+++ b/scripts/validate_xml.py
@@ -57,7 +57,32 @@ _MARKUP_TOKEN_PATTERNS = (
 )
 
 type _MarkupUnitKey = tuple[str, str]
-type _ElementPathRecord = tuple[str, str, ET.Element, bool]
+
+
+@dataclass(frozen=True)
+class _ElementPathRecord:
+    keyed_path: str
+    positional_path: str
+    element: ET.Element
+    uses_idless_name_fallback: bool
+    parent_keyed_path: str | None
+    sibling_tag_index: int
+
+
+type _SourceChildrenByParent = tuple[
+    dict[str, _ElementPathRecord],
+    defaultdict[str, list[_ElementPathRecord]],
+    dict[tuple[str, str, int], _ElementPathRecord],
+]
+
+
+@dataclass(frozen=True)
+class _PathWalkState:
+    keyed_path: str
+    positional_path: str
+    uses_idless_name_fallback: bool
+    parent_keyed_path: str | None
+    sibling_tag_index: int
 
 _MARKUP_COMPARISON_ATTRIBUTES = frozenset(
     {
@@ -99,6 +124,7 @@ _PREFERRED_PATH_DISCRIMINATOR_ATTRIBUTES = (
     "Speaker",
     "GotoID",
 )
+_PREFERRED_STABLE_REMATCH_ATTRIBUTES = ("ID", "Level", "x", "y")
 
 
 def _collect_xml_files(paths: list[Path]) -> list[Path]:
@@ -350,17 +376,20 @@ def _element_path_base(element: ET.Element, discriminator_attributes: Iterable[s
 def _element_path_records(root: ET.Element) -> list[_ElementPathRecord]:
     records: list[_ElementPathRecord] = []
 
-    def walk(
-        element: ET.Element,
-        keyed_path: str,
-        positional_path: str,
-        *,
-        uses_idless_name_fallback: bool,
-    ) -> None:
-        uses_idless_name_fallback = uses_idless_name_fallback or (
+    def walk(element: ET.Element, state: _PathWalkState) -> None:
+        uses_idless_name_fallback = state.uses_idless_name_fallback or (
             "ID" not in element.attrib and "Name" in element.attrib
         )
-        records.append((keyed_path, positional_path, element, uses_idless_name_fallback))
+        records.append(
+            _ElementPathRecord(
+                keyed_path=state.keyed_path,
+                positional_path=state.positional_path,
+                element=element,
+                uses_idless_name_fallback=uses_idless_name_fallback,
+                parent_keyed_path=state.parent_keyed_path,
+                sibling_tag_index=state.sibling_tag_index,
+            )
+        )
         keyed_groups: defaultdict[str, list[ET.Element]] = defaultdict(list)
         for child in element:
             keyed_groups[_element_path_key_base(child)].append(child)
@@ -378,19 +407,33 @@ def _element_path_records(root: ET.Element) -> list[_ElementPathRecord]:
             tag_counts[child.tag] += 1
             walk(
                 child,
-                f"{keyed_path}/{path_base}[{sibling_counts[path_base]}]",
-                f"{positional_path}/{child.tag}[{tag_counts[child.tag]}]",
-                uses_idless_name_fallback=uses_idless_name_fallback,
+                _PathWalkState(
+                    keyed_path=f"{state.keyed_path}/{path_base}[{sibling_counts[path_base]}]",
+                    positional_path=f"{state.positional_path}/{child.tag}[{tag_counts[child.tag]}]",
+                    uses_idless_name_fallback=uses_idless_name_fallback,
+                    parent_keyed_path=state.keyed_path,
+                    sibling_tag_index=tag_counts[child.tag],
+                ),
             )
 
-    walk(root, f"/{root.tag}[1]", f"/{root.tag}[1]", uses_idless_name_fallback=False)
+    walk(
+        root,
+        _PathWalkState(
+            keyed_path=f"/{root.tag}[1]",
+            positional_path=f"/{root.tag}[1]",
+            uses_idless_name_fallback=False,
+            parent_keyed_path=None,
+            sibling_tag_index=1,
+        ),
+    )
     return records
 
 
 def _markup_unit_values(root: ET.Element, *, use_positional_paths: bool = False) -> dict[_MarkupUnitKey, str]:
     values: dict[_MarkupUnitKey, str] = {}
-    for keyed_path, positional_path, element, _uses_idless_name_fallback in _element_path_records(root):
-        element_path = positional_path if use_positional_paths else keyed_path
+    for record in _element_path_records(root):
+        element = record.element
+        element_path = record.positional_path if use_positional_paths else record.keyed_path
         values[(element_path, "text()")] = element.text or ""
         for attribute_name, attribute_value in element.attrib.items():
             if attribute_name not in _MARKUP_COMPARISON_ATTRIBUTES:
@@ -401,10 +444,139 @@ def _markup_unit_values(root: ET.Element, *, use_positional_paths: bool = False)
 
 def _idless_name_element_fallback_paths(root: ET.Element) -> dict[str, str]:
     return {
-        keyed_path: positional_path
-        for keyed_path, positional_path, _element, uses_idless_name_fallback in _element_path_records(root)
-        if uses_idless_name_fallback
+        record.keyed_path: record.positional_path
+        for record in _element_path_records(root)
+        if record.uses_idless_name_fallback
     }
+
+
+def _stable_source_rematch(
+    localized_record: _ElementPathRecord,
+    source_candidates: list[_ElementPathRecord],
+) -> _ElementPathRecord | None:
+    element = localized_record.element
+    candidate_attribute_names = [
+        attribute_name
+        for attribute_name in _PREFERRED_STABLE_REMATCH_ATTRIBUTES
+        if element.attrib.get(attribute_name)
+    ]
+    candidate_attribute_names.extend(
+        sorted(
+            {
+                attribute_name
+                for attribute_name, attribute_value in element.attrib.items()
+                if attribute_value
+                and attribute_name not in candidate_attribute_names
+                and attribute_name != "Name"
+                and attribute_name not in _MARKUP_COMPARISON_ATTRIBUTES
+            }
+        )
+    )
+
+    selected_attribute_names: list[str] = []
+    for attribute_name in candidate_attribute_names:
+        selected_attribute_names.append(attribute_name)
+        matching_candidates = [
+            candidate
+            for candidate in source_candidates
+            if all(
+                candidate.element.attrib.get(selected_name) == element.attrib[selected_name]
+                for selected_name in selected_attribute_names
+            )
+        ]
+        if len(matching_candidates) == 1:
+            return matching_candidates[0]
+    return None
+
+
+def _source_children_by_parent(
+    source_records: list[_ElementPathRecord],
+) -> _SourceChildrenByParent:
+    source_record_by_keyed_path = {record.keyed_path: record for record in source_records}
+    source_children: defaultdict[str, list[_ElementPathRecord]] = defaultdict(list)
+    source_child_by_relative_position: dict[tuple[str, str, int], _ElementPathRecord] = {}
+    for record in source_records:
+        if record.parent_keyed_path is None:
+            continue
+        source_children[record.parent_keyed_path].append(record)
+        source_child_by_relative_position[
+            (record.parent_keyed_path, record.element.tag, record.sibling_tag_index)
+        ] = record
+    return source_record_by_keyed_path, source_children, source_child_by_relative_position
+
+
+def _is_translated_idless_name_record(record: _ElementPathRecord) -> bool:
+    return "ID" not in record.element.attrib and "Name" in record.element.attrib
+
+
+def _source_record_for_localized_record(
+    localized_record: _ElementPathRecord,
+    *,
+    source_parent_path: str,
+    rematch_paths: dict[str, str],
+    source_record_by_keyed_path: dict[str, _ElementPathRecord],
+    source_children_by_parent: defaultdict[str, list[_ElementPathRecord]],
+    source_child_by_relative_position: dict[tuple[str, str, int], _ElementPathRecord],
+) -> _ElementPathRecord | None:
+    if source_parent_path == localized_record.parent_keyed_path:
+        source_record = source_record_by_keyed_path.get(localized_record.keyed_path)
+        if source_record is not None:
+            return source_record
+
+    if _is_translated_idless_name_record(localized_record):
+        source_record = _stable_source_rematch(
+            localized_record,
+            [
+                candidate
+                for candidate in source_children_by_parent[source_parent_path]
+                if candidate.element.tag == localized_record.element.tag
+            ],
+        )
+        if source_record is not None:
+            return source_record
+
+    if localized_record.parent_keyed_path in rematch_paths:
+        return source_child_by_relative_position.get(
+            (source_parent_path, localized_record.element.tag, localized_record.sibling_tag_index)
+        )
+    return None
+
+
+def _source_stable_rematch_paths(localized_root: ET.Element, source_root: ET.Element) -> dict[str, str]:
+    localized_records = _element_path_records(localized_root)
+    source_records = _element_path_records(source_root)
+    if not localized_records or not source_records or localized_records[0].element.tag != source_records[0].element.tag:
+        return {}
+
+    source_record_by_keyed_path, source_children_by_parent, source_child_by_relative_position = (
+        _source_children_by_parent(source_records)
+    )
+
+    localized_to_source_paths = {localized_records[0].keyed_path: source_records[0].keyed_path}
+    rematch_paths: dict[str, str] = {}
+    for localized_record in localized_records[1:]:
+        if localized_record.parent_keyed_path is None:
+            continue
+        source_parent_path = localized_to_source_paths.get(localized_record.parent_keyed_path)
+        if source_parent_path is None:
+            continue
+
+        source_record = _source_record_for_localized_record(
+            localized_record,
+            source_parent_path=source_parent_path,
+            rematch_paths=rematch_paths,
+            source_record_by_keyed_path=source_record_by_keyed_path,
+            source_children_by_parent=source_children_by_parent,
+            source_child_by_relative_position=source_child_by_relative_position,
+        )
+
+        if source_record is None:
+            continue
+
+        localized_to_source_paths[localized_record.keyed_path] = source_record.keyed_path
+        if source_record.keyed_path != localized_record.keyed_path:
+            rematch_paths[localized_record.keyed_path] = source_record.keyed_path
+    return rematch_paths
 
 
 def _find_markup_token_drift(
@@ -417,11 +589,16 @@ def _find_markup_token_drift(
     localized_values = _markup_unit_values(localized_root)
     source_values = _markup_unit_values(source_root)
     localized_fallback_paths = _idless_name_element_fallback_paths(localized_root)
+    localized_rematch_paths = _source_stable_rematch_paths(localized_root, source_root)
     source_positional_values = _markup_unit_values(source_root, use_positional_paths=True)
     for unit_key, localized_value in sorted(localized_values.items()):
         element_path, unit_name = unit_key
         source_value = source_values.get(unit_key)
         warning_key = unit_key
+        if source_value is None and (rematch_path := localized_rematch_paths.get(element_path)) is not None:
+            rematch_key = (rematch_path, unit_name)
+            source_value = source_values.get(rematch_key, "")
+            warning_key = rematch_key
         if source_value is None and (fallback_path := localized_fallback_paths.get(element_path)) is not None:
             fallback_key = (fallback_path, unit_name)
             source_value = source_positional_values.get(fallback_key, "")
@@ -460,6 +637,8 @@ def _find_source_markup_token_drift(
 
     try:
         source_root = ET.parse(source_path).getroot()  # noqa: S314 -- local repository XML validation tool
+    except OSError as exc:
+        return [f"Source XML read failed for {source_relative_path.as_posix()}: {exc}"]
     except ET.ParseError as exc:
         return [f"Source XML parse failed for {source_relative_path.as_posix()}: {exc}"]
 

--- a/scripts/validate_xml.py
+++ b/scripts/validate_xml.py
@@ -246,6 +246,9 @@ def _markup_token_multiset(value: str) -> Counter[str]:
     tokens: Counter[str] = Counter()
     tokens.update(match.group(0) for match in _BARE_QUD_SPAN.finditer(value))
     bare_span_stripped = _BARE_QUD_SPAN.sub("", value)
+    # _MARKUP_TOKEN_PATTERNS intentionally scan the original value, while
+    # _QUD_CLOSER scans bare_span_stripped so closers inside _BARE_QUD_SPAN do
+    # not get double-counted.
     for pattern in _MARKUP_TOKEN_PATTERNS:
         tokens.update(match.group(0) for match in pattern.finditer(value))
     tokens.update(match.group(0) for match in _QUD_CLOSER.finditer(bare_span_stripped))


### PR DESCRIPTION
## Summary
- Add optional `--source-root` validation to compare localized `*.jp.xml` files with matching base XML files.
- Warn on markup token multiset drift in localized overlay text and text-like attributes.
- Add fixture coverage for nested source mapping, keyed matching, duplicate conditional sibling order, translated `@Name` fallback, and opt-in behavior.

## Verification
- `ruff check scripts/`
- `uv run pytest scripts/tests/test_validate_xml.py -q`
- `uv run pytest scripts/tests/`
- `python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json`
- `git diff --check`

Part of #409.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * CLIに`--source-root`オプションを追加し、ローカライズ版とソース版のマークアップ トークン差異を明示的に比較できるようになりました。警告には対応元の相対パスと欠落／余分トークンの詳細が含まれます。
* **テスト**
  * マークアップ差異検出、ローカライズ→ソースのパス対応（入れ子含む）、オプトイン挙動、継承値の扱い、安定した要素照合（キー優先・ID/Nameフォールバック等）を網羅する包括的なテストを追加しました。読み取り失敗や絶対/相対パスでの警告の決定論的出力も検証しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->