### PR TITLE
Add glossary consistency gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
         if: hashFiles('Mods/QudJP/Localization/**/*.ja.json') != ''
         run: python scripts/check_translation_tokens.py Mods/QudJP/Localization
 
+      - name: Check glossary consistency
+        if: hashFiles('Mods/QudJP/Localization/**/*') != ''
+        run: python scripts/check_glossary_consistency.py Mods/QudJP/Localization
+
       - name: Install pytest
         if: hashFiles('scripts/tests/**/*.py') != ''
         run: pip install pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCa
 ruff check scripts/
 uv run pytest scripts/tests/
 python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts
+python3.12 scripts/check_glossary_consistency.py Mods/QudJP/Localization
 python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
 python3.12 scripts/sync_mod.py
 ```

--- a/docs/release.md
+++ b/docs/release.md
@@ -29,6 +29,7 @@ ruff check scripts/
 uv run pytest scripts/tests/test_build_release.py scripts/tests/test_sync_mod.py scripts/tests/test_tokenize_corpus.py -q
 python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts
 python3.12 scripts/check_glossary_consistency.py Mods/QudJP/Localization
+python3.12 scripts/check_translation_tokens.py Mods/QudJP/Localization
 python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
 python3.12 scripts/build_release.py
 python3.12 scripts/sync_mod.py

--- a/docs/release.md
+++ b/docs/release.md
@@ -28,6 +28,7 @@ dotnet build Mods/QudJP/Assemblies/QudJP.csproj
 ruff check scripts/
 uv run pytest scripts/tests/test_build_release.py scripts/tests/test_sync_mod.py scripts/tests/test_tokenize_corpus.py -q
 python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts
+python3.12 scripts/check_glossary_consistency.py Mods/QudJP/Localization
 python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
 python3.12 scripts/build_release.py
 python3.12 scripts/sync_mod.py

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -23,6 +23,7 @@ ruff format scripts/
 uv run pytest scripts/tests/
 uv run pytest scripts/tests/ -k <pattern>
 python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts
+python3.12 scripts/check_glossary_consistency.py Mods/QudJP/Localization
 python3.12 scripts/check_translation_tokens.py Mods/QudJP/Localization
 python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
 scripts/decompile_game_dll.sh

--- a/scripts/check_glossary_consistency.py
+++ b/scripts/check_glossary_consistency.py
@@ -227,6 +227,15 @@ def _collect_xml_files(paths: list[Path]) -> list[Path]:
     return sorted(files, key=lambda item: item.as_posix())
 
 
+def _json_entry_location(entry_index: int) -> str:
+    """Build a JSON text location from the translation-token iterator's 1-based index.
+
+    `check_translation_tokens.iter_translation_entries` supplies `entry.index`
+    as 1-based, so this value is intentionally used without adding 1.
+    """
+    return f"entry[{entry_index}].text"
+
+
 def _iter_json_values(paths: list[Path]) -> tuple[set[str], list[LocalizedValue]]:
     files = check_translation_tokens.collect_translation_json_files(paths)
     values: list[LocalizedValue] = []
@@ -234,7 +243,7 @@ def _iter_json_values(paths: list[Path]) -> tuple[set[str], list[LocalizedValue]
         values.extend(
             LocalizedValue(
                 relative_path=entry.relative_path,
-                location=f"entry[{entry.index}].text",
+                location=_json_entry_location(entry.index),
                 text=entry.text,
             )
             for entry in check_translation_tokens.iter_translation_entries(path)

--- a/scripts/check_glossary_consistency.py
+++ b/scripts/check_glossary_consistency.py
@@ -321,20 +321,23 @@ def _find_raw_english_issues(values: list[LocalizedValue], terms: list[GlossaryT
 
 
 def _load_baseline(path: Path | None) -> dict[tuple[str, str, str, str], _BaselineOccurrence]:
-    if path is None or not path.exists():
+    if path is None:
         return {}
+    if not path.exists():
+        msg = f"Glossary baseline file not found: {path}"
+        raise FileNotFoundError(msg)
     payload = _load_json(path)
     if not isinstance(payload, dict):
         msg = f"Glossary baseline must be a JSON object: {path}"
-        raise TypeError(msg)
+        raise ValueError(msg)  # noqa: TRY004 -- Baseline schema validation reports ValueError.
     payload_fields = cast("dict[object, object]", payload)
     if payload_fields.get("version") != _BASELINE_VERSION:
         msg = f"Glossary baseline expected version {_BASELINE_VERSION}: {path}"
-        raise TypeError(msg)
+        raise ValueError(msg)
     occurrences = payload_fields.get("allowed_occurrences")
     if not isinstance(occurrences, list):
         msg = f"Glossary baseline must contain an 'allowed_occurrences' list: {path}"
-        raise TypeError(msg)
+        raise ValueError(msg)  # noqa: TRY004 -- Baseline schema validation reports ValueError.
     occurrence_items = cast("list[object]", occurrences)
 
     baseline: dict[tuple[str, str, str, str], _BaselineOccurrence] = {}
@@ -343,7 +346,7 @@ def _load_baseline(path: Path | None) -> dict[tuple[str, str, str, str], _Baseli
         identity = _baseline_identity(occurrence)
         if identity in baseline:
             msg = f"Glossary baseline contains duplicate occurrence for {identity!r}: {path}"
-            raise TypeError(msg)
+            raise ValueError(msg)
         baseline[identity] = occurrence
     return baseline
 
@@ -351,7 +354,7 @@ def _load_baseline(path: Path | None) -> dict[tuple[str, str, str, str], _Baseli
 def _baseline_occurrence(item: object, baseline_path: Path) -> _BaselineOccurrence:
     if not isinstance(item, dict):
         msg = f"Invalid glossary baseline occurrence in {baseline_path}: {item!r}"
-        raise TypeError(msg)
+        raise ValueError(msg)  # noqa: TRY004 -- Baseline schema validation reports ValueError.
     fields = cast("dict[object, object]", item)
     item_context = repr(fields)
     return _BaselineOccurrence(
@@ -371,8 +374,11 @@ def _baseline_string_field(
 ) -> str:
     value = fields.get(field_name)
     if not isinstance(value, str):
-        msg = f"Invalid glossary baseline occurrence in {baseline_path}: {item_context}"
-        raise TypeError(msg)
+        msg = (
+            f"Invalid glossary baseline occurrence in {baseline_path}: "
+            f"field {field_name!r} must be a string in {item_context}"
+        )
+        raise ValueError(msg)  # noqa: TRY004 -- Baseline schema validation reports ValueError.
     return value
 
 

--- a/scripts/check_glossary_consistency.py
+++ b/scripts/check_glossary_consistency.py
@@ -152,6 +152,7 @@ class _BaselineOccurrence:
 def load_glossary_terms(path: Path) -> list[GlossaryTerm]:
     """Load confirmed/approved glossary terms that have Japanese equivalents."""
     terms: list[GlossaryTerm] = []
+    first_active_english_by_normalized: dict[str, str] = {}
     with path.open(encoding="utf-8", newline="") as handle:
         reader = csv.DictReader(handle)
         for row in reader:
@@ -160,6 +161,15 @@ def load_glossary_terms(path: Path) -> list[GlossaryTerm]:
             japanese = row.get("Japanese", "").strip()
             if status not in _ACTIVE_STATUSES or not english or not japanese or english == japanese:
                 continue
+            normalized_english = english.casefold()
+            first_english = first_active_english_by_normalized.get(normalized_english)
+            if first_english is not None:
+                msg = (
+                    f"Duplicate active glossary English term '{english}' in {path} "
+                    f"(first active term: '{first_english}')"
+                )
+                raise ValueError(msg)
+            first_active_english_by_normalized[normalized_english] = english
             terms.append(
                 GlossaryTerm(
                     english=english,

--- a/scripts/check_glossary_consistency.py
+++ b/scripts/check_glossary_consistency.py
@@ -1,0 +1,503 @@
+"""Validate localized assets against approved glossary English residue."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+if __package__ in {None, ""}:
+    _PROJECT_ROOT = Path(__file__).resolve().parents[1]
+    _PROJECT_ROOT_STR = str(_PROJECT_ROOT)
+    if _PROJECT_ROOT_STR not in sys.path:
+        sys.path.insert(0, _PROJECT_ROOT_STR)
+
+from scripts import check_translation_tokens
+
+_DEFAULT_GLOSSARY = Path("docs/glossary.csv")
+_DEFAULT_BASELINE = Path(__file__).with_name("glossary_consistency_baseline.json")
+_BASELINE_VERSION = 1
+_ACTIVE_STATUSES = frozenset({"approved", "confirmed"})
+
+_VISIBLE_XML_ATTRIBUTES = frozenset(
+    {
+        "Accomplishment",
+        "Activity",
+        "ArableLand",
+        "BehaviorDescription",
+        "BiomeAdjective",
+        "BiomeEpithet",
+        "Blurb",
+        "BuyDescription",
+        "Category",
+        "ChargenDescription",
+        "ChargenTitle",
+        "ClassName",
+        "ColdName",
+        "CollapseMessage",
+        "CrafterName",
+        "DamageMessage",
+        "Description",
+        "DetonationMessage",
+        "DisplayName",
+        "DisplayText",
+        "FlightSourceDescription",
+        "Frozen",
+        "GenotypeAlt",
+        "Gospel",
+        "Hagiograph",
+        "HagiographCategory",
+        "HeatName",
+        "Long",
+        "Message",
+        "MessageByCountSuffix",
+        "Messages",
+        "NameContext",
+        "NameForStatus",
+        "NeedsItemFor",
+        "Ordinary",
+        "PhaseMessage",
+        "PoeticFeatures",
+        "Postfix",
+        "Prefix",
+        "PrepMessageOther",
+        "PrepMessageSelf",
+        "Primary",
+        "PullMessage",
+        "RecipeText",
+        "SacredThing",
+        "Says",
+        "ScopeDescription",
+        "Short",
+        "SingularTitle",
+        "Skin",
+        "Snippet",
+        "SpawnMessage",
+        "Text",
+        "Title",
+        "TinkerDisplayName",
+        "ValuedOre",
+        "Verb",
+        "VillageActivity",
+        "YounglingNoise",
+        "message",
+        "text",
+    }
+)
+_VISIBLE_NAME_ELEMENT_TAGS = frozenset({"zone"})
+
+_GAME_TEXT_VARIABLE = re.compile(r"=[A-Za-z_][A-Za-z0-9_.:']*=")
+_BRACE_PLACEHOLDER = re.compile(r"\{[A-Za-z0-9_][A-Za-z0-9_.:-]*\}")
+_LOWERCASE_STAR_PLACEHOLDER = re.compile(r"\*[a-z][a-z0-9_.:-]*\*")
+_QUD_OPENER = re.compile(r"\{\{[^|}]+\|")
+_BARE_QUD_SPAN = re.compile(r"\{\{[^|{}]+\}\}")
+_LEGACY_COLOR = re.compile(r"(?<![&^])[&^][A-Za-z0-9]")
+_HTML_COLOR_TAG = re.compile(r"</?color=[^>]+>|</color>")
+
+
+@dataclass(frozen=True)
+class GlossaryTerm:
+    """One authoritative glossary row."""
+
+    english: str
+    japanese: str
+    status: str
+    pattern: re.Pattern[str]
+
+
+@dataclass(frozen=True)
+class LocalizedValue:
+    """One player-visible localized value scanned by the glossary gate."""
+
+    relative_path: str
+    location: str
+    text: str
+
+
+@dataclass(frozen=True)
+class GlossaryIssue:
+    """A glossary consistency finding."""
+
+    kind: str
+    relative_path: str
+    location: str
+    term: str
+    expected_japanese: str | None
+    text: str
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Glossary consistency check result."""
+
+    file_count: int
+    value_count: int
+    issues: list[GlossaryIssue]
+
+
+@dataclass(frozen=True)
+class _BaselineOccurrence:
+    term: str
+    path: str
+    location: str
+    text: str
+
+
+def load_glossary_terms(path: Path) -> list[GlossaryTerm]:
+    """Load confirmed/approved glossary terms that have Japanese equivalents."""
+    terms: list[GlossaryTerm] = []
+    with path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            status = row.get("Status", "").strip().lower()
+            english = row.get("English", "").strip()
+            japanese = row.get("Japanese", "").strip()
+            if status not in _ACTIVE_STATUSES or not english or not japanese or english == japanese:
+                continue
+            terms.append(
+                GlossaryTerm(
+                    english=english,
+                    japanese=japanese,
+                    status=status,
+                    pattern=_compile_term_pattern(english),
+                ),
+            )
+    return terms
+
+
+def _compile_term_pattern(term: str) -> re.Pattern[str]:
+    return re.compile(rf"(?<![A-Za-z0-9]){re.escape(term)}(?![A-Za-z0-9])", re.IGNORECASE)
+
+
+def _load_json(path: Path) -> object:
+    return cast("object", json.loads(path.read_text(encoding="utf-8")))
+
+
+def _relative_path_from_marker(path: Path, marker: str) -> str | None:
+    parts = path.parts
+    if marker not in parts:
+        return None
+    index = len(parts) - 1 - parts[::-1].index(marker)
+    return Path(*parts[index + 1 :]).as_posix()
+
+
+def _relative_localization_path(path: Path) -> str:
+    for candidate in (path, path.resolve()):
+        relative_path = _relative_path_from_marker(candidate, "Localization")
+        if relative_path is not None:
+            return relative_path
+    return path.name
+
+
+def _collect_xml_files(paths: list[Path]) -> list[Path]:
+    files: set[Path] = set()
+    for input_path in paths:
+        if not input_path.exists():
+            msg = f"Path not found: {input_path}"
+            raise FileNotFoundError(msg)
+
+        resolved_input_path = input_path.resolve()
+        if resolved_input_path.is_file():
+            if resolved_input_path.name.endswith(".jp.xml"):
+                files.add(resolved_input_path)
+            continue
+
+        if resolved_input_path.is_dir():
+            files.update(path.resolve() for path in resolved_input_path.rglob("*.jp.xml") if path.is_file())
+            continue
+
+        msg = f"Path is not a regular file or directory: {input_path}"
+        raise ValueError(msg)
+    return sorted(files, key=lambda item: item.as_posix())
+
+
+def _iter_json_values(paths: list[Path]) -> tuple[set[str], list[LocalizedValue]]:
+    files = check_translation_tokens.collect_translation_json_files(paths)
+    values: list[LocalizedValue] = []
+    for path in files:
+        values.extend(
+            LocalizedValue(
+                relative_path=entry.relative_path,
+                location=f"entry[{entry.index}].text",
+                text=entry.text,
+            )
+            for entry in check_translation_tokens.iter_translation_entries(path)
+        )
+    return {_relative_localization_path(path) for path in files}, values
+
+
+def _iter_xml_values(paths: list[Path]) -> tuple[set[str], list[LocalizedValue]]:
+    files = _collect_xml_files(paths)
+    values: list[LocalizedValue] = []
+    for path in files:
+        root = ET.parse(path).getroot()  # noqa: S314 -- Scans local repo localization assets only.
+        relative_path = _relative_localization_path(path)
+        values.extend(_localized_values_from_xml(root, relative_path=relative_path))
+    return {_relative_localization_path(path) for path in files}, values
+
+
+def _localized_values_from_xml(root: ET.Element, *, relative_path: str) -> list[LocalizedValue]:
+    values: list[LocalizedValue] = []
+
+    def walk(element: ET.Element, element_path: str) -> None:
+        if element.text and element.text.strip():
+            values.append(
+                LocalizedValue(
+                    relative_path=relative_path,
+                    location=f"{element_path}/text()",
+                    text=element.text.strip(),
+                ),
+            )
+
+        for attribute_name, attribute_value in element.attrib.items():
+            if not _is_visible_xml_attribute(element, attribute_name):
+                continue
+            values.append(
+                LocalizedValue(
+                    relative_path=relative_path,
+                    location=f"{element_path}/@{attribute_name}",
+                    text=attribute_value,
+                ),
+            )
+
+        child_counts: dict[str, int] = {}
+        for child in element:
+            child_counts[child.tag] = child_counts.get(child.tag, 0) + 1
+            child_path = f"{element_path}/{child.tag}[{child_counts[child.tag]}]"
+            walk(child, child_path)
+            if child.tail and child.tail.strip():
+                values.append(
+                    LocalizedValue(
+                        relative_path=relative_path,
+                        location=f"{child_path}/tail()",
+                        text=child.tail.strip(),
+                    ),
+                )
+
+    walk(root, f"/{root.tag}[1]")
+    return values
+
+
+def _is_visible_xml_attribute(element: ET.Element, attribute_name: str) -> bool:
+    return attribute_name in _VISIBLE_XML_ATTRIBUTES or (
+        attribute_name == "Name" and element.tag in _VISIBLE_NAME_ELEMENT_TAGS
+    )
+
+
+def _visible_text_for_matching(value: str) -> str:
+    text = _GAME_TEXT_VARIABLE.sub(" ", value)
+    text = _BRACE_PLACEHOLDER.sub(" ", text)
+    text = _LOWERCASE_STAR_PLACEHOLDER.sub(" ", text)
+    text = _BARE_QUD_SPAN.sub(" ", text)
+    text = _QUD_OPENER.sub("", text).replace("}}", "")
+    text = _LEGACY_COLOR.sub(" ", text)
+    return _HTML_COLOR_TAG.sub(" ", text)
+
+
+def _find_raw_english_issues(values: list[LocalizedValue], terms: list[GlossaryTerm]) -> list[GlossaryIssue]:
+    issues: list[GlossaryIssue] = []
+    for value in values:
+        visible_text = _visible_text_for_matching(value.text)
+        for term in terms:
+            if not term.pattern.search(visible_text):
+                continue
+            issues.append(
+                GlossaryIssue(
+                    kind="RAW_ENGLISH",
+                    relative_path=value.relative_path,
+                    location=value.location,
+                    term=term.english,
+                    expected_japanese=term.japanese,
+                    text=value.text,
+                ),
+            )
+    return issues
+
+
+def _load_baseline(path: Path | None) -> dict[tuple[str, str, str, str], _BaselineOccurrence]:
+    if path is None or not path.exists():
+        return {}
+    payload = _load_json(path)
+    if not isinstance(payload, dict):
+        msg = f"Glossary baseline must be a JSON object: {path}"
+        raise TypeError(msg)
+    payload_fields = cast("dict[object, object]", payload)
+    if payload_fields.get("version") != _BASELINE_VERSION:
+        msg = f"Glossary baseline expected version {_BASELINE_VERSION}: {path}"
+        raise TypeError(msg)
+    occurrences = payload_fields.get("allowed_occurrences")
+    if not isinstance(occurrences, list):
+        msg = f"Glossary baseline must contain an 'allowed_occurrences' list: {path}"
+        raise TypeError(msg)
+    occurrence_items = cast("list[object]", occurrences)
+
+    baseline: dict[tuple[str, str, str, str], _BaselineOccurrence] = {}
+    for item in occurrence_items:
+        occurrence = _baseline_occurrence(item, path)
+        identity = _baseline_identity(occurrence)
+        if identity in baseline:
+            msg = f"Glossary baseline contains duplicate occurrence for {identity!r}: {path}"
+            raise TypeError(msg)
+        baseline[identity] = occurrence
+    return baseline
+
+
+def _baseline_occurrence(item: object, baseline_path: Path) -> _BaselineOccurrence:
+    if not isinstance(item, dict):
+        msg = f"Invalid glossary baseline occurrence in {baseline_path}: {item!r}"
+        raise TypeError(msg)
+    fields = cast("dict[object, object]", item)
+    item_context = repr(fields)
+    return _BaselineOccurrence(
+        term=_baseline_string_field(fields, "term", item_context=item_context, baseline_path=baseline_path),
+        path=_baseline_string_field(fields, "path", item_context=item_context, baseline_path=baseline_path),
+        location=_baseline_string_field(fields, "location", item_context=item_context, baseline_path=baseline_path),
+        text=_baseline_string_field(fields, "text", item_context=item_context, baseline_path=baseline_path),
+    )
+
+
+def _baseline_string_field(
+    fields: dict[object, object],
+    field_name: str,
+    *,
+    item_context: str,
+    baseline_path: Path,
+) -> str:
+    value = fields.get(field_name)
+    if not isinstance(value, str):
+        msg = f"Invalid glossary baseline occurrence in {baseline_path}: {item_context}"
+        raise TypeError(msg)
+    return value
+
+
+def _baseline_identity(occurrence: _BaselineOccurrence) -> tuple[str, str, str, str]:
+    return (occurrence.term, occurrence.path, occurrence.location, occurrence.text)
+
+
+def _issue_identity(issue: GlossaryIssue) -> tuple[str, str, str, str]:
+    return (issue.term, issue.relative_path, issue.location, issue.text)
+
+
+def _apply_baseline(
+    issues: list[GlossaryIssue],
+    baseline: dict[tuple[str, str, str, str], _BaselineOccurrence],
+    *,
+    scanned_paths: set[str],
+    report_unscanned_baseline: bool,
+) -> list[GlossaryIssue]:
+    current_identities = {_issue_identity(issue) for issue in issues}
+    filtered_issues = [issue for issue in issues if _issue_identity(issue) not in baseline]
+    for identity, occurrence in sorted(baseline.items()):
+        if identity in current_identities:
+            continue
+        if not report_unscanned_baseline and occurrence.path not in scanned_paths:
+            continue
+        filtered_issues.append(
+            GlossaryIssue(
+                kind="BASELINE",
+                relative_path=occurrence.path,
+                location=occurrence.location,
+                term=occurrence.term,
+                expected_japanese=None,
+                text=occurrence.text,
+            ),
+        )
+    return filtered_issues
+
+
+def _is_full_localization_scan(paths: list[Path]) -> bool:
+    for path in paths:
+        if not path.exists():
+            continue
+        resolved_path = path.resolve()
+        if resolved_path.is_dir() and resolved_path.name == "Localization":
+            return True
+    return False
+
+
+def check_paths(
+    paths: list[Path],
+    *,
+    glossary_path: Path = _DEFAULT_GLOSSARY,
+    baseline_path: Path | None = _DEFAULT_BASELINE,
+) -> CheckResult:
+    """Check localized JSON/XML values for raw English glossary residue."""
+    terms = load_glossary_terms(glossary_path)
+    json_paths, json_values = _iter_json_values(paths)
+    xml_paths, xml_values = _iter_xml_values(paths)
+    values = [*json_values, *xml_values]
+    scanned_paths = json_paths | xml_paths
+    issues = _find_raw_english_issues(values, terms)
+    issues = _apply_baseline(
+        issues,
+        _load_baseline(baseline_path),
+        scanned_paths=scanned_paths,
+        report_unscanned_baseline=_is_full_localization_scan(paths),
+    )
+    return CheckResult(
+        file_count=len(scanned_paths),
+        value_count=len(values),
+        issues=sorted(issues, key=lambda issue: (issue.relative_path, issue.location, issue.term, issue.kind)),
+    )
+
+
+def _print_report(result: CheckResult) -> None:
+    value_count = result.value_count
+    file_count = result.file_count
+    issue_count = len(result.issues)
+    summary = f"Scanned {value_count} localized value(s) from {file_count} file(s): {issue_count} issue(s)"
+    print(summary)  # noqa: T201
+    for issue in result.issues:
+        print(f"  [{issue.kind}] {issue.relative_path} {issue.location}: term={issue.term!r}")  # noqa: T201
+        if issue.expected_japanese is not None:
+            print(f"    expected Japanese={issue.expected_japanese!r}")  # noqa: T201
+        print(f"    text={issue.text!r}")  # noqa: T201
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the glossary consistency gate CLI."""
+    parser = argparse.ArgumentParser(
+        description="Validate approved/confirmed glossary terms against localized JSON/XML values.",
+    )
+    _ = parser.add_argument("paths", nargs="+", type=Path, help="Localization file or directory paths to scan.")
+    _ = parser.add_argument("--glossary", type=Path, default=_DEFAULT_GLOSSARY, help="Glossary CSV path.")
+    _ = parser.add_argument("--baseline", type=Path, default=_DEFAULT_BASELINE, help="Known occurrence baseline JSON.")
+    _ = parser.add_argument("--no-baseline", action="store_true", help="Do not suppress known occurrences.")
+    args = parser.parse_args(argv)
+    paths = cast("list[Path]", args.paths)
+    glossary_path = cast("Path", args.glossary)
+    baseline_path = None if cast("bool", args.no_baseline) else cast("Path", args.baseline)
+
+    try:
+        result = check_paths(
+            paths,
+            glossary_path=glossary_path,
+            baseline_path=baseline_path,
+        )
+    except (
+        ET.ParseError,
+        FileNotFoundError,
+        json.JSONDecodeError,
+        TypeError,
+        UnicodeDecodeError,
+        ValueError,
+    ) as exc:
+        print(f"Error: {exc}", file=sys.stderr)  # noqa: T201
+        return 1
+
+    if result.file_count == 0:
+        print("Error: No target localized JSON/XML files found.", file=sys.stderr)  # noqa: T201
+        return 1
+
+    _print_report(result)
+    return 1 if result.issues else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/glossary_consistency_baseline.json
+++ b/scripts/glossary_consistency_baseline.json
@@ -1,0 +1,53 @@
+{
+  "version": 1,
+  "allowed_occurrences": [
+    {
+      "term": "Tinker",
+      "path": "Books.jp.xml",
+      "location": "/books[1]/book[13]/page[1]/text()",
+      "text": "\"こめかみにこれを巻け。ぺちゃくちゃ言うな、問題ない。\n何が起こるっていうんだ？\"\n[[-Argyve, Tinker]]"
+    },
+    {
+      "term": "Barathrum",
+      "path": "Books.jp.xml",
+      "location": "/books[1]/book[13]/page[23]/text()",
+      "text": "\"私は地を穿つシュグ＝ルイスの百九の眼を見つめた。\"\n[[-Barathrum the Old]]"
+    },
+    {
+      "term": "Pax Klanq",
+      "path": "Books.jp.xml",
+      "location": "/books[1]/book[13]/page[29]/text()",
+      "text": "\"クランク、ぷーっとおまえに息を吹く。\"\n[[-Pax Klanq]]"
+    },
+    {
+      "term": "Moghra'yi",
+      "path": "Books.jp.xml",
+      "location": "/books[1]/book[30]/page[1]/text()",
+      "text": "Across Moghra'yi――大塩砂漠の彼方にある奇妙な文明の最上の目録（バッカタ・ユーヤーク著）、第1巻：サンダリーズ\n\n[[{{C|序文}}]]\n当然ながら、これら遠国に関する一次資料は存在しない。本書は、ドロマド商団の背に乗ってモグラヤイを渡った菌類たちの報告に大きく依拠している。\n\n慣例として、私はあらゆる出来事を本巻の刊行という歴史的事件からの時間距離で記す。ゆえに括弧内の日付は「刊行以前（prior publication）」を意味する。"
+    },
+    {
+      "term": "Omonporch",
+      "path": "ObjectBlueprints/Creatures.jp.xml",
+      "location": "/objects[1]/object[1045]/part[2]/@Primary",
+      "text": "Earl of Omonporch"
+    },
+    {
+      "term": "Sultan",
+      "path": "ObjectBlueprints/Furniture.jp.xml",
+      "location": "/objects[1]/object[47]/part[2]/@Primary",
+      "text": ", the Last Sultan"
+    },
+    {
+      "term": "Kyakukya",
+      "path": "ObjectBlueprints/Furniture.jp.xml",
+      "location": "/objects[1]/object[61]/part[2]/@Text",
+      "text": "このオブジェクトは、{{M|Kyakukya}} の歴史のシーンの記念碑だ。&#10;&#10;ビートルムーンの下、人々はエイプ・サード・オボロコルへの通過物資を集めるためにここに定住し、キャクキャが設立された。"
+    },
+    {
+      "term": "Kyakukya",
+      "path": "ObjectBlueprints/Furniture.jp.xml",
+      "location": "/objects[1]/object[62]/part[2]/@Text",
+      "text": "このオブジェクトは、{{M|Kyakukya}} の歴史のシーンの記念碑だ。&#10;&#10;979 年、伝説のアルビノ猿であるヌントゥは、物を撲殺することに飽きて、スヴィ川の根で絞められた場所へ旅しました。そこで彼はキャクキャとその住民に出会った。キャクキャの村人たちはヌントゥに行政官としての才能を発揮して村を率いるよう頼んだ。"
+    }
+  ]
+}

--- a/scripts/tests/test_check_glossary_consistency.py
+++ b/scripts/tests/test_check_glossary_consistency.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+import pytest
+
 if TYPE_CHECKING:
     from pathlib import Path
-
-    import pytest
 
 from scripts import check_glossary_consistency
 
@@ -45,6 +45,18 @@ def _write_baseline(path: Path, *occurrences: dict[str, str]) -> None:
             ensure_ascii=False,
         ),
         encoding="utf-8",
+    )
+
+
+def _check_with_baseline(tmp_path: Path, baseline_path: Path) -> None:
+    glossary_path = tmp_path / "glossary.csv"
+    localization = tmp_path / "Localization"
+    _write_glossary(glossary_path)
+    _write_entries(localization / "Dictionaries" / "demo.ja.json", [{"key": "Source", "text": "ゴルゴタ"}])
+    _ = check_glossary_consistency.check_paths(
+        [localization],
+        glossary_path=glossary_path,
+        baseline_path=baseline_path,
     )
 
 
@@ -225,6 +237,68 @@ def test_full_localization_scan_reports_deleted_file_baseline_entries(tmp_path: 
         ("BASELINE", "Dictionaries/deleted.ja.json", "entry[1].text"),
     ]
     assert partial_result.issues == []
+
+
+def test_missing_baseline_path_raises_explicit_error(tmp_path: Path) -> None:
+    """Passing a baseline path must fail explicitly if the file is absent."""
+    baseline_path = tmp_path / "missing-baseline.json"
+
+    with pytest.raises(FileNotFoundError, match=r"missing-baseline\.json"):
+        _check_with_baseline(tmp_path, baseline_path)
+
+
+def test_baseline_rejects_wrong_version(tmp_path: Path) -> None:
+    """Baseline schema errors use ValueError for caller-visible validation failures."""
+    baseline_path = tmp_path / "baseline.json"
+    _ = baseline_path.write_text(
+        json.dumps({"version": 2, "allowed_occurrences": []}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="expected version 1"):
+        _check_with_baseline(tmp_path, baseline_path)
+
+
+def test_baseline_rejects_duplicate_occurrences(tmp_path: Path) -> None:
+    """Duplicate baseline rows are rejected instead of silently collapsing."""
+    baseline_path = tmp_path / "baseline.json"
+    occurrence = {
+        "term": "Golgotha",
+        "path": "Dictionaries/demo.ja.json",
+        "location": "entry[1].text",
+        "text": "Golgotha remains for now.",
+    }
+    _write_baseline(baseline_path, occurrence, occurrence)
+
+    with pytest.raises(ValueError, match="duplicate occurrence"):
+        _check_with_baseline(tmp_path, baseline_path)
+
+
+@pytest.mark.parametrize(
+    ("occurrence", "message"),
+    [
+        (["not", "an", "object"], "Invalid glossary baseline occurrence"),
+        ({"term": "Golgotha", "path": "Dictionaries/demo.ja.json", "location": "entry[1].text"}, "field 'text'"),
+        (
+            {"term": "Golgotha", "path": "Dictionaries/demo.ja.json", "location": "entry[1].text", "text": 123},
+            "field 'text'",
+        ),
+    ],
+)
+def test_baseline_rejects_malformed_or_missing_required_fields(
+    tmp_path: Path,
+    occurrence: object,
+    message: str,
+) -> None:
+    """Each occurrence must be an object with the required string fields."""
+    baseline_path = tmp_path / "baseline.json"
+    _ = baseline_path.write_text(
+        json.dumps({"version": 1, "allowed_occurrences": [occurrence]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=message):
+        _check_with_baseline(tmp_path, baseline_path)
 
 
 def test_cli_reports_raw_english_residue(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/scripts/tests/test_check_glossary_consistency.py
+++ b/scripts/tests/test_check_glossary_consistency.py
@@ -11,17 +11,21 @@ if TYPE_CHECKING:
 from scripts import check_glossary_consistency
 
 
-def _write_glossary(path: Path) -> None:
+def _write_glossary_rows(path: Path, *rows: str) -> None:
     _ = path.write_text(
-        (
-            "English,Japanese,Short,Notes,Status\n"
-            "Golgotha,ゴルゴタ,,approved term,approved\n"
-            "Kyakukya,キャクキャ,,confirmed term,confirmed\n"
-            "Baetyls,ベテル,,confirmed term,confirmed\n"
-            "DraftOnly,下書き,,not authoritative,draft\n"
-            "Barathrumites,バラサラム派,,placeholder term,approved\n"
-        ),
+        "English,Japanese,Short,Notes,Status\n" + "\n".join(rows) + "\n",
         encoding="utf-8",
+    )
+
+
+def _write_glossary(path: Path) -> None:
+    _write_glossary_rows(
+        path,
+        "Golgotha,ゴルゴタ,,approved term,approved",
+        "Kyakukya,キャクキャ,,confirmed term,confirmed",
+        "Baetyls,ベテル,,confirmed term,confirmed",
+        "DraftOnly,下書き,,not authoritative,draft",
+        "Barathrumites,バラサラム派,,placeholder term,approved",
     )
 
 
@@ -68,6 +72,37 @@ def test_loads_only_confirmed_and_approved_rows_with_japanese_terms(tmp_path: Pa
     terms = check_glossary_consistency.load_glossary_terms(glossary_path)
 
     assert [term.english for term in terms] == ["Golgotha", "Kyakukya", "Baetyls", "Barathrumites"]
+
+
+def test_duplicate_active_glossary_english_terms_are_rejected(tmp_path: Path) -> None:
+    """Authoritative English terms must be unique after trim/casefold normalization."""
+    glossary_path = tmp_path / "glossary.csv"
+    _write_glossary_rows(
+        glossary_path,
+        "Golgotha,ゴルゴタ,,approved term,approved",
+        " golgotha ,別訳,,confirmed duplicate,confirmed",
+    )
+
+    with pytest.raises(ValueError, match="Duplicate active glossary English term 'golgotha'") as exc_info:
+        _ = check_glossary_consistency.load_glossary_terms(glossary_path)
+
+    message = str(exc_info.value)
+    assert "Duplicate active glossary English term 'golgotha'" in message
+    assert str(glossary_path) in message
+
+
+def test_draft_duplicate_glossary_english_term_does_not_block(tmp_path: Path) -> None:
+    """Draft duplicate rows do not block a single authoritative term."""
+    glossary_path = tmp_path / "glossary.csv"
+    _write_glossary_rows(
+        glossary_path,
+        "Golgotha,ゴルゴタ,,approved term,approved",
+        " golgotha ,別訳,,draft duplicate,draft",
+    )
+
+    terms = check_glossary_consistency.load_glossary_terms(glossary_path)
+
+    assert [term.english for term in terms] == ["Golgotha"]
 
 
 def test_json_scans_translated_text_values_not_source_keys(tmp_path: Path) -> None:

--- a/scripts/tests/test_check_glossary_consistency.py
+++ b/scripts/tests/test_check_glossary_consistency.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+from scripts import check_glossary_consistency
+
+
+def _write_glossary(path: Path) -> None:
+    _ = path.write_text(
+        (
+            "English,Japanese,Short,Notes,Status\n"
+            "Golgotha,ゴルゴタ,,approved term,approved\n"
+            "Kyakukya,キャクキャ,,confirmed term,confirmed\n"
+            "Baetyls,ベテル,,confirmed term,confirmed\n"
+            "DraftOnly,下書き,,not authoritative,draft\n"
+            "Barathrumites,バラサラム派,,placeholder term,approved\n"
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_entries(path: Path, entries: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text(json.dumps({"entries": entries}, ensure_ascii=False), encoding="utf-8")
+
+
+def _write_xml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text(content, encoding="utf-8")
+
+
+def _write_baseline(path: Path, *occurrences: dict[str, str]) -> None:
+    _ = path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "allowed_occurrences": list(occurrences),
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_loads_only_confirmed_and_approved_rows_with_japanese_terms(tmp_path: Path) -> None:
+    """Only approved/confirmed glossary rows are authoritative."""
+    glossary_path = tmp_path / "glossary.csv"
+    _write_glossary(glossary_path)
+
+    terms = check_glossary_consistency.load_glossary_terms(glossary_path)
+
+    assert [term.english for term in terms] == ["Golgotha", "Kyakukya", "Baetyls", "Barathrumites"]
+
+
+def test_json_scans_translated_text_values_not_source_keys(tmp_path: Path) -> None:
+    """JSON dictionary source keys are not scanned as localized text."""
+    glossary_path = tmp_path / "glossary.csv"
+    localization = tmp_path / "Localization"
+    _write_glossary(glossary_path)
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [
+            {"key": "Golgotha", "text": "ゴルゴタ"},
+            {"key": "Translated source", "text": "Travel to Golgotha."},
+        ],
+    )
+
+    result = check_glossary_consistency.check_paths([localization], glossary_path=glossary_path, baseline_path=None)
+
+    assert [issue.location for issue in result.issues] == ["entry[2].text"]
+    assert result.issues[0].term == "Golgotha"
+
+
+def test_draft_glossary_rows_do_not_block_residue(tmp_path: Path) -> None:
+    """Draft glossary rows remain review material, not gate inputs."""
+    glossary_path = tmp_path / "glossary.csv"
+    localization = tmp_path / "Localization"
+    _write_glossary(glossary_path)
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [{"key": "Source", "text": "DraftOnly remains review-only."}],
+    )
+
+    result = check_glossary_consistency.check_paths([localization], glossary_path=glossary_path, baseline_path=None)
+
+    assert result.issues == []
+
+
+def test_xml_scans_localized_visible_text_and_attributes_only(tmp_path: Path) -> None:
+    """XML source files and structural source ID attributes are ignored."""
+    glossary_path = tmp_path / "glossary.csv"
+    localization = tmp_path / "Localization"
+    _write_glossary(glossary_path)
+    _write_xml(
+        localization / "Factions.xml",
+        '<factions><faction Name="Baetyls" DisplayName="Baetyls" /></factions>',
+    )
+    _write_xml(
+        localization / "Factions.jp.xml",
+        '<factions><faction Name="Baetyls" DisplayName="ベテル" /></factions>',
+    )
+    _write_xml(
+        localization / "Books.jp.xml",
+        '<books><book Title="Kyakukya"><page>Golgotha appears here.</page></book></books>',
+    )
+
+    result = check_glossary_consistency.check_paths([localization], glossary_path=glossary_path, baseline_path=None)
+
+    assert [(issue.term, issue.relative_path, issue.location) for issue in result.issues] == [
+        ("Kyakukya", "Books.jp.xml", "/books[1]/book[1]/@Title"),
+        ("Golgotha", "Books.jp.xml", "/books[1]/book[1]/page[1]/text()"),
+    ]
+
+
+def test_xml_scans_mixed_content_child_tails(tmp_path: Path) -> None:
+    """Visible XML mixed-content tails after inline children are scanned."""
+    glossary_path = tmp_path / "glossary.csv"
+    localization = tmp_path / "Localization"
+    _write_glossary(glossary_path)
+    _write_xml(localization / "Mixed.jp.xml", '<root><p><stat Name="X" />Golgotha</p></root>')
+
+    result = check_glossary_consistency.check_paths([localization], glossary_path=glossary_path, baseline_path=None)
+
+    assert [(issue.term, issue.relative_path, issue.location) for issue in result.issues] == [
+        ("Golgotha", "Mixed.jp.xml", "/root[1]/p[1]/stat[1]/tail()"),
+    ]
+
+
+def test_xml_keeps_visible_qud_markup_text_but_ignores_game_text_placeholders(tmp_path: Path) -> None:
+    """Visible markup bodies are scanned, while runtime variables are ignored."""
+    glossary_path = tmp_path / "glossary.csv"
+    localization = tmp_path / "Localization"
+    _write_glossary(glossary_path)
+    _write_xml(
+        localization / "Conversations.jp.xml",
+        (
+            "<conversations>"
+            "<conversation>"
+            "<text>=factionaddress:Barathrumites= is a runtime placeholder.</text>"
+            "<text>{{M|Kyakukya}} is visible markup residue.</text>"
+            "</conversation>"
+            "</conversations>"
+        ),
+    )
+
+    result = check_glossary_consistency.check_paths([localization], glossary_path=glossary_path, baseline_path=None)
+
+    assert [(issue.term, issue.location) for issue in result.issues] == [
+        ("Kyakukya", "/conversations[1]/conversation[1]/text[2]/text()"),
+    ]
+
+
+def test_baseline_suppresses_current_occurrence_and_reports_stale_entries(tmp_path: Path) -> None:
+    """The reviewable baseline suppresses exact matches and reports stale rows."""
+    glossary_path = tmp_path / "glossary.csv"
+    localization = tmp_path / "Localization"
+    baseline_path = tmp_path / "baseline.json"
+    _write_glossary(glossary_path)
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [{"key": "Source", "text": "Golgotha remains for now."}],
+    )
+    _write_baseline(
+        baseline_path,
+        {
+            "term": "Golgotha",
+            "path": "Dictionaries/demo.ja.json",
+            "location": "entry[1].text",
+            "text": "Golgotha remains for now.",
+        },
+        {
+            "term": "Kyakukya",
+            "path": "Dictionaries/demo.ja.json",
+            "location": "entry[2].text",
+            "text": "Kyakukya used to be here.",
+        },
+    )
+
+    result = check_glossary_consistency.check_paths(
+        [localization],
+        glossary_path=glossary_path,
+        baseline_path=baseline_path,
+    )
+
+    assert [(issue.kind, issue.term, issue.location) for issue in result.issues] == [
+        ("BASELINE", "Kyakukya", "entry[2].text"),
+    ]
+
+
+def test_full_localization_scan_reports_deleted_file_baseline_entries(tmp_path: Path) -> None:
+    """Full-root scans report stale baseline rows for deleted or renamed files."""
+    glossary_path = tmp_path / "glossary.csv"
+    localization = tmp_path / "Localization"
+    baseline_path = tmp_path / "baseline.json"
+    _write_glossary(glossary_path)
+    _write_entries(localization / "Dictionaries" / "active.ja.json", [{"key": "Source", "text": "ゴルゴタ"}])
+    _write_baseline(
+        baseline_path,
+        {
+            "term": "Golgotha",
+            "path": "Dictionaries/deleted.ja.json",
+            "location": "entry[1].text",
+            "text": "Golgotha used to be here.",
+        },
+    )
+
+    full_result = check_glossary_consistency.check_paths(
+        [localization],
+        glossary_path=glossary_path,
+        baseline_path=baseline_path,
+    )
+    partial_result = check_glossary_consistency.check_paths(
+        [localization / "Dictionaries" / "active.ja.json"],
+        glossary_path=glossary_path,
+        baseline_path=baseline_path,
+    )
+
+    assert [(issue.kind, issue.relative_path, issue.location) for issue in full_result.issues] == [
+        ("BASELINE", "Dictionaries/deleted.ja.json", "entry[1].text"),
+    ]
+    assert partial_result.issues == []
+
+
+def test_cli_reports_raw_english_residue(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The CLI exits non-zero and prints glossary guidance for new residue."""
+    glossary_path = tmp_path / "glossary.csv"
+    localization = tmp_path / "Localization"
+    _write_glossary(glossary_path)
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [{"key": "Source", "text": "Golgotha remains untranslated."}],
+    )
+
+    exit_code = check_glossary_consistency.main(
+        [str(localization), "--glossary", str(glossary_path), "--no-baseline"],
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "[RAW_ENGLISH]" in captured.out
+    assert "expected Japanese='ゴルゴタ'" in captured.out

--- a/scripts/tests/test_check_glossary_consistency.py
+++ b/scripts/tests/test_check_glossary_consistency.py
@@ -124,6 +124,27 @@ def test_json_scans_translated_text_values_not_source_keys(tmp_path: Path) -> No
     assert result.issues[0].term == "Golgotha"
 
 
+def test_json_locations_are_one_based_for_first_and_second_entries(tmp_path: Path) -> None:
+    """JSON entry locations follow the translation-token checker's 1-based indexing."""
+    glossary_path = tmp_path / "glossary.csv"
+    localization = tmp_path / "Localization"
+    _write_glossary(glossary_path)
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [
+            {"key": "First source", "text": "Golgotha remains untranslated."},
+            {"key": "Second source", "text": "Kyakukya remains untranslated."},
+        ],
+    )
+
+    result = check_glossary_consistency.check_paths([localization], glossary_path=glossary_path, baseline_path=None)
+
+    assert [(issue.term, issue.location) for issue in result.issues] == [
+        ("Golgotha", "entry[1].text"),
+        ("Kyakukya", "entry[2].text"),
+    ]
+
+
 def test_draft_glossary_rows_do_not_block_residue(tmp_path: Path) -> None:
     """Draft glossary rows remain review material, not gate inputs."""
     glossary_path = tmp_path / "glossary.csv"
@@ -238,6 +259,44 @@ def test_baseline_suppresses_current_occurrence_and_reports_stale_entries(tmp_pa
     assert [(issue.kind, issue.term, issue.location) for issue in result.issues] == [
         ("BASELINE", "Kyakukya", "entry[2].text"),
     ]
+
+
+def test_baseline_matches_one_based_json_entry_locations(tmp_path: Path) -> None:
+    """Baseline rows suppress JSON entries using 1-based entry[N].text locations."""
+    glossary_path = tmp_path / "glossary.csv"
+    localization = tmp_path / "Localization"
+    baseline_path = tmp_path / "baseline.json"
+    _write_glossary(glossary_path)
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [
+            {"key": "First source", "text": "Golgotha remains for now."},
+            {"key": "Second source", "text": "Kyakukya remains for now."},
+        ],
+    )
+    _write_baseline(
+        baseline_path,
+        {
+            "term": "Golgotha",
+            "path": "Dictionaries/demo.ja.json",
+            "location": "entry[1].text",
+            "text": "Golgotha remains for now.",
+        },
+        {
+            "term": "Kyakukya",
+            "path": "Dictionaries/demo.ja.json",
+            "location": "entry[2].text",
+            "text": "Kyakukya remains for now.",
+        },
+    )
+
+    result = check_glossary_consistency.check_paths(
+        [localization],
+        glossary_path=glossary_path,
+        baseline_path=baseline_path,
+    )
+
+    assert result.issues == []
 
 
 def test_full_localization_scan_reports_deleted_file_baseline_entries(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- adds a deterministic glossary consistency gate for approved/confirmed glossary rows
- scans player-visible localized JSON values and `.jp.xml` visible text/attributes for raw English glossary residue
- records existing known residue in an explicit baseline and wires the gate into CI/static/release commands

## Notes
- `draft` glossary rows are excluded from blocking behavior
- JSON scanning follows the existing translation dictionary/BlueprintTemplates loader scope
- XML scanning includes mixed-content child tails and reports stale baseline entries during full Localization scans

## Verification
- `uv run pytest scripts/tests/test_check_glossary_consistency.py -q`
- `uv run pytest scripts/tests/`
- `python3.12 scripts/check_glossary_consistency.py Mods/QudJP/Localization`
- `python3.12 scripts/check_glossary_consistency.py Mods/QudJP/Localization --no-baseline` (expected 8 existing baseline issues)
- `python3.12 scripts/check_translation_tokens.py Mods/QudJP/Localization`
- `ruff check scripts/`
- `basedpyright scripts/check_glossary_consistency.py scripts/tests/test_check_glossary_consistency.py`
- `python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts`
- `python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 用語集とローカライズ文面の一貫性を自動検証するCLIを追加し、検出結果のベースライン抑制に対応する基準ファイルを追加しました。  
* **Chores**
  * CIワークフローおよびリリース前のプリフライトに該当チェックを組み込みました。  
* **Documentation**
  * 検証手順をドキュメントと運用ガイドに追記しました。  
* **Tests**
  * 一貫性チェック用の包括的なpytestスイートを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->