### PR TITLE
[codex] Document runtime owner route rollup

### DIFF
--- a/docs/reports/2026-05-04-issue-468-runtime-owner-route-rollup.md
+++ b/docs/reports/2026-05-04-issue-468-runtime-owner-route-rollup.md
@@ -1,0 +1,72 @@
+# Issue #468 runtime owner-route roll-up
+
+## Evidence
+
+Runtime log inspected:
+
+- `$HOME/Library/Logs/Freehold Games/CavesOfQud/Player.log`
+- mtime: `2026-05-04 00:55:36 JST`
+
+Command:
+
+```bash
+python3.12 scripts/triage_untranslated.py \
+  --log "$HOME/Library/Logs/Freehold Games/CavesOfQud/Player.log" \
+  --output .codex-artifacts/issue-468/triage-current.json
+```
+
+## Delta From Issue Opening
+
+Issue #468 opened from the 2026-05-03 runtime snapshot:
+
+| metric | issue opening | current local triage |
+| --- | ---: | ---: |
+| actionable total | 111 | 51 |
+| logic_required | 4 | 0 |
+| unresolved | 107 | 10 |
+| actionable `<no-context>` unresolved | 36 | 0 |
+
+Current triage no longer reports undifferentiated owner gaps for the original
+high-volume buckets. The remaining unresolved rows are route-owned:
+
+| route | unresolved |
+| --- | ---: |
+| `DescriptionLongDescriptionPatch` | 1 |
+| `DescriptionShortDescriptionPatch` | 4 |
+| `TradeLineTranslationPatch` | 1 |
+| `TradeUiPopupTranslationPatch` | 4 |
+
+Those rows are follow-up fix targets, not missing route assignment.
+
+## Slice Status
+
+| slice | issue | owner route / disposition | status |
+| --- | ---: | --- | --- |
+| Ability bar suffix tokens | #469 | `AbilityBarButtonTextTranslationPatch`; missing-key noise suppressed for absent suffix leaves | closed |
+| Description/world-mod lines | #470 | `Description*`, `DescriptionTextTranslator`, `WorldModsTextTranslator`; multiline no-pattern re-entry resolved | closed |
+| Display-name object state strings | #471 | `GetDisplayNamePatch` / `GetDisplayNameProcessPatch`; sink remains observation-only | closeout in #486 |
+| Journal/popup/message notices | #472 | `JournalPatternTranslator`, popup/message producer patterns; markup drift fixed | closed |
+| Player status compact values | #473 | `PlayerStatusBarProducerTranslationPatch.*`; dynamic readouts classified as producer-route runtime evidence | closed |
+| Owner tracing / `<no-context>` cleanup | #476 | runtime noise and Phase F drift separated from actionable triage | closed |
+
+## Non-Goals Preserved
+
+- No generic sink route compensation was added.
+- Dynamic composed strings were not promoted as broad dictionary leaves.
+- `UITextSkinTranslationPatch` and `SinkPrereqSetDataTranslationPatch` remain
+  observation or prerequisite repair surfaces, not display-name owners.
+
+## Closeout
+
+The #468 parent gate is satisfied:
+
+- each original slice now has an owner route or documented preserve/noise
+  classification,
+- regression tests exist on the behavior-changing child slices,
+- current triage shows materially reduced noise and zero actionable
+  `<no-context>` unresolved entries,
+- remaining unresolved rows are route-owned follow-up work rather than owner
+  assignment failures.
+
+Fresh in-game smoke after future trade/description follow-ups can improve
+release evidence, but the #468 route-assignment tracker itself is complete.


### PR DESCRIPTION
## Summary

- Documents the #468 runtime owner-route roll-up.
- Records current Player.log triage deltas from the original #468 snapshot.
- Maps each child slice to its owner route or preserve/noise disposition.

## Stack

- Depends on #486, which documents and closes #471.
- Base branch is `codex/display-name-ownership-471`; after #486 merges, rebase/retarget this PR to `main`.

## Verification

- `python3.12 scripts/triage_untranslated.py --log "$HOME/Library/Logs/Freehold Games/CavesOfQud/Player.log" --output .codex-artifacts/issue-468/triage-current.json`
- `git diff --check`

Closes #468
