### PR TITLE
Guard message pattern ordering

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorArbitraries.cs
@@ -5,13 +5,39 @@ namespace QudJP.Tests.L1.Pbt;
 
 public sealed record HitWithRollPatternCase(string Source, string ExpectedTranslated);
 
+public sealed record HitTargetWithWeaponDamagePatternCase(string Source, string ExpectedTranslated);
+
+public sealed record HitWeaponMultiplierDamagePatternCase(string Source, string ExpectedTranslated);
+
+public sealed record HitMultiplierWithWeaponPatternCase(string Source, string ExpectedTranslated);
+
+public sealed record IncomingHitWeaponMultiplierDamagePatternCase(string Source, string ExpectedTranslated);
+
+public sealed record ThirdPartyHitWeaponMultiplierDamagePatternCase(string Source, string ExpectedTranslated);
+
 public sealed record WeaponMissPatternCase(string Source, string ExpectedTranslated);
+
+public sealed record SpecificBleedingStopPatternCase(string Source, string ExpectedTranslated);
+
+public sealed record BlockedByArticlePatternCase(string Source, string ExpectedTranslated);
+
+public sealed record PassByArticlePatternCase(string Source, string ExpectedTranslated);
 
 public static class MessagePatternTranslatorArbitraries
 {
     private static Gen<string> SafeWeaponText()
     {
-        var characters = Gen.Elements('刀', '剣', '槍', '光', '炎', '鋼', '青', '銅');
+        return SafeTextFrom('刀', '剣', '槍', '光', '炎', '鋼', '青', '銅');
+    }
+
+    private static Gen<string> SafeObjectText()
+    {
+        return SafeTextFrom('熊', '豚', '鹿', '鱗', '岩', '筒', '芽', '樹');
+    }
+
+    private static Gen<string> SafeTextFrom(params char[] availableCharacters)
+    {
+        var characters = Gen.Elements(availableCharacters);
         return Gen.Choose(1, 6)
             .SelectMany(length => Gen.ArrayOf(characters, length))
             .Select(chars => new string(chars));
@@ -31,6 +57,65 @@ public static class MessagePatternTranslatorArbitraries
             .ToArbitrary();
     }
 
+    public static Arbitrary<HitTargetWithWeaponDamagePatternCase> HitTargetWithWeaponDamagePatternCases()
+    {
+        return (from target in SafeObjectText()
+                from weapon in SafeWeaponText()
+                from damage in Gen.Choose(1, 12)
+                let source = $"You hit the {target} with a {weapon} for {damage} damage!"
+                let expected = $"{weapon}で{target}に{damage}ダメージを与えた"
+                select new HitTargetWithWeaponDamagePatternCase(source, expected))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<HitWeaponMultiplierDamagePatternCase> HitWeaponMultiplierDamagePatternCases()
+    {
+        return (from target in SafeObjectText()
+                from weapon in SafeWeaponText()
+                from multiplier in Gen.Choose(1, 4)
+                from damage in Gen.Choose(1, 12)
+                let source = $"You hit the {target} with a {weapon} (x{multiplier}) for {damage} damage!"
+                let expected = $"{weapon}で{target}に{damage}ダメージを与えた！ (x{multiplier})"
+                select new HitWeaponMultiplierDamagePatternCase(source, expected))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<HitMultiplierWithWeaponPatternCase> HitMultiplierWithWeaponPatternCases()
+    {
+        return (from target in SafeObjectText()
+                from weapon in SafeWeaponText()
+                from multiplier in Gen.Choose(1, 4)
+                let source = $"You hit the {target} (x{multiplier}) with the {weapon}!"
+                let expected = $"{weapon}で{target}に命中した (x{multiplier})"
+                select new HitMultiplierWithWeaponPatternCase(source, expected))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<IncomingHitWeaponMultiplierDamagePatternCase> IncomingHitWeaponMultiplierDamagePatternCases()
+    {
+        return (from attacker in SafeObjectText()
+                from weapon in SafeWeaponText()
+                from multiplier in Gen.Choose(1, 4)
+                from damage in Gen.Choose(1, 12)
+                let source = $"The {attacker} hits you with the {weapon} (x{multiplier}) for {damage} damage!"
+                let expected = $"{attacker}の{weapon}で{damage}ダメージを受けた！ (x{multiplier})"
+                select new IncomingHitWeaponMultiplierDamagePatternCase(source, expected))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<ThirdPartyHitWeaponMultiplierDamagePatternCase> ThirdPartyHitWeaponMultiplierDamagePatternCases()
+    {
+        return (from attacker in SafeObjectText()
+                from target in SafeObjectText()
+                from weapon in SafeWeaponText()
+                from multiplier in Gen.Choose(1, 4)
+                from damage in Gen.Choose(1, 12)
+                let source = $"The {attacker} hits the {target} with the {weapon} (x{multiplier}) for {damage} damage!"
+                let expected = $"{attacker}が{weapon}で{target}に{damage}ダメージを与えた！ (x{multiplier})"
+                select new ThirdPartyHitWeaponMultiplierDamagePatternCase(source, expected))
+            .ToArbitrary();
+    }
+
     public static Arbitrary<WeaponMissPatternCase> WeaponMissPatternCases()
     {
         return (from weaponText in SafeWeaponText()
@@ -40,6 +125,34 @@ public static class MessagePatternTranslatorArbitraries
                 let source = $"{{{{r|You miss with your {weapon}! [{attacker} vs {defender}]}}}}"
                 let expected = $"{{{{r|{weapon}での攻撃は外れた。[{attacker} vs {defender}]}}}}"
                 select new WeaponMissPatternCase(source, expected))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<SpecificBleedingStopPatternCase> SpecificBleedingStopPatternCases()
+    {
+        return (from owner in SafeObjectText()
+                let source = $"One of {owner}の wounds stops bleeding."
+                let expected = $"{owner}の傷のひとつの出血が止まった。"
+                select new SpecificBleedingStopPatternCase(source, expected))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<BlockedByArticlePatternCase> BlockedByArticlePatternCases()
+    {
+        return (from article in Gen.Elements("some", "a")
+                from obstacle in SafeObjectText()
+                let source = $"The way is blocked by {article} {obstacle}."
+                let expected = $"{obstacle}が道を塞いでいる。"
+                select new BlockedByArticlePatternCase(source, expected))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<PassByArticlePatternCase> PassByArticlePatternCases()
+    {
+        return (from thing in SafeObjectText()
+                let source = $"You pass by a {thing}."
+                let expected = $"{thing}のそばを通り過ぎた。"
+                select new PassByArticlePatternCase(source, expected))
             .ToArbitrary();
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorArbitraries.cs
@@ -19,7 +19,10 @@ public sealed record WeaponMissPatternCase(string Source, string ExpectedTransla
 
 public sealed record SpecificBleedingStopPatternCase(string Source, string ExpectedTranslated);
 
-public sealed record BlockedByArticlePatternCase(string Source, string ExpectedTranslated);
+public sealed record BlockedByArticlePatternCase(
+    string Source,
+    string ExpectedTranslated,
+    string ExpectedGenericFallbackTranslated);
 
 public sealed record PassByArticlePatternCase(string Source, string ExpectedTranslated);
 
@@ -143,7 +146,8 @@ public static class MessagePatternTranslatorArbitraries
                 from obstacle in SafeObjectText()
                 let source = $"The way is blocked by {article} {obstacle}."
                 let expected = $"{obstacle}が道を塞いでいる。"
-                select new BlockedByArticlePatternCase(source, expected))
+                let expectedGenericFallback = $"{obstacle}に道を塞がれている。"
+                select new BlockedByArticlePatternCase(source, expected, expectedGenericFallback))
             .ToArbitrary();
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorArbitraries.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorArbitraries.cs
@@ -24,6 +24,8 @@ public sealed record BlockedByArticlePatternCase(
     string ExpectedTranslated,
     string ExpectedGenericFallbackTranslated);
 
+public sealed record BlockedByArticleColorTagPatternCase(string Source, string ExpectedTranslated);
+
 public sealed record PassByArticlePatternCase(string Source, string ExpectedTranslated);
 
 public static class MessagePatternTranslatorArbitraries
@@ -148,6 +150,18 @@ public static class MessagePatternTranslatorArbitraries
                 let expected = $"{obstacle}が道を塞いでいる。"
                 let expectedGenericFallback = $"{obstacle}に道を塞がれている。"
                 select new BlockedByArticlePatternCase(source, expected, expectedGenericFallback))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<BlockedByArticleColorTagPatternCase> BlockedByArticleColorTagPatternCases()
+    {
+        return (from article in Gen.Elements("some", "a")
+                from obstacle in SafeObjectText()
+                from color in Gen.Elements("#ff0", "#44ff88", "yellow")
+                let coloredObstacle = $"<color={color}>{obstacle}</color>"
+                let source = $"The way is blocked by {article} {coloredObstacle}."
+                let expected = $"{coloredObstacle}が道を塞いでいる。"
+                select new BlockedByArticleColorTagPatternCase(source, expected))
             .ToArbitrary();
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorPropertyTests.cs
@@ -76,6 +76,8 @@ public sealed class MessagePatternTranslatorPropertyTests
     [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
     public FsCheckProperty Translate_PrefersBlockedByArticleBeforeGenericBlockedBy(BlockedByArticlePatternCase sample)
     {
+        Assert.That(sample.ExpectedGenericFallbackTranslated, Is.Not.EqualTo(sample.ExpectedTranslated));
+
         return AssertTranslated(sample.Source, sample.ExpectedTranslated);
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorPropertyTests.cs
@@ -82,6 +82,40 @@ public sealed class MessagePatternTranslatorPropertyTests
     }
 
     [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty Translate_BlockedByArticleGenericFallback_UsesGenericBlockedByTranslation(
+        BlockedByArticlePatternCase sample)
+    {
+        Assert.That(sample.ExpectedGenericFallbackTranslated, Is.Not.EqualTo(sample.ExpectedTranslated));
+
+        var fallbackSource = sample.Source
+            .Replace(" by some ", " by an ", StringComparison.Ordinal)
+            .Replace(" by a ", " by an ", StringComparison.Ordinal);
+
+        return AssertTranslated(fallbackSource, sample.ExpectedGenericFallbackTranslated);
+    }
+
+    [Test]
+    public void Translate_BlockedByArticleEdgeCases_PreservesEmptyInput()
+    {
+        _ = AssertTranslated(string.Empty, string.Empty);
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty Translate_BlockedByArticleEdgeCases_PreservesDirectMarker(
+        BlockedByArticlePatternCase sample)
+    {
+        var markedSource = "\u0001" + sample.Source;
+        return AssertTranslated(markedSource, markedSource);
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty Translate_BlockedByArticleColorTags_PreserveCaptureMarkup(
+        BlockedByArticleColorTagPatternCase sample)
+    {
+        return AssertTranslated(sample.Source, sample.ExpectedTranslated);
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
     public FsCheckProperty Translate_PrefersPassByArticleBeforeGenericPassBy(PassByArticlePatternCase sample)
     {
         return AssertTranslated(sample.Source, sample.ExpectedTranslated);

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessagePatternTranslatorPropertyTests.cs
@@ -26,19 +26,70 @@ public sealed class MessagePatternTranslatorPropertyTests
     [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
     public FsCheckProperty Translate_PreservesHitWithRollWrappers(HitWithRollPatternCase sample)
     {
-        var translated = MessagePatternTranslator.Translate(sample.Source);
+        return AssertTranslated(sample.Source, sample.ExpectedTranslated);
+    }
 
-        Assert.That(translated, Is.EqualTo(sample.ExpectedTranslated));
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty Translate_PrefersHitWithWeaponDamageBeforeGenericHitDamage(HitTargetWithWeaponDamagePatternCase sample)
+    {
+        return AssertTranslated(sample.Source, sample.ExpectedTranslated);
+    }
 
-        return true.ToProperty();
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty Translate_PrefersWeaponMultiplierDamageBeforeGenericHitWithWeaponDamage(HitWeaponMultiplierDamagePatternCase sample)
+    {
+        return AssertTranslated(sample.Source, sample.ExpectedTranslated);
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty Translate_PrefersHitMultiplierWithWeaponBeforeGenericHitWithWeapon(HitMultiplierWithWeaponPatternCase sample)
+    {
+        return AssertTranslated(sample.Source, sample.ExpectedTranslated);
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty Translate_PrefersIncomingWeaponMultiplierDamageBeforeGenericIncomingWeaponDamage(
+        IncomingHitWeaponMultiplierDamagePatternCase sample)
+    {
+        return AssertTranslated(sample.Source, sample.ExpectedTranslated);
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty Translate_PrefersThirdPartyWeaponMultiplierDamageBeforeGenericThirdPartyWeaponDamage(
+        ThirdPartyHitWeaponMultiplierDamagePatternCase sample)
+    {
+        return AssertTranslated(sample.Source, sample.ExpectedTranslated);
     }
 
     [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
     public FsCheckProperty Translate_PreservesWeaponMissWrappers(WeaponMissPatternCase sample)
     {
-        var translated = MessagePatternTranslator.Translate(sample.Source);
+        return AssertTranslated(sample.Source, sample.ExpectedTranslated);
+    }
 
-        Assert.That(translated, Is.EqualTo(sample.ExpectedTranslated));
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty Translate_PrefersOneOfWoundsStopBleedingBeforeGenericStopBleeding(SpecificBleedingStopPatternCase sample)
+    {
+        return AssertTranslated(sample.Source, sample.ExpectedTranslated);
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty Translate_PrefersBlockedByArticleBeforeGenericBlockedBy(BlockedByArticlePatternCase sample)
+    {
+        return AssertTranslated(sample.Source, sample.ExpectedTranslated);
+    }
+
+    [FsCheck.NUnit.Property(Arbitrary = new[] { typeof(MessagePatternTranslatorArbitraries) }, MaxTest = 100, Replay = ReplaySeed)]
+    public FsCheckProperty Translate_PrefersPassByArticleBeforeGenericPassBy(PassByArticlePatternCase sample)
+    {
+        return AssertTranslated(sample.Source, sample.ExpectedTranslated);
+    }
+
+    private static FsCheckProperty AssertTranslated(string source, string expectedTranslated)
+    {
+        var translated = MessagePatternTranslator.Translate(source);
+
+        Assert.That(translated, Is.EqualTo(expectedTranslated));
 
         return true.ToProperty();
     }

--- a/Mods/QudJP/Localization/Dictionaries/messages.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/messages.ja.json
@@ -54,6 +54,11 @@
       "route": "emit-message"
     },
     {
+      "pattern": "^You hit (?:the |a |an )?(.+?) with (?:the |a |an )?(.+?) \\(x(\\d+)\\) for (\\d+) damage!$",
+      "template": "{1}で{0}に{3}ダメージを与えた！ (x{2})",
+      "route": "needs-harmony-patch"
+    },
+    {
       "pattern": "^You hit (?:the |a |an )?(.+?) with (?:a |an |the )?(.+?) for (\\d+) damage[.!]?$",
       "template": "{1}で{0}に{2}ダメージを与えた",
       "route": "emit-message"
@@ -434,6 +439,11 @@
       "route": "message-frame"
     },
     {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits you with (?:the |a |an )?(.+?) \\(x(\\d+)\\) for (\\d+) damage!$",
+      "template": "{0}の{1}で{3}ダメージを受けた！ (x{2})",
+      "route": "needs-harmony-patch"
+    },
+    {
       "pattern": "^(?:The |the |[Aa]n? )?(.+?) (?:hits|hit) you with (?:a |an |the )?(.+?) for (\\d+) damage[.!]?$",
       "template": "{0}の{1}で{2}ダメージを受けた",
       "route": "message-frame"
@@ -487,6 +497,11 @@
       "pattern": "^(?:The |the |[Aa]n? )?(.+?) (?:hits|hit) (?:the |a |an )?(?!you)(.+?) \\(x(\\d+)\\) with (?:a |an |the )?(.+?) for (\\d+) damage!$",
       "template": "{0}は{3}で{1}に{4}ダメージを与えた！ (x{2})",
       "route": "message-frame"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits (?:the |a |an )?(.+?) with (?:the |a |an )?(.+?) \\(x(\\d+)\\) for (\\d+) damage!$",
+      "template": "{0}が{2}で{1}に{4}ダメージを与えた！ (x{3})",
+      "route": "needs-harmony-patch"
     },
     {
       "pattern": "^(?:The |the |[Aa]n? )?(.+?) critically (?:hits|hit) (?:the |a |an )?(?!you)(.+?) with (?:a |an |the )?(.+?), but (?:his|her|its|their) mental attack has no effect[.!]?$",
@@ -1816,21 +1831,6 @@
     {
       "pattern": "^(?:The |the |[Aa]n? )?(.+?) cures you of (.+?)\\.$",
       "template": "{0}があなたの{1}を治した。",
-      "route": "needs-harmony-patch"
-    },
-    {
-      "pattern": "^You hit (?:the |a |an )?(.+?) with (?:the |a |an )?(.+?) \\(x(\\d+)\\) for (\\d+) damage!$",
-      "template": "{1}で{0}に{3}ダメージを与えた！ (x{2})",
-      "route": "needs-harmony-patch"
-    },
-    {
-      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits you with (?:the |a |an )?(.+?) \\(x(\\d+)\\) for (\\d+) damage!$",
-      "template": "{0}の{1}で{3}ダメージを受けた！ (x{2})",
-      "route": "needs-harmony-patch"
-    },
-    {
-      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits (?:the |a |an )?(.+?) with (?:the |a |an )?(.+?) \\(x(\\d+)\\) for (\\d+) damage!$",
-      "template": "{0}が{2}で{1}に{4}ダメージを与えた！ (x{3})",
       "route": "needs-harmony-patch"
     },
     {


### PR DESCRIPTION
## Summary
- Add order-aware MessagePatternTranslator FsCheck coverage for first-match-sensitive message families.
- Move three `(xN)` weapon damage patterns before their broader weapon damage patterns in `messages.ja.json`.
- Keep templates unchanged; this is a pattern order fix plus regression coverage.

## Verification
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "TestCategory=L1&FullyQualifiedName~MessagePatternTranslator"`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1`
- `python3.12 scripts/check_translation_tokens.py Mods/QudJP/Localization`
- `python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json`
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- `git diff --check`

Part of #409 and related to #378.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 戦闘メッセージの翻訳優先度を調整し、ヒット・被ヒット・武器乗数・第三者表現・ブロック・通過・出血停止などの翻訳精度を向上しました。色付けやキャプチャ表記、直接マーカーの保持にも対応します。
* **テスト**
  * 翻訳優先順や各種表現の整合性を検証するプロパティテストを多数追加し、翻訳品質の回帰防止を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->