### PR TITLE
[codex] Document runtime owner tracing closeout

### DIFF
--- a/docs/reports/2026-05-04-issue-476-runtime-owner-tracing-closeout.md
+++ b/docs/reports/2026-05-04-issue-476-runtime-owner-tracing-closeout.md
@@ -1,0 +1,100 @@
+# Issue #476 runtime owner tracing closeout
+
+## Evidence
+
+Runtime log inspected:
+
+- `/Users/toarupen/Library/Logs/Freehold Games/CavesOfQud/Player.log`
+- mtime: `2026-05-04 00:55:36 JST`
+
+Command:
+
+```bash
+python3.12 scripts/triage_untranslated.py \
+  --log "$HOME/Library/Logs/Freehold Games/CavesOfQud/Player.log" \
+  --output .codex-artifacts/issue-476/triage-current.json
+```
+
+## Current actionable summary
+
+The issue was opened from an older triage state with `total=111`,
+`unresolved=103`, and `<no-context>` carrying `36 unresolved` entries plus
+other mixed outcomes.
+
+Current triage of the latest local `Player.log` reports:
+
+| classification | count |
+| --- | ---: |
+| total | 51 |
+| static_leaf | 0 |
+| route_patch | 0 |
+| logic_required | 0 |
+| preserved_english | 0 |
+| unexpected_translation_of_preserved_token | 0 |
+| runtime_noise | 41 |
+| unresolved | 10 |
+
+`<no-context>` no longer contains actionable unresolved entries. The only
+remaining `<no-context>` actionable-section rows are `20` `runtime_noise`
+entries:
+
+| class | count | disposition |
+| --- | ---: | --- |
+| already-localized Japanese re-entry | 17 | non-actionable runtime re-entry |
+| whitespace-only formatting | 2 | non-actionable formatting noise |
+| known flat Translator re-entry token `items` | 1 | non-dictionary action; owner tracing follow-up if it recurs with user-visible English |
+
+## Remaining unresolved routes
+
+The remaining `10` actionable unresolved rows are not `<no-context>`; they
+carry owner route context:
+
+| route | unresolved |
+| --- | ---: |
+| `DescriptionLongDescriptionPatch` | 1 |
+| `DescriptionShortDescriptionPatch` | 4 |
+| `TradeLineTranslationPatch` | 1 |
+| `TradeUiPopupTranslationPatch` | 4 |
+
+Those are owner-routed follow-up/fix targets, not undifferentiated
+`<no-context>` tracing failures. The current runtime-triage batch PR handles
+the description and popup/message examples covered by #470 and #472. The
+trade-line `{{w|bronze}}` row remains a separate owner-routed trade/display
+name question.
+
+## Phase F evidence
+
+Phase F observations are now kept separate from actionable untranslated triage:
+
+| Phase F bucket | count |
+| --- | ---: |
+| total | 1788 |
+| dynamic_text_probe | 542 |
+| sink_observe | 274 |
+| final_output_probe | 972 |
+| markup_semantic_drift | 111 |
+
+`markup_semantic_drift` is therefore reportable as its own Phase F bucket. The
+sample drift set contains:
+
+- `JournalPatternTranslator` unmatched Qud close on a journal location notice,
+  covered by the #472 journal markup-drift fix.
+- `UITextSkinTranslationPatch` loading/progress-map strings with
+  `empty_qud_wrapper` and `unclosed_qud_scope`, which are final-output evidence
+  rather than dictionary work.
+- popup button nested-wrapper rows such as `{{W|{{W|[y]}} {{y|はい}}}}`,
+  which remain Restore/ownership follow-up evidence for #459.
+
+## Closeout
+
+#476's original blocker was that `<no-context>` mixed true untranslated text,
+already-localized Japanese fragments, preserved tokens, display-name artifacts,
+and flat Translator re-entry noise into one manual bucket. Current triage no
+longer collapses those cases:
+
+- preserved/Japanese/blank/re-entry rows are non-actionable classifications,
+- Phase F final output and semantic drift are separated from actionable triage,
+- remaining actionable rows have owner routes.
+
+Fresher runtime smoke can still improve release evidence, but this issue's
+owner-tracing and triage-classification gate is satisfied by the current report.

--- a/docs/reports/2026-05-04-issue-476-runtime-owner-tracing-closeout.md
+++ b/docs/reports/2026-05-04-issue-476-runtime-owner-tracing-closeout.md
@@ -4,7 +4,7 @@
 
 Runtime log inspected:
 
-- `/Users/toarupen/Library/Logs/Freehold Games/CavesOfQud/Player.log`
+- `$HOME/Library/Logs/Freehold Games/CavesOfQud/Player.log`
 - mtime: `2026-05-04 00:55:36 JST`
 
 Command:
@@ -35,8 +35,9 @@ Current triage of the latest local `Player.log` reports:
 | unresolved | 10 |
 
 `<no-context>` no longer contains actionable unresolved entries. The only
-remaining `<no-context>` actionable-section rows are `20` `runtime_noise`
-entries:
+remaining `<no-context>` rows in the report's actionable section are `20`
+`runtime_noise` entries, which are retained there for auditability but have
+non-actionable dispositions:
 
 | class | count | disposition |
 | --- | ---: | --- |
@@ -87,7 +88,7 @@ sample drift set contains:
 
 ## Closeout
 
-#476's original blocker was that `<no-context>` mixed true untranslated text,
+Issue #476's original blocker was that `<no-context>` mixed true untranslated text,
 already-localized Japanese fragments, preserved tokens, display-name artifacts,
 and flat Translator re-entry noise into one manual bucket. Current triage no
 longer collapses those cases:


### PR DESCRIPTION
## Summary

- documents the current #476 runtime owner-tracing closeout evidence
- records the latest local Player.log mtime and triage command
- shows that actionable `<no-context>` unresolved rows are now gone
- records Phase F counts, including `markup_semantic_drift` as its own bucket

## Key Evidence

The latest local Player.log triage now reports:

- total actionable rows: 51
- runtime_noise: 41
- unresolved: 10
- `<no-context>` actionable unresolved rows: 0
- `<no-context>` remaining actionable-section rows: 20 runtime_noise rows only
- Phase F total: 1788
- Phase F markup_semantic_drift: 111

Remaining unresolved rows are route-owned (`Description*`, `TradeLineTranslationPatch`, `TradeUiPopupTranslationPatch`) rather than undifferentiated `<no-context>` tracing failures.

## Verification

- `python3.12 scripts/triage_untranslated.py --log "$HOME/Library/Logs/Freehold Games/CavesOfQud/Player.log" --output .codex-artifacts/issue-476/triage-current.json`
- `uv run pytest scripts/tests/test_triage_classifier.py scripts/tests/test_triage_integration.py scripts/tests/test_triage_log_parser.py -q` passed: 67 tests
- `just python-check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメンテーション**
  * ランタイムオーナートレーシングのクローズアウト報告を追加しました。現在のトリアージ合計（合計51、ランタイムノイズ41、未解決10）を記録し、未解決の事項（10件）の概要を提示しています。
  * アクション対象外のノイズと「Phase F」証拠群（合計1788、ドリフト111）を切り分け、分類完了の到達を報告します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->