### PR TITLE
Fix runtime owner-route translation triage slices

### DIFF
--- a/Mods/QudJP/Assemblies/AGENTS.md
+++ b/Mods/QudJP/Assemblies/AGENTS.md
@@ -34,6 +34,7 @@ dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCa
   - use `just --list` to discover repo recipes when command routing is unclear
   - use `just sg-cs '<pattern>' Mods/QudJP/Assemblies/src` to compare repo-owned call shapes
   - use `just sg-cs '<pattern>'` with the default decompiled-source target when tracing upstream game producers
+- Optional examples: try patterns such as `DynamicTextObservability.RecordTransform($$$ARGS)`, `Popup.Show($$$ARGS)`, or the method/class name you are changing.
 - If structural search is intentionally skipped for C# route work, state the reason in the work note or PR summary.
 - Constraints:
   - one patch class per file in `src/Patches/`

--- a/Mods/QudJP/Assemblies/AGENTS.md
+++ b/Mods/QudJP/Assemblies/AGENTS.md
@@ -30,6 +30,11 @@ dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCa
 
 - Prefer producer-owned or stable mid-pipeline fixes. Many sink and near-sink routes are intentionally observation-only.
 - Use `~/dev/coq-decompiled_stable/` to trace upstream producers, verify signatures, and investigate unclaimed routes.
+- For C# patch, translator, observability, or target-method changes, use structural search before editing or before finalizing the patch:
+  - use `just --list` to discover repo recipes when command routing is unclear
+  - use `just sg-cs '<pattern>' Mods/QudJP/Assemblies/src` to compare repo-owned call shapes
+  - use `just sg-cs '<pattern>'` with the default decompiled-source target when tracing upstream game producers
+- If structural search is intentionally skipped for C# route work, state the reason in the work note or PR summary.
 - Constraints:
   - one patch class per file in `src/Patches/`
   - do not instantiate real game types in tests; use dummy targets with matching signatures

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -98,7 +98,7 @@ public sealed class ColorTagAllowlistCoverageTests
     private static readonly SortedDictionary<string, string> StripWithoutLocalRestoreAllowlist =
         new(StringComparer.Ordinal)
         {
-            ["Mods/QudJP/Assemblies/src/Observability/FinalOutputObservability.cs:116:RecordDirectMarker"] = "Observation-only final sink marker check.",
+            ["Mods/QudJP/Assemblies/src/Observability/FinalOutputObservability.cs:109:RecordDirectMarker"] = "Observation-only final sink marker check.",
             ["Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs:238:HasColorMarkup"] = "Predicate only; it compares stripped and original text.",
             ["Mods/QudJP/Assemblies/src/Patches/ActiveEffectTextTranslator.cs:69:TryTranslateTemplate"] = "Delegates restoration to the template helper selected by the matched rule.",
             ["Mods/QudJP/Assemblies/src/Patches/BedChairFragmentTranslator.cs:120:TryTranslate"] = "Delegates capture restoration to rule builders through RestoreVisible.",
@@ -114,7 +114,7 @@ public sealed class ColorTagAllowlistCoverageTests
             ["Mods/QudJP/Assemblies/src/Patches/FactionsLineTranslationPatch.cs:84:TranslateTextField"] = "Strips only to detect whether the already-localized field contains visible text.",
             ["Mods/QudJP/Assemblies/src/Patches/FactionsStatusScreenTranslationPatch.cs:895:AddLocalizedSearchFragment"] = "Strips only to add searchable plain text beside the colored display text.",
             ["Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs:880:TranslateDisplayNameModifier"] = "Strips only to classify display-name modifier text before composing a translated modifier.",
-            ["Mods/QudJP/Assemblies/src/Patches/JournalNotificationTranslator.cs:19:TryTranslate"] = "Strips source colors so journal notification patterns can replace the full system sentence.",
+            ["Mods/QudJP/Assemblies/src/Patches/JournalNotificationTranslator.cs:20:TryTranslate"] = "Strips source colors so journal notification patterns can replace the full system sentence.",
             ["Mods/QudJP/Assemblies/src/Patches/LiquidVolumeFragmentTranslator.cs:118:TryTranslate"] = "Delegates capture restoration to helper calls in the matched branch.",
             ["Mods/QudJP/Assemblies/src/Patches/MainMenuLocalizationPatch.cs:174:TranslateProducerText"] = "Strips only for already-localized/direct-route checks before TranslatePreservingColors owns restoration.",
             ["Mods/QudJP/Assemblies/src/Patches/MessageLogPatch.cs:77:Prefix"] = "Observation-only direct marker check before MessagePatternTranslator owns restoration.",
@@ -129,10 +129,10 @@ public sealed class ColorTagAllowlistCoverageTests
             ["Mods/QudJP/Assemblies/src/Patches/SkillsAndPowersLineTranslationPatch.cs:229:TranslateSkillRightText"] = "Strips only for skill right-text detection before a non-colored exact replacement.",
             ["Mods/QudJP/Assemblies/src/Patches/TradeUiPopupTranslationPatch.cs:261:TryTranslateTradeUiPopupText"] = "Delegates capture restoration to branch-specific RestoreCapture helpers.",
             ["Mods/QudJP/Assemblies/src/Patches/UITextSkinTranslationPatch.cs:100:TranslatePreservingColors"] = "Sink fallback uses stripped text only for already-localized/direct-route checks.",
-            ["Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs:490:TryTranslateCoProcessorTemplate"] = "Delegates restoration to the template helper.",
-            ["Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs:526:TryTranslateCounterweightedTemplate"] = "Delegates restoration to the template helper.",
-            ["Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs:560:TryTranslateElementalDamageTemplate"] = "Delegates restoration to the template helper.",
-            ["Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs:593:TryTranslateTemplate"] = "Delegates restoration to the template helper.",
+            ["Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs:505:TryTranslateCoProcessorTemplate"] = "Delegates restoration to the template helper.",
+            ["Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs:541:TryTranslateCounterweightedTemplate"] = "Delegates restoration to the template helper.",
+            ["Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs:575:TryTranslateElementalDamageTemplate"] = "Delegates restoration to the template helper.",
+            ["Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs:608:TryTranslateTemplate"] = "Delegates restoration to the template helper.",
             ["Mods/QudJP/Assemblies/src/Translation/ColorAwareTranslationComposer.cs:30:Strip"] = "Wrapper method exposes the Strip API; callers are checked where they consume the returned spans.",
             ["Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs:70:Translate"] = "Passes stripped text and spans to TranslateStripped, where template application restores colors.",
             ["Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs:79:Translate"] = "Passes stripped text and spans to TranslateStripped, where template application restores colors.",

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/CookingEffectFragmentTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/CookingEffectFragmentTranslatorTests.cs
@@ -18,6 +18,8 @@ public sealed class CookingEffectFragmentTranslatorTests
     [TestCase("@they get +31% max HP for 1 hour.", "@they は1時間のあいだ最大HP+31%を得る。")]
     [TestCase("@they get +30-40% max HP for 1 hour.", "@they は1時間のあいだ最大HP+30-40%を得る。")]
     [TestCase("@they get +<color=yellow>31</color>% max HP for 1 hour.", "@they は1時間のあいだ最大HP+<color=yellow>31</color>%を得る。")]
+    [TestCase("+12% max HP", "最大HP+12%")]
+    [TestCase("+10-15% max HP", "最大HP+10-15%")]
     [TestCase("+<color=yellow>31</color>% max HP", "最大HP+<color=yellow>31</color>%")]
     [TestCase("+31% max HP", "最大HP+31%")]
     public void TryTranslate_TranslatesConfiguredFragments(string input, string expected)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DynamicTextObservabilityTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DynamicTextObservabilityTests.cs
@@ -111,6 +111,24 @@ public sealed class DynamicTextObservabilityTests
                 "; route=DoesVerbRoute; family=verb; template_id=<missing>; payload_mode=full; payload_excerpt=You catch fire\\; route\\=Spoofed\\; family\\=spoof\\=value; payload_sha256=<missing>"));
     }
 
+    [Test]
+    public void RecordTransform_ExposesTranslatedMarkupSemanticDrift()
+    {
+        var output = TestTraceHelper.CaptureTrace(() =>
+            DynamicTextObservability.RecordTransform(
+                "JournalPatternTranslator",
+                "journal-pattern",
+                "You note the location of a lair.",
+                "ジャーナルの「場所 > 棲み処}}」欄に記録した。"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(output, Does.Contain("DynamicTextProbe/v1"));
+            Assert.That(output, Does.Contain("; markup_semantic_status=drift;"));
+            Assert.That(output, Does.Contain("; markup_semantic_flags=unmatched_qud_close"));
+        });
+    }
+
     private static string ComputeSha256Hex(string value)
     {
         var bytes = System.Text.Encoding.UTF8.GetBytes(value);

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/TranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/TranslatorTests.cs
@@ -227,6 +227,26 @@ public sealed class TranslatorTests
     }
 
     [Test]
+    public void Translate_UsesRuntimeRegisteredTranslation_WithoutMissingKeyNoise()
+    {
+        WriteDictionary("ui-test.ja.json", "Hello", "こんにちは");
+
+        Translator.RegisterRuntimeTranslationForOwnerRoute("Sprint [off] <1>", "スプリント [オフ] <1>");
+        Translator.RegisterRuntimeTranslationForOwnerRoute("スプリント [オフ] <1>", "スプリント [オフ] <1>");
+
+        var rawTranslated = Translator.Translate("Sprint [off] <1>");
+        var alreadyTranslated = Translator.Translate("スプリント [オフ] <1>");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rawTranslated, Is.EqualTo("スプリント [オフ] <1>"));
+            Assert.That(alreadyTranslated, Is.EqualTo("スプリント [オフ] <1>"));
+            Assert.That(Translator.GetMissingKeyHitCountForTests("Sprint [off] <1>"), Is.EqualTo(0));
+            Assert.That(Translator.GetMissingKeyHitCountForTests("スプリント [オフ] <1>"), Is.EqualTo(0));
+        });
+    }
+
+    [Test]
     public void Translate_MissingKeyLogging_IsThrottledToPowerOfTwoHits()
     {
         WriteDictionary("ui-test.ja.json", "Hello", "こんにちは");

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/WorldModsTextTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/WorldModsTextTranslatorTests.cs
@@ -131,6 +131,9 @@ public sealed class WorldModsTextTranslatorTests
     [TestCase(
         "Snail-Encrusted: This item is crawling with tiny snails and grants the wearer +250 reputation with mollusks.",
         "巻貝まみれ: 小さなカタツムリが這っており、装着者に軟体動物との評判+250を与える。")]
+    [TestCase(
+        "Offhand Attack Chance: 15%",
+        "オフハンド命中率: 15%")]
     public void TryTranslate_TranslatesDynamicWorldModsTemplates(string source, string expected)
     {
         WriteDynamicWorldModsDictionary();
@@ -354,6 +357,7 @@ public sealed class WorldModsTextTranslatorTests
             ("Freezing: When powered, this weapon deals additional cold damage on hit.", "冷却: 通電中、この武器は命中時に追加の冷気ダメージを与える。"),
             ("Freezing: When powered, this weapon deals an additional {0} cold damage on hit.", "冷却: 通電中、この武器は命中時に追加で{0}の冷気ダメージを与える。"),
             ("Feathered: This item grants the wearer {0} reputation with birds.", "羽飾り: 装着者に鳥類との評判{0}を与える。"),
+            ("Offhand Attack Chance: {0}%", "オフハンド命中率: {0}%"),
             ("Scaled: This item grants the wearer {0} reputation with unshelled reptiles.", "鱗状の: 装着者に甲無し爬虫類との評判{0}を与える。"),
             ("Snail-Encrusted: This item is crawling with tiny snails and grants the wearer {0} reputation with mollusks.", "巻貝まみれ: 小さなカタツムリが這っており、装着者に軟体動物との評判{0}を与える。"),
             ("Intelligence", "知力"));

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarButtonTextTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarButtonTextTranslationPatchTests.cs
@@ -128,6 +128,90 @@ public sealed class AbilityBarButtonTextTranslationPatchTests
     }
 
     [Test]
+    public void Postfix_RegistersRuntimeCompletedLabelsToSuppressFlatTranslatorMisses()
+    {
+        WriteDictionary(
+            ("Sprint", "スプリント"),
+            ("Make Camp", "野営"),
+            ("[disabled]", "[無効]"),
+            ("on", "オン"),
+            ("off", "オフ"));
+
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyAbilityBarButtonTextTarget), nameof(DummyAbilityBarButtonTextTarget.Update)),
+                postfix: new HarmonyMethod(RequirePatchMethod("Postfix", typeof(object))));
+
+            var target = new DummyAbilityBarButtonTextTarget();
+            var sprint = new DummyAbilityBarButton("Sprint [off] <1>");
+            var camp = new DummyAbilityBarButton("Make Camp <2>");
+            target.AbilityButtons.Add(sprint);
+            target.AbilityButtons.Add(camp);
+
+            target.Update();
+
+            var rawSprint = Translator.Translate("Sprint [off] <1>");
+            var translatedSprint = Translator.Translate("スプリント [オフ] <1>");
+            var rawCamp = Translator.Translate("Make Camp <2>");
+            var translatedCamp = Translator.Translate("野営 <2>");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sprint.Text.text, Is.EqualTo("スプリント [オフ] <1>"));
+                Assert.That(camp.Text.text, Is.EqualTo("野営 <2>"));
+                Assert.That(rawSprint, Is.EqualTo("スプリント [オフ] <1>"));
+                Assert.That(translatedSprint, Is.EqualTo("スプリント [オフ] <1>"));
+                Assert.That(rawCamp, Is.EqualTo("野営 <2>"));
+                Assert.That(translatedCamp, Is.EqualTo("野営 <2>"));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("Sprint [off] <1>"), Is.EqualTo(0));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("スプリント [オフ] <1>"), Is.EqualTo(0));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("Make Camp <2>"), Is.EqualTo(0));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("野営 <2>"), Is.EqualTo(0));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void Postfix_DoesNotLogMissingKeysForUnregisteredSuffixTokens()
+    {
+        WriteDictionary(("Sprint", "スプリント"));
+
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyAbilityBarButtonTextTarget), nameof(DummyAbilityBarButtonTextTarget.Update)),
+                postfix: new HarmonyMethod(RequirePatchMethod("Postfix", typeof(object))));
+
+            var target = new DummyAbilityBarButtonTextTarget();
+            var sprint = new DummyAbilityBarButton("Sprint [off] <1>");
+            target.AbilityButtons.Add(sprint);
+
+            target.Update();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sprint.Text.text, Is.EqualTo("スプリント [off] <1>"));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("[disabled]"), Is.EqualTo(0));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("on"), Is.EqualTo(0));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("off"), Is.EqualTo(0));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
     public void Postfix_LeavesDynamicAbilityButtonTextEnglish_WhenBaseLeafIsMissing()
     {
         WriteDictionary(("Joppa", "ジョッパ"));

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryAndEquipmentStatusScreenTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryAndEquipmentStatusScreenTranslationPatchTests.cs
@@ -202,7 +202,8 @@ public sealed class InventoryAndEquipmentStatusScreenTranslationPatchTests
                 Assert.That(screen.QUICK_EAT.Description, Is.EqualTo("素早く食べる"));
                 Assert.That(screen.QUICK_DRINK.Description, Is.EqualTo("素早く飲む"));
                 Assert.That(screen.QUICK_APPLY.Description, Is.EqualTo("素早く適用"));
-                Assert.That(screen.weightText.Text, Does.Contain("ポンド"));
+                Assert.That(screen.weightText.Text, Does.Contain("lbs."));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("lbs."), Is.EqualTo(0));
                 Assert.That(screen.cyberneticsHotkeySkin.Text, Does.Contain("サイバネティクス表示"));
             });
         }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryLineTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryLineTranslationPatchTests.cs
@@ -77,10 +77,11 @@ public sealed partial class Issue201StatusScreensBatch2Tests
             {
                 Assert.That(categoryTarget.categoryLabel.Text, Is.EqualTo("武器"));
                 Assert.That(categoryTarget.categoryWeightText.Text, Does.Contain("3 個"));
-                Assert.That(categoryTarget.categoryWeightText.Text, Does.Contain("17 ポンド"));
+                Assert.That(categoryTarget.categoryWeightText.Text, Does.Contain("17 lbs."));
                 Assert.That(categoryTarget.categoryExpandLabel.Text, Is.EqualTo("[-]"));
                 Assert.That(itemTarget.text.Text, Is.EqualTo("レーザーライフル"));
-                Assert.That(itemTarget.itemWeightText.Text, Is.EqualTo("[7 ポンド]"));
+                Assert.That(itemTarget.itemWeightText.Text, Is.EqualTo("[7 lbs.]"));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("lbs."), Is.EqualTo(0));
                 Assert.That(
                     DynamicTextObservability.GetRouteFamilyHitCountForTests(
                         nameof(InventoryLineTranslationPatch),

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupTranslationPatchTests.cs
@@ -1026,6 +1026,43 @@ public sealed class PopupTranslationPatchTests
     }
 
     [Test]
+    public void Prefix_JournalNotification_DoesNotLeaveUnmatchedCloseAfterColoredSectionPath()
+    {
+        WriteJournalPatternDictionary((
+            "^You note the location of (.+?) in the Locations > (.+?) section of your journal\\.[.!]?$",
+            "ジャーナルの「場所 > {t1}」欄に{0}の場所を記録した。"));
+        WriteDictionary(
+            ("Locations", "場所"),
+            ("Lairs", "棲み処"));
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyPopupTarget), nameof(DummyPopupTarget.ShowBlock)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(PopupTranslationPatch), nameof(PopupTranslationPatch.Prefix))));
+
+            DummyPopupTarget.ShowBlock(
+                "You note the location of {{M|コゲルゲルセプルムの巣, 伝説の光葉}} in the {{W|Locations > Lairs}} section of your journal.",
+                "Warning");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    DummyPopupTarget.LastShowBlockMessage,
+                    Is.EqualTo("ジャーナルの「場所 > 棲み処」欄に{{M|コゲルゲルセプルムの巣, 伝説の光葉}}の場所を記録した。"));
+                Assert.That(DummyPopupTarget.LastShowBlockMessage, Does.Not.Contain("棲み処}}"));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
     public void Prefix_JournalNotification_FallsBackToEnglish_WhenPatternMissing()
     {
         WriteJournalPatternDictionary((

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -541,6 +541,8 @@ public sealed class TargetMethodResolutionTests
         "",
         "",
         "",
+        "",
+        "",
     })]
     public void TargetMethods_ResolveExpectedOverloads(Type patchType, string[] expectedSignatures)
     {

--- a/Mods/QudJP/Assemblies/src/Observability/DynamicTextObservability.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/DynamicTextObservability.cs
@@ -48,6 +48,7 @@ internal static class DynamicTextObservability
             return;
         }
 
+        var semanticDiagnostics = MarkupSemanticDiagnostics.Analyze(translatedValue);
         QudJPMod.LogToUnity(
             "[QudJP] DynamicTextProbe/" + ProbeVersion +
             ": route='" + normalizedRoute +
@@ -57,7 +58,9 @@ internal static class DynamicTextObservability
             " source='" + ObservabilityHelpers.SanitizeForLog(sourceValue, MaxValueLength) +
             "' translated='" + ObservabilityHelpers.SanitizeForLog(translatedValue, MaxValueLength) +
             "'." + Translator.GetCurrentLogContextSuffix()
-            + ObservabilityHelpers.BuildHelperStructuredSuffix(structuredRoute, family, sourceValue));
+            + ObservabilityHelpers.BuildHelperStructuredSuffix(structuredRoute, family, sourceValue)
+            + "; markup_semantic_status=" + semanticDiagnostics.Status
+            + "; markup_semantic_flags=" + semanticDiagnostics.Flags);
     }
 
     private static string BuildCounterKey(string route, string family)

--- a/Mods/QudJP/Assemblies/src/Observability/FinalOutputObservability.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/FinalOutputObservability.cs
@@ -42,13 +42,6 @@ internal static class FinalOutputObservability
     private static readonly object HitCountsSync = new object();
     private static readonly Regex MarkupTokenPattern =
         new Regex(@"\{\{[^|}]+\||\}\}|&&|\^\^|&[A-Za-z]|\^[A-Za-z]|<color=[^>]+>|</color>|=[A-Za-z0-9_.]+=", RegexOptions.CultureInvariant | RegexOptions.Compiled);
-    private static readonly Regex EmptyQudWrapperPattern =
-        new Regex(@"\{\{[^|}]+\|\}\}", RegexOptions.CultureInvariant | RegexOptions.Compiled);
-    private static readonly Regex LiteralQudShaderFragmentPattern =
-        new Regex(@"\{\{[^|}]+\}\}\|", RegexOptions.CultureInvariant | RegexOptions.Compiled);
-    private static readonly Regex BracketCloseInsideNestedQudScopePattern =
-        new Regex(@"\[\{\{[^|}]+\|[^\]}]*\]\}\}", RegexOptions.CultureInvariant | RegexOptions.Compiled);
-
     internal static void ResetForTests()
     {
         lock (HitCountsSync)
@@ -176,7 +169,7 @@ internal static class FinalOutputObservability
             normalized.FinalText,
             sourceMarkupSpans,
             finalMarkupSpans);
-        var semanticDiagnostics = BuildMarkupSemanticDiagnostics(normalized.FinalText);
+        var semanticDiagnostics = MarkupSemanticDiagnostics.Analyze(normalized.FinalText);
         var sourceVisibleSha256 = ObservabilityHelpers.ComputeSha256Hex(BuildVisibleText(normalized.SourceText));
         var finalVisibleSha256 = ObservabilityHelpers.ComputeSha256Hex(BuildVisibleText(normalized.FinalText));
 
@@ -414,149 +407,6 @@ internal static class FinalOutputObservability
         }
 
         return string.Join("|", spans);
-    }
-
-    private static MarkupSemanticDiagnostics BuildMarkupSemanticDiagnostics(string? text)
-    {
-        var value = text ?? string.Empty;
-        var flags = new List<string>();
-        AddFlagIfMatched(flags, "empty_qud_wrapper", EmptyQudWrapperPattern, value);
-        AddFlagIfMatched(flags, "literal_qud_shader_fragment", LiteralQudShaderFragmentPattern, value);
-        AddFlagIfMatched(flags, "bracket_close_inside_nested_qud_scope", BracketCloseInsideNestedQudScopePattern, value);
-
-        var structuralFlags = ScanMarkupSemanticStructure(value);
-        AddFlagIf(flags, "repeated_same_qud_scope_start", structuralFlags.RepeatedSameQudScopeStart);
-        AddFlagIf(flags, "unclosed_qud_scope", structuralFlags.UnclosedQudScope);
-        AddFlagIf(flags, "unmatched_qud_close", structuralFlags.UnmatchedQudClose);
-        AddFlagIf(flags, "unclosed_tmp_scope", structuralFlags.UnclosedTmpScope);
-        AddFlagIf(flags, "unmatched_tmp_close", structuralFlags.UnmatchedTmpClose);
-
-        return flags.Count == 0
-            ? new MarkupSemanticDiagnostics(MarkupSemanticStatusClean, string.Empty)
-            : new MarkupSemanticDiagnostics(MarkupSemanticStatusDrift, string.Join(",", flags));
-    }
-
-    private static MarkupSemanticFlags ScanMarkupSemanticStructure(string value)
-    {
-        var stack = new Stack<MarkupScope>();
-        var flags = new MarkupSemanticFlags();
-        var visibleIndex = 0;
-        var index = 0;
-        while (index < value.Length)
-        {
-            if (TryReadQudOpen(value, index, out var qudShader, out var qudLength))
-            {
-                if (HasActiveScopeAtVisibleIndex(stack, "qud", qudShader, visibleIndex))
-                {
-                    flags.RepeatedSameQudScopeStart = true;
-                }
-
-                stack.Push(new MarkupScope("qud", qudShader, visibleIndex));
-                index += qudLength;
-                continue;
-            }
-
-            if (StartsWithOrdinal(value, index, "}}"))
-            {
-                if (!TryPopScope(stack, "qud", out _))
-                {
-                    flags.UnmatchedQudClose = true;
-                }
-
-                index += 2;
-                continue;
-            }
-
-            if (TryReadTmpColorOpen(value, index, out var tmpColor, out var tmpOpenLength))
-            {
-                stack.Push(new MarkupScope("tmp", tmpColor, visibleIndex));
-                index += tmpOpenLength;
-                continue;
-            }
-
-            if (StartsWithOrdinal(value, index, "</color>"))
-            {
-                if (!TryPopScope(stack, "tmp", out _))
-                {
-                    flags.UnmatchedTmpClose = true;
-                }
-
-                index += "</color>".Length;
-                continue;
-            }
-
-            if (StartsWithOrdinal(value, index, "&&") || StartsWithOrdinal(value, index, "^^"))
-            {
-                visibleIndex++;
-                index += 2;
-                continue;
-            }
-
-            if ((value[index] == '&' || value[index] == '^') && index + 1 < value.Length && IsAsciiLetter(value[index + 1]))
-            {
-                index += 2;
-                continue;
-            }
-
-            if (TryReadPlaceholder(value, index, out _, out var placeholderLength))
-            {
-                index += placeholderLength;
-                continue;
-            }
-
-            visibleIndex++;
-            index++;
-        }
-
-        while (stack.Count > 0)
-        {
-            var scope = stack.Pop();
-            if (string.Equals(scope.Kind, "qud", StringComparison.Ordinal))
-            {
-                flags.UnclosedQudScope = true;
-            }
-            else if (string.Equals(scope.Kind, "tmp", StringComparison.Ordinal))
-            {
-                flags.UnclosedTmpScope = true;
-            }
-        }
-
-        return flags;
-    }
-
-    private static bool HasActiveScopeAtVisibleIndex(
-        Stack<MarkupScope> stack,
-        string kind,
-        string value,
-        int visibleIndex)
-    {
-        foreach (var scope in stack)
-        {
-            if (string.Equals(scope.Kind, kind, StringComparison.Ordinal)
-                && string.Equals(scope.Value, value, StringComparison.Ordinal)
-                && scope.StartVisibleIndex == visibleIndex)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static void AddFlagIfMatched(List<string> flags, string flag, Regex pattern, string value)
-    {
-        if (pattern.IsMatch(value))
-        {
-            flags.Add(flag);
-        }
-    }
-
-    private static void AddFlagIf(List<string> flags, string flag, bool condition)
-    {
-        if (condition)
-        {
-            flags.Add(flag);
-        }
     }
 
     private static string BuildVisibleText(string text)
@@ -876,29 +726,4 @@ internal static class FinalOutputObservability
         internal int StartVisibleIndex { get; }
     }
 
-    private readonly struct MarkupSemanticDiagnostics
-    {
-        internal MarkupSemanticDiagnostics(string status, string flags)
-        {
-            Status = status;
-            Flags = flags;
-        }
-
-        internal string Status { get; }
-
-        internal string Flags { get; }
-    }
-
-    private struct MarkupSemanticFlags
-    {
-        internal bool RepeatedSameQudScopeStart { get; set; }
-
-        internal bool UnclosedQudScope { get; set; }
-
-        internal bool UnmatchedQudClose { get; set; }
-
-        internal bool UnclosedTmpScope { get; set; }
-
-        internal bool UnmatchedTmpClose { get; set; }
-    }
 }

--- a/Mods/QudJP/Assemblies/src/Observability/MarkupSemanticDiagnostics.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/MarkupSemanticDiagnostics.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace QudJP;
+
+internal static class MarkupSemanticDiagnostics
+{
+    internal const string StatusClean = "clean";
+    internal const string StatusDrift = "drift";
+
+    private static readonly Regex EmptyQudWrapperPattern =
+        new Regex(@"\{\{[^|}]+\|\}\}", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex LiteralQudShaderFragmentPattern =
+        new Regex(@"\{\{[^|}]+\}\}\|", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex BracketCloseInsideNestedQudScopePattern =
+        new Regex(@"\[\{\{[^|}]+\|[^\]}]*\]\}\}", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    internal static MarkupSemanticDiagnosticsResult Analyze(string? text)
+    {
+        var value = text ?? string.Empty;
+        var flags = new List<string>();
+        AddFlagIfMatched(flags, "empty_qud_wrapper", EmptyQudWrapperPattern, value);
+        AddFlagIfMatched(flags, "literal_qud_shader_fragment", LiteralQudShaderFragmentPattern, value);
+        AddFlagIfMatched(flags, "bracket_close_inside_nested_qud_scope", BracketCloseInsideNestedQudScopePattern, value);
+
+        var structuralFlags = ScanMarkupSemanticStructure(value);
+        AddFlagIf(flags, "repeated_same_qud_scope_start", structuralFlags.RepeatedSameQudScopeStart);
+        AddFlagIf(flags, "unclosed_qud_scope", structuralFlags.UnclosedQudScope);
+        AddFlagIf(flags, "unmatched_qud_close", structuralFlags.UnmatchedQudClose);
+        AddFlagIf(flags, "unclosed_tmp_scope", structuralFlags.UnclosedTmpScope);
+        AddFlagIf(flags, "unmatched_tmp_close", structuralFlags.UnmatchedTmpClose);
+
+        return flags.Count == 0
+            ? new MarkupSemanticDiagnosticsResult(StatusClean, string.Empty)
+            : new MarkupSemanticDiagnosticsResult(StatusDrift, string.Join(",", flags));
+    }
+
+    private static MarkupSemanticFlags ScanMarkupSemanticStructure(string value)
+    {
+        var stack = new Stack<MarkupScope>();
+        var flags = new MarkupSemanticFlags();
+        var visibleIndex = 0;
+        var index = 0;
+        while (index < value.Length)
+        {
+            if (TryReadQudOpen(value, index, out var qudShader, out var qudLength))
+            {
+                if (HasActiveScopeAtVisibleIndex(stack, "qud", qudShader, visibleIndex))
+                {
+                    flags.RepeatedSameQudScopeStart = true;
+                }
+
+                stack.Push(new MarkupScope("qud", qudShader, visibleIndex));
+                index += qudLength;
+                continue;
+            }
+
+            if (StartsWithOrdinal(value, index, "}}"))
+            {
+                if (!TryPopScope(stack, "qud", out _))
+                {
+                    flags.UnmatchedQudClose = true;
+                }
+
+                index += 2;
+                continue;
+            }
+
+            if (TryReadTmpColorOpen(value, index, out var tmpColor, out var tmpOpenLength))
+            {
+                stack.Push(new MarkupScope("tmp", tmpColor, visibleIndex));
+                index += tmpOpenLength;
+                continue;
+            }
+
+            if (StartsWithOrdinal(value, index, "</color>"))
+            {
+                if (!TryPopScope(stack, "tmp", out _))
+                {
+                    flags.UnmatchedTmpClose = true;
+                }
+
+                index += "</color>".Length;
+                continue;
+            }
+
+            if (StartsWithOrdinal(value, index, "&&") || StartsWithOrdinal(value, index, "^^"))
+            {
+                visibleIndex++;
+                index += 2;
+                continue;
+            }
+
+            if ((value[index] == '&' || value[index] == '^') && index + 1 < value.Length && IsAsciiLetter(value[index + 1]))
+            {
+                index += 2;
+                continue;
+            }
+
+            if (TryReadPlaceholder(value, index, out _, out var placeholderLength))
+            {
+                index += placeholderLength;
+                continue;
+            }
+
+            visibleIndex++;
+            index++;
+        }
+
+        while (stack.Count > 0)
+        {
+            var scope = stack.Pop();
+            if (string.Equals(scope.Kind, "qud", StringComparison.Ordinal))
+            {
+                flags.UnclosedQudScope = true;
+            }
+            else if (string.Equals(scope.Kind, "tmp", StringComparison.Ordinal))
+            {
+                flags.UnclosedTmpScope = true;
+            }
+        }
+
+        return flags;
+    }
+
+    private static bool HasActiveScopeAtVisibleIndex(
+        Stack<MarkupScope> stack,
+        string kind,
+        string value,
+        int visibleIndex)
+    {
+        foreach (var scope in stack)
+        {
+            if (string.Equals(scope.Kind, kind, StringComparison.Ordinal)
+                && string.Equals(scope.Value, value, StringComparison.Ordinal)
+                && scope.StartVisibleIndex == visibleIndex)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void AddFlagIfMatched(List<string> flags, string flag, Regex pattern, string value)
+    {
+        if (pattern.IsMatch(value))
+        {
+            flags.Add(flag);
+        }
+    }
+
+    private static void AddFlagIf(List<string> flags, string flag, bool condition)
+    {
+        if (condition)
+        {
+            flags.Add(flag);
+        }
+    }
+
+    private static bool TryReadQudOpen(string value, int index, out string shader, out int length)
+    {
+        shader = string.Empty;
+        length = 0;
+        if (!StartsWithOrdinal(value, index, "{{"))
+        {
+            return false;
+        }
+
+        var separatorIndex = -1;
+        for (var scanIndex = index + 2; scanIndex < value.Length; scanIndex++)
+        {
+            if (scanIndex + 1 < value.Length && value[scanIndex] == '}' && value[scanIndex + 1] == '}')
+            {
+                return false;
+            }
+
+            if (value[scanIndex] == '|')
+            {
+                separatorIndex = scanIndex;
+                break;
+            }
+        }
+
+        if (separatorIndex < 0)
+        {
+            return false;
+        }
+
+        var candidate = value.Substring(index + 2, separatorIndex - index - 2);
+        if (candidate.Length == 0)
+        {
+            return false;
+        }
+
+        shader = candidate;
+        length = separatorIndex - index + 1;
+        return true;
+    }
+
+    private static bool TryReadTmpColorOpen(string value, int index, out string color, out int length)
+    {
+        color = string.Empty;
+        length = 0;
+        if (!StartsWithOrdinal(value, index, "<color="))
+        {
+            return false;
+        }
+
+        var endIndex = value.IndexOf('>', index + "<color=".Length);
+        if (endIndex < 0)
+        {
+            return false;
+        }
+
+        color = value.Substring(index + "<color=".Length, endIndex - index - "<color=".Length);
+        length = endIndex - index + 1;
+        return true;
+    }
+
+    private static bool TryReadPlaceholder(string value, int index, out string placeholder, out int length)
+    {
+        placeholder = string.Empty;
+        length = 0;
+        if (value[index] != '=')
+        {
+            return false;
+        }
+
+        var endIndex = value.IndexOf('=', index + 1);
+        if (endIndex < 0)
+        {
+            return false;
+        }
+
+        var candidate = value.Substring(index + 1, endIndex - index - 1);
+        if (candidate.Length == 0)
+        {
+            return false;
+        }
+
+        for (var candidateIndex = 0; candidateIndex < candidate.Length; candidateIndex++)
+        {
+            var character = candidate[candidateIndex];
+            if (!IsAsciiLetterOrDigit(character) && character != '_' && character != '.')
+            {
+                return false;
+            }
+        }
+
+        placeholder = candidate;
+        length = endIndex - index + 1;
+        return true;
+    }
+
+    private static bool TryPopScope(Stack<MarkupScope> stack, string kind, out MarkupScope scope)
+    {
+        if (stack.Count > 0 && string.Equals(stack.Peek().Kind, kind, StringComparison.Ordinal))
+        {
+            scope = stack.Pop();
+            return true;
+        }
+
+        scope = default;
+        return false;
+    }
+
+    private static bool StartsWithOrdinal(string value, int index, string prefix)
+    {
+        return index <= value.Length - prefix.Length
+            && string.CompareOrdinal(value, index, prefix, 0, prefix.Length) == 0;
+    }
+
+    private static bool IsAsciiLetter(char character)
+    {
+        return (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z');
+    }
+
+    private static bool IsAsciiLetterOrDigit(char character)
+    {
+        return IsAsciiLetter(character) || (character >= '0' && character <= '9');
+    }
+
+    private readonly struct MarkupScope
+    {
+        internal MarkupScope(string kind, string value, int startVisibleIndex)
+        {
+            Kind = kind;
+            Value = value;
+            StartVisibleIndex = startVisibleIndex;
+        }
+
+        internal string Kind { get; }
+
+        internal string Value { get; }
+
+        internal int StartVisibleIndex { get; }
+    }
+
+    private struct MarkupSemanticFlags
+    {
+        internal bool RepeatedSameQudScopeStart { get; set; }
+
+        internal bool UnclosedQudScope { get; set; }
+
+        internal bool UnmatchedQudClose { get; set; }
+
+        internal bool UnclosedTmpScope { get; set; }
+
+        internal bool UnmatchedTmpClose { get; set; }
+    }
+}
+
+internal readonly struct MarkupSemanticDiagnosticsResult
+{
+    internal MarkupSemanticDiagnosticsResult(string status, string flags)
+    {
+        Status = status;
+        Flags = flags;
+    }
+
+    internal string Status { get; }
+
+    internal string Flags { get; }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/AbilityBarButtonTextTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/AbilityBarButtonTextTranslationPatch.cs
@@ -259,7 +259,6 @@ public static class AbilityBarButtonTextTranslationPatch
     {
         if (!StringHelpers.TryGetTranslationExactOrLowerAscii(source, out translated))
         {
-            translated = source;
             return false;
         }
 

--- a/Mods/QudJP/Assemblies/src/Patches/AbilityBarButtonTextTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/AbilityBarButtonTextTranslationPatch.cs
@@ -93,6 +93,8 @@ public static class AbilityBarButtonTextTranslationPatch
 
             if (UITextSkinReflectionAccessor.SetCurrentText(textObject, translated, Context))
             {
+                Translator.RegisterRuntimeTranslationForOwnerRoute(current!, translated);
+                Translator.RegisterRuntimeTranslationForOwnerRoute(translated, translated);
                 DynamicTextObservability.RecordTransform(route, "AbilityBar.ButtonText", current!, translated);
             }
         }
@@ -210,8 +212,7 @@ public static class AbilityBarButtonTextTranslationPatch
         }
         else
         {
-            translated = StringHelpers.TranslateExactOrLowerAscii(stripped);
-            if (translated is null)
+            if (!StringHelpers.TryGetTranslationExactOrLowerAscii(stripped, out translated))
             {
                 translated = TranslateDisplayNameRoutePreservingColors(
                     source,
@@ -256,14 +257,12 @@ public static class AbilityBarButtonTextTranslationPatch
 
     private static bool TryTranslateAbilityBarBaseLeaf(string source, out string translated)
     {
-        var maybeTranslated = StringHelpers.TranslateExactOrLowerAscii(source);
-        if (maybeTranslated is null)
+        if (!StringHelpers.TryGetTranslationExactOrLowerAscii(source, out translated))
         {
             translated = source;
             return false;
         }
 
-        translated = maybeTranslated;
         return true;
     }
 
@@ -274,8 +273,7 @@ public static class AbilityBarButtonTextTranslationPatch
             return zone;
         }
 
-        var exact = StringHelpers.TranslateExactOrLowerAscii(zone);
-        if (exact is not null)
+        if (StringHelpers.TryGetTranslationExactOrLowerAscii(zone, out var exact))
         {
             return exact;
         }
@@ -305,8 +303,7 @@ public static class AbilityBarButtonTextTranslationPatch
 
     private static string ReplaceExactToken(string source, string token)
     {
-        var translated = StringHelpers.TranslateExactOrLowerAscii(token);
-        if (translated is null)
+        if (!StringHelpers.TryGetTranslationExactOrLowerAscii(token, out var translated))
         {
             return source;
         }

--- a/Mods/QudJP/Assemblies/src/Patches/CookingEffectTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/CookingEffectTranslationPatch.cs
@@ -59,6 +59,8 @@ public static class CookingEffectTranslationPatch
             ("XRL.World.Effects.CookingDomainHP_IncreaseHP_ProceduralCookingTriggeredAction", "GetDescription"),
             ("XRL.World.Effects.CookingDomainHP_IncreaseHP_ProceduralCookingTriggeredAction", "GetTemplatedDescription"),
             ("XRL.World.Effects.CookingDomainHP_IncreaseHP_ProceduralCookingTriggeredActionEffect", "GetDetails"),
+            ("XRL.World.Effects.CookingDomainHP_UnitHP", "GetDescription"),
+            ("XRL.World.Effects.CookingDomainHP_UnitHP", "GetTemplatedDescription"),
         })
         {
             var type = AccessTools.TypeByName(target.typeName);

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryAndEquipmentStatusScreenTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryAndEquipmentStatusScreenTranslationPatch.cs
@@ -10,6 +10,8 @@ namespace QudJP.Patches;
 [HarmonyPatch]
 public static class InventoryAndEquipmentStatusScreenTranslationPatch
 {
+    private const string WeightUnit = "lbs.";
+
     private static readonly Regex HotkeyTogglePattern =
         new Regex(@"^(?<hotkey>\{\{hotkey\|\[[^\]]+\]\}\})\s+(?<label>.+)$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
@@ -121,13 +123,12 @@ public static class InventoryAndEquipmentStatusScreenTranslationPatch
             return source;
         }
 
-        var translatedUnit = Translator.Translate("lbs.");
         var translated = string.Format(
             CultureInfo.InvariantCulture,
             "{{{{C|{0}{{{{K|/{1}}}}} {2} }}}}",
             match.Groups["current"].Value,
             match.Groups["max"].Value,
-            translatedUnit);
+            WeightUnit);
         if (!string.Equals(translated, source, StringComparison.Ordinal))
         {
             DynamicTextObservability.RecordTransform(route, "InventoryAndEquipment.WeightText", source, translated);

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs
@@ -197,10 +197,12 @@ public static class InventoryLineTranslationPatch
         var translated = showItemCount
             ? $"|{amount.ToString(CultureInfo.InvariantCulture)} {translatedItems}|{weight.ToString(CultureInfo.InvariantCulture)} {WeightUnit}|"
             : $"|{weight.ToString(CultureInfo.InvariantCulture)} {WeightUnit}|";
-        if (!string.Equals(translated, source, StringComparison.Ordinal))
-        {
-            DynamicTextObservability.RecordTransform(route, "InventoryLine.WeightSummary", source, translated);
-        }
+        DynamicTextObservability.RecordTransform(
+            route,
+            "InventoryLine.WeightSummary",
+            source,
+            translated,
+            logWhenUnchanged: true);
 
         return translated;
     }
@@ -208,10 +210,12 @@ public static class InventoryLineTranslationPatch
     private static string TranslateItemWeightText(string source, int weight, string route)
     {
         var translated = $"[{weight.ToString(CultureInfo.InvariantCulture)} {WeightUnit}]";
-        if (!string.Equals(translated, source, StringComparison.Ordinal))
-        {
-            DynamicTextObservability.RecordTransform(route, "InventoryLine.WeightLabel", source, translated);
-        }
+        DynamicTextObservability.RecordTransform(
+            route,
+            "InventoryLine.WeightLabel",
+            source,
+            translated,
+            logWhenUnchanged: true);
 
         return translated;
     }

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs
@@ -10,6 +10,7 @@ namespace QudJP.Patches;
 public static class InventoryLineTranslationPatch
 {
     private const string Context = nameof(InventoryLineTranslationPatch);
+    private const string WeightUnit = "lbs.";
 
     [HarmonyTargetMethod]
     private static MethodBase? TargetMethod()
@@ -193,10 +194,9 @@ public static class InventoryLineTranslationPatch
     private static string TranslateCategoryWeightText(string source, int amount, int weight, bool showItemCount, string route)
     {
         var translatedItems = Translator.Translate("items");
-        var translatedWeightUnit = Translator.Translate("lbs.");
         var translated = showItemCount
-            ? $"|{amount.ToString(CultureInfo.InvariantCulture)} {translatedItems}|{weight.ToString(CultureInfo.InvariantCulture)} {translatedWeightUnit}|"
-            : $"|{weight.ToString(CultureInfo.InvariantCulture)} {translatedWeightUnit}|";
+            ? $"|{amount.ToString(CultureInfo.InvariantCulture)} {translatedItems}|{weight.ToString(CultureInfo.InvariantCulture)} {WeightUnit}|"
+            : $"|{weight.ToString(CultureInfo.InvariantCulture)} {WeightUnit}|";
         if (!string.Equals(translated, source, StringComparison.Ordinal))
         {
             DynamicTextObservability.RecordTransform(route, "InventoryLine.WeightSummary", source, translated);
@@ -207,8 +207,7 @@ public static class InventoryLineTranslationPatch
 
     private static string TranslateItemWeightText(string source, int weight, string route)
     {
-        var translatedWeightUnit = Translator.Translate("lbs.");
-        var translated = $"[{weight.ToString(CultureInfo.InvariantCulture)} {translatedWeightUnit}]";
+        var translated = $"[{weight.ToString(CultureInfo.InvariantCulture)} {WeightUnit}]";
         if (!string.Equals(translated, source, StringComparison.Ordinal))
         {
             DynamicTextObservability.RecordTransform(route, "InventoryLine.WeightLabel", source, translated);

--- a/Mods/QudJP/Assemblies/src/Patches/JournalNotificationTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/JournalNotificationTranslator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace QudJP.Patches;
 
@@ -32,7 +33,7 @@ internal static class JournalNotificationTranslator
             return false;
         }
 
-        translated = journalTranslated;
+        translated = RemoveUnmatchedSectionPathCloseIfNeeded(stripped, journalTranslated);
         DynamicTextObservability.RecordTransform(route, family, source, translated);
         return true;
     }
@@ -99,6 +100,51 @@ internal static class JournalNotificationTranslator
             sourceSectionStart,
             stripped.Length - sourceSectionStart - JournalSectionSuffix.Length);
         return sourceSectionPath.Length > 0;
+    }
+
+    private static bool TryGetNoteLocationSectionPath(string stripped, out string sourceSectionPath)
+    {
+        sourceSectionPath = string.Empty;
+        if (!stripped.StartsWith(NoteLocationPrefix, StringComparison.Ordinal)
+            || !stripped.EndsWith(JournalSectionSuffix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var sectionEnd = stripped.Length - JournalSectionSuffix.Length;
+        var separator = " in the ";
+        var separatorIndex = stripped.LastIndexOf(separator, sectionEnd - 1, sectionEnd, StringComparison.Ordinal);
+        if (separatorIndex < 0)
+        {
+            return false;
+        }
+
+        var sectionStart = separatorIndex + separator.Length;
+        sourceSectionPath = stripped.Substring(sectionStart, sectionEnd - sectionStart);
+        return sourceSectionPath.Length > 0;
+    }
+
+    private static string RemoveUnmatchedSectionPathCloseIfNeeded(string stripped, string translated)
+    {
+        if (!TryGetNoteLocationSectionPath(stripped, out var sourceSectionPath))
+        {
+            return translated;
+        }
+
+        var translatedSectionPath = TranslateJournalSectionPath(sourceSectionPath);
+        if (translatedSectionPath.Length == 0)
+        {
+            return translated;
+        }
+
+        var extraClose = translatedSectionPath + "}}";
+        var index = translated.IndexOf(extraClose, StringComparison.Ordinal);
+        if (index < 0 || translated.IndexOf(extraClose, index + extraClose.Length, StringComparison.Ordinal) >= 0)
+        {
+            return translated;
+        }
+
+        return translated.Remove(index + translatedSectionPath.Length, 2);
     }
 
     private static string RestoreSectionPathBoundaryWrappers(
@@ -187,6 +233,19 @@ internal static class JournalNotificationTranslator
         if (string.Equals(source, SultanHistoriesSource, StringComparison.Ordinal))
         {
             return SultanHistoriesTranslated;
+        }
+
+        try
+        {
+            if (StringHelpers.TryGetTranslationExactOrLowerAscii(source, out var translated)
+                && !string.Equals(source, translated, StringComparison.Ordinal))
+            {
+                return translated;
+            }
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceWarning("QudJP: JournalNotificationTranslator could not translate journal path segment '{0}': {1}", source, ex.Message);
         }
 
         return source;

--- a/Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs
@@ -63,6 +63,9 @@ internal static class WorldModsTextTranslator
     private static readonly Regex FactionSlayerPattern = new Regex(
         "^(?<chance>\\d+)% chance to behead (?<target>.+) on hit\\.$",
         RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex OffhandAttackChancePattern = new Regex(
+        "^Offhand Attack Chance: (?<chance>\\d+)%$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly Regex BlinkEscapePattern = new Regex(
         "^Whenever you're about to take avoidable damage, there's (?:a|an) (?<chance>\\d+)% chance you blink away instead\\.$",
         RegexOptions.CultureInvariant | RegexOptions.Compiled);
@@ -154,6 +157,18 @@ internal static class WorldModsTextTranslator
             DataDiskItemModificationPattern,
             "Adds item modification: {0}",
             (match, spans) => new[] { GetTranslatedCapture(match, spans, "description", TranslateNestedWorldModDescription) },
+            out translated))
+        {
+            return true;
+        }
+
+        if (TryTranslateTemplate(
+            source,
+            route,
+            family,
+            OffhandAttackChancePattern,
+            "Offhand Attack Chance: {0}%",
+            (match, spans) => new[] { GetTranslatedCapture(match, spans, "chance") },
             out translated))
         {
             return true;

--- a/Mods/QudJP/Assemblies/src/Translation/Translator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/Translator.cs
@@ -127,6 +127,16 @@ public static class Translator
         return routeSummary + Environment.NewLine + keySummary;
     }
 
+    internal static void RegisterRuntimeTranslationForOwnerRoute(string source, string translated)
+    {
+        if (string.IsNullOrEmpty(source) || string.IsNullOrEmpty(translated))
+        {
+            return;
+        }
+
+        _ = TranslationCache.TryAdd(source, translated);
+    }
+
     internal static IDisposable PushLogContext(string? context)
     {
         if (string.IsNullOrWhiteSpace(context))

--- a/Mods/QudJP/Localization/Dictionaries/world-effects-tonics.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/world-effects-tonics.ja.json
@@ -9,6 +9,11 @@
     },
     "entries": [
         {
+            "key": "This item is a tonic. Applying one tonic while under the effects of another may produce undesired results.",
+            "context": "XRL.World.Parts.TonicApplicator.Description",
+            "text": "このアイテムはトニックです。別のトニックの効果中にトニックを使用すると、望ましくない結果を招くことがあります。"
+        },
+        {
             "key": "{{blaze|blaze}} tonic",
             "context": "XRL.World.Effects.Blaze_Tonic.Description",
             "text": "{{blaze|ブレイズ}}トニック"

--- a/docs/reports/2026-05-03-issue-466-cooking-procedural-inventory.md
+++ b/docs/reports/2026-05-03-issue-466-cooking-procedural-inventory.md
@@ -1,0 +1,67 @@
+# Issue 466 Procedural Cooking Inventory Slice
+
+Date: 2026-05-03
+
+## Scope
+
+This is the first mechanical inventory slice for procedural cooking localization.
+It follows `docs/RULES.md`: dynamic/procedural cooking strings should be owned by
+producer or mid-pipeline translation routes, not by broad concrete dictionary
+entries.
+
+## Inventory Commands
+
+Structural check used for the known HP producer shape:
+
+```bash
+ast-grep run --lang csharp \
+  --pattern 'return "@they get +" + $TIER + "% max HP for 1 hour.";'
+```
+
+Method inventory was gathered from decompiled `XRL.World.Effects` cooking files
+for these methods:
+
+- `GetDescription`
+- `GetTemplatedDescription`
+- `GetDetails`
+- `GetTriggerDescription`
+- `GetTemplatedTriggerDescription`
+
+The initial scan found 207 candidate methods:
+
+- 88 dynamic/procedural candidates
+- 119 static or low-risk exact candidates
+
+## Current Owner Coverage
+
+`CookingEffectTranslationPatch` now targets 14 method routes. The newly covered
+routes in this slice are:
+
+- `XRL.World.Effects.CookingDomainHP_UnitHP.GetDescription`
+- `XRL.World.Effects.CookingDomainHP_UnitHP.GetTemplatedDescription`
+
+These reuse the existing `CookingEffectFragmentTranslator` max-HP details rule:
+
+- `+12% max HP` -> `最大HP+12%`
+- `+10-15% max HP` -> `最大HP+10-15%`
+
+## High-Confidence Follow-Up Clusters
+
+These dynamic clusters are good next candidates because their source shape is
+simple and already resembles existing dictionary exact/range entries:
+
+- stat/resistance units: `Bonus.Signed() + " Acid Resistance"`,
+  `Cold Resistance`, `Electric Resistance`, `Heat Resistance`, `AV`, `DV`,
+  `Agility`, `Ego`, `MA`
+- turn-bounded buffs: `@they gain@s +8 Agility for 50 turns.`,
+  `@they gain@s +6 AV for 50 turns.`, `@they gain@s +8 Strength for 50 turns.`
+- damage-trigger chances: `whenever @thisCreature take@s damage, there's a N%
+  chance`, including phase-on-damage and regen-on-damaged variants
+- mutation-use templates: `Can use {MutationDisplayName} at level ...` and
+  `+N level(s) to {MutationDisplayName}`
+
+## Deferred
+
+Do not bulk-remove static range entries from `world-effects-cooking.ja.json` in
+this slice. Range templates such as `+10-15% max HP` are still useful as stable
+template documentation until each owner route is explicitly patched and tested.

--- a/scripts/tests/test_triage_classifier.py
+++ b/scripts/tests/test_triage_classifier.py
@@ -80,12 +80,16 @@ def test_classify_unexpected_translation_of_preserved_stat_abbreviation() -> Non
     assert result.slot_evidence == ["STR"]
 
 
-def test_classify_route_specific_lbs_is_not_global() -> None:
-    """Compact lbs. labels are allowed only on routes that explicitly preserve them."""
+def test_classify_lbs_is_globally_preserved_compact_weight_unit() -> None:
+    """Compact lbs. labels are intentionally preserved across routes."""
     trade_result = classify(_mk("{{W|$50}} | {{K|123/200 lbs.}}", route="TradeScreenUpdateTotalsTranslationPatch"))
-    inventory_result = classify(_mk("123/200 lbs.", route="InventoryAndEquipmentStatusScreenTranslationPatch"))
+    japanese_weight_result = classify(_mk("\u91cd\u91cf\uff1a 1 lbs.", route="DescriptionLongDescriptionPatch"))
+    english_weight_result = classify(_mk("Weight: 1 lbs.", route="DescriptionShortDescriptionPatch"))
+    exact_result = classify(_mk("lbs.", route="<no-context>"))
     assert trade_result.classification == TriageClassification.PRESERVED_ENGLISH
-    assert inventory_result.classification == TriageClassification.LOGIC_REQUIRED
+    assert japanese_weight_result.classification == TriageClassification.PRESERVED_ENGLISH
+    assert english_weight_result.classification == TriageClassification.LOGIC_REQUIRED
+    assert exact_result.classification == TriageClassification.PRESERVED_ENGLISH
 
 
 def test_classify_numeric_stat_line() -> None:

--- a/scripts/tests/test_triage_integration.py
+++ b/scripts/tests/test_triage_integration.py
@@ -347,9 +347,12 @@ def test_cli_classifies_preserved_english_separately(tmp_path: Path) -> None:
     assert result == 0
 
     data = json.loads(out.read_text(encoding="utf-8"))
-    assert data["summary"]["preserved_english"] == 1
-    assert data["summary"]["logic_required"] == 1
-    assert [entry["text"] for entry in data["by_classification"]["preserved_english"]] == ["STR"]
+    assert data["summary"]["preserved_english"] == 2
+    assert data["summary"]["logic_required"] == 0
+    assert [entry["text"] for entry in data["by_classification"]["preserved_english"]] == [
+        "STR",
+        "123/200 lbs.",
+    ]
 
 
 def test_module_cli_classify_returns_error_when_output_parent_cannot_be_created(tmp_path: Path) -> None:

--- a/scripts/triage/classifier.py
+++ b/scripts/triage/classifier.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 _TRAILING_WHITESPACE = re.compile(r"\s+$")
 _LEADING_WHITESPACE = re.compile(r"^\s+(?!\s*\{\{)")
 _JAPANESE_CHARS = re.compile(r"[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]")
+_ASCII_LETTERS = re.compile(r"[A-Za-z]")
 _EMBEDDED_NUMBER = re.compile(r"(?<!\.)\b-?\d+\b(?!\.)")
 _STAT_LINE = re.compile(r"\d+/\d+")
 _DRAM_PATTERN = re.compile(r"\d+\s+drams?\s+of\s+", re.IGNORECASE)
@@ -55,6 +56,7 @@ def classify(entry: LogEntry) -> TriageResult:
         _classify_sink_observe,
         _classify_final_output_probe,
         _classify_fragment,
+        _classify_lbs_only_english_text,
         _classify_japanese_text,
         _classify_no_pattern,
         _classify_slot_text,
@@ -125,6 +127,23 @@ def _classify_fragment(entry: LogEntry) -> TriageResult | None:
             reason="Fragment: leading whitespace indicates string concatenation suffix",
         )
     return None
+
+
+def _classify_lbs_only_english_text(entry: LogEntry) -> TriageResult | None:
+    """Keep the compact lbs. unit when it is the only remaining English token."""
+    if "lbs." not in entry.text:
+        return None
+
+    without_lbs = entry.text.replace("lbs.", "")
+    if _ASCII_LETTERS.search(without_lbs):
+        return None
+
+    return TriageResult(
+        entry=entry,
+        classification=TriageClassification.PRESERVED_ENGLISH,
+        reason="Compact weight unit 'lbs.' is intentionally preserved in English",
+        slot_evidence=["lbs."],
+    )
 
 
 def _classify_japanese_text(entry: LogEntry) -> TriageResult | None:

--- a/scripts/triage/preserved_english_policy.json
+++ b/scripts/triage/preserved_english_policy.json
@@ -66,6 +66,17 @@
       ]
     },
     {
+      "id": "compact_weight_unit_lbs",
+      "category": "allowed_english_token",
+      "reason": "The compact weight unit lbs. is intentionally kept in English across UI and description routes.",
+      "texts": [
+        "lbs."
+      ],
+      "protected_tokens": [
+        "lbs."
+      ]
+    },
+    {
       "id": "trade_totals_compact_weight_unit",
       "category": "allowed_english_by_route",
       "reason": "Trade total labels intentionally keep the compact lbs. unit while translating drams separately.",


### PR DESCRIPTION
## Summary
- Add runtime owner-route cache registration and ability bar suffix miss suppression.
- Expand cooking/description/world-mod coverage, preserve `lbs.` as an English unit, and classify it in triage without masking other English.
- Fix journal notification markup drift and add owner-level `DynamicTextProbe` semantic drift diagnostics.

## Issues
- Closes #469
- Part of #470
- Part of #472
- Closes #474
- Related #466, #468

## Verification
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~AbilityBarButtonTextTranslationPatchTests|FullyQualifiedName~WorldModsTextTranslatorTests|FullyQualifiedName~DescriptionTextTranslatorTests|FullyQualifiedName~DescriptionLongDescriptionPatchTests|FullyQualifiedName~InventoryLineTranslationPatchTests|FullyQualifiedName~InventoryAndEquipmentStatusScreenTranslationPatchTests|FullyQualifiedName~PopupTranslationPatchTests.Prefix_JournalNotification|FullyQualifiedName~CookingEffectFragmentTranslatorTests|FullyQualifiedName~CookingEffectTranslationPatchTests|FullyQualifiedName~TargetMethodResolutionTests.TargetMethods_ResolveExpectedOverloads"`
- `ruff check scripts/`
- `uv run pytest scripts/tests/test_triage_classifier.py scripts/tests/test_preserved_english_policy.py`
- `python3.12 scripts/check_translation_tokens.py Mods/QudJP/Localization`
- `python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts`
- `python3.12 scripts/check_glossary_consistency.py Mods/QudJP/Localization`
- `python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json`
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- `python3.12 scripts/sync_mod.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 料理効果や「Offhand Attack Chance」など、翻訳対応パターンを追加しました。
  * トニック使用時の日本語ローカライズ文言を追加しました。

* **改善**
  * マークアップのセマンティック解析を導入し、翻訳出力の監視と診断情報を強化しました。
  * 重量表記の扱いを統一し、英語の「lbs.」保護を導入しました。
  * ジャーナル通知の翻訳後処理を改善し不整合の除去を強化しました。

* **テスト**
  * 多数の単体テストを追加・拡充して翻訳動作とログ出力を検証しました。

* **ドキュメント**
  * 構造検索の利用を含む作業手順ガイドを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->