### PR TITLE
[codex] Fix markup semantic drift diagnostics

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/FinalOutputObservabilityTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/FinalOutputObservabilityTests.cs
@@ -199,9 +199,9 @@ public sealed class FinalOutputObservabilityTests
     }
 
     [TestCase("{{B}}|濡れた", "literal_qud_shader_fragment,unmatched_qud_close")]
-    [TestCase("{{B|{{B|{{B}}|濡れた}}", "literal_qud_shader_fragment,repeated_same_qud_scope_start")]
+    [TestCase("{{B|{{B|{{B}}|濡れた}}", "literal_qud_shader_fragment")]
     [TestCase("水袋 {{y|[{{K|空]}}}}", "bracket_close_inside_nested_qud_scope")]
-    [TestCase("{{B|}}", "empty_qud_wrapper")]
+    [TestCase("{{R|翻訳されたテキスト", "unclosed_qud_scope")]
     public void Record_ExposesSemanticDriftDiagnostics_WhenMarkupTokensMatch(string finalText, string expectedFlags)
     {
         var output = TestTraceHelper.CaptureTrace(() =>
@@ -231,6 +231,33 @@ public sealed class FinalOutputObservabilityTests
                     strippedText: "[n] いいえ",
                     markupStatus: FinalOutputObservability.MarkupStatusMatched,
                     finalText: "{{W|[n]}} {{y|いいえ}}")));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(output, Does.Contain("markup_status='matched'"));
+            Assert.That(output, Does.Contain("; markup_span_status=matched;"));
+            Assert.That(output, Does.Contain("; markup_semantic_status=clean;"));
+            Assert.That(output, Does.Contain("; markup_semantic_flags=;"));
+        });
+    }
+
+    [TestCase("{{B|}}")]
+    [TestCase("{{B|{{B|同じ色}}}}")]
+    [TestCase("{{Y|}}{{Y| . . . . . . . . ■ .  . . . . . . . ■  . . . . . . . . ■  . . . . . . . . ■  . . . . . . . . {{Y|}}")]
+    [TestCase("{{Y|}}{{Y| . . .}}>{{K|. . . . . ■ .  . . . . . . . ■  . . . . . . . . ■  . . . . . . . . ■  . . . . . . . . {{Y|}}")]
+    [TestCase("{{W|{{W|[k]}} {{y|攻撃}}}}")]
+    [TestCase("{{W|{{W|[Space]}} {{y|続ける}}}}")]
+    [TestCase("{{y|{{y|安らぎあれ、friend。\\n\\nLive and drink.}}\\n\\n}}")]
+    [TestCase("{{y|{{y|汎用の会話文。}}\\n\\n}}")]
+    public void Record_TreatsSemanticallyIdempotentQudMarkupAsClean(string finalText)
+    {
+        var output = TestTraceHelper.CaptureTrace(() =>
+            FinalOutputObservability.Record(
+                CreateObservation(
+                    sourceText: finalText,
+                    strippedText: finalText,
+                    markupStatus: FinalOutputObservability.MarkupStatusMatched,
+                    finalText: finalText)));
 
         Assert.Multiple(() =>
         {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/UITextSkinTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/UITextSkinTranslationPatchTests.cs
@@ -136,6 +136,25 @@ public sealed class UITextSkinTranslationPatchTests
         });
     }
 
+    [TestCase("{{Y|}}{{Y| . . .}}>{{K|. . . . . ■ .  . . . . . . . ■  . . . . . . . . ■  . . . . . . . . ■  . . . . . . . . {{Y|}}")]
+    [TestCase("{{W|{{W|[k]}} {{y|攻撃}}}}")]
+    [TestCase("{{y|{{y|安らぎあれ、friend。\\n\\nLive and drink.}}\\n\\n}}")]
+    [TestCase("{{y|{{y|汎用の会話文。}}\\n\\n}}")]
+    public void TranslatePreservingColors_DoesNotReportSemanticDrift_ForSemanticallyIdempotentQudMarkup(string text)
+    {
+        var output = TestTraceHelper.CaptureTrace(() =>
+            Assert.That(
+                UITextSkinTranslationPatch.TranslatePreservingColors(text, nameof(UITextSkinTranslationPatch)),
+                Is.EqualTo(text)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(output, Does.Contain("translation_status='skipped'"));
+            Assert.That(output, Does.Contain("markup_semantic_status=clean"));
+            Assert.That(output, Does.Not.Contain("markup_semantic_status=drift"));
+        });
+    }
+
     [Test]
     public void TranslatePreservingColors_RecordsAlreadyLocalizedDirectRouteText()
     {

--- a/Mods/QudJP/Assemblies/src/Observability/MarkupSemanticDiagnostics.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/MarkupSemanticDiagnostics.cs
@@ -10,25 +10,23 @@ internal static class MarkupSemanticDiagnostics
     internal const string StatusClean = "clean";
     internal const string StatusDrift = "drift";
 
-    private static readonly Regex EmptyQudWrapperPattern =
-        new Regex(@"\{\{[^|}]+\|\}\}", RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly Regex LiteralQudShaderFragmentPattern =
         new Regex(@"\{\{[^|}]+\}\}\|", RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly Regex BracketCloseInsideNestedQudScopePattern =
         new Regex(@"\[\{\{[^|}]+\|[^\]}]*\]\}\}", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex WorldGenerationProgressBarPattern =
+        new Regex(@"^\{\{Y\|\}\}\{\{Y\|[ .]*(?:\}\}>\{\{K\|)?[ .■]+\{\{Y\|\}\}$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
     internal static MarkupSemanticDiagnosticsResult Analyze(string? text)
     {
         var value = text ?? string.Empty;
         var flags = new List<string>();
-        AddFlagIfMatched(flags, "empty_qud_wrapper", EmptyQudWrapperPattern, value);
         AddFlagIfMatched(flags, "literal_qud_shader_fragment", LiteralQudShaderFragmentPattern, value);
         AddFlagIfMatched(flags, "bracket_close_inside_nested_qud_scope", BracketCloseInsideNestedQudScopePattern, value);
 
         var structuralFlags = ScanMarkupSemanticStructure(value);
-        AddFlagIf(flags, "repeated_same_qud_scope_start", structuralFlags.RepeatedSameQudScopeStart);
-        AddFlagIf(flags, "unclosed_qud_scope", structuralFlags.UnclosedQudScope);
         AddFlagIf(flags, "unmatched_qud_close", structuralFlags.UnmatchedQudClose);
+        AddFlagIf(flags, "unclosed_qud_scope", structuralFlags.UnclosedQudScope && !IsWorldGenerationProgressBar(value));
         AddFlagIf(flags, "unclosed_tmp_scope", structuralFlags.UnclosedTmpScope);
         AddFlagIf(flags, "unmatched_tmp_close", structuralFlags.UnmatchedTmpClose);
 
@@ -37,22 +35,21 @@ internal static class MarkupSemanticDiagnostics
             : new MarkupSemanticDiagnosticsResult(StatusDrift, string.Join(",", flags));
     }
 
+    private static bool IsWorldGenerationProgressBar(string value)
+    {
+        return WorldGenerationProgressBarPattern.IsMatch(value);
+    }
+
     private static MarkupSemanticFlags ScanMarkupSemanticStructure(string value)
     {
-        var stack = new Stack<MarkupScope>();
+        var stack = new Stack<string>();
         var flags = new MarkupSemanticFlags();
-        var visibleIndex = 0;
         var index = 0;
         while (index < value.Length)
         {
-            if (TryReadQudOpen(value, index, out var qudShader, out var qudLength))
+            if (TryReadQudOpen(value, index, out var qudLength))
             {
-                if (HasActiveScopeAtVisibleIndex(stack, "qud", qudShader, visibleIndex))
-                {
-                    flags.RepeatedSameQudScopeStart = true;
-                }
-
-                stack.Push(new MarkupScope("qud", qudShader, visibleIndex));
+                stack.Push("qud");
                 index += qudLength;
                 continue;
             }
@@ -68,9 +65,9 @@ internal static class MarkupSemanticDiagnostics
                 continue;
             }
 
-            if (TryReadTmpColorOpen(value, index, out var tmpColor, out var tmpOpenLength))
+            if (TryReadTmpColorOpen(value, index, out var tmpOpenLength))
             {
-                stack.Push(new MarkupScope("tmp", tmpColor, visibleIndex));
+                stack.Push("tmp");
                 index += tmpOpenLength;
                 continue;
             }
@@ -86,62 +83,29 @@ internal static class MarkupSemanticDiagnostics
                 continue;
             }
 
-            if (StartsWithOrdinal(value, index, "&&") || StartsWithOrdinal(value, index, "^^"))
-            {
-                visibleIndex++;
-                index += 2;
-                continue;
-            }
-
-            if ((value[index] == '&' || value[index] == '^') && index + 1 < value.Length && IsAsciiLetter(value[index + 1]))
-            {
-                index += 2;
-                continue;
-            }
-
             if (TryReadPlaceholder(value, index, out _, out var placeholderLength))
             {
                 index += placeholderLength;
                 continue;
             }
 
-            visibleIndex++;
             index++;
         }
 
         while (stack.Count > 0)
         {
             var scope = stack.Pop();
-            if (string.Equals(scope.Kind, "qud", StringComparison.Ordinal))
+            if (string.Equals(scope, "qud", StringComparison.Ordinal))
             {
                 flags.UnclosedQudScope = true;
             }
-            else if (string.Equals(scope.Kind, "tmp", StringComparison.Ordinal))
+            else if (string.Equals(scope, "tmp", StringComparison.Ordinal))
             {
                 flags.UnclosedTmpScope = true;
             }
         }
 
         return flags;
-    }
-
-    private static bool HasActiveScopeAtVisibleIndex(
-        Stack<MarkupScope> stack,
-        string kind,
-        string value,
-        int visibleIndex)
-    {
-        foreach (var scope in stack)
-        {
-            if (string.Equals(scope.Kind, kind, StringComparison.Ordinal)
-                && string.Equals(scope.Value, value, StringComparison.Ordinal)
-                && scope.StartVisibleIndex == visibleIndex)
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static void AddFlagIfMatched(List<string> flags, string flag, Regex pattern, string value)
@@ -160,9 +124,8 @@ internal static class MarkupSemanticDiagnostics
         }
     }
 
-    private static bool TryReadQudOpen(string value, int index, out string shader, out int length)
+    private static bool TryReadQudOpen(string value, int index, out int length)
     {
-        shader = string.Empty;
         length = 0;
         if (!StartsWithOrdinal(value, index, "{{"))
         {
@@ -189,20 +152,17 @@ internal static class MarkupSemanticDiagnostics
             return false;
         }
 
-        var candidate = value.Substring(index + 2, separatorIndex - index - 2);
-        if (candidate.Length == 0)
+        if (separatorIndex == index + 2)
         {
             return false;
         }
 
-        shader = candidate;
         length = separatorIndex - index + 1;
         return true;
     }
 
-    private static bool TryReadTmpColorOpen(string value, int index, out string color, out int length)
+    private static bool TryReadTmpColorOpen(string value, int index, out int length)
     {
-        color = string.Empty;
         length = 0;
         if (!StartsWithOrdinal(value, index, "<color="))
         {
@@ -215,7 +175,6 @@ internal static class MarkupSemanticDiagnostics
             return false;
         }
 
-        color = value.Substring(index + "<color=".Length, endIndex - index - "<color=".Length);
         length = endIndex - index + 1;
         return true;
     }
@@ -255,15 +214,15 @@ internal static class MarkupSemanticDiagnostics
         return true;
     }
 
-    private static bool TryPopScope(Stack<MarkupScope> stack, string kind, out MarkupScope scope)
+    private static bool TryPopScope(Stack<string> stack, string kind, out string scope)
     {
-        if (stack.Count > 0 && string.Equals(stack.Peek().Kind, kind, StringComparison.Ordinal))
+        if (stack.Count > 0 && string.Equals(stack.Peek(), kind, StringComparison.Ordinal))
         {
             scope = stack.Pop();
             return true;
         }
 
-        scope = default;
+        scope = string.Empty;
         return false;
     }
 
@@ -273,39 +232,18 @@ internal static class MarkupSemanticDiagnostics
             && string.CompareOrdinal(value, index, prefix, 0, prefix.Length) == 0;
     }
 
-    private static bool IsAsciiLetter(char character)
-    {
-        return (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z');
-    }
-
     private static bool IsAsciiLetterOrDigit(char character)
     {
-        return IsAsciiLetter(character) || (character >= '0' && character <= '9');
-    }
-
-    private readonly struct MarkupScope
-    {
-        internal MarkupScope(string kind, string value, int startVisibleIndex)
-        {
-            Kind = kind;
-            Value = value;
-            StartVisibleIndex = startVisibleIndex;
-        }
-
-        internal string Kind { get; }
-
-        internal string Value { get; }
-
-        internal int StartVisibleIndex { get; }
+        return (character >= 'A' && character <= 'Z')
+            || (character >= 'a' && character <= 'z')
+            || (character >= '0' && character <= '9');
     }
 
     private struct MarkupSemanticFlags
     {
-        internal bool RepeatedSameQudScopeStart { get; set; }
+        internal bool UnmatchedQudClose { get; set; }
 
         internal bool UnclosedQudScope { get; set; }
-
-        internal bool UnmatchedQudClose { get; set; }
 
         internal bool UnclosedTmpScope { get; set; }
 

--- a/docs/reports/2026-05-06-issue-525-markup-semantic-drift.md
+++ b/docs/reports/2026-05-06-issue-525-markup-semantic-drift.md
@@ -1,0 +1,113 @@
+# Issue #525 Markup Semantic Drift Classification
+
+## Runtime Evidence
+
+Fresh triage against `~/Library/Logs/Freehold Games/CavesOfQud/Player.log`
+reproduced the issue count:
+
+| Phase F bucket | Count |
+| --- | ---: |
+| total | 1582 |
+| dynamic_text_probe | 381 |
+| sink_observe | 249 |
+| final_output_probe | 952 |
+| markup_semantic_drift | 107 |
+
+All 107 entries have:
+
+- `sink=UITextSkinTranslationPatch`
+- `route=UITextSkinTranslationPatch`
+- `detail=Skipped`
+- `translation_status=skipped`
+- `markup_status=matched`
+- `markup_span_status=matched`
+- `source_text_sample == final_text_sample`
+
+This means the observed strings reached `UITextSkin` already in that markup
+shape. The evidence does not show QudJP final-output mutation.
+
+## Producer Families
+
+| Count | Previous raw flags | Producer/screen family | Classification |
+| ---: | --- | --- | --- |
+| 92 | `empty_qud_wrapper,unclosed_qud_scope` | `Qud.UI.WorldGenerationScreen` progress bar (`ProgressBasis` plus `_IncrementProgress()` inserting `}}>{{K|`) | acceptable upstream relaxed markup |
+| 13 | `repeated_same_qud_scope_start` | `Qud.UI.SelectableTextMenuItem.SelectChanged()` selected row wrapper around hotkey/menu labels | acceptable upstream menu-state markup |
+| 2 | `repeated_same_qud_scope_start` | `Qud.UI.PopupMessage`/conversation body wrapper overlapping already yellow conversation text | acceptable upstream wrapper overlap; untranslated English is separate localization evidence |
+
+## Static Producer Evidence
+
+The classification is not based only on `Player.log` samples. Static inspection
+of the decompiled game source identifies the producer expressions that create
+the observed markup before QudJP sees it:
+
+- `Qud.UI.WorldGenerationScreen.ProgressBasis` defines the progress bar with
+  leading `{{Y|}}` and a trailing relaxed `{{Y|}}` marker. `_IncrementProgress()`
+  then inserts `}}>{{K|` into that string and calls `progressText.SetText(text)`.
+- `Qud.UI.SelectableTextMenuItem.SelectChanged()` calls
+  `item.SetText("{{W|" + itemText + "}}")` for selected rows. Popup and bottom
+  context menu item text already contains inner hotkey markup such as
+  `{{W|[y]}} {{y|Yes}}`, so selected rows naturally become nested
+  same-shader wrappers.
+- `XRL.UI.Popup.GetPopupOption()` builds hotkey options as
+  `{{W|[key]}} {{y|option}}`.
+- `Qud.UI.PopupMessage` defines standard buttons using the same inner hotkey
+  markup and sets message bodies with `Message.SetText("{{y|" + message + "}}")`.
+  If the incoming conversation text is already yellow, this creates the
+  same-shader body overlap.
+
+The static route therefore proves these families are upstream UI composition,
+not QudJP restore corruption.
+
+## Full UITextSkin Surface Verification
+
+It is feasible to verify the whole `UITextSkin` surface, but it is a broader
+inventory task than the 107 drift rows in issue #525. The right unit is not
+"all runtime strings" as literal values, because many `UITextSkin.SetText`
+arguments are data-bound values such as `message`, `itemText`, `sb.ToString()`,
+`GO.DisplayName`, or `playerStringData[...]`. Static analysis can prove the
+producer callsites and construction routes; it cannot enumerate every runtime
+value without complementary observations or focused fixtures.
+
+Current static bounds from the local decompiled `2.0.4` source:
+
+| Probe | Count | Notes |
+| --- | ---: | --- |
+| syntax `.SetText(...)` calls | 315 | name-only upper bound; includes same-name methods such as `HPBar.SetText`, `UIHotkeySkin.SetText`, and `TooltipTrigger.SetText` |
+| `TextConstructionInventory` `SetText` text constructions | 201 | Roslyn syntax inventory of string literals, concatenations, and interpolations directly inside `SetText` arguments |
+| `TextConstructionInventory` `DirectTextAssignment` text constructions | 154 | adjacent `UITextSkin.text = ...; Apply()`-style route candidates, not all necessarily `UITextSkin` |
+
+An authoritative full audit should add a symbol-backed Roslyn inventory for:
+
+- resolved calls to `XRL.UI.UITextSkin.SetText(string)`;
+- direct writes to `XRL.UI.UITextSkin.text` followed by `Apply()` or equivalent
+  render paths;
+- owner/screen grouping, argument shape classification, markup-risk flags, and
+  route ownership status;
+- explicit `resolved` / `candidate` / `unresolved` symbol status so same-name
+  methods do not become silent false positives.
+
+That scanner would let future work claim full `UITextSkin` surface coverage.
+For #525, the evidence needed is narrower: every currently observed drift row
+maps to the three upstream relaxed-markup families above. The diagnostic fix is
+now semantic rather than broadly shape-specific: empty Qud wrappers and
+same-shader nested wrappers are idempotent color composition and are not
+reported as drift. Unclosed Qud scopes remain reportable except for the
+statically proven `WorldGenerationScreen` progress-bar shape.
+
+## Fix Boundary
+
+`UITextSkinTranslationPatch` remains observation/pass-through for these strings.
+The fix is limited to `MarkupSemanticDiagnostics`: Qud color wrappers are now
+judged by semantic risk instead of raw shape. Idempotent color composition is
+clean, while malformed cases such as literal shader fragments, bracket-close
+drift, generic unclosed Qud scopes, unmatched Qud closes, unmatched TMP closes,
+and unclosed TMP color tags remain reportable. The only unclosed Qud exception
+is the statically proven world-generation progress-bar family.
+
+## Relationship To #459
+
+#459 tracks broad Restore ownership and producer-route gaps. #525 is narrower:
+it handles current `UITextSkinTranslationPatch` runtime semantic drift evidence.
+The 107 entries classified here are not new Restore ownership targets because
+they are upstream UI wrapper/progress-bar syntax and QudJP is not changing the
+final text.

--- a/docs/reports/2026-05-06-issue-525-markup-semantic-drift.md
+++ b/docs/reports/2026-05-06-issue-525-markup-semantic-drift.md
@@ -30,7 +30,7 @@ shape. The evidence does not show QudJP final-output mutation.
 
 | Count | Previous raw flags | Producer/screen family | Classification |
 | ---: | --- | --- | --- |
-| 92 | `empty_qud_wrapper,unclosed_qud_scope` | `Qud.UI.WorldGenerationScreen` progress bar (`ProgressBasis` plus `_IncrementProgress()` inserting `}}>{{K|`) | acceptable upstream relaxed markup |
+| 92 | `empty_qud_wrapper,unclosed_qud_scope` | `Qud.UI.WorldGenerationScreen` progress bar (`ProgressBasis` plus `_IncrementProgress()` inserting <code>}}>{{K&#124;</code>) | acceptable upstream relaxed markup |
 | 13 | `repeated_same_qud_scope_start` | `Qud.UI.SelectableTextMenuItem.SelectChanged()` selected row wrapper around hotkey/menu labels | acceptable upstream menu-state markup |
 | 2 | `repeated_same_qud_scope_start` | `Qud.UI.PopupMessage`/conversation body wrapper overlapping already yellow conversation text | acceptable upstream wrapper overlap; untranslated English is separate localization evidence |
 
@@ -106,7 +106,7 @@ is the statically proven world-generation progress-bar family.
 
 ## Relationship To #459
 
-#459 tracks broad Restore ownership and producer-route gaps. #525 is narrower:
+Issue `#459` tracks broad Restore ownership and producer-route gaps. Issue `#525` is narrower:
 it handles current `UITextSkinTranslationPatch` runtime semantic drift evidence.
 The 107 entries classified here are not new Restore ownership targets because
 they are upstream UI wrapper/progress-bar syntax and QudJP is not changing the


### PR DESCRIPTION
## Summary

- classify issue #525 `UITextSkinTranslationPatch` markup semantic drift evidence as upstream relaxed UI composition rather than QudJP restore corruption
- change `MarkupSemanticDiagnostics` to treat idempotent Qud color composition as clean while keeping real corruption signals reportable
- add L1/L2 coverage for progress-bar, selected-menu, conversation-wrapper, and generic unclosed-Qud cases
- add a report documenting runtime evidence, static producer routes, and the boundary for future full `UITextSkin` audit work

## Root Cause

The 107 `markup_semantic_drift` rows in the fresh runtime log all reached `UITextSkinTranslationPatch` as skipped/pass-through text with matching source/final markup spans. Static decompiled-source inspection maps those rows to upstream UI producers:

- `WorldGenerationScreen` progress-bar syntax
- `SelectableTextMenuItem` selected-row wrappers around already-colored hotkey labels
- `PopupMessage` body wrappers around already-colored conversation text

QudJP was not shifting color tags in those rows; the diagnostic was treating relaxed upstream UI markup shapes as semantic drift.

## Fix

`MarkupSemanticDiagnostics` now suppresses semantic drift for idempotent Qud wrapper composition, including empty wrappers and same-shader nested wrappers. Generic unclosed Qud scopes remain reportable, with a narrow exception for the statically proven world-generation progress-bar shape. Literal shader fragments, bracket-close drift, unmatched Qud closes, and TMP color tag imbalances remain reportable.

## Follow-up

Created #530 for broader color-tag infrastructure work: shared tokenizer, Roslyn-backed static checks, wrapper helper, and canonical color-map diagnostics.

## Validation

- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~QudJP.Tests.L1.FinalOutputObservabilityTests|FullyQualifiedName~QudJP.Tests.L2.UITextSkinTranslationPatchTests|FullyQualifiedName~QudJP.Tests.L1.DynamicTextObservabilityTests"`
- `just test-l1`
- `just test-l2`
- `git diff --check`

Closes #525


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * マークアップ処理の振る舞い（特に冗長・未閉じのケース）を検証するテストを追加・更新しました。

* **Refactor**
  * マークアップ検証ロジックの内部表現と解析フローを簡素化・再構成しました（動作に影響のない内部改善）。

* **Documentation**
  * マークアップ意味的振る舞いに関する解析レポートを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->