### PR TITLE
[codex] Add release note fragment automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -39,6 +41,13 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+
+      - name: Check release-note fragment
+        if: github.event_name == 'pull_request'
+        run: >
+          python scripts/release_notes.py check-fragment
+          --base-ref "${{ github.event.pull_request.base.sha }}"
+          --head-ref "${{ github.event.pull_request.head.sha }}"
 
       - name: Install ast-grep
         run: npm install -g @ast-grep/cli

--- a/docs/release-notes/unreleased/README.md
+++ b/docs/release-notes/unreleased/README.md
@@ -1,0 +1,23 @@
+# Unreleased Release Notes
+
+Add one markdown fragment here when a PR changes user-visible localization.
+
+Fragments use Keep a Changelog section headings:
+
+```markdown
+### Changed
+
+- Improve Japanese text in the trade and conversation UI.
+```
+
+Supported sections are:
+
+- `Added`
+- `Changed`
+- `Fixed`
+- `Removed`
+- `Deprecated`
+- `Security`
+
+Write bullets for Workshop users. Lead with visible translation, UI, runtime,
+packaging, or known-issue impact rather than internal class names.

--- a/docs/release-notes/unreleased/README.md
+++ b/docs/release-notes/unreleased/README.md
@@ -1,6 +1,6 @@
 # Unreleased Release Notes
 
-Add one markdown fragment here when a PR changes user-visible localization.
+Add at least one markdown fragment here when a PR changes user-visible localization.
 
 Fragments use Keep a Changelog section headings:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -81,6 +81,38 @@ python3.12 scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-ba
 python3.12 scripts/build_release.py
 ```
 
+## Release Notes
+
+Localization PRs that change `Mods/QudJP/Localization/` must include at least
+one release-note fragment under `docs/release-notes/unreleased/*.md`. CI checks
+this on pull requests.
+
+Fragments use Keep a Changelog section headings and user-facing bullets:
+
+```markdown
+### Changed
+
+- Improve Japanese text in the trade and conversation UI.
+```
+
+Before release, render the fragments into drafts for `CHANGELOG.md` and the
+Steam Workshop changenote:
+
+```bash
+git rev-parse --short=12 HEAD
+python3.12 scripts/release_notes.py render \
+  --version 0.1.0 \
+  --git-hash <short-git-hash> \
+  --date YYYY-MM-DD \
+  --changelog-output /tmp/qudjp-changelog-entry.md \
+  --workshop-output /tmp/qudjp-workshop-changenote.txt
+```
+
+Review `/tmp/qudjp-changelog-entry.md`, copy it into `CHANGELOG.md`, and use
+`/tmp/qudjp-workshop-changenote.txt` as the `build_workshop_upload.py`
+`--changenote-file`. Do not publish to Steam until the upload gate below is
+explicitly confirmed.
+
 Spot-check the release ZIP:
 
 ```bash

--- a/docs/release.md
+++ b/docs/release.md
@@ -153,14 +153,12 @@ PY
 
 ## Generate Workshop Upload Files
 
-Draft the Workshop changenote from the template. Put the short git hash next to
-the version, and summarize the accumulated commits as user-visible changes:
+Use the rendered Workshop changenote draft from the Release Notes step as the
+baseline. If needed, enrich it with commit-range context before upload:
 
 ```bash
 git describe --tags --abbrev=0
 git log --oneline <previous-tag>..HEAD
-git rev-parse --short=12 HEAD
-cp steam/changenote_template.txt /tmp/qudjp-workshop-changenote.txt
 $EDITOR /tmp/qudjp-workshop-changenote.txt
 ```
 

--- a/justfile
+++ b/justfile
@@ -37,6 +37,14 @@ localization-check:
 translation-token-check:
   python3.12 scripts/check_translation_tokens.py Mods/QudJP/Localization
 
+# Require release-note fragments for localization changes.
+release-note-check base_ref="origin/main" head_ref="HEAD":
+  python3.12 scripts/release_notes.py check-fragment --base-ref "{{base_ref}}" --head-ref "{{head_ref}}"
+
+# Render release and Workshop changenote drafts from unreleased fragments.
+render-release-notes version git_hash date:
+  python3.12 scripts/release_notes.py render --version "{{version}}" --git-hash "{{git_hash}}" --date "{{date}}" --changelog-output /tmp/qudjp-changelog-entry.md --workshop-output /tmp/qudjp-workshop-changenote.txt
+
 # Sync the built mod into the local game install.
 sync-mod:
   python3.12 scripts/sync_mod.py

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -265,9 +265,10 @@ python scripts/sync_mod.py --dry-run
 `steamcmd` 用 VDF を生成します。Workshop item ID や title などの公開
 metadata は `steam/workshop_metadata.json`、Workshop description は
 `steam/workshop_description.ja.txt` を source of truth にします。Workshop
-changenote は `steam/changenote_template.txt` を一時ファイルにコピーし、
+changenote は `scripts/release_notes.py render` で
+`docs/release-notes/unreleased/*.md` から下書きを生成し、必要に応じて
 `git log --oneline <previous-tag>..HEAD` と
-`git rev-parse --short=12 HEAD` を見て埋めます。
+`git rev-parse --short=12 HEAD` で補足します。
 
 **使い方**:
 
@@ -294,6 +295,47 @@ steamcmd +login "$STEAM_USER" +workshop_build_item dist/workshop/workshop_item.v
 ```
 
 Steam credentials、2FA material、login script は repo に置かないでください。
+
+**終了コード**: 0 = 正常終了、1 = エラー
+
+---
+
+## release_notes.py
+
+`scripts/release_notes.py` は release-note fragment を検証し、release 時の
+`CHANGELOG.md` 用 entry と Steam Workshop changenote の下書きを生成します。
+`Mods/QudJP/Localization/` を変更する PR では
+`docs/release-notes/unreleased/*.md` の fragment が必要です。
+
+**fragment 例**:
+
+```markdown
+### Changed
+
+- Improve Japanese text in the trade and conversation UI.
+```
+
+**使い方**:
+
+```bash
+# Localization 差分に release-note fragment が含まれるか確認
+python3.12 scripts/release_notes.py check-fragment \
+  --base-ref origin/main \
+  --head-ref HEAD
+
+# CHANGELOG / Workshop changenote の下書きを生成
+python3.12 scripts/release_notes.py render \
+  --version 0.1.0 \
+  --git-hash "$(git rev-parse --short=12 HEAD)" \
+  --date YYYY-MM-DD \
+  --changelog-output /tmp/qudjp-changelog-entry.md \
+  --workshop-output /tmp/qudjp-workshop-changenote.txt
+```
+
+**出力**:
+
+- `/tmp/qudjp-changelog-entry.md`: `CHANGELOG.md` にコピーする release entry
+- `/tmp/qudjp-workshop-changenote.txt`: `build_workshop_upload.py --changenote-file` に渡す changenote
 
 **終了コード**: 0 = 正常終了、1 = エラー
 

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -56,8 +56,7 @@ def check_fragment_requirement(changed_files: list[str], *, fragments_dir: Path 
         return
     if not changed_fragment_paths:
         msg = (
-            "Localization changes require a release-note fragment under "
-            "docs/release-notes/unreleased/*.md."
+            f"Localization changes require a release-note fragment under {fragments_dir}/*.md."
         )
         raise ReleaseNoteError(msg)
     _validate_changed_fragments(changed_fragment_paths)

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,0 +1,236 @@
+"""Validate and render QudJP release-note fragments."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Self
+
+FRAGMENTS_DIR = Path("docs/release-notes/unreleased")
+LOCALIZATION_PREFIX = "Mods/QudJP/Localization/"
+FRAGMENT_PREFIX = "docs/release-notes/unreleased/"
+SECTION_ORDER = ("Added", "Changed", "Fixed", "Removed", "Deprecated", "Security")
+
+
+class ReleaseNoteError(ValueError):
+    """Raised when release-note fragments are missing or malformed."""
+
+
+@dataclass(frozen=True)
+class ReleaseNoteFragments:
+    """Grouped release-note bullets."""
+
+    sections: dict[str, list[str]] = field(default_factory=dict)
+
+    def has_entries(self) -> bool:
+        """Return whether any release-note bullet was collected."""
+        return any(self.sections.values())
+
+
+def _is_fragment_path(path: str) -> bool:
+    return path.startswith(FRAGMENT_PREFIX) and path.endswith(".md") and not path.endswith("/README.md")
+
+
+def _is_localization_path(path: str) -> bool:
+    return path.startswith(LOCALIZATION_PREFIX)
+
+
+def check_fragment_requirement(changed_files: list[str], *, fragments_dir: Path = FRAGMENTS_DIR) -> None:
+    """Require an unreleased fragment when localization assets change."""
+    has_localization_change = any(_is_localization_path(path) for path in changed_files)
+    has_fragment_change = any(_is_fragment_path(path) for path in changed_files)
+    if not has_localization_change:
+        return
+    if not has_fragment_change:
+        msg = (
+            "Localization changes require a release-note fragment under "
+            "docs/release-notes/unreleased/*.md."
+        )
+        raise ReleaseNoteError(msg)
+    fragments = collect_fragments(fragments_dir)
+    if not fragments.has_entries():
+        msg = f"No release-note fragments found under {fragments_dir}"
+        raise ReleaseNoteError(msg)
+
+
+def collect_fragments(fragments_dir: Path = FRAGMENTS_DIR) -> ReleaseNoteFragments:
+    """Collect unreleased markdown fragments grouped by changelog section."""
+    sections: dict[str, list[str]] = {section: [] for section in SECTION_ORDER}
+    if not fragments_dir.exists():
+        return ReleaseNoteFragments(sections={})
+
+    for path in sorted(fragments_dir.glob("*.md")):
+        if path.name == "README.md":
+            continue
+        _collect_fragment(path, sections)
+
+    return ReleaseNoteFragments(sections={section: entries for section, entries in sections.items() if entries})
+
+
+def _collect_fragment(path: Path, sections: dict[str, list[str]]) -> None:
+    current_section: str | None = None
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("### "):
+            section = line.removeprefix("### ").strip()
+            if section not in SECTION_ORDER:
+                msg = f"{path}:{line_number}: unsupported release-note section: {section}"
+                raise ReleaseNoteError(msg)
+            current_section = section
+            continue
+        if line.startswith("- "):
+            if current_section is None:
+                msg = f"{path}:{line_number}: bullet appears before a section heading"
+                raise ReleaseNoteError(msg)
+            bullet = line.removeprefix("- ").strip()
+            if not bullet:
+                msg = f"{path}:{line_number}: empty release-note bullet"
+                raise ReleaseNoteError(msg)
+            sections[current_section].append(bullet)
+            continue
+        msg = f"{path}:{line_number}: expected a '### Section' heading or '- ' bullet"
+        raise ReleaseNoteError(msg)
+
+
+def render_changelog_entry(
+    *,
+    version: str,
+    release_date: str,
+    fragments: ReleaseNoteFragments,
+) -> str:
+    """Render a Keep a Changelog entry from collected fragments."""
+    lines = [f"## [{version}] - {release_date}", ""]
+    lines.extend(_render_section_lines(fragments))
+    return "\n".join(lines)
+
+
+def render_workshop_changenote(
+    *,
+    version: str,
+    git_hash: str,
+    fragments: ReleaseNoteFragments,
+) -> str:
+    """Render a Steam Workshop changenote from collected fragments."""
+    lines = [f"v{version} / {git_hash}", "", "更新内容:"]
+    for section in SECTION_ORDER:
+        lines.extend(f"- {bullet}" for bullet in fragments.sections.get(section, []))
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _render_section_lines(fragments: ReleaseNoteFragments) -> list[str]:
+    lines: list[str] = []
+    for section in SECTION_ORDER:
+        entries = fragments.sections.get(section, [])
+        if not entries:
+            continue
+        lines.extend([f"### {section}", ""])
+        lines.extend(f"- {entry}" for entry in entries)
+        lines.append("")
+    return lines
+
+
+def git_changed_files(base_ref: str, head_ref: str) -> list[str]:
+    """Return changed file paths between two git refs."""
+    git = shutil.which("git")
+    if git is None:
+        msg = "git executable not found"
+        raise ReleaseNoteError(msg)
+    result = subprocess.run(  # noqa: S603
+        [git, "diff", "--name-only", f"{base_ref}...{head_ref}"],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _write_output(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _require_fragments(fragments_dir: Path) -> ReleaseNoteFragments:
+    fragments = collect_fragments(fragments_dir)
+    if not fragments.has_entries():
+        msg = f"No release-note fragments found under {fragments_dir}"
+        raise ReleaseNoteError(msg)
+    return fragments
+
+
+class _Parser(argparse.ArgumentParser):
+    def error(self: Self, message: str) -> None:
+        """Print argparse errors without a traceback."""
+        raise ReleaseNoteError(message)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the release-notes CLI parser."""
+    parser = _Parser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check_parser = subparsers.add_parser(
+        "check-fragment",
+        help="Require an unreleased release-note fragment for localization changes.",
+    )
+    check_parser.add_argument("--base-ref", default="origin/main")
+    check_parser.add_argument("--head-ref", default="HEAD")
+    check_parser.add_argument("--fragments-dir", type=Path, default=FRAGMENTS_DIR)
+    check_parser.add_argument(
+        "--changed-file",
+        action="append",
+        default=[],
+        help="Changed file path. If provided, git diff is not invoked.",
+    )
+
+    render_parser = subparsers.add_parser(
+        "render",
+        help="Render changelog and Workshop changenote drafts from unreleased fragments.",
+    )
+    render_parser.add_argument("--version", required=True)
+    render_parser.add_argument("--git-hash", required=True)
+    render_parser.add_argument("--date", required=True)
+    render_parser.add_argument("--fragments-dir", type=Path, default=FRAGMENTS_DIR)
+    render_parser.add_argument("--changelog-output", type=Path)
+    render_parser.add_argument("--workshop-output", type=Path)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the release-notes CLI."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "check-fragment":
+            changed_files = args.changed_file or git_changed_files(args.base_ref, args.head_ref)
+            check_fragment_requirement(changed_files, fragments_dir=args.fragments_dir)
+            return 0
+        if args.command == "render":
+            fragments = _require_fragments(args.fragments_dir)
+            changelog = render_changelog_entry(version=args.version, release_date=args.date, fragments=fragments)
+            workshop = render_workshop_changenote(version=args.version, git_hash=args.git_hash, fragments=fragments)
+            if args.changelog_output is None and args.workshop_output is None:
+                print(changelog)  # noqa: T201
+                print("---")  # noqa: T201
+                print(workshop)  # noqa: T201
+                return 0
+            if args.changelog_output is not None:
+                _write_output(args.changelog_output, changelog)
+            if args.workshop_output is not None:
+                _write_output(args.workshop_output, workshop)
+            return 0
+    except ReleaseNoteError as exc:
+        print(f"error: {exc}", file=sys.stderr)  # noqa: T201
+        return 1
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -49,15 +49,18 @@ def check_fragment_requirement(changed_files: list[str], *, fragments_dir: Path 
     """Require an unreleased fragment when localization assets change."""
     has_localization_change = any(_is_localization_path(path) for path in changed_files)
     fragment_prefix = _fragment_prefix(fragments_dir)
-    has_fragment_change = any(_is_fragment_path(path, fragment_prefix=fragment_prefix) for path in changed_files)
+    changed_fragment_paths = [
+        Path(path) for path in changed_files if _is_fragment_path(path, fragment_prefix=fragment_prefix)
+    ]
     if not has_localization_change:
         return
-    if not has_fragment_change:
+    if not changed_fragment_paths:
         msg = (
             "Localization changes require a release-note fragment under "
             "docs/release-notes/unreleased/*.md."
         )
         raise ReleaseNoteError(msg)
+    _validate_changed_fragments(changed_fragment_paths)
     fragments = collect_fragments(fragments_dir)
     if not fragments.has_entries():
         msg = f"No release-note fragments found under {fragments_dir}"
@@ -78,7 +81,8 @@ def collect_fragments(fragments_dir: Path = FRAGMENTS_DIR) -> ReleaseNoteFragmen
     return ReleaseNoteFragments(sections={section: entries for section, entries in sections.items() if entries})
 
 
-def _collect_fragment(path: Path, sections: dict[str, list[str]]) -> None:
+def _collect_fragment(path: Path, sections: dict[str, list[str]]) -> int:
+    entry_count = 0
     current_section: str | None = None
     for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         line = raw_line.strip()
@@ -100,9 +104,23 @@ def _collect_fragment(path: Path, sections: dict[str, list[str]]) -> None:
                 msg = f"{path}:{line_number}: empty release-note bullet"
                 raise ReleaseNoteError(msg)
             sections[current_section].append(bullet)
+            entry_count += 1
             continue
         msg = f"{path}:{line_number}: expected a '### Section' heading or '- ' bullet"
         raise ReleaseNoteError(msg)
+    return entry_count
+
+
+def _validate_changed_fragments(paths: list[Path]) -> None:
+    """Validate the fragment files that were part of the change set."""
+    for path in paths:
+        if not path.is_file():
+            msg = f"Changed release-note fragment not found: {path}"
+            raise ReleaseNoteError(msg)
+        sections: dict[str, list[str]] = {section: [] for section in SECTION_ORDER}
+        if _collect_fragment(path, sections) == 0:
+            msg = f"Changed release-note fragment has no entries: {path}"
+            raise ReleaseNoteError(msg)
 
 
 def render_changelog_entry(

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -12,7 +12,6 @@ from typing import Self
 
 FRAGMENTS_DIR = Path("docs/release-notes/unreleased")
 LOCALIZATION_PREFIX = "Mods/QudJP/Localization/"
-FRAGMENT_PREFIX = "docs/release-notes/unreleased/"
 SECTION_ORDER = ("Added", "Changed", "Fixed", "Removed", "Deprecated", "Security")
 
 
@@ -31,18 +30,26 @@ class ReleaseNoteFragments:
         return any(self.sections.values())
 
 
-def _is_fragment_path(path: str) -> bool:
-    return path.startswith(FRAGMENT_PREFIX) and path.endswith(".md") and not path.endswith("/README.md")
+def _fragment_prefix(fragments_dir: Path) -> str:
+    """Return the changed-file prefix for a fragment directory."""
+    return f"{fragments_dir.as_posix().rstrip('/')}/"
+
+
+def _is_fragment_path(path: str, *, fragment_prefix: str) -> bool:
+    """Return whether a changed file path is an unreleased fragment."""
+    return path.startswith(fragment_prefix) and path.endswith(".md") and not path.endswith("/README.md")
 
 
 def _is_localization_path(path: str) -> bool:
+    """Return whether a changed file path is a localization asset."""
     return path.startswith(LOCALIZATION_PREFIX)
 
 
 def check_fragment_requirement(changed_files: list[str], *, fragments_dir: Path = FRAGMENTS_DIR) -> None:
     """Require an unreleased fragment when localization assets change."""
     has_localization_change = any(_is_localization_path(path) for path in changed_files)
-    has_fragment_change = any(_is_fragment_path(path) for path in changed_files)
+    fragment_prefix = _fragment_prefix(fragments_dir)
+    has_fragment_change = any(_is_fragment_path(path, fragment_prefix=fragment_prefix) for path in changed_files)
     if not has_localization_change:
         return
     if not has_fragment_change:
@@ -142,21 +149,28 @@ def git_changed_files(base_ref: str, head_ref: str) -> list[str]:
     if git is None:
         msg = "git executable not found"
         raise ReleaseNoteError(msg)
-    result = subprocess.run(  # noqa: S603
-        [git, "diff", "--name-only", f"{base_ref}...{head_ref}"],
-        check=True,
-        stdout=subprocess.PIPE,
-        text=True,
-    )
+    try:
+        result = subprocess.run(  # noqa: S603
+            [git, "diff", "--name-only", f"{base_ref}...{head_ref}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip() or str(exc)
+        msg = f"git diff failed for {base_ref}...{head_ref}: {detail}"
+        raise ReleaseNoteError(msg) from exc
     return [line for line in result.stdout.splitlines() if line]
 
 
 def _write_output(path: Path, text: str) -> None:
+    """Write rendered release-note output to a UTF-8 file."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
 
 
 def _require_fragments(fragments_dir: Path) -> ReleaseNoteFragments:
+    """Collect fragments and fail if no release-note entries exist."""
     fragments = collect_fragments(fragments_dir)
     if not fragments.has_entries():
         msg = f"No release-note fragments found under {fragments_dir}"

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -220,8 +220,8 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     """Run the release-notes CLI."""
     parser = build_parser()
-    args = parser.parse_args(argv)
     try:
+        args = parser.parse_args(argv)
         if args.command == "check-fragment":
             changed_files = args.changed_file or git_changed_files(args.base_ref, args.head_ref)
             check_fragment_requirement(changed_files, fragments_dir=args.fragments_dir)

--- a/scripts/tests/test_release_notes.py
+++ b/scripts/tests/test_release_notes.py
@@ -1,0 +1,137 @@
+"""Tests for release-note fragment validation and rendering."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.release_notes import (
+    ReleaseNoteError,
+    check_fragment_requirement,
+    collect_fragments,
+    render_changelog_entry,
+    render_workshop_changenote,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_collect_fragments_groups_keep_a_changelog_sections(tmp_path: Path) -> None:
+    """Unreleased fragments are grouped by Keep a Changelog section headings."""
+    fragments_dir = tmp_path / "docs" / "release-notes" / "unreleased"
+    fragments_dir.mkdir(parents=True)
+    (fragments_dir / "ui-update.md").write_text(
+        "### Added\n\n"
+        "- Add Japanese labels to the game summary screen.\n\n"
+        "### Fixed\n\n"
+        "- Fix untranslated popup button text.\n",
+        encoding="utf-8",
+    )
+
+    fragments = collect_fragments(fragments_dir)
+
+    assert fragments.sections == {
+        "Added": ["Add Japanese labels to the game summary screen."],
+        "Fixed": ["Fix untranslated popup button text."],
+    }
+
+
+def test_collect_fragments_rejects_bullets_before_heading(tmp_path: Path) -> None:
+    """Fragments must declare an explicit release-note section."""
+    fragments_dir = tmp_path / "docs" / "release-notes" / "unreleased"
+    fragments_dir.mkdir(parents=True)
+    (fragments_dir / "bad.md").write_text("- Missing section heading.\n", encoding="utf-8")
+
+    with pytest.raises(ReleaseNoteError, match="section heading"):
+        collect_fragments(fragments_dir)
+
+
+def test_render_changelog_entry_uses_version_date_and_sections(tmp_path: Path) -> None:
+    """Generated changelog entries are suitable for CHANGELOG.md insertion."""
+    fragments_dir = tmp_path / "docs" / "release-notes" / "unreleased"
+    fragments_dir.mkdir(parents=True)
+    (fragments_dir / "translations.md").write_text(
+        "### Changed\n\n- Improve conversation and trade UI translations.\n",
+        encoding="utf-8",
+    )
+
+    entry = render_changelog_entry(
+        version="0.1.0",
+        release_date="2026-05-04",
+        fragments=collect_fragments(fragments_dir),
+    )
+
+    assert (
+        entry
+        == "## [0.1.0] - 2026-05-04\n\n"
+        "### Changed\n\n"
+        "- Improve conversation and trade UI translations.\n"
+    )
+
+
+def test_render_workshop_changenote_is_user_facing(tmp_path: Path) -> None:
+    """Workshop changenotes include version, git hash, and user-visible bullets."""
+    fragments_dir = tmp_path / "docs" / "release-notes" / "unreleased"
+    fragments_dir.mkdir(parents=True)
+    (fragments_dir / "runtime.md").write_text(
+        "### Fixed\n\n- Fix untranslated sleep and game-summary messages.\n",
+        encoding="utf-8",
+    )
+
+    changenote = render_workshop_changenote(
+        version="0.1.0",
+        git_hash="abc1234def56",
+        fragments=collect_fragments(fragments_dir),
+    )
+
+    assert (
+        changenote
+        == "v0.1.0 / abc1234def56\n\n"
+        "更新内容:\n"
+        "- Fix untranslated sleep and game-summary messages.\n"
+    )
+
+
+def test_check_fragment_requirement_requires_fragment_for_localization_change() -> None:
+    """Localization updates must carry a release-note fragment."""
+    changed_files = [
+        "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+        "Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs",
+    ]
+
+    with pytest.raises(ReleaseNoteError, match="release-note fragment"):
+        check_fragment_requirement(changed_files)
+
+
+def test_check_fragment_requirement_passes_when_fragment_changes(tmp_path: Path) -> None:
+    """Localization updates are accepted when an unreleased fragment is present."""
+    fragments_dir = tmp_path / "docs" / "release-notes" / "unreleased"
+    fragments_dir.mkdir(parents=True)
+    (fragments_dir / "ui-popup.md").write_text("### Fixed\n\n- Fix popup translation coverage.\n", encoding="utf-8")
+    changed_files = [
+        "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+        "docs/release-notes/unreleased/ui-popup.md",
+    ]
+
+    check_fragment_requirement(changed_files, fragments_dir=fragments_dir)
+
+
+def test_check_fragment_requirement_rejects_malformed_fragment(tmp_path: Path) -> None:
+    """Localization PRs must include a parseable release-note fragment."""
+    fragments_dir = tmp_path / "docs" / "release-notes" / "unreleased"
+    fragments_dir.mkdir(parents=True)
+    (fragments_dir / "ui-popup.md").write_text("### Unknown\n\n- Fix popup translation coverage.\n", encoding="utf-8")
+    changed_files = [
+        "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+        "docs/release-notes/unreleased/ui-popup.md",
+    ]
+
+    with pytest.raises(ReleaseNoteError, match="unsupported release-note section"):
+        check_fragment_requirement(changed_files, fragments_dir=fragments_dir)
+
+
+def test_check_fragment_requirement_ignores_non_localization_changes() -> None:
+    """Non-localization PRs do not need release-note fragments."""
+    check_fragment_requirement(["scripts/release_notes.py"])

--- a/scripts/tests/test_release_notes.py
+++ b/scripts/tests/test_release_notes.py
@@ -145,6 +145,43 @@ def test_check_fragment_requirement_rejects_malformed_fragment(
         check_fragment_requirement(changed_files, fragments_dir=fragments_dir)
 
 
+def test_check_fragment_requirement_rejects_missing_changed_fragment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The changed fragment path itself must still exist."""
+    monkeypatch.chdir(tmp_path)
+    fragments_dir = Path("custom-release-notes")
+    fragments_dir.mkdir(parents=True)
+    (fragments_dir / "other.md").write_text("### Fixed\n\n- Fix another translation.\n", encoding="utf-8")
+    changed_files = [
+        "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+        "custom-release-notes/ui-popup.md",
+    ]
+
+    with pytest.raises(ReleaseNoteError, match="Changed release-note fragment not found"):
+        check_fragment_requirement(changed_files, fragments_dir=fragments_dir)
+
+
+def test_check_fragment_requirement_rejects_empty_changed_fragment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The changed fragment path must contain at least one release-note bullet."""
+    monkeypatch.chdir(tmp_path)
+    fragments_dir = Path("custom-release-notes")
+    fragments_dir.mkdir(parents=True)
+    (fragments_dir / "ui-popup.md").write_text("", encoding="utf-8")
+    (fragments_dir / "other.md").write_text("### Fixed\n\n- Fix another translation.\n", encoding="utf-8")
+    changed_files = [
+        "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+        "custom-release-notes/ui-popup.md",
+    ]
+
+    with pytest.raises(ReleaseNoteError, match="Changed release-note fragment has no entries"):
+        check_fragment_requirement(changed_files, fragments_dir=fragments_dir)
+
+
 def test_check_fragment_requirement_ignores_non_localization_changes() -> None:
     """Non-localization PRs do not need release-note fragments."""
     check_fragment_requirement(["scripts/release_notes.py"])
@@ -163,6 +200,7 @@ def test_git_changed_files_wraps_git_diff_errors(monkeypatch: pytest.MonkeyPatch
             stderr="fatal: bad revision 'bad...HEAD'",
         )
 
+    monkeypatch.setattr(release_notes.shutil, "which", lambda _name: "git")
     monkeypatch.setattr(release_notes.subprocess, "run", fake_run)
 
     with pytest.raises(ReleaseNoteError, match="git diff failed for bad\\.\\.\\.HEAD"):
@@ -176,3 +214,4 @@ def test_main_reports_parse_errors_without_traceback(capsys: pytest.CaptureFixtu
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "error: the following arguments are required" in captured.err
+    assert "Traceback" not in captured.err

--- a/scripts/tests/test_release_notes.py
+++ b/scripts/tests/test_release_notes.py
@@ -110,6 +110,14 @@ def test_check_fragment_requirement_requires_fragment_for_localization_change() 
         check_fragment_requirement(changed_files)
 
 
+def test_check_fragment_requirement_reports_configured_fragment_dir() -> None:
+    """Missing-fragment errors point at the configured fragment directory."""
+    changed_files = ["Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json"]
+
+    with pytest.raises(ReleaseNoteError, match=r"custom-release-notes/\*.md"):
+        check_fragment_requirement(changed_files, fragments_dir=Path("custom-release-notes"))
+
+
 def test_check_fragment_requirement_passes_when_fragment_changes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/scripts/tests/test_release_notes.py
+++ b/scripts/tests/test_release_notes.py
@@ -2,20 +2,24 @@
 
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
+from scripts import release_notes
 from scripts.release_notes import (
     ReleaseNoteError,
     check_fragment_requirement,
     collect_fragments,
+    git_changed_files,
     render_changelog_entry,
     render_workshop_changenote,
 )
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from collections.abc import Sequence
 
 
 def test_collect_fragments_groups_keep_a_changelog_sections(tmp_path: Path) -> None:
@@ -105,27 +109,35 @@ def test_check_fragment_requirement_requires_fragment_for_localization_change() 
         check_fragment_requirement(changed_files)
 
 
-def test_check_fragment_requirement_passes_when_fragment_changes(tmp_path: Path) -> None:
+def test_check_fragment_requirement_passes_when_fragment_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Localization updates are accepted when an unreleased fragment is present."""
-    fragments_dir = tmp_path / "docs" / "release-notes" / "unreleased"
+    monkeypatch.chdir(tmp_path)
+    fragments_dir = Path("custom-release-notes")
     fragments_dir.mkdir(parents=True)
     (fragments_dir / "ui-popup.md").write_text("### Fixed\n\n- Fix popup translation coverage.\n", encoding="utf-8")
     changed_files = [
         "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
-        "docs/release-notes/unreleased/ui-popup.md",
+        "custom-release-notes/ui-popup.md",
     ]
 
     check_fragment_requirement(changed_files, fragments_dir=fragments_dir)
 
 
-def test_check_fragment_requirement_rejects_malformed_fragment(tmp_path: Path) -> None:
+def test_check_fragment_requirement_rejects_malformed_fragment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Localization PRs must include a parseable release-note fragment."""
-    fragments_dir = tmp_path / "docs" / "release-notes" / "unreleased"
+    monkeypatch.chdir(tmp_path)
+    fragments_dir = Path("custom-release-notes")
     fragments_dir.mkdir(parents=True)
     (fragments_dir / "ui-popup.md").write_text("### Unknown\n\n- Fix popup translation coverage.\n", encoding="utf-8")
     changed_files = [
         "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
-        "docs/release-notes/unreleased/ui-popup.md",
+        "custom-release-notes/ui-popup.md",
     ]
 
     with pytest.raises(ReleaseNoteError, match="unsupported release-note section"):
@@ -135,3 +147,22 @@ def test_check_fragment_requirement_rejects_malformed_fragment(tmp_path: Path) -
 def test_check_fragment_requirement_ignores_non_localization_changes() -> None:
     """Non-localization PRs do not need release-note fragments."""
     check_fragment_requirement(["scripts/release_notes.py"])
+
+
+def test_git_changed_files_wraps_git_diff_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Git diff failures are reported as release-note CLI errors."""
+
+    def fake_run(
+        _args: Sequence[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(
+            returncode=128,
+            cmd="git diff --name-only bad...HEAD",
+            stderr="fatal: bad revision 'bad...HEAD'",
+        )
+
+    monkeypatch.setattr(release_notes.subprocess, "run", fake_run)
+
+    with pytest.raises(ReleaseNoteError, match="git diff failed for bad\\.\\.\\.HEAD"):
+        git_changed_files("bad", "HEAD")

--- a/scripts/tests/test_release_notes.py
+++ b/scripts/tests/test_release_notes.py
@@ -14,6 +14,7 @@ from scripts.release_notes import (
     check_fragment_requirement,
     collect_fragments,
     git_changed_files,
+    main,
     render_changelog_entry,
     render_workshop_changenote,
 )
@@ -166,3 +167,12 @@ def test_git_changed_files_wraps_git_diff_errors(monkeypatch: pytest.MonkeyPatch
 
     with pytest.raises(ReleaseNoteError, match="git diff failed for bad\\.\\.\\.HEAD"):
         git_changed_files("bad", "HEAD")
+
+
+def test_main_reports_parse_errors_without_traceback(capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI argument errors are normalized into the release-note error format."""
+    assert main(["render"]) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "error: the following arguments are required" in captured.err


### PR DESCRIPTION
## Summary
- Add `scripts/release_notes.py` to require release-note fragments for localization PRs and render release/Workshop changenote drafts from unreleased fragments.
- Add CI enforcement for localization changes and local `just` recipes for checking and rendering release notes.
- Document the fragment workflow in `docs/release.md`, `scripts/README.md`, and `docs/release-notes/unreleased/README.md`.

## Release workflow impact
- Translation updates now need a user-facing fragment under `docs/release-notes/unreleased/*.md`.
- Release prep can render `/tmp/qudjp-changelog-entry.md` and `/tmp/qudjp-workshop-changenote.txt` from accumulated fragments.
- Steam Workshop publish remains manual-gated; this PR does not automate `steamcmd` upload or any Steam-side state change.

## Validation
- `ruff check scripts/`
- `uv run pytest scripts/tests/` (`829 passed`)
- `uv run python scripts/release_notes.py check-fragment --base-ref origin/main --head-ref HEAD`
- `git diff --check`
- `npx secretlint .`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * リリースノート断片のテンプレートと記載ルール（Keep a Changelog 構成、見出し順）を追加。
  * リリース手順を更新し、断片からCHANGELOGおよびワークショップ用下書きを生成する流れと出力先を明記。
  * READMEに断片検証とレンダリング手順、例と出力仕様を追記。

* **Chores**
  * CIに断片検証ステップとフル履歴取得を導入。
  * ビルドレシピを追加し、断片検証と下書き生成を自動化。

* **Tests**
  * 断片収集・検証・レンダリングを検証するテスト群を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->