### PR TITLE
[codex] Install ast-grep in Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install Python tools
         run: pip install hypothesis pytest ruff
 
+      - name: Install ast-grep
+        run: npm install -g @ast-grep/cli
+
       - name: Validate release identity
         id: identity
         shell: bash

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -34,6 +34,15 @@ def test_release_workflow_requires_main_ancestor_and_identity_validation() -> No
     assert "--main-ref origin/main" in workflow
 
 
+def test_release_workflow_installs_python_test_tooling() -> None:
+    """Release full-suite Python tests must have their external CLI dependencies."""
+    workflow = _workflow_text()
+
+    assert "pip install hypothesis pytest ruff" in workflow
+    assert "npm install -g @ast-grep/cli" in workflow
+    assert workflow.index("npm install -g @ast-grep/cli") < workflow.index("pytest scripts/tests/")
+
+
 def test_release_workflow_creates_draft_github_release_without_steam_upload() -> None:
     """GitHub Release artifact creation stays separate from Steam Workshop upload."""
     workflow = _workflow_text()


### PR DESCRIPTION
## Summary

- Install `@ast-grep/cli` in the tag-triggered Release workflow before running the full Python test suite.
- Add a workflow contract test so Release workflow Python tests keep their external CLI dependency.

## Failure Addressed

Release workflow run `25385376984` for `v0.2.3` failed in `pytest scripts/tests/` because scanner tests require `ast-grep` and the Release workflow did not install it.

## Validation

- `uv run pytest scripts/tests/test_release_workflow_contract.py -q` -> 4 passed
- `actionlint .github/workflows/release.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * リリースワークフローで必要なCLIツールのセットアップを自動化しました。

* **Tests**
  * リリースワークフローが正しく依存関係をインストールしていることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->