### PR TITLE
test: cover birth-origin Annals fixtures

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/Fixtures/annals-samples.json
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/Fixtures/annals-samples.json
@@ -236,6 +236,42 @@
       "expected_japanese_exact": "One rainy evening、ひとりの嬰児（with quartz skin）がレッドロックにて、メカニマス教団の一団により産着に包まれた姿で見いだされた。彼らはhimを仲間に迎えてhimを育み、heはYarad、メカニマス教団のArgentなるHeirとして知られるようになった。"
     },
     {
+      "candidate_id": "Adopted#gospel",
+      "event_property": "gospel",
+      "input_source": "Nuntu was adopted by glassblowers who love glass-making.",
+      "expected_japanese_exact": "Nuntuは、glass-makingを愛するglassblowersに養子として迎えられた。"
+    },
+    {
+      "candidate_id": "BornAsHeir#gospel",
+      "event_property": "gospel",
+      "input_source": "One starry night in Salt Dunes, a healthy child was born to the sultan at Red Rock. At the moment of her birth, a glass comet crossed the sky, and in celebration the people danced in the streets. The babe was named Nuntu, but the people called her the Glassborn.",
+      "expected_japanese_exact": "One starry night、Salt Dunesのレッドロックにて、スルタンに健やかなる子が生まれた。herの誕生の瞬間、a glass comet crossed the sky、祝賀として民はdanced in the streets。その嬰児はNuntuと名づけられたが、民はherをthe Glassbornと呼んだ。"
+    },
+    {
+      "candidate_id": "BornAsHeir#tombInscription",
+      "event_property": "tombInscription",
+      "input_source": "Look! Behold the life of Nuntu -- called the Glassborn! -- scion of the Fossilized Saads and she who was dowered the Glass Crown. Observe the twin miracles of the High Salt Sun: the heiress was born, and a glass comet crossed the sky.",
+      "expected_japanese_exact": "調べるよ！ Behold、Nuntuの生涯を。すなわちthe Glassbornと呼ばれし者、化石化せしサアドの裔にして、Glass Crownを授けられし者なり。ハイ・ソルト・サンの双つの奇跡を見よ。heiressが生まれ、そしてa glass comet crossed the sky。"
+    },
+    {
+      "candidate_id": "Marry#gospel#opt:base",
+      "event_property": "gospel",
+      "input_source": "Under a glass eclipse, Nuntu cemented her friendship with glassblowers by marrying Arconaut's Hall.",
+      "expected_japanese_exact": "Under a glass eclipse、NuntuはArconaut's Hallと婚姻を結ぶことにより、glassblowersとのherの友誼を固めた。"
+    },
+    {
+      "candidate_id": "Marry#gospel#opt:with1",
+      "event_property": "gospel",
+      "input_source": "Under a glass eclipse, Nuntu cemented her friendship with Farmers' Guild by marrying Arconaut's Hall. In celebration, the Farmers' Guild bestowed upon Nuntu a wedding gift they called the Glass Torch.",
+      "expected_japanese_exact": "Under a glass eclipse、NuntuはArconaut's Hallと婚姻を結ぶことにより、農夫ギルドとのherの友誼を固めた。In celebration、農夫ギルドはNuntuに、彼らがthe Glass Torchと呼ぶ婚礼の贈り物を授けた。"
+    },
+    {
+      "candidate_id": "Marry#tombInscription",
+      "event_property": "tombInscription",
+      "input_source": "Blessed union, Nuntu and Arconaut's Hall, whose legendary alliance by marriage founded glassblowers' guildhalls.",
+      "expected_japanese_exact": "Blessed union、NuntuとArconaut's Hall、その伝説的な婚姻同盟はfounded glassblowers' guildhalls。"
+    },
+    {
       "candidate_id": "edge_empty_gospel",
       "event_property": "gospel",
       "input_source": "",

--- a/Mods/QudJP/Localization/Dictionaries/annals-patterns.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/annals-patterns.ja.json
@@ -53,7 +53,7 @@
     },
     {
       "pattern": "^(.+?)\\ in\\ (.+?),\\ a\\ healthy\\ child\\ was\\ born\\ to\\ the\\ sultan\\ at\\ (.+?)\\.\\ At\\ the\\ moment\\ of\\ (.+?)\\ birth,\\ (.+?),\\ and\\ in\\ celebration\\ the\\ people\\ (.+?)\\.\\ The\\ babe\\ was\\ named\\ (.+?),\\ but\\ the\\ people\\ called\\ (.+?)\\ (.+?)\\.$",
-      "template": "{t0}、{t1}の{t2}にて、スルタンに健やかなる子が生まれた。{t3}誕生の瞬間、{t4}、祝賀として民は{t5}。その嬰児は{t6}と名づけられたが、民は{t7}を{t8}と呼んだ。",
+      "template": "{t0}、{t1}の{t2}にて、スルタンに健やかなる子が生まれた。{t3}の誕生の瞬間、{t4}、祝賀として民は{t5}。その嬰児は{t6}と名づけられたが、民は{t7}を{t8}と呼んだ。",
       "route": "annals"
     },
     {
@@ -68,7 +68,7 @@
     },
     {
       "pattern": "^(.+?)!\\ (.+?)\\ the\\ life\\ of\\ (.+?)\\ --\\ called\\ (.+?)!\\ --\\ scion\\ of\\ the\\ Fossilized\\ Saads\\ and\\ (.+?)\\ who\\ was\\ dowered\\ the\\ (.+?)\\.\\ Observe\\ the\\ twin\\ miracles\\ of\\ the\\ (.+?):\\ the\\ (.+?)\\ was\\ born,\\ and\\ (.+?)\\.$",
-      "template": "{t0}よ！ {t2}の生涯を{t1}、すなわち{t3}と呼ばれし者の生涯を！ 化石化せしサアドの裔にして、{t5}を授けられし{t4}なり。{t6}の双つの奇跡を見よ。{t7}が生まれ、そして{t8}。",
+      "template": "{t0}よ！ {t1}、{t2}の生涯を。すなわち{t3}と呼ばれし者、化石化せしサアドの裔にして、{t5}を授けられし者なり。{t6}の双つの奇跡を見よ。{t7}が生まれ、そして{t8}。",
       "route": "annals"
     },
     {
@@ -158,7 +158,7 @@
     },
     {
       "pattern": "^(.+?),\\ (.+?)\\ cemented\\ (.+?)\\ friendship\\ with\\ (.+?)\\ by\\ marrying\\ (.+?)\\.\\ (.+?),\\ the\\ (.+?)\\ bestowed\\ upon\\ (.+?)\\ a\\ wedding\\ gift\\ they\\ called\\ (.+?)\\.$",
-      "template": "{t0}、{t1}は{t4}と婚姻を結ぶことにより、{t3}との{t2}友誼を固めた。{t5}、{t6}は{t7}に、彼らが{t8}と呼ぶ婚礼の贈り物を授けた。",
+      "template": "{t0}、{t1}は{t4}と婚姻を結ぶことにより、{t3}との{t2}の友誼を固めた。{t5}、{t6}は{t7}に、彼らが{t8}と呼ぶ婚礼の贈り物を授けた。",
       "route": "annals"
     },
     {
@@ -268,12 +268,12 @@
     },
     {
       "pattern": "^(.+?),\\ (.+?)\\ cemented\\ (.+?)\\ friendship\\ with\\ (.+?)\\ by\\ marrying\\ (.+?)\\.$",
-      "template": "{t0}、{t1}は{t4}と婚姻を結ぶことにより、{t3}との{t2}友誼を固めた。",
+      "template": "{t0}、{t1}は{t4}と婚姻を結ぶことにより、{t3}との{t2}の友誼を固めた。",
       "route": "annals"
     },
     {
       "pattern": "^(.+?),\\ (.+?)\\ and\\ (.+?),\\ whose\\ (.+?)\\ alliance\\ by\\ marriage\\ (.+?)\\.$",
-      "template": "{t0}、{t1}と{t2}、その{t3}婚姻の同盟は{t4}。",
+      "template": "{t0}、{t1}と{t2}、その{t3}な婚姻同盟は{t4}。",
       "route": "annals"
     },
     {

--- a/scripts/_artifacts/annals/candidates_pending.json
+++ b/scripts/_artifacts/annals/candidates_pending.json
@@ -486,7 +486,7 @@
       ],
       "status": "accepted",
       "reason": "",
-      "ja_template": "{t0}、{t1}の{t2}にて、スルタンに健やかなる子が生まれた。{t3}誕生の瞬間、{t4}、祝賀として民は{t5}。その嬰児は{t6}と名づけられたが、民は{t7}を{t8}と呼んだ。",
+      "ja_template": "{t0}、{t1}の{t2}にて、スルタンに健やかなる子が生まれた。{t3}の誕生の瞬間、{t4}、祝賀として民は{t5}。その嬰児は{t6}と名づけられたが、民は{t7}を{t8}と呼んだ。",
       "review_notes": "",
       "route": "annals",
       "en_template_hash": "sha256:b629addf0e49ec9a1f65d76bbac0b9c8b815f81e3ea3289841adb95a3a4a4562"
@@ -557,7 +557,7 @@
       ],
       "status": "accepted",
       "reason": "",
-      "ja_template": "{t0}よ！ {t2}の生涯を{t1}、すなわち{t3}と呼ばれし者の生涯を！ 化石化せしサアドの裔にして、{t5}を授けられし{t4}なり。{t6}の双つの奇跡を見よ。{t7}が生まれ、そして{t8}。",
+      "ja_template": "{t0}よ！ {t1}、{t2}の生涯を。すなわち{t3}と呼ばれし者、化石化せしサアドの裔にして、{t5}を授けられし者なり。{t6}の双つの奇跡を見よ。{t7}が生まれ、そして{t8}。",
       "review_notes": "",
       "route": "annals",
       "en_template_hash": "sha256:7f067f9f7f2cf3cc71235083167ff3372be511c37b65f4d7e7bea997dfb7434e"
@@ -1243,7 +1243,7 @@
       ],
       "status": "accepted",
       "reason": "",
-      "ja_template": "{t0}、{t1}は{t4}と婚姻を結ぶことにより、{t3}との{t2}友誼を固めた。",
+      "ja_template": "{t0}、{t1}は{t4}と婚姻を結ぶことにより、{t3}との{t2}の友誼を固めた。",
       "review_notes": "",
       "route": "annals",
       "en_template_hash": "sha256:ce29afe90ea02a33072c19a58b557c71dd15a9413973c79856cccd47ab006d37"
@@ -1314,7 +1314,7 @@
       ],
       "status": "accepted",
       "reason": "",
-      "ja_template": "{t0}、{t1}は{t4}と婚姻を結ぶことにより、{t3}との{t2}友誼を固めた。{t5}、{t6}は{t7}に、彼らが{t8}と呼ぶ婚礼の贈り物を授けた。",
+      "ja_template": "{t0}、{t1}は{t4}と婚姻を結ぶことにより、{t3}との{t2}の友誼を固めた。{t5}、{t6}は{t7}に、彼らが{t8}と呼ぶ婚礼の贈り物を授けた。",
       "review_notes": "",
       "route": "annals",
       "en_template_hash": "sha256:beb11a404551ddefab0ccec7a96775047d89865691612f445d8c2524ff48bc91"
@@ -1361,7 +1361,7 @@
       ],
       "status": "accepted",
       "reason": "",
-      "ja_template": "{t0}、{t1}と{t2}、その{t3}婚姻の同盟は{t4}。",
+      "ja_template": "{t0}、{t1}と{t2}、その{t3}な婚姻同盟は{t4}。",
       "review_notes": "",
       "route": "annals",
       "en_template_hash": "sha256:b40c0d7b8c072dd75501dcf5f2613ab440441e5d5e90e873dab328282e7f5e3f"


### PR DESCRIPTION
## Summary

- Add L2 fixture coverage for `Adopted`, `BornAsHeir`, and `Marry` Annals patterns.
- Polish existing accepted templates for `BornAsHeir` and `Marry` in `candidates_pending.json`.
- Regenerate `annals-patterns.ja.json` deterministically from the candidate file.

Follow-up static coverage slice from #422. No runtime evidence is included in this PR.

## Verification

- `python3.12 scripts/validate_candidate_schema.py scripts/_artifacts/annals/candidates_pending.json`
- `python3.12 scripts/merge_annals_patterns.py scripts/_artifacts/annals/candidates_pending.json`
- `jq empty Mods/QudJP/Assemblies/QudJP.Tests/L2/Fixtures/annals-samples.json Mods/QudJP/Localization/Dictionaries/annals-patterns.ja.json scripts/_artifacts/annals/candidates_pending.json`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~ReshephHistoryTranslationTests'`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~AnnalsPatterns'`
- `python3.12 scripts/check_translation_tokens.py Mods/QudJP/Localization`
- `python3.12 scripts/check_glossary_consistency.py Mods/QudJP/Localization`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'TestCategory=L1|TestCategory=L2'`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/coq-japanese_stable/pull/456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * 年代記（annals）の複数シナリオに対応したテストケースを追加。「養子」「世嗣人として誕生」「墓碑銘」「婚姻」など、新たなテストケースでカバレッジを拡充。

* **ドキュメント**
  * 日本語年代記テンプレートの文法と句読点を調整。より正確な日本語表記で、翻訳パターンの品質を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->