### PR TITLE
Add annals death patterns

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/Fixtures/annals-samples.json
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/Fixtures/annals-samples.json
@@ -176,6 +176,30 @@
       "expected_japanese_exact": "Salt Dunesの辺りをさまよううち、Nuntuは秘密の儀式を行う農夫ギルドの一族に出くわした。his chromatic auraゆえ、彼らはhimを仲間に迎え入れ、himに彼らの秘密を授けた。"
     },
     {
+      "candidate_id": "GenericDeath#gospel",
+      "event_property": "gospel",
+      "input_source": "In 5597 BR, Yarad, Hammer-in-Turquoise, the Ilep Sorrow, died of natural causes. He was 216 years old.",
+      "expected_japanese_exact": "5597年、Yarad, Hammer-in-Turquoise, the Ilep Sorrowは自然の理により身罷った。享年216歳であった。"
+    },
+    {
+      "candidate_id": "GenericDeath#tombInscription",
+      "event_property": "tombInscription",
+      "input_source": "In the High Salt Sun, Yarad, Hammer-in-Turquoise, the Ilep Sorrow laid his body to rest and crossed into Brightsheol. He was 216 years old.",
+      "expected_japanese_exact": "ハイ・ソルト・サン、Yarad, Hammer-in-Turquoise, the Ilep Sorrowはその身を休め、ブライトシェオルへ渡った。享年216歳であった。"
+    },
+    {
+      "candidate_id": "FakedDeath#gospel",
+      "event_property": "gospel",
+      "input_source": "In 5597 BR, it was discovered that Yarad II's death had been faked. Despite reports to the contrary, Yarad II was alive and well. She was known thenceforth as the Gleaming Ghost of Barracks District Temrir.",
+      "expected_japanese_exact": "5597年、Yarad II's death had been fakedとの事実が明らかになった。相反する報告にもかかわらず、Yarad IIは健在だった。Yarad IIは以後the Gleaming Ghost of Barracks District Temrirとして知られるようになった。"
+    },
+    {
+      "candidate_id": "FakedDeath#tombInscription",
+      "event_property": "tombInscription",
+      "input_source": "Look! Behold the Gleaming Ghost of Barracks District Temrir, who in the High Salt Sun defied death and emerged from the glassy ruins.",
+      "expected_japanese_exact": "見よ、驚嘆せよ！ the Gleaming Ghost of Barracks District Temrirはハイ・ソルト・サンに死を退け、glassy ruinsより現れた。"
+    },
+    {
       "candidate_id": "edge_empty_gospel",
       "event_property": "gospel",
       "input_source": "",

--- a/Mods/QudJP/Localization/Dictionaries/annals-patterns.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/annals-patterns.ja.json
@@ -182,6 +182,11 @@
       "route": "annals"
     },
     {
+      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ (.+?)\\ that\\ (.+?)\\.\\ Despite\\ reports\\ to\\ the\\ contrary,\\ (.+?)\\ was\\ alive\\ and\\ well\\.\\ (.+?)\\ was\\ known\\ thenceforth\\ as\\ (.+?)\\.$",
+      "template": "{0}年、{t2}との事実が明らかになった。相反する報告にもかかわらず、{t3}は健在だった。{t3}は以後{t5}として知られるようになった。",
+      "route": "annals"
+    },
+    {
       "pattern": "^(?:In|Throughout(?:\\ the\\ entirety\\ of)?)\\ (\\d+)\\ (?:BR|AR),\\ (.+?)\\ (.+?)\\ all\\ of\\ (.+?),\\ (.+?)\\ of\\ (.+?)\\ and\\ (.+?)\\.\\ (.+?)\\ became\\ known\\ as\\ (.+?)\\.$",
       "template": "{0}年、{t1}は{t3}全土を{t2}、{t5}と{t6}に{t4}をもたらした。{t7}は{t8}として知られるようになった。",
       "route": "annals"
@@ -222,8 +227,18 @@
       "route": "annals"
     },
     {
+      "pattern": "^In\\ the\\ (.+?),\\ ([^,]+?)((?:,\\ [^,]+)*),?\\ laid\\ (.+?)\\ body\\ to\\ rest\\ and\\ crossed\\ into\\ Brightsheol\\.\\ (.+?)\\ was\\ (.+?)\\ years\\ old\\.$",
+      "template": "{t0}、{t1}{t2}はその身を休め、ブライトシェオルへ渡った。享年{t5}歳であった。",
+      "route": "annals"
+    },
+    {
       "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ Resheph\\ appointed\\ Rebekah\\ administrator\\ of\\ (.+?)\\.\\ She\\ tendered\\ alms\\ for\\ the\\ sick\\ in\\ his\\ name\\.$",
       "template": "{0}年、レシェフはレベカを{t1}の施政官に任じた。彼女は彼の名において病める者へ施しを捧げた。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ ([^,]+?)((?:,\\ [^,]+)*),?\\ died\\ of\\ natural\\ causes\\.\\ (.+?)\\ was\\ (.+?)\\ years\\ old\\.$",
+      "template": "{0}年、{t1}{t2}は自然の理により身罷った。享年{t4}歳であった。",
       "route": "annals"
     },
     {
@@ -244,6 +259,11 @@
     {
       "pattern": "^Deep\\ in\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
       "template": "{t0}の奥深くにて、{t1}は{t2}を見いだした。そこで{t3}は{t4}と親交を結び、{t5}。",
+      "route": "annals"
+    },
+    {
+      "pattern": "^(.+?)!\\ (.+?)\\ (.+?),\\ who\\ in\\ the\\ (.+)\\ (.+?)\\ death\\ and\\ (.+?)\\ from\\ the\\ (.+?)\\.$",
+      "template": "見よ、驚嘆せよ！ {t2}は{t3}に死を退け、{t6}より現れた。",
       "route": "annals"
     },
     {

--- a/Mods/QudJP/Localization/Dictionaries/annals-patterns.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/annals-patterns.ja.json
@@ -232,6 +232,11 @@
       "route": "annals"
     },
     {
+      "pattern": "^(.+?)!\\ (.+?)\\ (.+?),\\ who\\ in\\ the\\ (.+?)\\ (defied|flouted|mocked|spurned|thwarted|scorned|eluded)\\ death\\ and\\ (.+?)\\ from\\ the\\ (.+?)\\.$",
+      "template": "見よ、驚嘆せよ！ {t2}は{t3}に死を退け、{t6}より現れた。",
+      "route": "annals"
+    },
+    {
       "pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ Resheph\\ appointed\\ Rebekah\\ administrator\\ of\\ (.+?)\\.\\ She\\ tendered\\ alms\\ for\\ the\\ sick\\ in\\ his\\ name\\.$",
       "template": "{0}年、レシェフはレベカを{t1}の施政官に任じた。彼女は彼の名において病める者へ施しを捧げた。",
       "route": "annals"
@@ -259,11 +264,6 @@
     {
       "pattern": "^Deep\\ in\\ (.+?),\\ (.+?)\\ discovered\\ (.+?)\\.\\ There\\ (.+?)\\ befriended\\ (.+?)\\ and\\ (.+?)\\.$",
       "template": "{t0}の奥深くにて、{t1}は{t2}を見いだした。そこで{t3}は{t4}と親交を結び、{t5}。",
-      "route": "annals"
-    },
-    {
-      "pattern": "^(.+?)!\\ (.+?)\\ (.+?),\\ who\\ in\\ the\\ (.+)\\ (.+?)\\ death\\ and\\ (.+?)\\ from\\ the\\ (.+?)\\.$",
-      "template": "見よ、驚嘆せよ！ {t2}は{t3}に死を退け、{t6}より現れた。",
       "route": "annals"
     },
     {

--- a/scripts/_artifacts/annals/candidates_pending.json
+++ b/scripts/_artifacts/annals/candidates_pending.json
@@ -3283,6 +3283,218 @@
       "review_notes": "Issue #422 annals micro-slice: extractor-proven SecretRitual accepted-gospel wandering arm",
       "route": "annals",
       "en_template_hash": "sha256:0eac0d08795b50b51649b0a693ad9b9da72a41c961f0d0b73cf5ad2e41e85a7f"
+    },
+    {
+      "id": "GenericDeath#gospel",
+      "source_file": "GenericDeath.cs",
+      "annal_class": "GenericDeath",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "In {0} AR, {1}{2} died of natural causes. {3} was {4} years old.",
+      "extracted_pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ ([^,]+?)((?:,\\ [^,]+)*),?\\ died\\ of\\ natural\\ causes\\.\\ (.+?)\\ was\\ (.+?)\\ years\\ old\\.$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "hse-expansion",
+          "raw": "year",
+          "default": "{t0}"
+        },
+        {
+          "index": 1,
+          "type": "historykit-token",
+          "raw": "<entity.name>",
+          "default": "{t1}"
+        },
+        {
+          "index": 2,
+          "type": "helper-call",
+          "raw": "QudHistoryHelpers.ListAllCognomen(entity.GetSnapshotAtYear(entity.lastYear))",
+          "default": "{t2}"
+        },
+        {
+          "index": 3,
+          "type": "historykit-token",
+          "raw": "<entity.subjectPronoun.capitalize>",
+          "default": "{t3}"
+        },
+        {
+          "index": 4,
+          "type": "format-arg",
+          "raw": "(int)(year - entity.firstYear)",
+          "default": "{t4}"
+        }
+      ],
+      "status": "accepted",
+      "reason": "",
+      "ja_template": "{0}年、{t1}{t2}は自然の理により身罷った。享年{t4}歳であった。",
+      "review_notes": "Issue #422 death/dramatic micro-slice: static GenericDeath natural-death gospel",
+      "route": "annals",
+      "en_template_hash": "sha256:2a18f37dc5eee5451dc2dc65fd4d7456052461a844b566d5d772f5948944e09a"
+    },
+    {
+      "id": "GenericDeath#tombInscription",
+      "source_file": "GenericDeath.cs",
+      "annal_class": "GenericDeath",
+      "switch_case": "default",
+      "event_property": "tombInscription",
+      "sample_source": "In the {0}, {1}{2} laid {3} body to rest and crossed into Brightsheol. {4} was {5} years old.",
+      "extracted_pattern": "^In\\ the\\ (.+?),\\ ([^,]+?)((?:,\\ [^,]+)*),?\\ laid\\ (.+?)\\ body\\ to\\ rest\\ and\\ crossed\\ into\\ Brightsheol\\.\\ (.+?)\\ was\\ (.+?)\\ years\\ old\\.$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "helper-call",
+          "raw": "QudHistoryHelpers.GenerateSultanateYearName()",
+          "default": "{t0}"
+        },
+        {
+          "index": 1,
+          "type": "historykit-token",
+          "raw": "<entity.name>",
+          "default": "{t1}"
+        },
+        {
+          "index": 2,
+          "type": "helper-call",
+          "raw": "QudHistoryHelpers.ListAllCognomen(entity.GetSnapshotAtYear(entity.lastYear))",
+          "default": "{t2}"
+        },
+        {
+          "index": 3,
+          "type": "historykit-token",
+          "raw": "<entity.possessivePronoun>",
+          "default": "{t3}"
+        },
+        {
+          "index": 4,
+          "type": "historykit-token",
+          "raw": "<entity.subjectPronoun.capitalize>",
+          "default": "{t4}"
+        },
+        {
+          "index": 5,
+          "type": "format-arg",
+          "raw": "(int)(year - entity.firstYear)",
+          "default": "{t5}"
+        }
+      ],
+      "status": "accepted",
+      "reason": "",
+      "ja_template": "{t0}、{t1}{t2}はその身を休め、ブライトシェオルへ渡った。享年{t5}歳であった。",
+      "review_notes": "Issue #422 death/dramatic micro-slice: static GenericDeath tomb inscription",
+      "route": "annals",
+      "en_template_hash": "sha256:94d8f7bab41d358bc177b55731f4cd2fb38297850e34390177547d554cad6d47"
+    },
+    {
+      "id": "FakedDeath#gospel",
+      "source_file": "FakedDeath.cs",
+      "annal_class": "FakedDeath",
+      "switch_case": "default",
+      "event_property": "gospel",
+      "sample_source": "In {0} AR, {1} that {2}. Despite reports to the contrary, {3} was alive and well. {4} was known thenceforth as {5}.",
+      "extracted_pattern": "^In\\ (.+?)\\ (?:BR|AR),\\ (.+?)\\ that\\ (.+?)\\.\\ Despite\\ reports\\ to\\ the\\ contrary,\\ (.+?)\\ was\\ alive\\ and\\ well\\.\\ (.+?)\\ was\\ known\\ thenceforth\\ as\\ (.+?)\\.$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "hse-expansion",
+          "raw": "year",
+          "default": "{t0}"
+        },
+        {
+          "index": 1,
+          "type": "historykit-token",
+          "raw": "<spice.commonPhrases.itWasDiscovered.!random>",
+          "default": "{t1}"
+        },
+        {
+          "index": 2,
+          "type": "helper-call",
+          "raw": "ExpandString(\"<spice.instancesOf.backToLife.!random>\").Replace(\"*var*\", Grammar.MakePossessive(snapshotAtYear.GetProperty(\"name\")))",
+          "default": "{t2}"
+        },
+        {
+          "index": 3,
+          "type": "historykit-token",
+          "raw": "<entity.name>",
+          "default": "{t3}"
+        },
+        {
+          "index": 4,
+          "type": "historykit-token",
+          "raw": "<entity.subjectPronoun.capitalize>",
+          "default": "{t4}"
+        },
+        {
+          "index": 5,
+          "type": "helper-call",
+          "raw": "Grammar.MakeTitleCaseWithArticle(ExpandString(text))",
+          "default": "{t5}"
+        }
+      ],
+      "status": "accepted",
+      "reason": "",
+      "ja_template": "{0}年、{t2}との事実が明らかになった。相反する報告にもかかわらず、{t3}は健在だった。{t3}は以後{t5}として知られるようになった。",
+      "review_notes": "Issue #422 death/dramatic micro-slice: static FakedDeath returned-alive gospel",
+      "route": "annals",
+      "en_template_hash": "sha256:cf35f79162a90e26057ad72c5189df6ee734be7f674bb3896a3012142777255b"
+    },
+    {
+      "id": "FakedDeath#tombInscription",
+      "source_file": "FakedDeath.cs",
+      "annal_class": "FakedDeath",
+      "switch_case": "default",
+      "event_property": "tombInscription",
+      "sample_source": "{0}! {1} {2}, who in the {3} {4} death and {5} from the {6}.",
+      "extracted_pattern": "^(.+?)!\\ (.+?)\\ (.+?),\\ who\\ in\\ the\\ (.+)\\ (.+?)\\ death\\ and\\ (.+?)\\ from\\ the\\ (.+?)\\.$",
+      "slots": [
+        {
+          "index": 0,
+          "type": "historykit-token",
+          "raw": "<spice.commonPhrases.onlooker.!random.capitalize>",
+          "default": "{t0}"
+        },
+        {
+          "index": 1,
+          "type": "historykit-token",
+          "raw": "<spice.instancesOf.observeInWonder.!random.capitalize>",
+          "default": "{t1}"
+        },
+        {
+          "index": 2,
+          "type": "helper-call",
+          "raw": "Grammar.MakeTitleCaseWithArticle(ExpandString(text))",
+          "default": "{t2}"
+        },
+        {
+          "index": 3,
+          "type": "helper-call",
+          "raw": "QudHistoryHelpers.GenerateSultanateYearName()",
+          "default": "{t3}"
+        },
+        {
+          "index": 4,
+          "type": "historykit-token",
+          "raw": "<spice.commonPhrases.defied.!random>",
+          "default": "{t4}"
+        },
+        {
+          "index": 5,
+          "type": "historykit-token",
+          "raw": "<spice.commonPhrases.emerged.!random>",
+          "default": "{t5}"
+        },
+        {
+          "index": 6,
+          "type": "historykit-token",
+          "raw": "<spice.history.gospels.{QudHistoryHelpers.GetSultanateEra(snapshotAtYear)}.adjective.!random> <spice.history.gospels.{QudHistoryHelpers.GetSultanateEra(snapshotAtYear)}.location.!random>",
+          "default": "{t6}"
+        }
+      ],
+      "status": "accepted",
+      "reason": "",
+      "ja_template": "見よ、驚嘆せよ！ {t2}は{t3}に死を退け、{t6}より現れた。",
+      "review_notes": "Issue #422 death/dramatic micro-slice: static FakedDeath tomb inscription",
+      "route": "annals",
+      "en_template_hash": "sha256:2f7bde8ca179bf4657c91b459d6e537585064a9951122417168392d4cbbfaf72"
     }
   ]
 }

--- a/scripts/_artifacts/annals/candidates_pending.json
+++ b/scripts/_artifacts/annals/candidates_pending.json
@@ -3444,7 +3444,7 @@
       "switch_case": "default",
       "event_property": "tombInscription",
       "sample_source": "{0}! {1} {2}, who in the {3} {4} death and {5} from the {6}.",
-      "extracted_pattern": "^(.+?)!\\ (.+?)\\ (.+?),\\ who\\ in\\ the\\ (.+)\\ (.+?)\\ death\\ and\\ (.+?)\\ from\\ the\\ (.+?)\\.$",
+      "extracted_pattern": "^(.+?)!\\ (.+?)\\ (.+?),\\ who\\ in\\ the\\ (.+?)\\ (defied|flouted|mocked|spurned|thwarted|scorned|eluded)\\ death\\ and\\ (.+?)\\ from\\ the\\ (.+?)\\.$",
       "slots": [
         {
           "index": 0,


### PR DESCRIPTION
## Summary
- adds four accepted Annals candidates for GenericDeath and FakedDeath
- merges the new patterns into `annals-patterns.ja.json`
- adds L2 fixture coverage, including year-name lookup through `{tN}` captures

## Candidates
- `GenericDeath#gospel`
- `GenericDeath#tombInscription`
- `FakedDeath#gospel`
- `FakedDeath#tombInscription`

## Verification
- `python3.12 scripts/validate_candidate_schema.py scripts/_artifacts/annals/candidates_pending.json`
- `python3.12 scripts/merge_annals_patterns.py scripts/_artifacts/annals/candidates_pending.json`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~ReshephHistoryTranslationTests"`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "TestCategory=L1|TestCategory=L2"`
- `python3.12 scripts/check_translation_tokens.py Mods/QudJP/Localization`
- `python3.12 scripts/check_glossary_consistency.py Mods/QudJP/Localization`
- `python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ローカライゼーション**
  * 死亡関連イベント（自然死および虚偽の死）の日本語翻訳パターンを追加しました。年号や埋葬表現などの地域化対応を改善しています。

* **テスト**
  * 新しい翻訳ケースの検証用テストデータを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->