### PR TITLE
[codex] Fix Control Mapping category grouping

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyKeybindsScreenTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyKeybindsScreenTargets.cs
@@ -35,15 +35,15 @@ internal sealed class DummyKeybindsScreenTarget
 
         menuItems.Add(new DummyKeybindCategoryRowTarget
         {
-            CategoryId = "General",
-            CategoryDescription = "General",
+            CategoryId = "Basic Move / Attack",
+            CategoryDescription = "Basic Move / Attack",
         });
         menuItems.Add(new DummyKeybindDataRowTarget
         {
-            CategoryId = "General",
+            CategoryId = "Basic Move / Attack",
             KeyId = "InteractNearby",
             KeyDescription = "Interact Nearby",
-            SearchWords = "General Interact Nearby",
+            SearchWords = "Basic Move / Attack Interact Nearby",
             Bind1 = "Ctrl+Space",
         });
     }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
@@ -8,6 +8,24 @@ namespace QudJP.Tests.L1;
 [Category("L1")]
 public sealed class LocalizationCoverageTests
 {
+    private static readonly HashSet<string> CommandCategoryKeys = new(StringComparer.Ordinal)
+    {
+        "Ability Bar",
+        "Advanced Adventuring",
+        "Adventuring",
+        "Basic Move / Attack",
+        "Character Creation",
+        "Character Sheet",
+        "Debug",
+        "Menus",
+        "Mouse-specific",
+        "Shortcuts to Character Sheet",
+        "System",
+        "Targeting",
+        "Trade",
+        "UI",
+    };
+
     private string localizationRoot = null!;
 
     [SetUp]
@@ -54,6 +72,30 @@ public sealed class LocalizationCoverageTests
             Assert.That(skillNames.Except(skillNameKeys).ToArray(), Is.Empty, "Missing skill-name entries in skills dictionaries.");
             Assert.That(powerNames.Except(skillNameKeys).ToArray(), Is.Empty, "Missing power-name entries in skills dictionaries.");
         });
+    }
+
+    [Test]
+    public void CommandsXml_CommandCategoriesRemainStableGroupingKeys()
+    {
+        var commandsDocument = XDocument.Load(Path.Combine(localizationRoot, "Commands.jp.xml"));
+        var categoryValues = commandsDocument.Root!
+            .Elements("command")
+            .Select(element => element.Attribute("Category")?.Value)
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Cast<string>()
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        var unsupportedCategories = categoryValues
+            .Where(category => !CommandCategoryKeys.Contains(category))
+            .ToArray();
+
+        Assert.That(
+            unsupportedCategories,
+            Is.Empty,
+            "Command Category is a stable grouping key consumed by Control Mapping. "
+            + "Translate category labels at the UI route instead of localizing Category attributes.");
     }
 
     [Test]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
@@ -26,6 +26,24 @@ public sealed class LocalizationCoverageTests
         "UI",
     };
 
+    private static readonly IReadOnlyDictionary<string, string> CommandCategoryLabels = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["Ability Bar"] = "アビリティバー",
+        ["Advanced Adventuring"] = "高度な冒険操作",
+        ["Adventuring"] = "冒険操作",
+        ["Basic Move / Attack"] = "基本移動／攻撃",
+        ["Character Creation"] = "キャラクター作成",
+        ["Character Sheet"] = "キャラクターシート",
+        ["Debug"] = "デバッグ",
+        ["Menus"] = "メニュー操作",
+        ["Mouse-specific"] = "マウス操作",
+        ["Shortcuts to Character Sheet"] = "キャラクターシートショートカット",
+        ["System"] = "システム",
+        ["Targeting"] = "ターゲティング",
+        ["Trade"] = "取引",
+        ["UI"] = "UI",
+    };
+
     private string localizationRoot = null!;
 
     [SetUp]
@@ -96,6 +114,75 @@ public sealed class LocalizationCoverageTests
             Is.Empty,
             "Command Category is a stable grouping key consumed by Control Mapping. "
             + "Translate category labels at the UI route instead of localizing Category attributes.");
+    }
+
+    [Test]
+    public void TranslateCommandCategoryLabel_CoversStableCategoryKeysAndFallbacks()
+    {
+        const string route = "Qud.UI.KeybindsScreen:category";
+        const string family = "ui:keybind-category";
+
+        Assert.Multiple(() =>
+        {
+            foreach (var (source, expected) in CommandCategoryLabels)
+            {
+                Assert.That(
+                    UiBindingTranslationHelpers.TranslateCommandCategoryLabel(source, route, family),
+                    Is.EqualTo(expected),
+                    source);
+
+                Assert.That(
+                    UiBindingTranslationHelpers.TranslateCommandCategoryLabel(source.ToUpperInvariant(), route, family),
+                    Is.EqualTo(expected),
+                    source.ToUpperInvariant());
+            }
+
+            Assert.That(UiBindingTranslationHelpers.TranslateCommandCategoryLabel("Unknown Category", route, family), Is.EqualTo("Unknown Category"));
+            Assert.That(UiBindingTranslationHelpers.TranslateCommandCategoryLabel("{{C|Basic Move / Attack}}", route, family), Is.EqualTo("{{C|Basic Move / Attack}}"));
+            Assert.That(UiBindingTranslationHelpers.TranslateCommandCategoryLabel("\x01Basic Move / Attack", route, family), Is.EqualTo("\x01Basic Move / Attack"));
+            Assert.That(UiBindingTranslationHelpers.TranslateCommandCategoryLabel(string.Empty, route, family), Is.EqualTo(string.Empty));
+            Assert.That(UiBindingTranslationHelpers.TranslateCommandCategoryLabel(null!, route, family), Is.Null);
+        });
+    }
+
+    [Test]
+    public void CommandsXml_DirectionalBindingsRemainAlignedWithCommandIds()
+    {
+        var commandsDocument = XDocument.Load(Path.Combine(localizationRoot, "Commands.jp.xml"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                CommandElement(commandsDocument, "CmdAttackU")
+                    .Elements("keyboardBind")
+                    .Any(static element =>
+                        string.Equals(element.Attribute("Modifier")?.Value, "ctrl,shift", StringComparison.Ordinal)
+                        && string.Equals(element.Attribute("Key")?.Value, "comma", StringComparison.Ordinal)),
+                Is.True,
+                "CmdAttackU should keep the upstream Shift+, vertical-up bind.");
+
+            Assert.That(
+                CommandElement(commandsDocument, "CmdAttackD")
+                    .Elements("keyboardBind")
+                    .Any(static element =>
+                        string.Equals(element.Attribute("Modifier")?.Value, "ctrl,shift", StringComparison.Ordinal)
+                        && string.Equals(element.Attribute("Key")?.Value, "period", StringComparison.Ordinal)),
+                Is.True,
+                "CmdAttackD should keep the upstream Shift+. vertical-down bind.");
+
+            Assert.That(
+                CommandElement(commandsDocument, "UI:DetailsNavigate/left").Attribute("CanShareBindsWith")?.Value,
+                Is.EqualTo("IndicateDirection/left,CmdMoveW"));
+            Assert.That(
+                CommandElement(commandsDocument, "UI:DetailsNavigate/left").Attribute("UpgradeFrom")?.Value,
+                Is.EqualTo("CmdMoveW"));
+            Assert.That(
+                CommandElement(commandsDocument, "UI:DetailsNavigate/right").Attribute("CanShareBindsWith")?.Value,
+                Is.EqualTo("IndicateDirection/right,CmdMoveE"));
+            Assert.That(
+                CommandElement(commandsDocument, "UI:DetailsNavigate/right").Attribute("UpgradeFrom")?.Value,
+                Is.EqualTo("CmdMoveE"));
+        });
     }
 
     [Test]
@@ -1115,6 +1202,13 @@ public sealed class LocalizationCoverageTests
     private static bool IsAsciiDigits(string value)
     {
         return value.Length > 0 && value.All(static ch => ch is >= '0' and <= '9');
+    }
+
+    private static XElement CommandElement(XDocument document, string id)
+    {
+        return document.Root!
+            .Elements("command")
+            .Single(element => string.Equals(element.Attribute("ID")?.Value, id, StringComparison.Ordinal));
     }
 
     [Test]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/KeybindsScreenTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/KeybindsScreenTranslationPatchTests.cs
@@ -12,7 +12,6 @@ public sealed partial class Issue201StatusScreensBatch2Tests
         WriteDictionary(
             ("Configuring Controller:", "設定中のコントローラー:"),
             ("Keyboard && Mouse", "キーボード＆マウス"),
-            ("General", "一般"),
             ("Interact Nearby", "近くと交互作用"),
             ("remove keybind", "キーバインド削除"),
             ("Delete", "削除"),
@@ -29,11 +28,17 @@ public sealed partial class Issue201StatusScreensBatch2Tests
 
             var screen = new DummyKeybindsScreenTarget();
             screen.QueryKeybinds();
+            var categoryRow = screen.menuItems.OfType<DummyKeybindCategoryRowTarget>().Single();
+            var dataRow = screen.menuItems.OfType<DummyKeybindDataRowTarget>().Single();
 
             Assert.Multiple(() =>
             {
                 Assert.That(screen.OriginalExecuted, Is.True);
                 Assert.That(screen.inputTypeText.Text, Is.EqualTo("{{C|設定中のコントローラー:}} {{c|キーボード＆マウス}}"));
+                Assert.That(categoryRow.CategoryId, Is.EqualTo("Basic Move / Attack"));
+                Assert.That(categoryRow.CategoryDescription, Is.EqualTo("基本移動／攻撃"));
+                Assert.That(dataRow.CategoryId, Is.EqualTo("Basic Move / Attack"));
+                Assert.That(dataRow.KeyDescription, Is.EqualTo("近くと交互作用"));
                 Assert.That(DummyKeybindsScreenTarget.REMOVE_BIND.Description, Is.EqualTo("キーバインド削除"));
                 Assert.That(DummyKeybindsScreenTarget.RESTORE_DEFAULTS.Description, Is.EqualTo("デフォルトに戻す"));
                 Assert.That(

--- a/Mods/QudJP/Assemblies/src/Patches/KeybindRowTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/KeybindRowTranslationPatch.cs
@@ -151,7 +151,10 @@ public static class KeybindRowTranslationPatch
         if (rawCategoryDescription is null) { rawCategoryDescription = string.Empty; }
         var categorySource = rawCategoryDescription.ToUpperInvariant();
         var categoryRoute = ObservabilityHelpers.ComposeContext(Context, "field=categoryDescription");
-        var translatedCategory = TranslateVisibleText(categorySource, categoryRoute, "KeybindRow.CategoryDescription");
+        var translatedCategory = UiBindingTranslationHelpers.TranslateCommandCategoryLabel(
+            categorySource,
+            categoryRoute,
+            "KeybindRow.CategoryDescription");
         SetAppliedTranslatedText(
             GetMemberValue(instance, "categoryDescription"),
             "{{C|" + categorySource + "}}",

--- a/Mods/QudJP/Assemblies/src/Patches/KeybindsScreenTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/KeybindsScreenTranslationPatch.cs
@@ -109,7 +109,10 @@ public static class KeybindsScreenTranslationPatch
             if (!string.IsNullOrEmpty(categoryDescription))
             {
                 var route = ObservabilityHelpers.ComposeContext(Context, "field=CategoryDescription");
-                var translated = TranslateVisibleText(categoryDescription!, route, "KeybindsScreen.CategoryDescription");
+                var translated = UiBindingTranslationHelpers.TranslateCommandCategoryLabel(
+                    categoryDescription!,
+                    route,
+                    "KeybindsScreen.CategoryDescription");
                 SetMemberValue(item, "CategoryDescription", translated);
             }
 

--- a/Mods/QudJP/Assemblies/src/Patches/UiBindingTranslationHelpers.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/UiBindingTranslationHelpers.cs
@@ -1,10 +1,63 @@
 using System;
+using System.Collections.Generic;
 using HarmonyLib;
 
 namespace QudJP.Patches;
 
 internal static class UiBindingTranslationHelpers
 {
+    private static readonly IReadOnlyDictionary<string, string> CommandCategoryLabels =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["Ability Bar"] = "アビリティバー",
+            ["ABILITY BAR"] = "アビリティバー",
+            ["Advanced Adventuring"] = "高度な冒険操作",
+            ["ADVANCED ADVENTURING"] = "高度な冒険操作",
+            ["Adventuring"] = "冒険操作",
+            ["ADVENTURING"] = "冒険操作",
+            ["Basic Move / Attack"] = "基本移動／攻撃",
+            ["BASIC MOVE / ATTACK"] = "基本移動／攻撃",
+            ["Character Creation"] = "キャラクター作成",
+            ["CHARACTER CREATION"] = "キャラクター作成",
+            ["Character Sheet"] = "キャラクターシート",
+            ["CHARACTER SHEET"] = "キャラクターシート",
+            ["Debug"] = "デバッグ",
+            ["DEBUG"] = "デバッグ",
+            ["Menus"] = "メニュー操作",
+            ["MENUS"] = "メニュー操作",
+            ["Mouse-specific"] = "マウス操作",
+            ["MOUSE-SPECIFIC"] = "マウス操作",
+            ["Shortcuts to Character Sheet"] = "キャラクターシートショートカット",
+            ["SHORTCUTS TO CHARACTER SHEET"] = "キャラクターシートショートカット",
+            ["System"] = "システム",
+            ["SYSTEM"] = "システム",
+            ["Targeting"] = "ターゲティング",
+            ["TARGETING"] = "ターゲティング",
+            ["Trade"] = "取引",
+            ["TRADE"] = "取引",
+            ["UI"] = "UI",
+        };
+
+    public static string TranslateCommandCategoryLabel(string source, string route, string family)
+    {
+        if (string.IsNullOrEmpty(source))
+        {
+            return source;
+        }
+
+        if (!CommandCategoryLabels.TryGetValue(source, out var translated))
+        {
+            return TranslateVisibleText(source, route, family);
+        }
+
+        if (!string.Equals(translated, source, StringComparison.Ordinal))
+        {
+            DynamicTextObservability.RecordTransform(route, family, source, translated);
+        }
+
+        return translated;
+    }
+
     public static string TranslateVisibleText(string source, string route, string family)
     {
         if (string.IsNullOrEmpty(source))

--- a/Mods/QudJP/Localization/Commands.jp.xml
+++ b/Mods/QudJP/Localization/Commands.jp.xml
@@ -104,198 +104,198 @@
 
   
   
-  <command ID="CmdMoveNW" DisplayText="北西へ移動" Category="基本移動／攻撃" Layer="AdventureNav">
+  <command ID="CmdMoveNW" DisplayText="北西へ移動" Category="Basic Move / Attack" Layer="AdventureNav">
     <keyboardBind Key="numpad7" />
     <keyboardBind Modifier="shift" Key="upArrow" />
     <keyboardBind Key="y" Set="hjkl" />
   </command>
-  <command ID="CmdMoveN" DisplayText="北へ移動" Category="基本移動／攻撃" Layer="AdventureNav">
+  <command ID="CmdMoveN" DisplayText="北へ移動" Category="Basic Move / Attack" Layer="AdventureNav">
     <keyboardBind Key="numpad8" />
     <keyboardBind Key="upArrow" />
     <keyboardBind Key="k" Set="hjkl" />
   </command>
-  <command ID="CmdMoveNE" DisplayText="北東へ移動" Category="基本移動／攻撃" Layer="AdventureNav">
+  <command ID="CmdMoveNE" DisplayText="北東へ移動" Category="Basic Move / Attack" Layer="AdventureNav">
     <keyboardBind Key="numpad9" />
     <keyboardBind Modifier="shift" Key="rightArrow" />
     <keyboardBind Key="u" Set="hjkl" />
   </command>
-  <command ID="CmdMoveW" DisplayText="西へ移動" Category="基本移動／攻撃" Layer="AdventureNav">
+  <command ID="CmdMoveW" DisplayText="西へ移動" Category="Basic Move / Attack" Layer="AdventureNav">
     <keyboardBind Key="numpad4" />
     <keyboardBind Key="leftArrow" />
     <keyboardBind Key="h" Set="hjkl" />
   </command>
-  <command ID="CmdMoveE" DisplayText="東へ移動" Category="基本移動／攻撃" Layer="AdventureNav">
+  <command ID="CmdMoveE" DisplayText="東へ移動" Category="Basic Move / Attack" Layer="AdventureNav">
     <keyboardBind Key="numpad6" />
     <keyboardBind Key="rightArrow" />
     <keyboardBind Key="l" Set="hjkl" />
   </command>
-  <command ID="CmdMoveSW" DisplayText="南西へ移動" Category="基本移動／攻撃" Layer="AdventureNav">
+  <command ID="CmdMoveSW" DisplayText="南西へ移動" Category="Basic Move / Attack" Layer="AdventureNav">
     <keyboardBind Key="numpad1" />
     <keyboardBind Modifier="shift" Key="leftArrow" />
     <keyboardBind Key="b" Set="hjkl" />
   </command>
-  <command ID="CmdMoveS" DisplayText="南へ移動" Category="基本移動／攻撃" Layer="AdventureNav">
+  <command ID="CmdMoveS" DisplayText="南へ移動" Category="Basic Move / Attack" Layer="AdventureNav">
     <keyboardBind Key="numpad2" />
     <keyboardBind Key="downArrow" />
     <keyboardBind Key="j" Set="hjkl" />
   </command>
-  <command ID="CmdMoveSE" DisplayText="南東へ移動" Category="基本移動／攻撃" Layer="AdventureNav">
+  <command ID="CmdMoveSE" DisplayText="南東へ移動" Category="Basic Move / Attack" Layer="AdventureNav">
     <keyboardBind Key="numpad3" />
     <keyboardBind Modifier="shift" Key="downArrow" />
     <keyboardBind Key="n" Set="hjkl" />
   </command>
-  <command ID="CmdMoveU" DisplayText="上階へ移動" Category="基本移動／攻撃" Layer="AdventureNav" CanShareBindsWith="V Positive,V Negative">
+  <command ID="CmdMoveU" DisplayText="上階へ移動" Category="Basic Move / Attack" Layer="AdventureNav" CanShareBindsWith="V Positive,V Negative">
     <keyboardBind Key="numpadMinus" />
     <keyboardBind Modifier="shift" Key="comma" />
     <keyboardBind Key="s" />
     <gamepadBind Button="dpad/up" />
   </command>
-  <command ID="CmdMoveD" DisplayText="下階へ移動" Category="基本移動／攻撃" Layer="AdventureNav" CanShareBindsWith="V Positive,V Negative">
+  <command ID="CmdMoveD" DisplayText="下階へ移動" Category="Basic Move / Attack" Layer="AdventureNav" CanShareBindsWith="V Positive,V Negative">
     <keyboardBind Key="numpadPlus" />
     <keyboardBind Modifier="shift" Key="period" />
     <keyboardBind Key="d" />
     <gamepadBind Button="dpad/down" />
   </command>
-  <command ID="CmdMoveTo" DisplayText="指定マスへ移動" Category="基本移動／攻撃" Layer="Adventure" Auto="Down">
+  <command ID="CmdMoveTo" DisplayText="指定マスへ移動" Category="Basic Move / Attack" Layer="Adventure" Auto="Down">
     <keyboardBind Modifier="ctrl" Key="enter" />
   </command>
   
-  <command ID="CmdAttackNW" DisplayText="北西を強制攻撃" Category="基本移動／攻撃" Layer="Adventure">
+  <command ID="CmdAttackNW" DisplayText="北西を強制攻撃" Category="Basic Move / Attack" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="numpad7" />
     <keyboardBind Modifier="ctrl,shift" Key="upArrow" />
     <keyboardBind Modifier="ctrl" Key="y" Set="hjkl" />
   </command>
-  <command ID="CmdAttackN" DisplayText="北を強制攻撃" Category="基本移動／攻撃" Layer="Adventure">
+  <command ID="CmdAttackN" DisplayText="北を強制攻撃" Category="Basic Move / Attack" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="numpad8" />
     <keyboardBind Modifier="ctrl" Key="upArrow" />
     <keyboardBind Modifier="ctrl" Key="k" Set="hjkl" />
   </command>
-  <command ID="CmdAttackNE" DisplayText="北東を強制攻撃" Category="基本移動／攻撃" Layer="Adventure">
+  <command ID="CmdAttackNE" DisplayText="北東を強制攻撃" Category="Basic Move / Attack" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="numpad9" />
     <keyboardBind Modifier="ctrl,shift" Key="rightArrow" />
     <keyboardBind Modifier="ctrl" Key="u" Set="hjkl" />
   </command>
-  <command ID="CmdAttackW" DisplayText="西を強制攻撃" Category="基本移動／攻撃" Layer="Adventure">
+  <command ID="CmdAttackW" DisplayText="西を強制攻撃" Category="Basic Move / Attack" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="numpad4" />
     <keyboardBind Modifier="ctrl" Key="leftArrow" />
     <keyboardBind Modifier="ctrl" Key="h" Set="hjkl" />
   </command>
-  <command ID="CmdAttackE" DisplayText="東を強制攻撃" Category="基本移動／攻撃" Layer="Adventure">
+  <command ID="CmdAttackE" DisplayText="東を強制攻撃" Category="Basic Move / Attack" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="numpad6" />
     <keyboardBind Modifier="ctrl" Key="rightArrow" />
     <keyboardBind Modifier="ctrl" Key="l" Set="hjkl" />
   </command>
-  <command ID="CmdAttackSW" DisplayText="南西を強制攻撃" Category="基本移動／攻撃" Layer="Adventure">
+  <command ID="CmdAttackSW" DisplayText="南西を強制攻撃" Category="Basic Move / Attack" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="numpad1" />
     <keyboardBind Modifier="ctrl,shift" Key="leftArrow" />
     <keyboardBind Modifier="ctrl" Key="b" Set="hjkl" />
   </command>
-  <command ID="CmdAttackS" DisplayText="南を強制攻撃" Category="基本移動／攻撃" Layer="Adventure">
+  <command ID="CmdAttackS" DisplayText="南を強制攻撃" Category="Basic Move / Attack" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="numpad2" />
     <keyboardBind Modifier="ctrl" Key="downArrow" />
     <keyboardBind Modifier="ctrl" Key="j" Set="hjkl" />
   </command>
-  <command ID="CmdAttackSE" DisplayText="南東を強制攻撃" Category="基本移動／攻撃" Layer="Adventure">
+  <command ID="CmdAttackSE" DisplayText="南東を強制攻撃" Category="Basic Move / Attack" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="numpad3" />
     <keyboardBind Modifier="ctrl,shift" Key="downArrow" />
     <keyboardBind Modifier="ctrl" Key="n" Set="hjkl" />
   </command>
-  <command ID="CmdAttackU" DisplayText="上を強制攻撃" Category="基本移動／攻撃" Layer="Adventure">
+  <command ID="CmdAttackU" DisplayText="上を強制攻撃" Category="Basic Move / Attack" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="numpadMinus" />
     <keyboardBind Modifier="ctrl,shift" Key="period" />
   </command>
-  <command ID="CmdAttackD" DisplayText="下を強制攻撃" Category="基本移動／攻撃" Layer="Adventure">
+  <command ID="CmdAttackD" DisplayText="下を強制攻撃" Category="Basic Move / Attack" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="numpadPlus" />
     <keyboardBind Modifier="ctrl,shift" Key="comma" />
   </command>
-  <command ID="CmdAttackDirection" DisplayText="方向を指定して強制攻撃" Category="基本移動／攻撃" Layer="Adventure" Auto="Down">
+  <command ID="CmdAttackDirection" DisplayText="方向を指定して強制攻撃" Category="Basic Move / Attack" Layer="Adventure" Auto="Down">
     <keyboardBind Key="backslash" />
   </command>
-  <command ID="CmdAttackCell" DisplayText="強制攻撃するマスを選択" Category="基本移動／攻撃" Layer="Adventure" Auto="Down">
+  <command ID="CmdAttackCell" DisplayText="強制攻撃するマスを選択" Category="Basic Move / Attack" Layer="Adventure" Auto="Down">
     <keyboardBind Modifier="ctrl" Key="backslash" />
   </command>
 
 
-  <command ID="IndicateDirection" DisplayText="方向を指示" Category="基本移動／攻撃" Layer="AdventureNav" Type="Value">
+  <command ID="IndicateDirection" DisplayText="方向を指示" Category="Basic Move / Attack" Layer="AdventureNav" Type="Value">
     <gamepadBind Button="leftStick" />
   </command>
-  <command ID="IndicateDirection/up" DisplayText="北を指示" Category="基本移動／攻撃" Layer="AdventureNav" />
-  <command ID="IndicateDirection/down" DisplayText="南を指示" Category="基本移動／攻撃" Layer="AdventureNav" />
-  <command ID="IndicateDirection/left" DisplayText="西を指示" Category="基本移動／攻撃" Layer="AdventureNav" />
-  <command ID="IndicateDirection/right" DisplayText="東を指示" Category="基本移動／攻撃" Layer="AdventureNav" />
+  <command ID="IndicateDirection/up" DisplayText="北を指示" Category="Basic Move / Attack" Layer="AdventureNav" />
+  <command ID="IndicateDirection/down" DisplayText="南を指示" Category="Basic Move / Attack" Layer="AdventureNav" />
+  <command ID="IndicateDirection/left" DisplayText="西を指示" Category="Basic Move / Attack" Layer="AdventureNav" />
+  <command ID="IndicateDirection/right" DisplayText="東を指示" Category="Basic Move / Attack" Layer="AdventureNav" />
 
-  <command ID="Take A Step" DisplayText="指示後に1歩進む" Category="基本移動／攻撃" Layer="AdventureNav">
+  <command ID="Take A Step" DisplayText="指示後に1歩進む" Category="Basic Move / Attack" Layer="AdventureNav">
     <gamepadBind Button="rightTrigger" />
   </command>
-  <command ID="ForceAttack" DisplayText="指示後に強制攻撃" Category="基本移動／攻撃" Layer="Adventure">
+  <command ID="ForceAttack" DisplayText="指示後に強制攻撃" Category="Basic Move / Attack" Layer="Adventure">
     <gamepadBind Alt="true" Button="leftShoulder" />
   </command>
   
   
-  <command ID="Accept" DisplayText="決定" Category="メニュー操作" Layer="UINav" CanShareBindsWith="Submit,CmdUse" InputModuleBind="submit" SkipUpgrade="true" Required="true">
+  <command ID="Accept" DisplayText="決定" Category="Menus" Layer="UINav" CanShareBindsWith="Submit,CmdUse" InputModuleBind="submit" SkipUpgrade="true" Required="true">
     <keyboardBind Key="space" />
     <keyboardBind Key="enter" />
     <keyboardBind Key="numpadenter" />
     <gamepadBind Button="buttonSouth" />
   </command>
-  <command ID="Cancel" DisplayText="キャンセル" Category="メニュー操作" Layer="UINav" CanShareBindsWith="CmdSystemMenu" InputModuleBind="cancel" SkipUpgrade="true" Required="true">
+  <command ID="Cancel" DisplayText="キャンセル" Category="Menus" Layer="UINav" CanShareBindsWith="CmdSystemMenu" InputModuleBind="cancel" SkipUpgrade="true" Required="true">
     <keyboardBind Key="escape" />
     <gamepadBind Button="buttonEast" />
   </command>
   
-  <command ID="UI:Navigate" DisplayText="ナビゲート" Category="メニュー操作" Layer="UINav" Type="Value" CanShareBindsWith="IndicateDirection" Required="true">
+  <command ID="UI:Navigate" DisplayText="ナビゲート" Category="Menus" Layer="UINav" Type="Value" CanShareBindsWith="IndicateDirection" Required="true">
     <gamepadBind Button="leftStick" />
   </command>
-  <command ID="UI:Navigate/up" DisplayText="上へ移動" Category="メニュー操作" Layer="UINav" CanShareBindsWith="IndicateDirection/up,CmdMoveN" UpgradeFrom="CmdMoveN" Required="true">
+  <command ID="UI:Navigate/up" DisplayText="上へ移動" Category="Menus" Layer="UINav" CanShareBindsWith="IndicateDirection/up,CmdMoveN" UpgradeFrom="CmdMoveN" Required="true">
     <gamepadBind Button="dpad/up" />
     <keyboardBind Key="upArrow" />
     <keyboardBind Key="numpad8" />
     <keyboardBind Key="k" Set="hjkl" />
   </command>
-  <command ID="UI:Navigate/down" DisplayText="下へ移動" Category="メニュー操作" Layer="UINav" CanShareBindsWith="IndicateDirection/down,CmdMoveS" UpgradeFrom="CmdMoveS" Required="true">
+  <command ID="UI:Navigate/down" DisplayText="下へ移動" Category="Menus" Layer="UINav" CanShareBindsWith="IndicateDirection/down,CmdMoveS" UpgradeFrom="CmdMoveS" Required="true">
     <gamepadBind Button="dpad/down" />
     <keyboardBind Key="downArrow" />
     <keyboardBind Key="numpad2" />
     <keyboardBind Key="j" Set="hjkl" />
   </command>
-  <command ID="UI:Navigate/left" DisplayText="左へ移動" Category="メニュー操作" Layer="UINav" CanShareBindsWith="IndicateDirection/left,CmdMoveW" UpgradeFrom="CmdMoveW" Required="true">
+  <command ID="UI:Navigate/left" DisplayText="左へ移動" Category="Menus" Layer="UINav" CanShareBindsWith="IndicateDirection/left,CmdMoveW" UpgradeFrom="CmdMoveW" Required="true">
     <gamepadBind Button="dpad/left" />
     <keyboardBind Key="leftArrow" />
     <keyboardBind Key="numpad4" />
     <keyboardBind Key="h" Set="hjkl" />
   </command>
-  <command ID="UI:Navigate/right" DisplayText="右へ移動" Category="メニュー操作" Layer="UINav" CanShareBindsWith="IndicateDirection/right,CmdMoveE" UpgradeFrom="CmdMoveE" Required="true">
+  <command ID="UI:Navigate/right" DisplayText="右へ移動" Category="Menus" Layer="UINav" CanShareBindsWith="IndicateDirection/right,CmdMoveE" UpgradeFrom="CmdMoveE" Required="true">
     <gamepadBind Button="dpad/right" />
     <keyboardBind Key="rightArrow" />
     <keyboardBind Key="numpad6" />
     <keyboardBind Key="l" Set="hjkl" />
   </command>
 
-  <command ID="UI:DetailsNavigate" DisplayText="詳細をナビゲート" Category="メニュー操作" Layer="CategoryNav">
+  <command ID="UI:DetailsNavigate" DisplayText="詳細をナビゲート" Category="Menus" Layer="CategoryNav">
     <gamepadBind Button="rightStick" />
   </command>
-  <command ID="UI:DetailsNavigate/up" DisplayText="詳細: 上へ移動" Category="メニュー操作" Layer="UINav" CanShareBindsWith="IndicateDirection/up,CmdMoveN" UpgradeFrom="CmdMoveN" Required="true">
+  <command ID="UI:DetailsNavigate/up" DisplayText="詳細: 上へ移動" Category="Menus" Layer="UINav" CanShareBindsWith="IndicateDirection/up,CmdMoveN" UpgradeFrom="CmdMoveN" Required="true">
     <gamepadBind Button="rightStick/up" />
     <keyboardBind Modifier="shift" Key="upArrow" />
     <keyboardBind Modifier="shift" Key="k" Set="hjkl" />
   </command>
-  <command ID="UI:DetailsNavigate/down" DisplayText="詳細: 下へ移動" Category="メニュー操作" Layer="UINav" CanShareBindsWith="IndicateDirection/down,CmdMoveS" UpgradeFrom="CmdMoveS" Required="true">
+  <command ID="UI:DetailsNavigate/down" DisplayText="詳細: 下へ移動" Category="Menus" Layer="UINav" CanShareBindsWith="IndicateDirection/down,CmdMoveS" UpgradeFrom="CmdMoveS" Required="true">
     <gamepadBind Button="rightStick/down" />
     <keyboardBind Modifier="shift" Key="downArrow" />
     <keyboardBind Modifier="shift" Key="j" Set="hjkl" />
   </command>
-  <command ID="UI:DetailsNavigate/left" DisplayText="詳細: 左へ移動" Category="メニュー操作" Layer="UINav" CanShareBindsWith="IndicateDirection/up,CmdMoveN" UpgradeFrom="CmdMoveN" Required="true">
+  <command ID="UI:DetailsNavigate/left" DisplayText="詳細: 左へ移動" Category="Menus" Layer="UINav" CanShareBindsWith="IndicateDirection/up,CmdMoveN" UpgradeFrom="CmdMoveN" Required="true">
     <gamepadBind Button="rightStick/left" />
     <keyboardBind Modifier="shift" Key="leftArrow" />
     <keyboardBind Modifier="shift" Key="h" Set="hjkl" />
   </command>
-  <command ID="UI:DetailsNavigate/right" DisplayText="詳細: 右へ移動" Category="メニュー操作" Layer="UINav" CanShareBindsWith="IndicateDirection/down,CmdMoveS" UpgradeFrom="CmdMoveS" Required="true">
+  <command ID="UI:DetailsNavigate/right" DisplayText="詳細: 右へ移動" Category="Menus" Layer="UINav" CanShareBindsWith="IndicateDirection/down,CmdMoveS" UpgradeFrom="CmdMoveS" Required="true">
     <gamepadBind Button="rightStick/right" />
     <keyboardBind Modifier="shift" Key="rightArrow" />
     <keyboardBind Modifier="shift" Key="l" Set="hjkl" />
   </command>
 
-  <command ID="Page Up" DisplayText="1ページ上へ" Category="メニュー操作" Layer="Menus" CanShareBindsWith="CmdMoveSW,CmdMoveSE,CmdMoveNW,CmdMoveNE,CmdMoveN,CmdMoveS,CmdMoveE,CmdMoveU,CmdMoveD" Required="true">
+  <command ID="Page Up" DisplayText="1ページ上へ" Category="Menus" Layer="Menus" CanShareBindsWith="CmdMoveSW,CmdMoveSE,CmdMoveNW,CmdMoveNE,CmdMoveN,CmdMoveS,CmdMoveE,CmdMoveU,CmdMoveD" Required="true">
     <keyboardBind Key="pageUp" />
     <keyboardBind Modifier="ctrl" Key="upArrow" />
     <keyboardBind Modifier="ctrl" Key="numpad9" />
@@ -304,7 +304,7 @@
     <keyboardBind Modifier="ctrl" Key="k" Set="hjkl" />
   </command>
 
-  <command ID="Page Down" DisplayText="1ページ下へ" Category="メニュー操作" Layer="Menus" CanShareBindsWith="CmdMoveSW,CmdMoveSE,CmdMoveNW,CmdMoveNE,CmdMoveN,CmdMoveS,CmdMoveE,CmdMoveU,CmdMoveD">
+  <command ID="Page Down" DisplayText="1ページ下へ" Category="Menus" Layer="Menus" CanShareBindsWith="CmdMoveSW,CmdMoveSE,CmdMoveNW,CmdMoveNE,CmdMoveN,CmdMoveS,CmdMoveE,CmdMoveU,CmdMoveD">
     <keyboardBind Key="pageDown" />
     <keyboardBind Modifier="ctrl" Key="downArrow" />
     <keyboardBind Modifier="ctrl" Key="numpad3" />
@@ -313,84 +313,84 @@
     <keyboardBind Modifier="ctrl" Key="j" Set="hjkl" />
   </command>
 
-  <command ID="Page Right" DisplayText="次のページ" Category="メニュー操作" Layer="Menus" CanShareBindsWith="CmdMoveSW,CmdMoveSE,CmdMoveNW,CmdMoveNE,CmdMoveN,CmdMoveS,CmdMoveE,CmdMoveU,CmdMoveD,CmdFire">
+  <command ID="Page Right" DisplayText="次のページ" Category="Menus" Layer="Menus" CanShareBindsWith="CmdMoveSW,CmdMoveSE,CmdMoveNW,CmdMoveNE,CmdMoveN,CmdMoveS,CmdMoveE,CmdMoveU,CmdMoveD,CmdFire">
     <keyboardBind Key="numpad9" />
     <keyboardBind Key="end" />
     <gamepadBind Button="rightShoulder" />
     <keyboardBind Key="u" Set="hjkl" />
   </command>
-  <command ID="Page Left" DisplayText="前のページ" Category="メニュー操作" Layer="Menus" CanShareBindsWith="CmdMoveSW,CmdMoveSE,CmdMoveNW,CmdMoveNE,CmdMoveN,CmdMoveS,CmdMoveE,CmdMoveU,CmdMoveD">
+  <command ID="Page Left" DisplayText="前のページ" Category="Menus" Layer="Menus" CanShareBindsWith="CmdMoveSW,CmdMoveSE,CmdMoveNW,CmdMoveNE,CmdMoveN,CmdMoveS,CmdMoveE,CmdMoveU,CmdMoveD">
     <keyboardBind Key="numpad7" />
     <keyboardBind Key="home" />
     <gamepadBind Button="leftShoulder" />
     <keyboardBind Key="y" Set="hjkl" />
   </command>
 
-  <command ID="Category Right" DisplayText="次のカテゴリ" Category="メニュー操作" Layer="CategoryNav" CanShareBindsWith="CmdMoveSW,CmdMoveSE,CmdMoveNW,CmdMoveNE,CmdMoveN,CmdMoveS,CmdMoveE,CmdMoveU,CmdMoveD">
+  <command ID="Category Right" DisplayText="次のカテゴリ" Category="Menus" Layer="CategoryNav" CanShareBindsWith="CmdMoveSW,CmdMoveSE,CmdMoveNW,CmdMoveNE,CmdMoveN,CmdMoveS,CmdMoveE,CmdMoveU,CmdMoveD">
     <gamepadBind Alt="true" Button="dpad/right" />
     <keyboardBind Key="E" />
     <keyboardBind Modifier="ctrl" Key="rightArrow" />
   </command>
-  <command ID="Category Left" DisplayText="前のカテゴリ" Category="メニュー操作" Layer="CategoryNav" CanShareBindsWith="CmdMoveSW,CmdMoveSE,CmdMoveNW,CmdMoveNE,CmdMoveN,CmdMoveS,CmdMoveE,CmdMoveU,CmdMoveD">
+  <command ID="Category Left" DisplayText="前のカテゴリ" Category="Menus" Layer="CategoryNav" CanShareBindsWith="CmdMoveSW,CmdMoveSE,CmdMoveNW,CmdMoveNE,CmdMoveN,CmdMoveS,CmdMoveE,CmdMoveU,CmdMoveD">
     <gamepadBind Alt="true" Button="dpad/left" />
     <keyboardBind Key="Q" />
     <keyboardBind Modifier="ctrl" Key="leftArrow" />
   </command>  
 
-  <command ID="CmdInsert" DisplayText="挿入" Category="メニュー操作" Layer="Menus" Auto="DownPass">
+  <command ID="CmdInsert" DisplayText="挿入" Category="Menus" Layer="Menus" Auto="DownPass">
     <keyboardBind Key="insert" />
     <gamepadBind Alt="true" Button="buttonNorth" />
     <keyboardBind Modifier="ctrl" Key="]" Set="hjkl" />
   </command>
-  <command ID="CmdDelete" DisplayText="削除" Category="メニュー操作" Layer="Menus" Auto="DownPass">
+  <command ID="CmdDelete" DisplayText="削除" Category="Menus" Layer="Menus" Auto="DownPass">
     <keyboardBind Key="delete" />
     <keyboardBind Key="backspace" />
     <gamepadBind Alt="true" Button="buttonWest" />
     <keyboardBind Key="[" Set="hjkl" />
   </command>
-  <command ID="V Positive" DisplayText="値を増やす" Category="メニュー操作" Layer="Menus" Auto="Down" CanShareBindsWith="CmdMoveU,CmdMoveD">
+  <command ID="V Positive" DisplayText="値を増やす" Category="Menus" Layer="Menus" Auto="Down" CanShareBindsWith="CmdMoveU,CmdMoveD">
     <keyboardBind Key="numpadPlus" />
     <keyboardBind Key="equals" />
     <gamepadBind Button="buttonWest" />
   </command>
-  <command ID="V Negative" DisplayText="値を減らす" Category="メニュー操作" Layer="Menus" Auto="Down" CanShareBindsWith="CmdMoveU,CmdMoveD">
+  <command ID="V Negative" DisplayText="値を減らす" Category="Menus" Layer="Menus" Auto="Down" CanShareBindsWith="CmdMoveU,CmdMoveD">
     <keyboardBind Key="numpadMinus" />
     <keyboardBind Key="minus" />
     <gamepadBind Button="buttonNorth" />
   </command>
-  <command ID="CmdFilter" DisplayText="フィルター／検索" Category="メニュー操作" Layer="Menus" Auto="DownPass">
+  <command ID="CmdFilter" DisplayText="フィルター／検索" Category="Menus" Layer="Menus" Auto="DownPass">
     <keyboardBind Modifier="ctrl" Key="f" />
   </command>
-  <command ID="Submit" DisplayText="テキストを送信" Category="メニュー操作" Layer="UINav" CanShareBindsWith="Accept" Required="true">
+  <command ID="Submit" DisplayText="テキストを送信" Category="Menus" Layer="UINav" CanShareBindsWith="Accept" Required="true">
     <keyboardBind Key="enter" />
     <keyboardBind Key="numpadenter" />
   </command>
 
-  <command ID="CmdHelp" DisplayText="ヘルプ" Category="メニュー操作" Layer="UI" Auto="DownPass">
+  <command ID="CmdHelp" DisplayText="ヘルプ" Category="Menus" Layer="UI" Auto="DownPass">
     <keyboardBind Key="F1" />
     <gamepadBind Alt="true" Button="start" />
   </command>
 
-  <command ID="CmdOptions" DisplayText="オプションを表示" Category="メニュー操作" Layer="Menus" Auto="DownPass">
+  <command ID="CmdOptions" DisplayText="オプションを表示" Category="Menus" Layer="Menus" Auto="DownPass">
     <keyboardBind Key="tab" />
     <gamepadBind Button="rightTrigger" />
   </command>
 
-  <command ID="Toggle" DisplayText="切り替える" Category="メニュー操作" Layer="Menus" Auto="DownPass">
+  <command ID="Toggle" DisplayText="切り替える" Category="Menus" Layer="Menus" Auto="DownPass">
     <keyboardBind Modifier="ctrl" Key="tab" />
     <gamepadBind Button="select" />
   </command>
 
   
-  <command ID="GamepadAlt" DisplayText="ゲームパッド Alt" Category="メニュー操作" Layer="Adventure">
+  <command ID="GamepadAlt" DisplayText="ゲームパッド Alt" Category="Menus" Layer="Adventure">
     <gamepadBind Button="leftTrigger" />
   </command>
 
-  <command ID="Take All" DisplayText="すべて取得" Category="メニュー操作" Layer="Menus" Auto="DownPass" CanShareBindsWith="Toggle">
+  <command ID="Take All" DisplayText="すべて取得" Category="Menus" Layer="Menus" Auto="DownPass" CanShareBindsWith="Toggle">
     <keyboardBind Key="tab" />
     <gamepadBind Button="rightTrigger" />
   </command>
-  <command ID="Store Items" DisplayText="アイテムを収納" Category="メニュー操作" Layer="Menus" Auto="DownPass">
+  <command ID="Store Items" DisplayText="アイテムを収納" Category="Menus" Layer="Menus" Auto="DownPass">
     <keyboardBind Key="F2" />
     <keyboardBind Key="numpadMultiply" />
     <gamepadBind Button="rightShoulder" />
@@ -398,105 +398,105 @@
 
 
   
-  <command ID="CmdUse" DisplayText="使用する" Category="冒険操作" Layer="Adventure">
+  <command ID="CmdUse" DisplayText="使用する" Category="Adventuring" Layer="Adventure">
     <keyboardBind Key="space" />
     <gamepadBind Button="buttonSouth" />
   </command>
-  <command ID="CmdTalk" DisplayText="話す" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdTalk" DisplayText="話す" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Key="c" />
   </command>
-  <command ID="CmdLook" DisplayText="見渡す" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdLook" DisplayText="見渡す" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Key="l" Set="default" />
     <keyboardBind Key="semicolon" Set="hjkl" />
   </command>
-  <command ID="LookDirection" DisplayText="指定方向を観察" Type="Value" Category="冒険操作" Layer="AdventureNav">
+  <command ID="LookDirection" DisplayText="指定方向を観察" Type="Value" Category="Adventuring" Layer="AdventureNav">
     <gamepadBind Button="rightStick" />
   </command>  
-  <command ID="CmdGet" DisplayText="拾う" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdGet" DisplayText="拾う" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Key="g" />
   </command>
-  <command ID="CmdMoveToPointOfInterest" DisplayText="注目地点まで移動" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdMoveToPointOfInterest" DisplayText="注目地点まで移動" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Key="backspace" />
     <gamepadBind Button="leftStickPress" />
   </command>
-  <command ID="CmdMoveToEdge" DisplayText="ゾーン端まで移動" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdMoveToEdge" DisplayText="ゾーン端まで移動" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Modifier="shift" Key="enter" />
     <gamepadBind Button="buttonNorth" />
   </command>  
-  <command ID="CmdGetFrom" DisplayText="周囲の対象とやり取り" Category="冒険操作" Layer="Adventure">
+  <command ID="CmdGetFrom" DisplayText="周囲の対象とやり取り" Category="Adventuring" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="space" />
     <keyboardBind Modifier="ctrl" Key="g" />
     <gamepadBind Alt="true" Button="buttonSouth" />
   </command>
-  <command ID="CmdOpen" DisplayText="開く" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdOpen" DisplayText="開く" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Key="o" />
   </command>
-  <command ID="CmdFire" DisplayText="飛び道具で射撃" Category="冒険操作" Layer="AdventureTargeting" Auto="Down" CanShareBindsWith="Page Right">
+  <command ID="CmdFire" DisplayText="飛び道具で射撃" Category="Adventuring" Layer="AdventureTargeting" Auto="Down" CanShareBindsWith="Page Right">
     <keyboardBind Key="f" />
     <gamepadBind Button="rightShoulder" />
   </command>
-  <command ID="CmdReload" DisplayText="飛び道具を再装填" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdReload" DisplayText="飛び道具を再装填" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Key="r" />
     <gamepadBind Button="rightStickPress" />
   </command>
-  <command ID="CmdReplaceCell" DisplayText="エネルギーセルを交換" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdReplaceCell" DisplayText="エネルギーセルを交換" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Modifier="ctrl" Key="r" />
     <gamepadBind Alt="true" Button="rightStickPress" />
   </command>
-  <command ID="CmdThrow" DisplayText="投げる" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdThrow" DisplayText="投げる" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Key="t" />
     <gamepadBind Alt="true" Button="rightShoulder" />
   </command>
-  <command ID="CmdTarget" DisplayText="対象を選択" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdTarget" DisplayText="対象を選択" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Modifier="ctrl" Key="t" />
   </command>
-  <command ID="CmdAttackNearest" DisplayText="最寄りの敵を近接攻撃" Category="冒険操作" Layer="Adventure" Auto="Repeat">
+  <command ID="CmdAttackNearest" DisplayText="最寄りの敵を近接攻撃" Category="Adventuring" Layer="Adventure" Auto="Repeat">
     <gamepadBind Button="leftShoulder" />
   </command>
-  <command ID="CmdWait" DisplayText="待機／炎を払う" Category="冒険操作" Layer="Adventure" Auto="Repeat">
+  <command ID="CmdWait" DisplayText="待機／炎を払う" Category="Adventuring" Layer="Adventure" Auto="Repeat">
     <keyboardBind Key="numpad5" />
     <keyboardBind Modifier="shift" Key="space" />
   </command>
-  <command ID="CmdWait20" DisplayText="20ターン待機" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdWait20" DisplayText="20ターン待機" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Key="numpadPeriod" />
   </command>
-  <command ID="CmdWait100" DisplayText="100ターン待機" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdWait100" DisplayText="100ターン待機" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Modifier="ctrl" Key="numpadPeriod" />
   </command>
   <command ID="CmdWaitN" DisplayText="指定ターン待機" Category="Adventuring" Layer="Adventure" Auto="Down" />
-  <command ID="CmdWaitUntilHealed" DisplayText="回復するまで休む" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdWaitUntilHealed" DisplayText="回復するまで休む" Category="Adventuring" Layer="Adventure" Auto="Down">
     <gamepadBind Button="buttonEast" />
     <keyboardBind Key="backquote" />
   </command>
   <command ID="CmdWaitUntilPartyHealed" DisplayText="仲間が全快するまで休む" Category="Adventuring" Layer="Adventure" Auto="Down">
   </command>
   <command ID="CmdWaitUntilMorning" DisplayText="夜明けまで休む" Category="Adventuring" Layer="Adventure" Auto="Down" />
-  <command ID="CmdWaitMenu" DisplayText="休憩メニューを開く" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdWaitMenu" DisplayText="休憩メニューを開く" Category="Adventuring" Layer="Adventure" Auto="Down">
     <gamepadBind Alt="true" Button="buttonEast" />
     <keyboardBind Modifier="ctrl" Key="backquote" />
   </command>
-  <command ID="CmdMoveMenu" DisplayText="移動メニューを開く" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdMoveMenu" DisplayText="移動メニューを開く" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Modifier="shift" Key="m" />
   </command>
-  <command ID="CmdAutoExplore" DisplayText="自動探索" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdAutoExplore" DisplayText="自動探索" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Key="numpad0" />
     <gamepadBind Alt="true" Button="buttonNorth" />
   </command>
-  <command ID="CmdWalk" DisplayText="方向を指定して歩く" Category="冒険操作" Layer="AdventureLooker" Auto="Down">
+  <command ID="CmdWalk" DisplayText="方向を指定して歩く" Category="Adventuring" Layer="AdventureLooker" Auto="Down">
     <keyboardBind Key="w" />
   </command>
-  <command ID="CmdAutoAttack" DisplayText="近接自動攻撃" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdAutoAttack" DisplayText="近接自動攻撃" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Modifier="ctrl" Key="a" />
   </command>
-  <command ID="CmdCompanions" DisplayText="仲間とやり取り" Category="冒険操作" Layer="Adventure" Auto="Down">
+  <command ID="CmdCompanions" DisplayText="仲間とやり取り" Category="Adventuring" Layer="Adventure" Auto="Down">
     <keyboardBind Modifier="ctrl" Key="c" />
   </command>
-  <command ID="CmdStartTrade" DisplayText="会話中に取引を開始" Category="冒険操作" Layer="Conversation" Auto="DownPass" CanShareBindsWith="Toggle">
+  <command ID="CmdStartTrade" DisplayText="会話中に取引を開始" Category="Adventuring" Layer="Conversation" Auto="DownPass" CanShareBindsWith="Toggle">
     <keyboardBind Key="tab" />
     <keyboardBind Key="T" />
     <gamepadBind Button="start" />
   </command>  
-  <command ID="Highlight" DisplayText="オーバーレイ／ツールチップを表示" Category="冒険操作" Layer="Adventure">
+  <command ID="Highlight" DisplayText="オーバーレイ／ツールチップを表示" Category="Adventuring" Layer="Adventure">
     <gamepadBind Alt="true" Button="rightTrigger" />
   </command>
   <command ID="LookDirection/up" DisplayText="北を見る" Category="Adventuring" Layer="AdventureNav">
@@ -510,273 +510,273 @@
   <command ID="Navigate Vertical" DisplayText="垂直移動（レガシー UI の上下移動）" Category="Adventuring" Layer="AdventureNav" />
   <command ID="Navigate Horizontal" DisplayText="水平移動（レガシー UI の左右移動）" Category="Adventuring" Layer="AdventureNav" />
   
-  <command ID="CmdMoveFarNW" DisplayText="北西端まで移動" Category="高度な冒険操作" Layer="AdventureNav" Auto="Down">
+  <command ID="CmdMoveFarNW" DisplayText="北西端まで移動" Category="Advanced Adventuring" Layer="AdventureNav" Auto="Down">
     <keyboardBind Modifier="alt" Key="numpad7" />
     <keyboardBind Modifier="alt,shift" Key="upArrow" />
   </command>
-  <command ID="CmdMoveFarN" DisplayText="北端まで移動" Category="高度な冒険操作" Layer="AdventureNav" Auto="Down">
+  <command ID="CmdMoveFarN" DisplayText="北端まで移動" Category="Advanced Adventuring" Layer="AdventureNav" Auto="Down">
     <keyboardBind Modifier="alt" Key="numpad8" />
     <keyboardBind Modifier="alt" Key="upArrow" />
   </command>
-  <command ID="CmdMoveFarNE" DisplayText="北東端まで移動" Category="高度な冒険操作" Layer="AdventureNav" Auto="Down">
+  <command ID="CmdMoveFarNE" DisplayText="北東端まで移動" Category="Advanced Adventuring" Layer="AdventureNav" Auto="Down">
     <keyboardBind Modifier="alt" Key="numpad9" />
     <keyboardBind Modifier="alt,shift" Key="rightArrow" />
   </command>
-  <command ID="CmdMoveFarW" DisplayText="西端まで移動" Category="高度な冒険操作" Layer="AdventureNav" Auto="Down">
+  <command ID="CmdMoveFarW" DisplayText="西端まで移動" Category="Advanced Adventuring" Layer="AdventureNav" Auto="Down">
     <keyboardBind Modifier="alt" Key="numpad4" />
     <keyboardBind Modifier="alt" Key="leftArrow" />
   </command>
-  <command ID="CmdMoveFarE" DisplayText="東端まで移動" Category="高度な冒険操作" Layer="AdventureNav" Auto="Down">
+  <command ID="CmdMoveFarE" DisplayText="東端まで移動" Category="Advanced Adventuring" Layer="AdventureNav" Auto="Down">
     <keyboardBind Modifier="alt" Key="numpad6" />
     <keyboardBind Modifier="alt" Key="rightArrow" />
   </command>
-  <command ID="CmdMoveFarSW" DisplayText="南西端まで移動" Category="高度な冒険操作" Layer="AdventureNav" Auto="Down">
+  <command ID="CmdMoveFarSW" DisplayText="南西端まで移動" Category="Advanced Adventuring" Layer="AdventureNav" Auto="Down">
     <keyboardBind Modifier="alt" Key="numpad1" />
     <keyboardBind Modifier="alt,shift" Key="leftArrow" />
   </command>
-  <command ID="CmdMoveFarS" DisplayText="南端まで移動" Category="高度な冒険操作" Layer="AdventureNav" Auto="Down">
+  <command ID="CmdMoveFarS" DisplayText="南端まで移動" Category="Advanced Adventuring" Layer="AdventureNav" Auto="Down">
     <keyboardBind Modifier="alt" Key="numpad2" />
     <keyboardBind Modifier="alt" Key="downArrow" />
   </command>
-  <command ID="CmdMoveFarSE" DisplayText="南東端まで移動" Category="高度な冒険操作" Layer="AdventureNav" Auto="Down">
+  <command ID="CmdMoveFarSE" DisplayText="南東端まで移動" Category="Advanced Adventuring" Layer="AdventureNav" Auto="Down">
     <keyboardBind Modifier="alt" Key="numpad3" />
     <keyboardBind Modifier="alt,shift" Key="downArrow" />
   </command>
-  <command ID="CmdMoveCenter" DisplayText="中央へ移動" Category="高度な冒険操作" Layer="AdventureNav" Auto="Down">
+  <command ID="CmdMoveCenter" DisplayText="中央へ移動" Category="Advanced Adventuring" Layer="AdventureNav" Auto="Down">
     <keyboardBind Modifier="alt" Key="numpad5" />
   </command>
   
 
   
-  <command ID="CmdMissileWeaponMenu" DisplayText="飛び道具メニューを開く" Category="ターゲティング" Layer="Targeting" Auto="DownPass" CanShareBindsWith="V Positive,V Negative">
+  <command ID="CmdMissileWeaponMenu" DisplayText="飛び道具メニューを開く" Category="Targeting" Layer="Targeting" Auto="DownPass" CanShareBindsWith="V Positive,V Negative">
     <gamepadBind Button="buttonNorth" />
   </command>
-  <command ID="CmdTargetSelf" DisplayText="自分を対象にする" Category="ターゲティング" Layer="Targeting" Auto="DownPass">
+  <command ID="CmdTargetSelf" DisplayText="自分を対象にする" Category="Targeting" Layer="Targeting" Auto="DownPass">
     <keyboardBind Key="numpad5" />
     <keyboardBind Key="period" />
     <gamepadBind Button="leftShoulder" />
   </command>
-  <command ID="CmdMarkTarget" DisplayText="対象をマーキング" Category="ターゲティング" Layer="Targeting" Auto="DownPass">
+  <command ID="CmdMarkTarget" DisplayText="対象をマーキング" Category="Targeting" Layer="Targeting" Auto="DownPass">
     <keyboardBind Key="m" />
   </command>
-  <command ID="CmdLockUnlock" DisplayText="ターゲットロック切り替え" Category="メニュー操作" Layer="Targeting" Auto="DownPass">
+  <command ID="CmdLockUnlock" DisplayText="ターゲットロック切り替え" Category="Menus" Layer="Targeting" Auto="DownPass">
     <keyboardBind Key="F1" />
     <gamepadBind Button="rightStickPress" />
   </command>
-  <command ID="CmdAltFire1" DisplayText="代替射撃1" Category="ターゲティング" Layer="Targeting" Auto="DownPass">
+  <command ID="CmdAltFire1" DisplayText="代替射撃1" Category="Targeting" Layer="Targeting" Auto="DownPass">
     <keyboardBind Key="1" />
   </command>
-  <command ID="CmdAltFire2" DisplayText="代替射撃2" Category="ターゲティング" Layer="Targeting" Auto="DownPass">
+  <command ID="CmdAltFire2" DisplayText="代替射撃2" Category="Targeting" Layer="Targeting" Auto="DownPass">
     <keyboardBind Key="2" />
   </command>
-  <command ID="CmdAltFire3" DisplayText="代替射撃3" Category="ターゲティング" Layer="Targeting" Auto="DownPass">
+  <command ID="CmdAltFire3" DisplayText="代替射撃3" Category="Targeting" Layer="Targeting" Auto="DownPass">
     <keyboardBind Key="3" />
   </command>
-  <command ID="CmdAltFire4" DisplayText="代替射撃4" Category="ターゲティング" Layer="Targeting" Auto="DownPass">
+  <command ID="CmdAltFire4" DisplayText="代替射撃4" Category="Targeting" Layer="Targeting" Auto="DownPass">
     <keyboardBind Key="4" />
   </command>
-  <command ID="CmdAltFire5" DisplayText="代替射撃5" Category="ターゲティング" Layer="Targeting" Auto="DownPass">
+  <command ID="CmdAltFire5" DisplayText="代替射撃5" Category="Targeting" Layer="Targeting" Auto="DownPass">
     <keyboardBind Key="5" />
   </command>
 
 
   
   
-  <command ID="CmdAbility1" DisplayText="アビリティ1を使用" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbility1" DisplayText="アビリティ1を使用" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Key="1" />
   </command>
-  <command ID="CmdAbility2" DisplayText="アビリティ2を使用" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbility2" DisplayText="アビリティ2を使用" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Key="2" />
   </command>
-  <command ID="CmdAbility3" DisplayText="アビリティ3を使用" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbility3" DisplayText="アビリティ3を使用" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Key="3" />
   </command>
-  <command ID="CmdAbility4" DisplayText="アビリティ4を使用" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbility4" DisplayText="アビリティ4を使用" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Key="4" />
   </command>
-  <command ID="CmdAbility5" DisplayText="アビリティ5を使用" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbility5" DisplayText="アビリティ5を使用" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Key="5" />
   </command>
-  <command ID="CmdAbility6" DisplayText="アビリティ6を使用" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbility6" DisplayText="アビリティ6を使用" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Key="6" />
   </command>
-  <command ID="CmdAbility7" DisplayText="アビリティ7を使用" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbility7" DisplayText="アビリティ7を使用" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Key="7" />
   </command>
-  <command ID="CmdAbility8" DisplayText="アビリティ8を使用" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbility8" DisplayText="アビリティ8を使用" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Key="8" />
   </command>
-  <command ID="CmdAbility9" DisplayText="アビリティ9を使用" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbility9" DisplayText="アビリティ9を使用" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Key="9" />
   </command>
-  <command ID="CmdAbility10" DisplayText="アビリティ10を使用" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbility10" DisplayText="アビリティ10を使用" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Key="0" />
   </command>
 
-  <command ID="CmdAbilityBar1" DisplayText="アビリティバー1に切り替え" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbilityBar1" DisplayText="アビリティバー1に切り替え" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="1" />
   </command>
-  <command ID="CmdAbilityBar2" DisplayText="アビリティバー2に切り替え" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbilityBar2" DisplayText="アビリティバー2に切り替え" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="2" />
   </command>
-  <command ID="CmdAbilityBar3" DisplayText="アビリティバー3に切り替え" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbilityBar3" DisplayText="アビリティバー3に切り替え" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="3" />
   </command>
-  <command ID="CmdAbilityBar4" DisplayText="アビリティバー4に切り替え" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbilityBar4" DisplayText="アビリティバー4に切り替え" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="4" />
   </command>
-  <command ID="CmdAbilityBar5" DisplayText="アビリティバー5に切り替え" Category="アビリティバー" Layer="Adventure">
+  <command ID="CmdAbilityBar5" DisplayText="アビリティバー5に切り替え" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="5" />
   </command>  
-  <command ID="Ability Page Up" DisplayText="アビリティバーを前ページへ" Category="アビリティバー" Layer="Adventure">
+  <command ID="Ability Page Up" DisplayText="アビリティバーを前ページへ" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="tab" />
     <gamepadBind Alt="true" Button="dpad/up" />
   </command>
-  <command ID="Ability Page Down" DisplayText="アビリティバーを次ページへ" Category="アビリティバー" Layer="Adventure">
+  <command ID="Ability Page Down" DisplayText="アビリティバーを次ページへ" Category="Ability Bar" Layer="Adventure">
     <keyboardBind Modifier="ctrl,shift" Key="tab" />
     <gamepadBind Alt="true" Button="dpad/down" />
   </command>
-  <command ID="Next Ability" DisplayText="次のアビリティ" Category="アビリティバー" Layer="Adventure">
+  <command ID="Next Ability" DisplayText="次のアビリティ" Category="Ability Bar" Layer="Adventure">
     <gamepadBind Button="dpad/right" />
   </command>
-  <command ID="Previous Ability" DisplayText="前のアビリティ" Category="アビリティバー" Layer="Adventure">
+  <command ID="Previous Ability" DisplayText="前のアビリティ" Category="Ability Bar" Layer="Adventure">
     <gamepadBind Button="dpad/left" />
   </command>
-  <command ID="Use Ability" DisplayText="選択中の能力を使用" Category="冒険操作" Layer="Adventure">
+  <command ID="Use Ability" DisplayText="選択中の能力を使用" Category="Adventuring" Layer="Adventure">
     <gamepadBind Button="buttonWest" />
   </command>
               
 
   
-  <command ID="CmdAbilities" DisplayText="能力画面を開く" Category="キャラクターシートショートカット" Layer="Adventure" Auto="Down" Required="true">
+  <command ID="CmdAbilities" DisplayText="能力画面を開く" Category="Shortcuts to Character Sheet" Layer="Adventure" Auto="Down" Required="true">
     <keyboardBind Key="a" />
     <gamepadBind Alt="true" Button="buttonWest" />
   </command>
-  <command ID="CmdInventory" DisplayText="インベントリを開く" Category="キャラクターシートショートカット" Layer="Adventure" Auto="Down">
+  <command ID="CmdInventory" DisplayText="インベントリを開く" Category="Shortcuts to Character Sheet" Layer="Adventure" Auto="Down">
     <keyboardBind Key="i" />
   </command>
-  <command ID="CmdEquipment" DisplayText="装備画面を開く" Category="キャラクターシートショートカット" Layer="Adventure" Auto="Down">
+  <command ID="CmdEquipment" DisplayText="装備画面を開く" Category="Shortcuts to Character Sheet" Layer="Adventure" Auto="Down">
     <keyboardBind Key="e" />
   </command>
-  <command ID="CmdSkillsPowers" DisplayText="技能画面を開く" Category="キャラクターシートショートカット" Layer="Adventure" Auto="Down">
+  <command ID="CmdSkillsPowers" DisplayText="技能画面を開く" Category="Shortcuts to Character Sheet" Layer="Adventure" Auto="Down">
     <keyboardBind Key="k" Set="default" />
     <keyboardBind Modifier="shift" Key="k" Set="hjkl" />
   </command>
-  <command ID="CmdCharacter" DisplayText="能力値画面を開く" Category="キャラクターシートショートカット" Layer="Adventure" Auto="Down">
+  <command ID="CmdCharacter" DisplayText="能力値画面を開く" Category="Shortcuts to Character Sheet" Layer="Adventure" Auto="Down">
     <keyboardBind Key="tab" />
     <keyboardBind Key="x" />
     <gamepadBind Button="start" />
   </command>
-  <command ID="CmdQuests" DisplayText="クエスト画面を開く" Category="キャラクターシートショートカット" Layer="Adventure" Auto="Down">
+  <command ID="CmdQuests" DisplayText="クエスト画面を開く" Category="Shortcuts to Character Sheet" Layer="Adventure" Auto="Down">
     <keyboardBind Key="q" />
   </command>
-  <command ID="CmdFactions" DisplayText="評判画面を開く" Category="キャラクターシートショートカット" Layer="Adventure" Auto="Down">
+  <command ID="CmdFactions" DisplayText="評判画面を開く" Category="Shortcuts to Character Sheet" Layer="Adventure" Auto="Down">
     <keyboardBind Modifier="ctrl" Key="f" />
   </command>  
-  <command ID="CmdTinkering" DisplayText="工作画面を開く" Category="キャラクターシートショートカット" Layer="Adventure" Auto="Down">
+  <command ID="CmdTinkering" DisplayText="工作画面を開く" Category="Shortcuts to Character Sheet" Layer="Adventure" Auto="Down">
     <keyboardBind Key="n" Set="default" />
     <keyboardBind Modifier="shift" Key="n" Set="hjkl" />
   </command>
-  <command ID="CmdJournal" DisplayText="ジャーナルを開く" Category="キャラクターシートショートカット" Layer="Adventure" Auto="Down">
+  <command ID="CmdJournal" DisplayText="ジャーナルを開く" Category="Shortcuts to Character Sheet" Layer="Adventure" Auto="Down">
     <keyboardBind Key="j" Set="default" />
     <keyboardBind Modifier="shift" Key="j" Set="hjkl" />
   </command>
-  <command ID="CmdActiveEffects" DisplayText="状態効果を開く" Category="キャラクターシートショートカット" Layer="Adventure" Auto="Down">
+  <command ID="CmdActiveEffects" DisplayText="状態効果を開く" Category="Shortcuts to Character Sheet" Layer="Adventure" Auto="Down">
     <keyboardBind Modifier="ctrl" Key="e" />
   </command>
-  <command ID="CmdLastStatusPage" DisplayText="直前のシートページを開く" Category="キャラクターシートショートカット" Layer="Adventure" Auto="Down" />    
-  <command ID="CmdMessageHistory" DisplayText="メッセージ履歴を表示" Category="キャラクターシートショートカット" Layer="Adventure" Auto="Down" />
+  <command ID="CmdLastStatusPage" DisplayText="直前のシートページを開く" Category="Shortcuts to Character Sheet" Layer="Adventure" Auto="Down" />
+  <command ID="CmdMessageHistory" DisplayText="メッセージ履歴を表示" Category="Shortcuts to Character Sheet" Layer="Adventure" Auto="Down" />
 
 
 
   
-  <command ID="InventoryQuickDrop" DisplayText="インベントリ: 捨てる" Category="キャラクターシート" Layer="StatusScreens" Auto="DownPass">
+  <command ID="InventoryQuickDrop" DisplayText="インベントリ: 捨てる" Category="Character Sheet" Layer="StatusScreens" Auto="DownPass">
     <keyboardBind Modifier="ctrl" Key="d" />
   </command>
-  <command ID="InventoryQuickEat" DisplayText="インベントリ: 食べる" Category="キャラクターシート" Layer="StatusScreens" Auto="DownPass">
+  <command ID="InventoryQuickEat" DisplayText="インベントリ: 食べる" Category="Character Sheet" Layer="StatusScreens" Auto="DownPass">
     <keyboardBind Modifier="ctrl" Key="a" />
   </command>
-  <command ID="InventoryQuickDrink" DisplayText="インベントリ: 飲む" Category="キャラクターシート" Layer="StatusScreens" Auto="DownPass">
+  <command ID="InventoryQuickDrink" DisplayText="インベントリ: 飲む" Category="Character Sheet" Layer="StatusScreens" Auto="DownPass">
     <keyboardBind Modifier="ctrl" Key="q" />
   </command>
-  <command ID="InventoryQuickApply" DisplayText="インベントリ: 使う" Category="キャラクターシート" Layer="StatusScreens" Auto="DownPass">
+  <command ID="InventoryQuickApply" DisplayText="インベントリ: 使う" Category="Character Sheet" Layer="StatusScreens" Auto="DownPass">
     <keyboardBind Modifier="ctrl" Key="p" />
   </command>
-  <command ID="CmdStatusBuyMutation" DisplayText="能力: 新しい突然変異を取得" Category="キャラクターシート" Layer="StatusScreens:Charsheet" Auto="DownPass">
+  <command ID="CmdStatusBuyMutation" DisplayText="能力: 新しい突然変異を取得" Category="Character Sheet" Layer="StatusScreens:Charsheet" Auto="DownPass">
     <keyboardBind Key="m" />
     <gamepadBind Button="buttonNorth" />
   </command>
-  <command ID="CmdStatusShowEffects" DisplayText="能力: 状態効果を表示" Category="キャラクターシート" Layer="StatusScreens:Charsheet" Auto="DownPass">
+  <command ID="CmdStatusShowEffects" DisplayText="能力: 状態効果を表示" Category="Character Sheet" Layer="StatusScreens:Charsheet" Auto="DownPass">
     <keyboardBind Key="e" />
     <gamepadBind Button="buttonWest" />
   </command>
 
 
   
-  <command ID="CmdTradeAdd" DisplayText="アイテムを1つ追加" Category="取引" Layer="Trade" Auto="Repeat" CanShareBindsWith="V Positive">
+  <command ID="CmdTradeAdd" DisplayText="アイテムを1つ追加" Category="Trade" Layer="Trade" Auto="Repeat" CanShareBindsWith="V Positive">
     <keyboardBind Key="equals" />
     <keyboardBind Key="numpadPlus" />
     <gamepadBind Button="rightShoulder" />
     <keyboardBind Key="numpad9" />
   </command>
-  <command ID="CmdTradeRemove" DisplayText="アイテムを1つ除外" Category="取引" Layer="Trade" Auto="Repeat" CanShareBindsWith="V Negative">
+  <command ID="CmdTradeRemove" DisplayText="アイテムを1つ除外" Category="Trade" Layer="Trade" Auto="Repeat" CanShareBindsWith="V Negative">
     <keyboardBind Key="minus" />
     <keyboardBind Key="numpadMinus" />
     <keyboardBind Key="numpad7" />
     <gamepadBind Button="leftShoulder" />
   </command>
-  <command ID="CmdTradeAllItems" DisplayText="アイテム束を追加／削除" Category="取引" Layer="Trade" Auto="DownPass" CanShareBindsWith="Accept,Submit">
+  <command ID="CmdTradeAllItems" DisplayText="アイテム束を追加／削除" Category="Trade" Layer="Trade" Auto="DownPass" CanShareBindsWith="Accept,Submit">
     <keyboardBind Key="enter" />
     <keyboardBind Key="numpadEnter" />
     <keyboardBind Modifier="ctrl" Key="space" />
     <gamepadBind Button="rightTrigger" />
     <gamepadBind Button="buttonSouth" />
   </command>
-  <command ID="CmdTradeToggleAll" DisplayText="所持品をすべて追加／削除" Category="取引" Layer="Trade" Auto="DownPass">
+  <command ID="CmdTradeToggleAll" DisplayText="所持品をすべて追加／削除" Category="Trade" Layer="Trade" Auto="DownPass">
     <keyboardBind Key="tab" />
   </command>
-  <command ID="CmdTradeOffer" DisplayText="取引を申し出る" Category="取引" Layer="Trade" Auto="DownPass">
+  <command ID="CmdTradeOffer" DisplayText="取引を申し出る" Category="Trade" Layer="Trade" Auto="DownPass">
     <keyboardBind Key="o" />
     <gamepadBind Button="start" />
   </command>
-  <command ID="CmdVendorActions" DisplayText="アイテム操作" Category="取引" Layer="Trade" Auto="DownPass">
+  <command ID="CmdVendorActions" DisplayText="アイテム操作" Category="Trade" Layer="Trade" Auto="DownPass">
     <keyboardBind Key="space" />
     <gamepadBind Alt="true" Button="buttonSouth" />
   </command>
-  <command ID="CmdVendorLook" DisplayText="アイテムを観察" Category="取引" Layer="Trade" Auto="DownPass">
+  <command ID="CmdVendorLook" DisplayText="アイテムを観察" Category="Trade" Layer="Trade" Auto="DownPass">
     <keyboardBind Key="l" />
   </command>
-  <command ID="CmdVendorRead" DisplayText="書物を読む" Category="取引" Layer="Trade" Auto="DownPass">
+  <command ID="CmdVendorRead" DisplayText="書物を読む" Category="Trade" Layer="Trade" Auto="DownPass">
     <keyboardBind Key="b" />
   </command>
-  <command ID="CmdVendorRepair" DisplayText="修理を依頼" Category="取引" Layer="Trade" Auto="DownPass">
+  <command ID="CmdVendorRepair" DisplayText="修理を依頼" Category="Trade" Layer="Trade" Auto="DownPass">
     <keyboardBind Key="r" />
   </command>
-  <command ID="CmdVendorRecharge" DisplayText="充電を依頼" Category="取引" Layer="Trade" Auto="DownPass">
+  <command ID="CmdVendorRecharge" DisplayText="充電を依頼" Category="Trade" Layer="Trade" Auto="DownPass">
     <keyboardBind Key="c" />
   </command>
-  <command ID="CmdVendorExamine" DisplayText="鑑定を依頼" Category="取引" Layer="Trade" Auto="DownPass">
+  <command ID="CmdVendorExamine" DisplayText="鑑定を依頼" Category="Trade" Layer="Trade" Auto="DownPass">
     <keyboardBind Key="i" />
   </command>
 
 
   
-  <command ID="CmdChargenRandom" DisplayText="ランダムに選択" Category="キャラクター作成" Layer="Chargen">
+  <command ID="CmdChargenRandom" DisplayText="ランダムに選択" Category="Character Creation" Layer="Chargen">
     <keyboardBind Key="r" />
     <gamepadBind Button="buttonWest" />
   </command>
-  <command ID="CmdChargenReset" DisplayText="選択をリセット" Category="キャラクター作成" Layer="Chargen">
+  <command ID="CmdChargenReset" DisplayText="選択をリセット" Category="Character Creation" Layer="Chargen">
     <keyboardBind Key="delete" />
     <gamepadBind Button="buttonNorth" />
   </command>
-  <command ID="CmdChargenItemOptions" DisplayText="項目のオプションを選ぶ" Category="キャラクター作成" Layer="Chargen">
+  <command ID="CmdChargenItemOptions" DisplayText="項目のオプションを選ぶ" Category="Character Creation" Layer="Chargen">
     <keyboardBind Key="o" />
     <gamepadBind Button="dpad/left" />
   </command>
-  <command ID="CmdChargenMutationVariant" DisplayText="突然変異のバリアントを選ぶ" Category="キャラクター作成" Layer="Chargen">
+  <command ID="CmdChargenMutationVariant" DisplayText="突然変異のバリアントを選ぶ" Category="Character Creation" Layer="Chargen">
     <keyboardBind Key="v" />
   </command>
-  <command ID="CmdDebugQuickstart" DisplayText="クイックスタート (デバッグ)" Category="キャラクター作成" Layer="Chargen" />
+  <command ID="CmdDebugQuickstart" DisplayText="クイックスタート (デバッグ)" Category="Character Creation" Layer="Chargen" />
   
   
   
@@ -796,66 +796,66 @@
 
   
   
-  <command ID="CmdQuit" DisplayText="終了" Category="システム" Layer="System">
+  <command ID="CmdQuit" DisplayText="終了" Category="System" Layer="System">
     <keyboardBind Modifier="ctrl" Key="q" />
   </command>
-  <command ID="CmdLoad" DisplayText="ロード" Category="システム" Layer="System">
+  <command ID="CmdLoad" DisplayText="ロード" Category="System" Layer="System">
     <keyboardBind Key="F9" />
   </command>
-  <command ID="CmdSave" DisplayText="セーブ" Category="システム" Layer="System">
+  <command ID="CmdSave" DisplayText="セーブ" Category="System" Layer="System">
     <keyboardBind Key="F5" />
   </command>
-  <command ID="CmdSystemMenu" DisplayText="システムメニュー" Category="システム" Layer="System">
+  <command ID="CmdSystemMenu" DisplayText="システムメニュー" Category="System" Layer="System">
     <keyboardBind Key="escape" />
     <gamepadBind Button="select" />
   </command>  
 
   
-  <command ID="AdventureMouseContextAction" DisplayText="マウス: スマート使用" Category="マウス操作" Layer="Adventure">
+  <command ID="AdventureMouseContextAction" DisplayText="マウス: スマート使用" Category="Mouse-specific" Layer="Adventure">
     <mouseBind Button="leftButton" />
   </command>
-  <command ID="AdventureMouseInteract" DisplayText="マウス: インタラクト" Category="マウス操作" Layer="Adventure">
+  <command ID="AdventureMouseInteract" DisplayText="マウス: インタラクト" Category="Mouse-specific" Layer="Adventure">
     <mouseBind Button="rightButton" />
   </command>
-  <command ID="AdventureMouseInteractAll" DisplayText="マウス: まとめてインタラクト" Category="マウス操作" Layer="Adventure">
+  <command ID="AdventureMouseInteractAll" DisplayText="マウス: まとめてインタラクト" Category="Mouse-specific" Layer="Adventure">
     <mouseBind Modifier="ctrl" Button="rightButton" />
   </command>
-  <command ID="AdventureMouseLook" DisplayText="マウス: 観察" Category="マウス操作" Layer="Adventure">
+  <command ID="AdventureMouseLook" DisplayText="マウス: 観察" Category="Mouse-specific" Layer="Adventure">
     <mouseBind Modifier="shift" Button="rightButton" />
   </command>
-  <command ID="AdventureMouseQuickLook" DisplayText="マウス: クイック観察" Category="マウス操作" Layer="Adventure" />
-  <command ID="AdventureMouseForceAttack" DisplayText="マウス: 強制攻撃" Category="マウス操作" Layer="Adventure">
+  <command ID="AdventureMouseQuickLook" DisplayText="マウス: クイック観察" Category="Mouse-specific" Layer="Adventure" />
+  <command ID="AdventureMouseForceAttack" DisplayText="マウス: 強制攻撃" Category="Mouse-specific" Layer="Adventure">
     <mouseBind Modifier="ctrl" Button="leftButton" />
   </command>
-  <command ID="AdventureMouseForceMove" DisplayText="マウス: 強制移動" Category="マウス操作" Layer="Adventure">
+  <command ID="AdventureMouseForceMove" DisplayText="マウス: 強制移動" Category="Mouse-specific" Layer="Adventure">
     <mouseBind Modifier="shift" Button="leftButton" />
   </command>
 
-  <command ID="AdventureNavMouseLeftClick" DisplayText="マウス: ターゲット左クリック" Category="マウス操作" Layer="UINav">
+  <command ID="AdventureNavMouseLeftClick" DisplayText="マウス: ターゲット左クリック" Category="Mouse-specific" Layer="UINav">
     <mouseBind Button="leftButton" />
   </command>
 
-  <command ID="AdventureNavMouseRightClick" DisplayText="マウス: ターゲット右クリック" Category="マウス操作" Layer="UINav">
+  <command ID="AdventureNavMouseRightClick" DisplayText="マウス: ターゲット右クリック" Category="Mouse-specific" Layer="UINav">
     <mouseBind Button="rightButton" />
   </command>
 
   
   
-  <command ID="CmdShowReachability" DisplayText="到達範囲マップを表示" Category="デバッグ" Layer="Adventure" Auto="DownPass" />
-  <command ID="CmdShowFPS" DisplayText="FPS を表示" Category="デバッグ" Layer="Adventure" Auto="DownPass" />
-  <command ID="CmdToggleAnimation" DisplayText="アニメーションを切り替え" Category="デバッグ" Layer="Adventure" Auto="DownPass" />
-  <command ID="CmdShowBrainlog" DisplayText="Brainlog を表示" Category="デバッグ" Layer="Adventure" Auto="DownPass" />
-  <command ID="CmdWish" DisplayText="願い事" Category="デバッグ" Layer="Adventure" Auto="DownPass">
+  <command ID="CmdShowReachability" DisplayText="到達範囲マップを表示" Category="Debug" Layer="Adventure" Auto="DownPass" />
+  <command ID="CmdShowFPS" DisplayText="FPS を表示" Category="Debug" Layer="Adventure" Auto="DownPass" />
+  <command ID="CmdToggleAnimation" DisplayText="アニメーションを切り替え" Category="Debug" Layer="Adventure" Auto="DownPass" />
+  <command ID="CmdShowBrainlog" DisplayText="Brainlog を表示" Category="Debug" Layer="Adventure" Auto="DownPass" />
+  <command ID="CmdWish" DisplayText="願い事" Category="Debug" Layer="Adventure" Auto="DownPass">
     <keyboardBind Modifier="ctrl" Key="w" />
   </command>
-  <command ID="CmdWishMenu" DisplayText="願い事メニュー" Category="デバッグ" Layer="Adventure" Auto="DownPass">
+  <command ID="CmdWishMenu" DisplayText="願い事メニュー" Category="Debug" Layer="Adventure" Auto="DownPass">
     <keyboardBind Modifier="shift" Key="w" />
   </command>  
-  <command ID="CmdXP" DisplayText="経験値 250,000 を得る" Category="デバッグ" Layer="Adventure" Auto="DownPass" />
-  <command ID="CmdExplore" DisplayText="マップ全域を表示" Category="デバッグ" Layer="Adventure" Auto="DownPass" />
-  <command ID="CmdNoclipD" DisplayText="ノークリップ下降" Category="デバッグ" Layer="Adventure" Auto="DownPass" />
-  <command ID="CmdNoclipU" DisplayText="ノークリップ上昇" Category="デバッグ" Layer="Adventure" Auto="DownPass" />
-  <command ID="CmdDismemberLimb" DisplayText="四肢を切断" Category="デバッグ" Layer="Adventure" Auto="DownPass" />
-  <command ID="CmdRegenerateLimb" DisplayText="四肢を再生" Category="デバッグ" Layer="Adventure" Auto="DownPass" />   
+  <command ID="CmdXP" DisplayText="経験値 250,000 を得る" Category="Debug" Layer="Adventure" Auto="DownPass" />
+  <command ID="CmdExplore" DisplayText="マップ全域を表示" Category="Debug" Layer="Adventure" Auto="DownPass" />
+  <command ID="CmdNoclipD" DisplayText="ノークリップ下降" Category="Debug" Layer="Adventure" Auto="DownPass" />
+  <command ID="CmdNoclipU" DisplayText="ノークリップ上昇" Category="Debug" Layer="Adventure" Auto="DownPass" />
+  <command ID="CmdDismemberLimb" DisplayText="四肢を切断" Category="Debug" Layer="Adventure" Auto="DownPass" />
+  <command ID="CmdRegenerateLimb" DisplayText="四肢を再生" Category="Debug" Layer="Adventure" Auto="DownPass" />
 
 </commands>

--- a/Mods/QudJP/Localization/Commands.jp.xml
+++ b/Mods/QudJP/Localization/Commands.jp.xml
@@ -202,11 +202,11 @@
   </command>
   <command ID="CmdAttackU" DisplayText="上を強制攻撃" Category="Basic Move / Attack" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="numpadMinus" />
-    <keyboardBind Modifier="ctrl,shift" Key="period" />
+    <keyboardBind Modifier="ctrl,shift" Key="comma" />
   </command>
   <command ID="CmdAttackD" DisplayText="下を強制攻撃" Category="Basic Move / Attack" Layer="Adventure">
     <keyboardBind Modifier="ctrl" Key="numpadPlus" />
-    <keyboardBind Modifier="ctrl,shift" Key="comma" />
+    <keyboardBind Modifier="ctrl,shift" Key="period" />
   </command>
   <command ID="CmdAttackDirection" DisplayText="方向を指定して強制攻撃" Category="Basic Move / Attack" Layer="Adventure" Auto="Down">
     <keyboardBind Key="backslash" />
@@ -284,12 +284,12 @@
     <keyboardBind Modifier="shift" Key="downArrow" />
     <keyboardBind Modifier="shift" Key="j" Set="hjkl" />
   </command>
-  <command ID="UI:DetailsNavigate/left" DisplayText="詳細: 左へ移動" Category="Menus" Layer="UINav" CanShareBindsWith="IndicateDirection/up,CmdMoveN" UpgradeFrom="CmdMoveN" Required="true">
+  <command ID="UI:DetailsNavigate/left" DisplayText="詳細: 左へ移動" Category="Menus" Layer="UINav" CanShareBindsWith="IndicateDirection/left,CmdMoveW" UpgradeFrom="CmdMoveW" Required="true">
     <gamepadBind Button="rightStick/left" />
     <keyboardBind Modifier="shift" Key="leftArrow" />
     <keyboardBind Modifier="shift" Key="h" Set="hjkl" />
   </command>
-  <command ID="UI:DetailsNavigate/right" DisplayText="詳細: 右へ移動" Category="Menus" Layer="UINav" CanShareBindsWith="IndicateDirection/down,CmdMoveS" UpgradeFrom="CmdMoveS" Required="true">
+  <command ID="UI:DetailsNavigate/right" DisplayText="詳細: 右へ移動" Category="Menus" Layer="UINav" CanShareBindsWith="IndicateDirection/right,CmdMoveE" UpgradeFrom="CmdMoveE" Required="true">
     <gamepadBind Button="rightStick/right" />
     <keyboardBind Modifier="shift" Key="rightArrow" />
     <keyboardBind Modifier="shift" Key="l" Set="hjkl" />

--- a/docs/release-notes/unreleased/control-mapping-categories.md
+++ b/docs/release-notes/unreleased/control-mapping-categories.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed Control Mapping category grouping and preserved upstream directional key bindings.


### PR DESCRIPTION
## Summary
- keep `Commands.jp.xml` command `Category` values as upstream stable grouping keys
- translate Control Mapping category labels at the UI route instead of localizing grouping keys
- add L1/L2 regression coverage for stable command categories and translated category display

## Root Cause
`Category` is consumed by `CommandBindingManager` and `KeybindsScreen` as a grouping key. Localizing that attribute created new Japanese groups while the old English category order remained, producing duplicate/empty categories in Control Mapping.

## Verification
- `just build`
- `just test-l1`
- `just test-l2`
- `just localization-check`
- `just translation-token-check`
- `just release-note-check`
- `git diff --check`

Fixes #496

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 高度な移動、ターゲティング、アビリティバー、クイック操作など多数のキーバインドコマンドを追加

* **改善**
  * コマンドカテゴリ表記を標準化（分類ラベルを統一）し、キー表示の翻訳精度を向上
  * キーバインド画面でカテゴリ名・行の翻訳が正しく表示されるよう改善

* **ドキュメント**
  * コントロール分類に関する未リリース注記を更新して修正点を明記

* **テスト**
  * コマンドカテゴリと方向キー割当の整合性を検証するテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->