### PR TITLE
[codex] Mark future GitHub releases as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,6 @@ jobs:
             "dist/QudJP-v${version}.zip.sha256" \
             --draft \
             --verify-tag \
-            --latest=false \
+            --latest \
             --title "QudJP v${version}" \
             --notes-file dist/github-release-notes.md

--- a/docs/release.md
+++ b/docs/release.md
@@ -167,7 +167,10 @@ Workshop staging.
 
 The tag-triggered GitHub Actions `Release` workflow builds and verifies
 `QudJP-vX.Y.Z.zip`, renders GitHub Release notes from `CHANGELOG.md`, writes a
-SHA256 checksum file, and creates a draft GitHub Release.
+SHA256 checksum file, and creates a draft GitHub Release. The created release is
+explicitly marked as GitHub's `Latest` release for the tag version so the
+repository release page follows the newest shipped release when the draft is
+published.
 
 The workflow is intentionally tag-only:
 

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -41,6 +41,7 @@ def test_release_workflow_creates_draft_github_release_without_steam_upload() ->
     assert "gh release create" in workflow
     assert "GH_REPO: ${{ github.repository }}" in workflow
     assert "--draft" in workflow
-    assert "--latest=false" in workflow
+    assert "--latest" in workflow
+    assert "--latest=false" not in workflow
     assert "contents: write" in workflow
     assert "workshop_build_item" not in workflow


### PR DESCRIPTION
## Summary

- Make the tag-triggered GitHub Release workflow mark future releases as GitHub `Latest`.
- Update the workflow contract test so `--latest=false` cannot regress back in.
- Document that the draft release created by the workflow is intended to become the latest release when published.

## Validation

- `uv run pytest scripts/tests/test_release_workflow_contract.py -q` -> 3 passed
- `actionlint .github/workflows/release.yml`
- `git diff --check`

## Note

The existing `v0.2.2` release has already been corrected manually and now shows as `Latest` in `gh release list`.
