### PR TITLE
[codex] Record v0.2.2 GitHub Release URL

### DIFF
--- a/docs/reports/2026-05-05-workshop-v0.2.2.md
+++ b/docs/reports/2026-05-05-workshop-v0.2.2.md
@@ -7,7 +7,7 @@
 - Git tag: `v0.2.2`
 - Previous release tag/range: `v0.2.1..v0.2.2`
 - Version source: `Mods/QudJP/manifest.json` `Version = 0.2.2`
-- GitHub Release URL, if created: N/A (not created yet)
+- GitHub Release URL: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.2
 - Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
 - Steam app ID: `333640`
 - Published file ID: `3718988020`


### PR DESCRIPTION
## Summary

- Update the v0.2.2 Workshop release evidence report with the published GitHub Release URL.

## Validation

- `git diff --check`
- `just download-release-zip 0.2.2` -> `QudJP-v0.2.2.zip: OK`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * リリースドキュメントのアイデンティティセクションを更新し、実際のリリースURLを反映させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->