### PR TITLE
[codex] Add agent-cycle and Roslyn just guardrails

### DIFF
--- a/justfile
+++ b/justfile
@@ -141,6 +141,44 @@ sync-mod:
 # Run the broad local verification gate.
 check: build test-l1 test-l2 test-l2g python-check python-test localization-check translation-token-check
 
+# Build all repo-local Roslyn tool projects.
+roslyn-build:
+  dotnet build scripts/tools/AnnalsPatternExtractor/AnnalsPatternExtractor.csproj --configuration Release --no-incremental
+  dotnet build scripts/tools/StaticProducerInventoryScanner/StaticProducerInventoryScanner.csproj --configuration Release --no-incremental
+  dotnet build scripts/tools/TextConstructionInventory/TextConstructionInventory.csproj --configuration Release --no-incremental
+
+# Run focused tests for repo-local Roslyn tools and Python wrappers.
+roslyn-test:
+  uv run pytest scripts/tests/test_roslyn_extractor_smoke.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_extract_annals_patterns.py scripts/tests/test_roslyn_text_construction_inventory.py -q
+
+# Run Python static checks for the currently type-clean Roslyn wrapper surface.
+roslyn-python-check:
+  ruff check scripts/scan_static_producer_inventory.py scripts/extract_annals_patterns.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_extract_annals_patterns.py scripts/tests/test_roslyn_extractor_smoke.py scripts/tests/test_roslyn_text_construction_inventory.py
+  uvx basedpyright scripts/scan_static_producer_inventory.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_roslyn_extractor_smoke.py
+
+# Run the non-regenerating local Roslyn verification gate.
+roslyn-check: roslyn-build roslyn-test roslyn-python-check
+
+# Preview static producer inventory against decompiled source without touching tracked docs.
+static-producer-preview source_root="$HOME/dev/coq-decompiled_stable" output="/tmp/qudjp-static-producer-inventory.json":
+  {{python}} scripts/scan_static_producer_inventory.py --source-root "{{source_root}}" --output "{{output}}"
+
+# Intentionally regenerate the tracked static producer inventory artifact.
+static-producer-regenerate-tracked source_root="$HOME/dev/coq-decompiled_stable":
+  {{python}} scripts/scan_static_producer_inventory.py --source-root "{{source_root}}" --output docs/static-producer-inventory.json
+
+# Preview Annals Roslyn candidates without touching the tracked pending artifact.
+annals-pattern-preview source_root="$HOME/dev/coq-decompiled_stable/XRL.Annals" include="Resheph*.cs" output="/tmp/qudjp-annals-candidates.json":
+  {{python}} scripts/extract_annals_patterns.py --source-root "{{source_root}}" --include "{{include}}" --output "{{output}}" --force
+
+# Intentionally regenerate the tracked Annals pending candidates artifact.
+annals-pattern-extract-tracked source_root="$HOME/dev/coq-decompiled_stable/XRL.Annals" include="Resheph*.cs":
+  {{python}} scripts/extract_annals_patterns.py --source-root "{{source_root}}" --include "{{include}}" --output scripts/_artifacts/annals/candidates_pending.json --force
+
+# Preview Roslyn text construction inventory without touching tracked docs.
+text-construction-inventory source_root="$HOME/dev/coq-decompiled_stable" output="/tmp/qudjp-text-construction-inventory.json" summary="/tmp/qudjp-text-construction-inventory-summary.md":
+  dotnet run --project scripts/tools/TextConstructionInventory/TextConstructionInventory.csproj -- --source-root "{{source_root}}" --output "{{output}}" --summary-output "{{summary}}"
+
 # Verify agent-loop tools and dotfiles script availability.
 tool-check:
   bash scripts/agent_cycle.sh tool-check

--- a/justfile
+++ b/justfile
@@ -149,17 +149,21 @@ tool-check:
 ast-grep-check:
   bash scripts/agent_cycle.sh ast-grep-check
 
+# Run the ast-grep structural-search smoke fixture.
+ast-grep-smoke:
+  bash scripts/agent_cycle.sh ast-grep-smoke
+
 # Run an ast-grep structural search.
 sg lang pattern path=".":
-  AST_GREP_PATTERN='{{pattern}}' AST_GREP_PATH='{{path}}' bash scripts/agent_cycle.sh sg "{{lang}}"
+  AST_GREP_PATTERN={{quote(pattern)}} AST_GREP_PATH={{quote(path)}} bash scripts/agent_cycle.sh sg {{quote(lang)}}
 
 # Search C# structure. Defaults to the decompiled game source.
 sg-cs pattern path="":
-  AST_GREP_PATTERN='{{pattern}}' AST_GREP_PATH='{{path}}' bash scripts/agent_cycle.sh sg csharp
+  AST_GREP_PATTERN={{quote(pattern)}} AST_GREP_PATH={{quote(path)}} bash scripts/agent_cycle.sh sg csharp
 
 # Search Python structure.
 sg-py pattern path="scripts":
-  AST_GREP_PATTERN='{{pattern}}' AST_GREP_PATH='{{path}}' bash scripts/agent_cycle.sh sg python
+  AST_GREP_PATTERN={{quote(pattern)}} AST_GREP_PATH={{quote(path)}} bash scripts/agent_cycle.sh sg python
 
 # Render skill-eval prompts from this repo's manifest.
 render-skill-evals skill="" scenario="":

--- a/rules/README.md
+++ b/rules/README.md
@@ -8,3 +8,7 @@ Follow the `ast-grep-practice` skill workflow:
 1. Add a failing case under `rule-tests/`.
 2. Add the smallest matching rule under this directory.
 3. Run `just ast-grep-check`.
+
+When no project rules are registered yet, `just ast-grep-check` reports that
+state explicitly and runs `just ast-grep-smoke` so the ast-grep CLI path is
+still exercised.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -22,6 +22,10 @@ ruff check scripts/
 ruff format scripts/
 uv run pytest scripts/tests/
 uv run pytest scripts/tests/ -k <pattern>
+just roslyn-check
+just static-producer-preview
+just annals-pattern-preview
+just text-construction-inventory
 just ast-grep-smoke
 just ast-grep-check
 DOTFILES_ROOT=~/Dev/dotfiles just render-skill-evals <skill> <scenario>
@@ -40,6 +44,9 @@ python3.12 scripts/sync_mod.py
 - Prefer extending an existing script over creating a parallel tool for the same job.
 - Keep error paths explicit and actionable; these scripts support validation and deployment.
 - Python baseline is `3.12+`, with typed and documented public interfaces.
+- Roslyn tracked artifact recipes are intentionally named `*-tracked`;
+  prefer preview recipes for review and validation unless the task explicitly
+  owns the generated artifact.
 - Skill eval execution is orchestrator-owned: render prompts with `just render-skill-evals`,
   run them in fresh Codex subagents from the parent session, append results that match
   `skill-eval-result.schema.json`, then summarize with `just summarize-skill-evals`.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -22,6 +22,10 @@ ruff check scripts/
 ruff format scripts/
 uv run pytest scripts/tests/
 uv run pytest scripts/tests/ -k <pattern>
+just ast-grep-smoke
+just ast-grep-check
+DOTFILES_ROOT=~/Dev/dotfiles just render-skill-evals <skill> <scenario>
+DOTFILES_ROOT=~/Dev/dotfiles just summarize-skill-evals /tmp/skill-eval-results.jsonl
 python3.12 scripts/check_encoding.py Mods/QudJP/Localization scripts
 python3.12 scripts/check_glossary_consistency.py Mods/QudJP/Localization
 python3.12 scripts/check_translation_tokens.py Mods/QudJP/Localization
@@ -36,6 +40,9 @@ python3.12 scripts/sync_mod.py
 - Prefer extending an existing script over creating a parallel tool for the same job.
 - Keep error paths explicit and actionable; these scripts support validation and deployment.
 - Python baseline is `3.12+`, with typed and documented public interfaces.
+- Skill eval execution is orchestrator-owned: render prompts with `just render-skill-evals`,
+  run them in fresh Codex subagents from the parent session, append results that match
+  `skill-eval-result.schema.json`, then summarize with `just summarize-skill-evals`.
 - If a task touches Phase F observability or triage docs, treat `docs/RULES.md` as the source of truth and keep this guide aligned to it.
 
 ## Annals pattern extraction pipeline (issue #420)

--- a/scripts/agent_cycle.sh
+++ b/scripts/agent_cycle.sh
@@ -11,6 +11,7 @@ usage() {
 Usage:
   scripts/agent_cycle.sh tool-check
   scripts/agent_cycle.sh ast-grep-check
+  scripts/agent_cycle.sh ast-grep-smoke
   scripts/agent_cycle.sh sg <lang> [pattern] [path]
   scripts/agent_cycle.sh render-skill-evals [skill] [scenario]
   scripts/agent_cycle.sh summarize-skill-evals [results-jsonl]
@@ -67,8 +68,33 @@ tool_check() {
 ast_grep_check() {
   cd "$ROOT_DIR"
   require_file "$ROOT_DIR/sgconfig.yml"
-  ast-grep test --skip-snapshot-tests
-  ast-grep scan .
+  local rule_count
+  local test_count
+  rule_count=$(find "$ROOT_DIR/rules" -type f \( -name '*.yml' -o -name '*.yaml' \) | wc -l | tr -d '[:space:]')
+  test_count=$(find "$ROOT_DIR/rule-tests" -type f \( -name '*.yml' -o -name '*.yaml' \) | wc -l | tr -d '[:space:]')
+  if [[ "$rule_count" == "0" && "$test_count" == "0" ]]; then
+    echo "No project ast-grep rules registered; running structural-search smoke only."
+  elif [[ "$rule_count" == "0" || "$test_count" == "0" ]]; then
+    echo "ast-grep rules and rule tests must be added together (rules=$rule_count tests=$test_count)" >&2
+    return 1
+  else
+    ast-grep test --skip-snapshot-tests
+    ast-grep scan .
+  fi
+  ast_grep_smoke
+}
+
+ast_grep_smoke() {
+  cd "$ROOT_DIR"
+  require_file "$ROOT_DIR/sgconfig.yml"
+  local fixture_path="scripts/tests/fixtures/static_producer_inventory"
+  local output
+  output=$(structural_search csharp 'Popup.Show($$$ARGS)' "$fixture_path")
+  printf '%s\n' "$output"
+  if ! grep -q 'Demo/StaticProducerCases.cs:25:' <<<"$output"; then
+    echo "ast-grep smoke did not find the expected Popup.Show fixture hit" >&2
+    return 1
+  fi
 }
 
 expand_search_path() {
@@ -182,6 +208,9 @@ main() {
       ;;
     ast-grep-check)
       ast_grep_check
+      ;;
+    ast-grep-smoke)
+      ast_grep_smoke
       ;;
     sg)
       structural_search "${1:-}" "${2:-}" "${3:-}"

--- a/scripts/tests/test_agent_cycle.py
+++ b/scripts/tests/test_agent_cycle.py
@@ -1,0 +1,51 @@
+"""Tests for scripts/agent_cycle.sh."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_CYCLE = REPO_ROOT / "scripts" / "agent_cycle.sh"
+
+
+def _run_agent_cycle(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 -- tests invoke the repo-local shell script via bash
+        ["bash", str(AGENT_CYCLE), *args],  # noqa: S607
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+
+@pytest.mark.skipif(not shutil.which("ast-grep"), reason="ast-grep CLI not available")
+def test_ast_grep_smoke_finds_static_producer_fixture() -> None:
+    """The agent-cycle ast-grep smoke must prove structural search actually works."""
+    completed = _run_agent_cycle("ast-grep-smoke")
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Demo/StaticProducerCases.cs:25:" in completed.stdout
+    assert 'Popup.Show("Popup body", Title: "Ignored title")' in completed.stdout
+
+
+@pytest.mark.skipif(not shutil.which("ast-grep"), reason="ast-grep CLI not available")
+def test_ast_grep_check_reports_empty_rule_set_and_runs_smoke() -> None:
+    """An empty rule directory should be explicit, not a silent 0-test pass."""
+    rule_files = [
+        *list((REPO_ROOT / "rules").rglob("*.yml")),
+        *list((REPO_ROOT / "rules").rglob("*.yaml")),
+        *list((REPO_ROOT / "rule-tests").rglob("*.yml")),
+        *list((REPO_ROOT / "rule-tests").rglob("*.yaml")),
+    ]
+    if rule_files:
+        pytest.skip("project ast-grep rules are registered")
+
+    completed = _run_agent_cycle("ast-grep-check")
+
+    assert completed.returncode == 0, completed.stderr
+    assert "No project ast-grep rules registered" in completed.stdout
+    assert "Demo/StaticProducerCases.cs:25:" in completed.stdout


### PR DESCRIPTION
## Summary

- add explicit Roslyn just recipes for build, focused tests, static checks, and safe preview regeneration
- split Roslyn preview recipes from intentionally tracked artifact regeneration recipes
- add an explicit ast-grep smoke recipe for structural-search verification
- make ast-grep-check report empty rule sets and still exercise the smoke fixture
- document orchestrator-owned skill eval rendering and summarization flow
- fix just quoting for structural search patterns and paths

## Roslyn recipes

- `just roslyn-check`
- `just static-producer-preview`
- `just static-producer-regenerate-tracked`
- `just annals-pattern-preview`
- `just annals-pattern-extract-tracked`
- `just text-construction-inventory`

## Validation

- just roslyn-check
- just static-producer-preview
- just annals-pattern-preview
- just text-construction-inventory
- just python-check
- uv run pytest scripts/tests/test_agent_cycle.py -q
- just ast-grep-check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 複数のローカル検証・アーティファクト管理タスクと、AST‑Grep用のスモークテストコマンドを追加しました。
  * コマンド引数の扱いを改善し、CLI実行時の安定性を向上しました。

* **Documentation**
  * ルール未登録時の挙動やスキル評価実行手順をドキュメントに追記しました。

* **Tests**
  * AST‑Grep関連の振る舞いを検証する新しい統合テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->