### PR TITLE
[codex] Release QudJP v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+[0.2.3]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.3
 [0.2.2]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.2
 [0.2.1]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.1
 [0.2.0]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.2.3] - 2026-05-06
+
+### Changed
+
+- Added the tag-triggered GitHub Release ZIP workflow as the source artifact
+  for Steam Workshop staging.
+- Marked newly created GitHub Releases as `Latest` so the repository release
+  page follows the newest shipped version.
+- Documented and verified the release artifact download path used before
+  Workshop upload.
+
+### Notes
+
+- This is a release-pipeline validation release. Game localization content is
+  unchanged from v0.2.2 except for the manifest version.
+
+---
+
 ## [0.2.2] - 2026-05-05
 
 ### Fixed

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud \u65e5\u672c\u8a9e\u5316",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.2.2",
+  "Version": "0.2.3",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}


### PR DESCRIPTION
## Summary

- Release QudJP v0.2.3 from the current latest main head.
- Update `Mods/QudJP/manifest.json` to `0.2.3`.
- Add `CHANGELOG.md` notes for the release-pipeline validation release.

## Release Scope

This is a release-pipeline validation release. Game localization content is unchanged from v0.2.2 except for the manifest version.

## Validation

- `uv run python scripts/release_identity.py --tag v0.2.3 --skip-git` -> `0.2.3`
- `uv run python scripts/release_notes.py extract-changelog --version 0.2.3 --output /tmp/qudjp-v0.2.3-github-release-notes.md`
- `uv run pytest scripts/tests/test_release_identity.py scripts/tests/test_release_notes.py scripts/tests/test_build_release.py -q` -> 61 passed
- `git diff --check`

## Follow-up After Merge

After this PR lands, create annotated tag `v0.2.3` on `main` and push it to trigger the GitHub Release workflow. The resulting GitHub Release should be marked `Latest` and used as the source artifact for Workshop staging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * バージョンを v0.2.3 に更新しました
  * タグ付きリリースに基づくアーティファクト公開の処理を導入し、リリース生成を自動化しました
  * 新規リリースを「Latest」としてマークするように変更しました
  * 既存のWorkshopアップロード/ダウンロードパスを記録するようにしました
  * ゲームのローカライズは v0.2.2 から変更ありません（マニフェストのバージョンのみ更新）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->