### PR TITLE
[codex] Document Workshop shipping skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ QudJP is the Japanese localization mod for Caves of Qud `2.0.4`. The repo contai
   - workflow rules and operating constraints: `docs/RULES.md`
   - runtime evidence: fresh logs under `~/Library/Logs/Freehold Games/CavesOfQud/`
   - Steam Workshop release procedure: `docs/release.md`
+    - Codex local workflow shortcut: `~/.codex/skills/ship-steam-workshop/SKILL.md`
 
 ## How
 


### PR DESCRIPTION
## Summary
- Add a root AGENTS.md pointer to the local Codex Steam Workshop shipping skill.
- Keep docs/release.md as the source of truth while making the local workflow discoverable for future agents.

## Validation
- python3 /Users/sankenbisha/.codex/skills/agents-md-best-practices/scripts/agents_md_tool.py audit --root .

## Notes
- The local skill itself lives outside this repository at ~/.codex/skills/ship-steam-workshop/SKILL.md and is not part of this PR.