### PR TITLE
[codex] Add QudJP agent workflow recipes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,18 +25,20 @@ QudJP is the Japanese localization mod for Caves of Qud `2.0.4`. The repo contai
   wrappers, assignments, or attributes matter. Prefer `just sg-cs
   'Popup.Show($$$ARGS)'` for common C# searches; plain `rg` is still fine for
   literal text, symbol names, and file discovery.
+- Prefer `just` recipes for routine validation so local runs match the repo task runner.
+  Raw commands below document what the recipes execute.
 - Core commands:
 
 ```bash
-dotnet build Mods/QudJP/Assemblies/QudJP.csproj
-dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1
-dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2
-ruff check scripts/
-uv run pytest scripts/tests/
-python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts
-python3.12 scripts/check_glossary_consistency.py Mods/QudJP/Localization
-python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
-python3.12 scripts/sync_mod.py
+just build
+just test-l1
+just test-l2
+just test-l2g
+just python-check
+just python-test
+just localization-check
+just translation-token-check
+just sync-mod
 ```
 
 - Decompiled game source lives in `~/dev/coq-decompiled_stable/` and must never be committed.

--- a/justfile
+++ b/justfile
@@ -15,6 +15,10 @@ test-l1:
 test-l2:
   dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2
 
+# Run C# L2 tests that require the game DLL reference.
+test-l2g:
+  dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2G
+
 # Run Python static checks.
 python-check:
   ruff check scripts/
@@ -29,8 +33,16 @@ localization-check:
   python3.12 scripts/check_glossary_consistency.py Mods/QudJP/Localization
   python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
 
+# Check placeholder and markup-token parity in JSON localization assets.
+translation-token-check:
+  python3.12 scripts/check_translation_tokens.py Mods/QudJP/Localization
+
+# Sync the built mod into the local game install.
+sync-mod:
+  python3.12 scripts/sync_mod.py
+
 # Run the broad local verification gate.
-check: build test-l1 test-l2 python-check python-test localization-check
+check: build test-l1 test-l2 test-l2g python-check python-test localization-check translation-token-check
 
 # Verify agent-loop tools and dotfiles script availability.
 tool-check:


### PR DESCRIPTION
## Summary
- Prefer `just` recipes in `AGENTS.md` for routine QudJP validation
- Add missing task-runner recipes for L2G tests, translation token checks, and local mod sync
- Include L2G and translation token checks in the broad `just check` gate

## Validation
- `python3 /Users/toarupen/Dev/dotfiles/home/.codex/skills/agents-md-best-practices/scripts/agents_md_tool.py audit --root . --require-why-what-how`
- `just --list`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * コマンド実行のドキュメントが更新され、推奨される呼び出し方法が統一されました。

* **新機能**
  * 新しいテスト検証タスクが追加されました。
  * ローカリゼーション検証パイプラインが強化されました。
  * モッド同期機能が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->