### PR TITLE
[codex] Add GitHub release artifact workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           python=false
           localization=false
 
-          if matches '^\.github/workflows/ci\.yml$'; then
+          if matches '^\.github/workflows/.*\.ya?ml$'; then
             run_all=true
           fi
           if [[ "$run_all" == true ]] || matches '^Mods/QudJP/Assemblies/'; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,163 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    outputs:
+      version: ${{ steps.identity.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install Python tools
+        run: pip install hypothesis pytest ruff
+
+      - name: Validate release identity
+        id: identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          tag_sha="$(git rev-list -n1 "$tag")"
+          main_sha="$(git rev-parse origin/main)"
+
+          echo "tag=$tag"
+          echo "version=$version"
+          echo "tag_sha=$tag_sha"
+          echo "origin_main_sha=$main_sha"
+          git merge-base --is-ancestor "$tag_sha" origin/main
+
+          python scripts/release_identity.py --tag "$tag" --main-ref origin/main
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build QudJP
+        run: dotnet build Mods/QudJP/Assemblies/QudJP.csproj --configuration Release
+
+      - name: Build QudJP.Tests
+        run: dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release
+
+      - name: Test QudJP
+        run: dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-build
+
+      - name: Lint Python
+        run: ruff check scripts/
+
+      - name: Test Python
+        run: pytest scripts/tests/
+
+      - name: Check localization assets
+        run: |
+          python scripts/check_encoding.py Mods/QudJP/Localization scripts
+          python scripts/check_glossary_consistency.py Mods/QudJP/Localization
+          python scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
+          python scripts/check_translation_tokens.py Mods/QudJP/Localization
+
+      - name: Build release ZIP
+        run: python scripts/build_release.py
+
+      - name: Validate release ZIP identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.identity.outputs.version }}"
+          release_zip="dist/QudJP-v${version}.zip"
+          python scripts/release_identity.py --tag "v${version}" --release-zip "$release_zip" --main-ref origin/main
+          (cd dist && sha256sum "QudJP-v${version}.zip" > "QudJP-v${version}.zip.sha256")
+
+      - name: Render GitHub Release notes
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.identity.outputs.version }}"
+          release_zip="dist/QudJP-v${version}.zip"
+          checksum_file="${release_zip}.sha256"
+          checksum="$(cut -d ' ' -f1 "$checksum_file")"
+
+          python scripts/release_notes.py extract-changelog \
+            --version "$version" \
+            --output /tmp/qudjp-github-release-notes.md
+
+          {
+            cat /tmp/qudjp-github-release-notes.md
+            echo
+            echo "## Release Artifact"
+            echo
+            echo "- Git tag: \`v${version}\`"
+            echo "- Git commit: \`${GITHUB_SHA}\`"
+            echo "- ZIP: \`QudJP-v${version}.zip\`"
+            echo "- ZIP SHA256: \`${checksum}\`"
+            echo "- Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo
+            echo "This draft GitHub Release contains the verified ZIP intended for the manual Steam Workshop upload."
+          } > dist/github-release-notes.md
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qudjp-release-${{ steps.identity.outputs.version }}
+          path: |
+            dist/QudJP-v${{ steps.identity.outputs.version }}.zip
+            dist/QudJP-v${{ steps.identity.outputs.version }}.zip.sha256
+            dist/github-release-notes.md
+
+  draft-github-release:
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: qudjp-release-${{ needs.build.outputs.version }}
+          path: dist
+
+      - name: Create draft GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          version="${{ needs.build.outputs.version }}"
+          gh release create "v${version}" \
+            "dist/QudJP-v${version}.zip" \
+            "dist/QudJP-v${version}.zip.sha256" \
+            --draft \
+            --verify-tag \
+            --latest=false \
+            --title "QudJP v${version}" \
+            --notes-file dist/github-release-notes.md

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,8 @@
-# Steam Workshop Release Guide
+# Release Guide
 
-This guide covers publishing QudJP to Steam Workshop with `steamcmd`.
+This guide covers publishing QudJP through GitHub Releases and Steam Workshop.
+The GitHub Release ZIP is the source artifact for the manual Steam Workshop
+upload.
 
 ## Agent Quick Path
 
@@ -9,9 +11,14 @@ When asked to update the Steam Workshop item, do this first:
 1. Read this file, `steam/workshop_metadata.json`, and
    `steam/changenote_template.txt`.
 2. Confirm the target Workshop item is `3718988020`.
-3. Inspect tags, release range, and head identity:
+3. Prepare and merge a release PR that updates `Mods/QudJP/manifest.json`,
+   `CHANGELOG.md`, and release-note fragments.
+4. After the release PR is merged, update local `main` and inspect tags,
+   release range, and head identity:
 
    ```bash
+   git switch main
+   git pull --ff-only origin main
    git status --short --branch
    git tag --sort=-creatordate | head -20
    git describe --tags --abbrev=0 --match 'v[0-9]*'
@@ -19,17 +26,24 @@ When asked to update the Steam Workshop item, do this first:
    git rev-parse --short=12 HEAD
    ```
 
-4. Confirm or create the release tag according to the Tag and Release Policy
-   below. The tag, manifest version, release ZIP, and staged Workshop content
-   must all identify the same release.
-5. Draft a user-facing changenote from the accumulated commits. Keep internal
+5. Create and push the release tag from `main` according to the Tag and Release
+   Policy below. The tag, manifest version, GitHub Release ZIP, staged Workshop
+   content, and changenote must all identify the same release.
+6. Wait for the tag-triggered `Release` GitHub Actions workflow to create a
+   draft GitHub Release with `QudJP-vX.Y.Z.zip` and
+   `QudJP-vX.Y.Z.zip.sha256`.
+7. Draft a user-facing changenote from the accumulated commits. Keep internal
    implementation names secondary; lead with visible translation, UI, runtime,
    and packaging changes.
-6. Run the Preflight recipe below.
-7. Generate `dist/workshop/QudJP/` and `dist/workshop/workshop_item.vdf` with
-   the Workshop staging recipe.
-8. Stop before running `steamcmd` unless the user explicitly confirms upload
+8. Download and verify the GitHub Release ZIP with the local release ZIP
+   download recipe.
+9. Generate `dist/workshop/QudJP/` and `dist/workshop/workshop_item.vdf` with
+   the Workshop staging recipe, passing the downloaded GitHub Release ZIP
+   explicitly.
+10. Stop before running `steamcmd` unless the user explicitly confirms upload
    credentials and permission to publish.
+11. After Steam upload and smoke checks, publish the draft GitHub Release and
+    commit the Workshop release evidence report outside the release tag.
 
 Use `just` recipes for release commands so local runs match the repo task
 runner. The recipes execute Python through `uv run python`; do not rewrite the
@@ -37,14 +51,17 @@ documented workflow just because a local shell lacks `python3.12`.
 
 For each Workshop update, copy
 `docs/reports/templates/workshop-release.md` to a dated file under
-`docs/reports/` and fill it as release evidence, including preflight, upload,
-and post-publish smoke results.
+`docs/reports/` and fill it as release evidence, including GitHub Release,
+preflight, upload, and post-publish smoke results. The release evidence report
+records observed publication results and normally stays outside the release
+tag. Commit it after upload with the actual Steam manifest ID, public metadata
+check, and download validation results.
 
 ## Release Scope
 
-The Workshop upload source is a generated staging directory that contains only
-the shipped mod files. Do not upload source trees, test projects, build
-directories, decompiled game files, or game binaries.
+The GitHub Release ZIP and Workshop upload source contain only the shipped mod
+files. Do not upload source trees, test projects, build directories, decompiled
+game files, or game binaries.
 
 Public Workshop metadata:
 
@@ -55,6 +72,8 @@ Public Workshop metadata:
 | Metadata source | `steam/workshop_metadata.json` |
 | Description source | `steam/workshop_description.ja.txt` |
 | Changenote template | `steam/changenote_template.txt` |
+| GitHub Release ZIP | `QudJP-vX.Y.Z.zip` |
+| GitHub Release checksum | `QudJP-vX.Y.Z.zip.sha256` |
 | Generated content folder | `dist/workshop/QudJP/` |
 | Generated VDF | `dist/workshop/workshop_item.vdf` |
 
@@ -77,14 +96,16 @@ Steam Workshop updates, Git tags, and GitHub Releases are separate publication
 surfaces:
 
 - Git tag: immutable source identity for a release commit.
-- GitHub Release: optional GitHub distribution page attached to a tag.
+- GitHub Release: draft distribution page attached to a tag. The ZIP asset is
+  the source artifact for Steam Workshop staging.
 - Steam Workshop update: the `steamcmd` upload to published file ID
   `3718988020`.
 
-Normal Workshop shipping uses an annotated Git tag named `vX.Y.Z` before upload.
-The tag must point at the exact commit used to build the release ZIP and
-Workshop VDF. The `Mods/QudJP/manifest.json` `Version`, release ZIP name, release
-report, changenote first line, and Git tag must all use the same version.
+Normal shipping uses an annotated Git tag named `vX.Y.Z` after the release PR is
+merged to `main`. The tag must point at a commit reachable from `origin/main`;
+do not tag a PR branch. The `Mods/QudJP/manifest.json` `Version`, GitHub
+Release ZIP name, release report, changenote first line, and Git tag must all
+use the same version.
 
 Do not create or move tags as a hidden side effect. Creating a tag, pushing a
 tag, deleting a tag, or retagging requires explicit current user confirmation.
@@ -106,20 +127,29 @@ the new release tag. After `vX.Y.Z` exists, `git describe --tags --abbrev=0`
 returns the current release tag from `HEAD`, so it is no longer a valid way to
 discover the previous release.
 
-After release notes, changelog, manifest, and other release files are final and
-committed, create the release tag:
+After release notes, changelog, manifest, and other release files are final,
+merged, and pulled locally on `main`, create the release tag:
 
 ```bash
+git switch main
+git pull --ff-only origin main
 git tag -a vX.Y.Z -m "QudJP vX.Y.Z"
 git rev-list -n1 vX.Y.Z
 git rev-parse HEAD
 ```
 
-Push the tag only after explicit confirmation:
+Confirm that the tag target is on `origin/main`, then push the tag only after
+explicit confirmation:
 
 ```bash
+git merge-base --is-ancestor "$(git rev-list -n1 vX.Y.Z)" origin/main
 git push origin vX.Y.Z
 ```
+
+Pushing `vX.Y.Z` triggers `.github/workflows/release.yml`. That workflow fails
+before draft release creation if the tag is not reachable from `origin/main`, if
+the tag and manifest versions differ, or if `CHANGELOG.md` has no matching
+entry.
 
 If no prior local tag exists, do not invent the previous release range. Use one
 of these sources and record which one was used in the release evidence report:
@@ -133,9 +163,30 @@ of these sources and record which one was used in the release evidence report:
 If the prior release identity still cannot be established, stop before building
 Workshop staging.
 
-## Preflight
+## GitHub Release Artifact
 
-Run this from the repository root before generating the Workshop upload VDF:
+The tag-triggered GitHub Actions `Release` workflow builds and verifies
+`QudJP-vX.Y.Z.zip`, renders GitHub Release notes from `CHANGELOG.md`, writes a
+SHA256 checksum file, and creates a draft GitHub Release.
+
+The workflow is intentionally tag-only:
+
+```yaml
+on:
+  push:
+    tags:
+      - "v*.*.*"
+```
+
+PRs, `main` pushes, documentation edits, and workflow maintenance do not create
+GitHub Releases. The workflow does not run `steamcmd` and must not contain Steam
+credentials.
+
+## Local Preflight
+
+The GitHub Release workflow is the source of the release ZIP, but a local
+operator can still run the same preflight before tagging or when diagnosing a
+release:
 
 ```bash
 just workshop-preflight X.Y.Z
@@ -143,7 +194,7 @@ just workshop-preflight X.Y.Z
 
 The preflight recipe requires a clean worktree, verifies `vX.Y.Z` points at
 `HEAD`, then runs build, Python lint/tests, localization checks,
-translation-token checks, and `scripts/build_release.py`. Do not build release
+translation-token checks, and `scripts/build_release.py`. Do not upload release
 artifacts from a dirty worktree; uncommitted files can make the ZIP differ from
 the tagged source.
 
@@ -200,22 +251,25 @@ Use the previous release ref recorded before tag creation or documented in the
 release evidence report. Do not recompute it with `git describe` after the new
 release tag exists.
 
-Build the generated content folder and steamcmd VDF from the latest
-`dist/QudJP-v*.zip`:
+Download and verify the draft GitHub Release ZIP:
 
 ```bash
-just build-workshop-upload
+just download-release-zip X.Y.Z
 ```
 
-For a specific release archive:
+This writes the verified ZIP under `dist/release-assets/vX.Y.Z/`. Build the
+generated content folder and steamcmd VDF from that explicit archive:
 
 ```bash
-just build-workshop-upload dist/QudJP-vX.Y.Z.zip /tmp/qudjp-workshop-changenote.txt
+just build-workshop-upload \
+  dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip \
+  /tmp/qudjp-workshop-changenote.txt
 ```
 
 The script regenerates `dist/workshop/QudJP/` and writes
 `dist/workshop/workshop_item.vdf`. `dist/` is ignored by git; do not commit
-generated upload files.
+generated upload files. Do not rely on the default latest-zip lookup for
+shipping; pass the GitHub Release ZIP path explicitly.
 
 Steam renders Workshop description and changenote text from literal newline
 characters in the generated VDF. Do not escape newlines as the two-character
@@ -231,6 +285,28 @@ Run steamcmd with the generated VDF:
 ```bash
 steamcmd +login "$STEAM_USER" +workshop_build_item dist/workshop/workshop_item.vdf +quit
 ```
+
+Before upload, confirm that the same `steamcmd` executable you will use for
+`workshop_build_item` has usable cached credentials. The desktop Steam client
+being logged in is not enough; Homebrew or other `steamcmd` installs can use a
+different credential store. Check the executable path and run a login probe with
+that exact command:
+
+```bash
+command -v steamcmd
+steamcmd +login "$STEAM_USER" +quit
+```
+
+If the upload command will use an explicit executable path, use that same path
+for the login probe too:
+
+```bash
+/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +quit
+```
+
+If `steamcmd` reports `Cached credentials not found`, have the operator log in
+interactively through that same executable before upload. Do not pipe, commit,
+or record Steam passwords, Steam Guard codes, or login scripts.
 
 Do not commit Steam credentials, 2FA material, or login scripts. The
 `publishedfileid` is public and intentionally committed in
@@ -256,6 +332,8 @@ After Steam finishes processing the item:
    build markers, missing glyph warnings, compile errors, or `MODWARN`.
 7. Record the smoke result in the dated release evidence file copied from
    `docs/reports/templates/workshop-release.md`.
+8. Publish the draft GitHub Release only after the Steam Workshop upload and
+   minimum post-publish checks are acceptable.
 
 ## Rollback
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -234,7 +234,7 @@ just release-zip-check
 For a specific release archive:
 
 ```bash
-just release-zip-check dist/QudJP-vX.Y.Z.zip
+just release-zip-check dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip
 ```
 
 ## Generate Workshop Upload Files

--- a/docs/reports/templates/workshop-release.md
+++ b/docs/reports/templates/workshop-release.md
@@ -7,7 +7,7 @@
 - Git tag:
 - Previous release tag/range:
 - Version source:
-- GitHub Release URL, if created:
+- GitHub Release URL:
 - Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
 - Steam app ID: `333640`
 - Published file ID: `3718988020`
@@ -35,6 +35,8 @@ vX.Y.Z / <short-git-hash>
 
 - Release ZIP:
 - Release ZIP SHA256:
+- GitHub Release asset:
+- GitHub Release asset SHA256:
 - Workshop content folder: `dist/workshop/QudJP/`
 - Workshop VDF: `dist/workshop/workshop_item.vdf`
 
@@ -44,15 +46,19 @@ vX.Y.Z / <short-git-hash>
 - [ ] Release range established from previous tag, release report, changelog/GitHub release, or explicit user range
 - [ ] `Mods/QudJP/manifest.json` version, `vX.Y.Z` tag, release ZIP name, changenote first line, and report version match
 - [ ] `git rev-list -n1 vX.Y.Z` matches `git rev-parse HEAD`
+- [ ] `git merge-base --is-ancestor "$(git rev-list -n1 vX.Y.Z)" origin/main`
+- [ ] Draft GitHub Release created by tag workflow
+- [ ] `just download-release-zip X.Y.Z`
 - [ ] `just workshop-preflight X.Y.Z`
-- [ ] `just release-zip-check dist/QudJP-vX.Y.Z.zip`
-- [ ] `just build-workshop-upload dist/QudJP-vX.Y.Z.zip /tmp/qudjp-workshop-changenote.txt`
+- [ ] `just release-zip-check dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip`
+- [ ] `just build-workshop-upload dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip /tmp/qudjp-workshop-changenote.txt`
 
 ## Upload
 
 - steamcmd command:
 - Upload completed at:
 - Steam output summary:
+- GitHub Release published at:
 
 ## Post-Publish Smoke
 

--- a/justfile
+++ b/justfile
@@ -134,6 +134,28 @@ build-workshop-upload release_zip="" changenote_file="/tmp/qudjp-workshop-change
     {{python}} scripts/build_workshop_upload.py --changenote-file "{{changenote_file}}"; \
   fi
 
+# Download and verify the GitHub Release ZIP used for Workshop staging.
+download-release-zip version:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  version={{quote(version)}}
+  if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    printf 'error: version must be X.Y.Z: %q\n' "${version}" >&2
+    exit 1
+  fi
+  tag="v${version}"
+  zip_name="QudJP-${tag}.zip"
+  checksum_name="${zip_name}.sha256"
+  asset_dir="dist/release-assets/${tag}"
+  mkdir -p "${asset_dir}"
+  gh release download "${tag}" \
+    --pattern "${zip_name}" \
+    --pattern "${checksum_name}" \
+    --dir "${asset_dir}" \
+    --clobber
+  (cd "${asset_dir}" && shasum -a 256 -c "${checksum_name}")
+  printf '%s\n' "${asset_dir}/${zip_name}"
+
 # Sync the built mod into the local game install.
 sync-mod:
   {{python}} scripts/sync_mod.py

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -299,7 +299,8 @@ python scripts/sync_mod.py --dry-run
 ## build_workshop_upload.py
 
 `scripts/build_workshop_upload.py` は `scripts/build_release.py` が作成した
-`dist/QudJP-v*.zip` から Steam Workshop 用の staging directory と
+`dist/QudJP-v*.zip`、または GitHub Release から取得した
+`dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip` から Steam Workshop 用の staging directory と
 `steamcmd` 用 VDF を生成します。Workshop item ID や title などの公開
 metadata は `steam/workshop_metadata.json`、Workshop description は
 `steam/workshop_description.ja.txt` を source of truth にします。Workshop
@@ -315,9 +316,11 @@ changenote は `scripts/release_notes.py render` で
 python3.12 scripts/build_workshop_upload.py \
   --changenote-file /tmp/qudjp-workshop-changenote.txt
 
-# 特定の release ZIP を指定
+# GitHub Release から取得・検証した release ZIP を指定
+just download-release-zip 0.2.2
+
 python3.12 scripts/build_workshop_upload.py \
-  --release-zip dist/QudJP-v0.2.0.zip \
+  --release-zip dist/release-assets/v0.2.2/QudJP-v0.2.2.zip \
   --changenote-file /tmp/qudjp-workshop-changenote.txt
 ```
 
@@ -368,12 +371,46 @@ python3.12 scripts/release_notes.py render \
   --date YYYY-MM-DD \
   --changelog-output /tmp/qudjp-changelog-entry.md \
   --workshop-output /tmp/qudjp-workshop-changenote.txt
+
+# GitHub Release notes 用に確定済み CHANGELOG entry を抽出
+python3.12 scripts/release_notes.py extract-changelog \
+  --version 0.2.2 \
+  --output /tmp/qudjp-github-release-notes.md
 ```
 
 **出力**:
 
 - `/tmp/qudjp-changelog-entry.md`: `CHANGELOG.md` にコピーする release entry
 - `/tmp/qudjp-workshop-changenote.txt`: `build_workshop_upload.py --changenote-file` に渡す changenote
+- `/tmp/qudjp-github-release-notes.md`: GitHub Release body の元になる確定済み changelog entry
+
+**終了コード**: 0 = 正常終了、1 = エラー
+
+---
+
+## release_identity.py
+
+`scripts/release_identity.py` は release tag、`manifest.json`、`CHANGELOG.md`、
+release ZIP の version identity を検証します。GitHub Release workflow は
+draft release を作成する前にこのチェックを実行します。
+
+**使い方**:
+
+```bash
+# tag / manifest / CHANGELOG / main 到達性を確認
+python3.12 scripts/release_identity.py \
+  --tag v0.2.2 \
+  --main-ref origin/main
+
+# release ZIP 内 manifest も確認
+python3.12 scripts/release_identity.py \
+  --tag v0.2.2 \
+  --release-zip dist/QudJP-v0.2.2.zip \
+  --main-ref origin/main
+```
+
+`vX.Y.Z` tag が `origin/main` から到達できない場合、PR branch 上の tag として
+扱い release は停止します。
 
 **終了コード**: 0 = 正常終了、1 = エラー
 

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -26,7 +26,6 @@ import sys
 import zipfile
 from pathlib import Path
 
-RELEASE_VERSION = "0.2.1"
 _LOCALIZATION_ASSET_SUFFIXES = {".json", ".txt", ".xml"}
 
 

--- a/scripts/release_identity.py
+++ b/scripts/release_identity.py
@@ -1,0 +1,188 @@
+"""Validate that release tags, metadata, and artifacts identify one version."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+from typing import NoReturn, Self
+
+try:
+    from scripts.build_release import read_version
+except ModuleNotFoundError:  # pragma: no cover - exercised by direct script execution
+    from build_release import read_version
+
+_RELEASE_TAG_RE = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
+
+
+class ReleaseIdentityError(ValueError):
+    """Raised when release identity checks fail."""
+
+
+def parse_release_tag(tag: str) -> str:
+    """Return the bare X.Y.Z version from a vX.Y.Z release tag."""
+    match = _RELEASE_TAG_RE.fullmatch(tag.strip())
+    if match is None:
+        msg = f"Release tag must use vX.Y.Z format: {tag!r}"
+        raise ReleaseIdentityError(msg)
+    return match.group("version")
+
+
+def _changelog_has_entry(changelog_path: Path, version: str) -> bool:
+    """Return whether CHANGELOG.md contains a release entry for version."""
+    heading = re.compile(rf"^## \[{re.escape(version)}\](?:\s+-\s+.+)?$", re.MULTILINE)
+    return heading.search(changelog_path.read_text(encoding="utf-8")) is not None
+
+
+def _zip_manifest_version(zip_path: Path) -> str:
+    """Read QudJP/manifest.json Version from a release ZIP."""
+    with zipfile.ZipFile(zip_path) as zf:
+        try:
+            raw_manifest = zf.read("QudJP/manifest.json")
+        except KeyError as exc:
+            msg = f"Release ZIP is missing QudJP/manifest.json: {zip_path}"
+            raise ReleaseIdentityError(msg) from exc
+    data = json.loads(raw_manifest.decode("utf-8"))
+    version = str(data.get("Version", "")).strip()
+    if not version:
+        msg = f"Release ZIP manifest has no Version: {zip_path}"
+        raise ReleaseIdentityError(msg)
+    return version
+
+
+def _git_executable() -> str:
+    """Resolve git or raise the release-domain error used by this CLI."""
+    git = shutil.which("git")
+    if git is None:
+        msg = "git executable not found"
+        raise ReleaseIdentityError(msg)
+    return git
+
+
+def _git_output(args: list[str], *, cwd: Path) -> str:
+    """Run git and return stripped stdout, converting failures to release errors."""
+    git = _git_executable()
+    try:
+        result = subprocess.run(  # noqa: S603
+            [git, *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or str(exc)).strip()
+        msg = f"git {' '.join(args)} failed: {detail}"
+        raise ReleaseIdentityError(msg) from exc
+    return result.stdout.strip()
+
+
+def _validate_git_identity(project_root: Path, *, tag: str, main_ref: str | None) -> None:
+    """Validate tag target and optional main ancestry."""
+    tag_sha = _git_output(["rev-list", "-n1", tag], cwd=project_root)
+    head_sha = _git_output(["rev-parse", "HEAD"], cwd=project_root)
+    if tag_sha != head_sha:
+        msg = f"{tag} points at {tag_sha}, but HEAD is {head_sha}"
+        raise ReleaseIdentityError(msg)
+
+    if main_ref is None:
+        return
+    git = _git_executable()
+    try:
+        subprocess.run(  # noqa: S603
+            [git, "merge-base", "--is-ancestor", tag_sha, main_ref],
+            cwd=project_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or "").strip()
+        suffix = f": {detail}" if detail else ""
+        msg = f"{tag} target {tag_sha} is not reachable from {main_ref}{suffix}"
+        raise ReleaseIdentityError(msg) from exc
+
+
+def validate_release_identity(
+    *,
+    project_root: Path,
+    tag: str,
+    release_zip: Path | None = None,
+    main_ref: str | None = None,
+    check_git: bool = True,
+) -> str:
+    """Validate that a release tag, manifest, changelog, and optional ZIP match."""
+    project_root = project_root.resolve()
+    version = parse_release_tag(tag)
+
+    manifest_path = project_root / "Mods" / "QudJP" / "manifest.json"
+    manifest_version = read_version(manifest_path)
+    if manifest_version != version:
+        msg = f"manifest.json Version {manifest_version!r} does not match release tag {tag!r}"
+        raise ReleaseIdentityError(msg)
+
+    changelog_path = project_root / "CHANGELOG.md"
+    if not changelog_path.is_file() or not _changelog_has_entry(changelog_path, version):
+        msg = f"CHANGELOG.md has no release entry for {version}"
+        raise ReleaseIdentityError(msg)
+
+    if release_zip is not None:
+        resolved_zip = release_zip if release_zip.is_absolute() else project_root / release_zip
+        expected_name = f"QudJP-v{version}.zip"
+        if resolved_zip.name != expected_name:
+            msg = f"Release ZIP filename must be {expected_name}: {resolved_zip}"
+            raise ReleaseIdentityError(msg)
+        zip_version = _zip_manifest_version(resolved_zip)
+        if zip_version != version:
+            msg = f"Release ZIP manifest Version {zip_version!r} does not match release tag {tag!r}"
+            raise ReleaseIdentityError(msg)
+
+    if check_git:
+        _validate_git_identity(project_root, tag=tag, main_ref=main_ref)
+    return version
+
+
+class _Parser(argparse.ArgumentParser):
+    def error(self: Self, message: str) -> NoReturn:
+        """Normalize argparse errors for release workflow logs."""
+        raise ReleaseIdentityError(message)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the release identity CLI parser."""
+    parser = _Parser(description=__doc__)
+    parser.add_argument("--project-root", type=Path, default=Path.cwd())
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--release-zip", type=Path)
+    parser.add_argument("--main-ref", help="Require the release tag target to be reachable from this ref.")
+    parser.add_argument("--skip-git", action="store_true", help="Skip git tag/HEAD/main ancestry checks.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run release identity validation."""
+    parser = build_parser()
+    try:
+        args = parser.parse_args(argv)
+        version = validate_release_identity(
+            project_root=args.project_root,
+            tag=args.tag,
+            release_zip=args.release_zip,
+            main_ref=args.main_ref,
+            check_git=not args.skip_git,
+        )
+    except (ReleaseIdentityError, FileNotFoundError, ValueError, zipfile.BadZipFile) as exc:
+        print(f"error: {exc}", file=sys.stderr)  # noqa: T201
+        return 1
+
+    print(version)  # noqa: T201
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import argparse
+import re
 import shutil
 import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Self
+from typing import NoReturn, Self
 
 FRAGMENTS_DIR = Path("docs/release-notes/unreleased")
 LOCALIZATION_PREFIX = "Mods/QudJP/Localization/"
@@ -147,6 +148,29 @@ def render_workshop_changenote(
     return "\n".join(lines)
 
 
+def extract_changelog_entry(changelog_path: Path, version: str) -> str:
+    """Extract one committed CHANGELOG.md release entry by version."""
+    if not changelog_path.is_file():
+        msg = f"CHANGELOG file not found: {changelog_path}"
+        raise ReleaseNoteError(msg)
+
+    text = changelog_path.read_text(encoding="utf-8")
+    heading_pattern = re.compile(rf"^## \[{re.escape(version)}\](?:\s+-\s+.+)?$", re.MULTILINE)
+    match = heading_pattern.search(text)
+    if match is None:
+        msg = f"CHANGELOG entry not found for version {version}"
+        raise ReleaseNoteError(msg)
+
+    remaining_text = text[match.end() :]
+    next_heading = re.search(r"^## \[", remaining_text, flags=re.MULTILINE)
+    end = match.end() + next_heading.start() if next_heading is not None else len(text)
+    entry = text[match.start() : end].strip()
+    if not any(line.startswith("- ") for line in entry.splitlines()):
+        msg = f"CHANGELOG entry for version {version} has no bullets"
+        raise ReleaseNoteError(msg)
+    return re.sub(r"\n---\s*$", "", entry).rstrip()
+
+
 def _render_section_lines(fragments: ReleaseNoteFragments) -> list[str]:
     lines: list[str] = []
     for section in SECTION_ORDER:
@@ -195,7 +219,7 @@ def _require_fragments(fragments_dir: Path) -> ReleaseNoteFragments:
 
 
 class _Parser(argparse.ArgumentParser):
-    def error(self: Self, message: str) -> None:
+    def error(self: Self, message: str) -> NoReturn:
         """Print argparse errors without a traceback."""
         raise ReleaseNoteError(message)
 
@@ -233,6 +257,14 @@ def build_parser() -> argparse.ArgumentParser:
     render_parser.add_argument("--changelog-output", type=Path)
     render_parser.add_argument("--workshop-output", type=Path)
 
+    extract_parser = subparsers.add_parser(
+        "extract-changelog",
+        help="Extract a committed CHANGELOG.md entry for GitHub Release notes.",
+    )
+    extract_parser.add_argument("--version", required=True)
+    extract_parser.add_argument("--changelog", type=Path, default=Path("CHANGELOG.md"))
+    extract_parser.add_argument("--output", type=Path)
+
     return parser
 
 
@@ -258,6 +290,13 @@ def main(argv: list[str] | None = None) -> int:
                 _write_output(args.changelog_output, changelog)
             if args.workshop_output is not None:
                 _write_output(args.workshop_output, workshop)
+            return 0
+        if args.command == "extract-changelog":
+            entry = extract_changelog_entry(args.changelog, args.version)
+            if args.output is None:
+                print(entry)  # noqa: T201
+                return 0
+            _write_output(args.output, entry)
             return 0
     except ReleaseNoteError as exc:
         print(f"error: {exc}", file=sys.stderr)  # noqa: T201

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from scripts.build_release import (
-    RELEASE_VERSION,
     build_dll,
     build_release,
     collect_localization_files,
@@ -78,9 +77,12 @@ class TestProjectManifest:
     """Tests for the checked-in release manifest."""
 
     def test_manifest_version_is_release_semver(self) -> None:
-        """Checked-in manifest uses the current release setup version."""
+        """Checked-in manifest uses a release-compatible semver version."""
         manifest = PROJECT_ROOT / "Mods" / "QudJP" / "manifest.json"
-        assert read_version(manifest) == RELEASE_VERSION
+        version = read_version(manifest)
+        parts = version.split(".")
+        assert len(parts) == 3
+        assert all(part.isdigit() for part in parts)
 
     def test_preview_image_points_to_checked_in_asset(self) -> None:
         """Checked-in manifest points at the committed Workshop preview asset."""

--- a/scripts/tests/test_release_identity.py
+++ b/scripts/tests/test_release_identity.py
@@ -1,0 +1,110 @@
+"""Tests for release identity validation."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import zipfile
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.release_identity import ReleaseIdentityError, parse_release_tag, validate_release_identity
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_release_project(root: Path, *, version: str = "1.2.3") -> None:
+    """Create a minimal release project tree."""
+    mod_dir = root / "Mods" / "QudJP"
+    mod_dir.mkdir(parents=True)
+    (mod_dir / "manifest.json").write_text(json.dumps({"Version": version}), encoding="utf-8")
+    (root / "CHANGELOG.md").write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "---\n\n"
+        f"## [{version}] - 2026-05-05\n\n"
+        "### Fixed\n\n"
+        "- Fix release validation.\n",
+        encoding="utf-8",
+    )
+
+
+def _write_release_zip(root: Path, *, version: str = "1.2.3", manifest_version: str | None = None) -> Path:
+    """Create a minimal release ZIP with a manifest."""
+    zip_path = root / "dist" / f"QudJP-v{version}.zip"
+    zip_path.parent.mkdir(parents=True)
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("QudJP/manifest.json", json.dumps({"Version": manifest_version or version}))
+    return zip_path
+
+
+def _git(args: list[str], *, cwd: Path) -> None:
+    git = shutil.which("git")
+    assert git is not None
+    subprocess.run([git, *args], cwd=cwd, check=True, capture_output=True, text=True)  # noqa: S603
+
+
+def test_parse_release_tag_accepts_semver_tag() -> None:
+    """Release tags use vX.Y.Z and expose the bare version."""
+    assert parse_release_tag("v1.2.3") == "1.2.3"
+
+
+def test_parse_release_tag_rejects_non_release_tag() -> None:
+    """Non-semver tags do not trigger release identity validation."""
+    with pytest.raises(ReleaseIdentityError, match=r"vX\.Y\.Z"):
+        parse_release_tag("v1.2")
+
+
+def test_validate_release_identity_rejects_manifest_mismatch(tmp_path: Path) -> None:
+    """Manifest Version must match the release tag."""
+    _write_release_project(tmp_path, version="1.2.2")
+
+    with pytest.raises(ReleaseIdentityError, match=r"manifest\.json Version"):
+        validate_release_identity(project_root=tmp_path, tag="v1.2.3")
+
+
+def test_validate_release_identity_rejects_missing_changelog_entry(tmp_path: Path) -> None:
+    """CHANGELOG must contain the released version entry."""
+    _write_release_project(tmp_path, version="1.2.3")
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\n## [Unreleased]\n", encoding="utf-8")
+
+    with pytest.raises(ReleaseIdentityError, match=r"CHANGELOG\.md"):
+        validate_release_identity(project_root=tmp_path, tag="v1.2.3")
+
+
+def test_validate_release_identity_rejects_zip_manifest_mismatch(tmp_path: Path) -> None:
+    """Release ZIP manifest Version must match the tag."""
+    _write_release_project(tmp_path, version="1.2.3")
+    zip_path = _write_release_zip(tmp_path, version="1.2.3", manifest_version="1.2.2")
+
+    with pytest.raises(ReleaseIdentityError, match="Release ZIP manifest Version"):
+        validate_release_identity(project_root=tmp_path, tag="v1.2.3", release_zip=zip_path)
+
+
+def test_validate_release_identity_accepts_matching_zip(tmp_path: Path) -> None:
+    """A matching tag, manifest, changelog, and ZIP pass validation."""
+    _write_release_project(tmp_path, version="1.2.3")
+    zip_path = _write_release_zip(tmp_path, version="1.2.3")
+
+    validate_release_identity(project_root=tmp_path, tag="v1.2.3", release_zip=zip_path, check_git=False)
+
+
+def test_validate_release_identity_rejects_tag_not_on_main(tmp_path: Path) -> None:
+    """Release tags must be reachable from the configured main ref."""
+    _write_release_project(tmp_path, version="1.2.3")
+    _git(["init", "-b", "main"], cwd=tmp_path)
+    _git(["config", "user.email", "test@example.invalid"], cwd=tmp_path)
+    _git(["config", "user.name", "Release Test"], cwd=tmp_path)
+    _git(["add", "."], cwd=tmp_path)
+    _git(["commit", "-m", "base"], cwd=tmp_path)
+    _git(["checkout", "-b", "release-branch"], cwd=tmp_path)
+    (tmp_path / "extra.txt").write_text("branch only\n", encoding="utf-8")
+    _git(["add", "extra.txt"], cwd=tmp_path)
+    _git(["commit", "-m", "branch only"], cwd=tmp_path)
+    _git(["tag", "-a", "v1.2.3", "-m", "release"], cwd=tmp_path)
+
+    with pytest.raises(ReleaseIdentityError, match="not reachable"):
+        validate_release_identity(project_root=tmp_path, tag="v1.2.3", main_ref="main")

--- a/scripts/tests/test_release_justfile_contract.py
+++ b/scripts/tests/test_release_justfile_contract.py
@@ -9,10 +9,20 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _justfile_text() -> str:
+    return (_REPO_ROOT / "justfile").read_text(encoding="utf-8")
+
+
 def test_download_release_zip_quotes_version_argument() -> None:
     """The release download recipe must not splice raw version text into shell syntax."""
     just = shutil.which("just")
-    assert just is not None
+    if just is None:
+        justfile = _justfile_text()
+
+        assert "version={{quote(version)}}" in justfile
+        assert 'tag="v{{version}}"' not in justfile
+        assert "QudJP-v{{version}}" not in justfile
+        return
 
     probe = '1.2.3"; touch /tmp/qudjp-just-injection #'
     result = subprocess.run(  # noqa: S603 - intentionally probes shell quoting via just dry-run.

--- a/scripts/tests/test_release_justfile_contract.py
+++ b/scripts/tests/test_release_justfile_contract.py
@@ -13,15 +13,23 @@ def _justfile_text() -> str:
     return (_REPO_ROOT / "justfile").read_text(encoding="utf-8")
 
 
+def _download_release_zip_recipe() -> str:
+    justfile = _justfile_text()
+    return justfile.split("\ndownload-release-zip version:\n", maxsplit=1)[1].split(
+        "\n# Sync the built mod",
+        maxsplit=1,
+    )[0]
+
+
 def test_download_release_zip_quotes_version_argument() -> None:
     """The release download recipe must not splice raw version text into shell syntax."""
     just = shutil.which("just")
     if just is None:
-        justfile = _justfile_text()
+        recipe = _download_release_zip_recipe()
 
-        assert "version={{quote(version)}}" in justfile
-        assert 'tag="v{{version}}"' not in justfile
-        assert "QudJP-v{{version}}" not in justfile
+        assert "version={{quote(version)}}" in recipe
+        assert 'tag="v{{version}}"' not in recipe
+        assert "QudJP-v{{version}}" not in recipe
         return
 
     probe = '1.2.3"; touch /tmp/qudjp-just-injection #'

--- a/scripts/tests/test_release_justfile_contract.py
+++ b/scripts/tests/test_release_justfile_contract.py
@@ -1,0 +1,29 @@
+"""Static contract tests for release just recipes."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_download_release_zip_quotes_version_argument() -> None:
+    """The release download recipe must not splice raw version text into shell syntax."""
+    just = shutil.which("just")
+    assert just is not None
+
+    probe = '1.2.3"; touch /tmp/qudjp-just-injection #'
+    result = subprocess.run(  # noqa: S603 - intentionally probes shell quoting via just dry-run.
+        [just, "--dry-run", "download-release-zip", probe],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    dry_run = result.stdout + result.stderr
+
+    assert 'tag="v1.2.3"; touch /tmp/qudjp-just-injection #' not in dry_run
+    assert "version='1.2.3\"; touch /tmp/qudjp-just-injection #'" in dry_run

--- a/scripts/tests/test_release_justfile_contract.py
+++ b/scripts/tests/test_release_justfile_contract.py
@@ -16,7 +16,9 @@ def _justfile_text() -> str:
 
 def _download_release_zip_recipe() -> str:
     justfile = _justfile_text()
-    remainder = justfile.split("\ndownload-release-zip version:\n", maxsplit=1)[1]
+    marker = "\ndownload-release-zip version:\n"
+    _prefix, separator, remainder = justfile.partition(marker)
+    assert separator, "download-release-zip version: recipe not found in justfile"
     next_recipe = re.search(r"^[A-Za-z0-9_-]+(?:\s+[^:\n]+)*:\n", remainder, flags=re.MULTILINE)
     return remainder[: next_recipe.start()] if next_recipe is not None else remainder
 

--- a/scripts/tests/test_release_justfile_contract.py
+++ b/scripts/tests/test_release_justfile_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -15,10 +16,9 @@ def _justfile_text() -> str:
 
 def _download_release_zip_recipe() -> str:
     justfile = _justfile_text()
-    return justfile.split("\ndownload-release-zip version:\n", maxsplit=1)[1].split(
-        "\n# Sync the built mod",
-        maxsplit=1,
-    )[0]
+    remainder = justfile.split("\ndownload-release-zip version:\n", maxsplit=1)[1]
+    next_recipe = re.search(r"^[A-Za-z0-9_-]+(?:\s+[^:\n]+)*:\n", remainder, flags=re.MULTILINE)
+    return remainder[: next_recipe.start()] if next_recipe is not None else remainder
 
 
 def test_download_release_zip_quotes_version_argument() -> None:
@@ -43,5 +43,5 @@ def test_download_release_zip_quotes_version_argument() -> None:
 
     dry_run = result.stdout + result.stderr
 
-    assert 'tag="v1.2.3"; touch /tmp/qudjp-just-injection #' not in dry_run
-    assert "version='1.2.3\"; touch /tmp/qudjp-just-injection #'" in dry_run
+    assert re.search(r"^version=(['\"]).*touch /tmp/qudjp-just-injection.*\1$", dry_run, re.MULTILINE)
+    assert not re.search(r"^(?!version=).*;\s*touch\s+/tmp/qudjp-just-injection", dry_run, re.MULTILINE)

--- a/scripts/tests/test_release_notes.py
+++ b/scripts/tests/test_release_notes.py
@@ -13,6 +13,7 @@ from scripts.release_notes import (
     ReleaseNoteError,
     check_fragment_requirement,
     collect_fragments,
+    extract_changelog_entry,
     git_changed_files,
     main,
     render_changelog_entry,
@@ -96,6 +97,68 @@ def test_render_workshop_changenote_is_user_facing(tmp_path: Path) -> None:
         "更新内容:\n"
         "- Fix untranslated sleep and game-summary messages.\n"
     )
+
+
+def test_extract_changelog_entry_returns_requested_release_section(tmp_path: Path) -> None:
+    """GitHub Release notes come from the committed CHANGELOG entry."""
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "---\n\n"
+        "## [1.2.3] - 2026-05-05\n\n"
+        "### Fixed\n\n"
+        "- Fix release workflow.\n\n"
+        "---\n\n"
+        "## [1.2.2] - 2026-05-04\n\n"
+        "### Fixed\n\n"
+        "- Older fix.\n",
+        encoding="utf-8",
+    )
+
+    assert extract_changelog_entry(changelog, "1.2.3") == (
+        "## [1.2.3] - 2026-05-05\n\n"
+        "### Fixed\n\n"
+        "- Fix release workflow."
+    )
+
+
+def test_extract_changelog_entry_rejects_missing_version(tmp_path: Path) -> None:
+    """Missing CHANGELOG entries fail before a GitHub Release is created."""
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## [Unreleased]\n", encoding="utf-8")
+
+    with pytest.raises(ReleaseNoteError, match="CHANGELOG entry"):
+        extract_changelog_entry(changelog, "1.2.3")
+
+
+def test_main_extracts_changelog_entry(tmp_path: Path) -> None:
+    """The CLI writes release notes from a committed CHANGELOG entry."""
+    changelog = tmp_path / "CHANGELOG.md"
+    output = tmp_path / "github-release-notes.md"
+    changelog.write_text(
+        "# Changelog\n\n"
+        "## [1.2.3] - 2026-05-05\n\n"
+        "### Fixed\n\n"
+        "- Fix release workflow.\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        main(
+            [
+                "extract-changelog",
+                "--version",
+                "1.2.3",
+                "--changelog",
+                str(changelog),
+                "--output",
+                str(output),
+            ],
+        )
+        == 0
+    )
+    assert "Fix release workflow" in output.read_text(encoding="utf-8")
 
 
 def test_main_renders_workshop_changenote_without_git_hash(tmp_path: Path) -> None:

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -16,6 +16,9 @@ def test_release_workflow_runs_only_for_release_tags() -> None:
     workflow = _workflow_text()
 
     assert "pull_request:" not in workflow
+    assert "workflow_dispatch:" not in workflow
+    assert "schedule:" not in workflow
+    assert "repository_dispatch:" not in workflow
     assert "branches:" not in workflow
     assert "tags:" in workflow
     assert '"v*.*.*"' in workflow

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -1,0 +1,43 @@
+"""Static contract tests for the GitHub Release workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _workflow_text() -> str:
+    return (_REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+
+def test_release_workflow_runs_only_for_release_tags() -> None:
+    """Release publishing is triggered by vX.Y.Z tags, not branch pushes or PRs."""
+    workflow = _workflow_text()
+
+    assert "pull_request:" not in workflow
+    assert "branches:" not in workflow
+    assert "tags:" in workflow
+    assert '"v*.*.*"' in workflow
+
+
+def test_release_workflow_requires_main_ancestor_and_identity_validation() -> None:
+    """Tag releases must prove main ancestry and version identity before publishing."""
+    workflow = _workflow_text()
+
+    assert "git merge-base --is-ancestor" in workflow
+    assert "origin/main" in workflow
+    assert "scripts/release_identity.py" in workflow
+    assert "--main-ref origin/main" in workflow
+
+
+def test_release_workflow_creates_draft_github_release_without_steam_upload() -> None:
+    """GitHub Release artifact creation stays separate from Steam Workshop upload."""
+    workflow = _workflow_text()
+
+    assert "gh release create" in workflow
+    assert "GH_REPO: ${{ github.repository }}" in workflow
+    assert "--draft" in workflow
+    assert "--latest=false" in workflow
+    assert "contents: write" in workflow
+    assert "workshop_build_item" not in workflow


### PR DESCRIPTION
## Summary

- Add a tag-only GitHub Actions release workflow for `vX.Y.Z` tags.
- Build, test, validate release identity, generate `QudJP-vX.Y.Z.zip`, write SHA256, and create a draft GitHub Release.
- Keep Steam Workshop upload manual and require Workshop staging to consume the verified GitHub Release ZIP.
- Update release docs, evidence template, `just` recipes, release identity validation, changelog extraction, and regression tests.

## Release Safety

- The Release workflow only runs on `v*.*.*` tag pushes.
- Draft GitHub Release creation uses `contents: write` only in the release draft job and sets `GH_REPO` explicitly.
- Release identity validates tag, manifest version, CHANGELOG entry, ZIP filename, ZIP manifest version, HEAD identity, and `origin/main` reachability.
- GitHub Actions do not run `steamcmd` and do not use Steam credentials.
- Local Workshop staging downloads and checksum-verifies the GitHub Release ZIP before passing it explicitly to staging.

## Reviews

- Separate code/security/verification reviewers initially requested changes.
- Findings were fixed and re-reviewed to approval.
- A simplify pass was run and final PR review returned approve / merge ready.

## Validation

- `pyright scripts/release_identity.py scripts/release_notes.py`
- `ruff check scripts/`
- `uv run pytest scripts/tests/test_release_identity.py scripts/tests/test_release_workflow_contract.py scripts/tests/test_release_justfile_contract.py scripts/tests/test_release_notes.py scripts/tests/test_build_release.py -q` -> 65 passed
- `uv run pytest scripts/tests/ -q` -> 853 passed
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * タグプッシュで起動するリリースワークフローを追加し、リリースZIP・SHA256・ドラフトリリースノートを生成・アップロード

* **Chores**
  * CIの変更検出をワークフロー全体に拡大してビルド/テストを確実化
  * リリースZIP名をマニフェストのVersionに基づくよう更新

* **Documentation**
  * リリース手順をタグ中心に再編、ローカル事前検証と署名済ZIP取得手順を明記
  * ワークショップ用テンプレートとアップロード手順を更新

* **New Tools**
  * リリース整合性検証CLI、CHANGELOG抽出CLI、リリースZIP取得タスクを追加

* **Tests**
  * リリース関連の自動検証テスト群と契約テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->