### PR TITLE
[codex] Add Markdown report guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           roslyn_tools=false
           python=false
           localization=false
+          markdown_reports=false
 
           if matches '^\.github/workflows/.*\.ya?ml$'; then
             run_all=true
@@ -80,13 +81,19 @@ jobs:
           if [[ "$run_all" == true ]] || matches '^(Mods/QudJP/Localization/|scripts/(check_translation_tokens|check_glossary_consistency)\.py|scripts/(translation_token_duplicate_baseline|glossary_consistency_baseline)\.json)'; then
             localization=true
           fi
+          if [[ "$run_all" == true ]] || matches '^docs/reports/.*\.md$' || matches '^scripts/check_markdown_reports\.py$'; then
+            markdown_reports=true
+          fi
 
           {
+            echo "base_ref=$base"
+            echo "head_ref=$head"
             echo "qudjp_dotnet=$qudjp_dotnet"
             echo "roslyn_tools=$roslyn_tools"
             echo "dotnet=$([[ "$qudjp_dotnet" == true || "$roslyn_tools" == true ]] && echo true || echo false)"
             echo "python=$python"
             echo "localization=$localization"
+            echo "markdown_reports=$markdown_reports"
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup .NET
@@ -137,12 +144,19 @@ jobs:
         run: dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-build
 
       - name: Setup Python
-        if: steps.changes.outputs.python == 'true' || steps.changes.outputs.localization == 'true'
+        if: steps.changes.outputs.python == 'true' || steps.changes.outputs.localization == 'true' || steps.changes.outputs.markdown_reports == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
+
+      - name: Check Markdown reports
+        if: steps.changes.outputs.markdown_reports == 'true'
+        run: >
+          python scripts/check_markdown_reports.py
+          --base-ref "${{ steps.changes.outputs.base_ref }}"
+          --head-ref "${{ steps.changes.outputs.head_ref }}"
 
       - name: Check release-note fragment
         if: github.event_name == 'pull_request' && steps.changes.outputs.localization == 'true'

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -151,6 +151,12 @@ For color-aware restoration:
 
 Mixed Qud markup and TMP markup must be fixed route-by-route, with tests that preserve the exact broken input shape.
 
+Markup semantic diagnostics must distinguish raw token shape from user-visible
+semantic drift. Repeated same-color Qud wrappers and statically proven upstream
+relaxed markup are not automatically QudJP drift. Keep every exception narrow:
+tie it to a producer route, document the route, and add tests for both the
+accepted relaxed shape and a nearby still-broken shape.
+
 ## Known boundaries
 
 Some behavior is outside QudJP's ownership:

--- a/justfile
+++ b/justfile
@@ -62,6 +62,10 @@ translation-token-baseline:
 release-note-check base_ref="origin/main" head_ref="HEAD":
   {{python}} scripts/release_notes.py check-fragment --base-ref "{{base_ref}}" --head-ref "{{head_ref}}"
 
+# Check changed Markdown reports for recurring GitHub rendering pitfalls.
+markdown-report-check base_ref="origin/main" head_ref="HEAD":
+  {{python}} scripts/check_markdown_reports.py --base-ref "{{base_ref}}" --head-ref "{{head_ref}}"
+
 # Render release and Workshop changenote drafts from unreleased fragments.
 render-release-notes version git_hash date:
   {{python}} scripts/release_notes.py render --version "{{version}}" --git-hash "{{git_hash}}" --date "{{date}}" --changelog-output /tmp/qudjp-changelog-entry.md --workshop-output /tmp/qudjp-workshop-changenote.txt
@@ -205,11 +209,12 @@ runtime-evidence-check: test-l1
   uv run pytest scripts/tests/test_triage_integration.py -q -k sample_log_smoke
 
 # Run the broad local verification gate.
-check: build test-l1 test-l2 test-l2g python-check python-test localization-check translation-token-check
+check: build test-l1 test-l2 test-l2g python-check python-test localization-check translation-token-check markdown-report-check
 
 # Run the CI-like PR gate before pushing broad C#, script, or localization changes.
 pr-check base_ref="origin/main" head_ref="HEAD": ci-dotnet roslyn-build python-check python-test localization-check translation-token-check
   {{python}} scripts/release_notes.py check-fragment --base-ref "{{base_ref}}" --head-ref "{{head_ref}}"
+  {{python}} scripts/check_markdown_reports.py --base-ref "{{base_ref}}" --head-ref "{{head_ref}}"
 
 # Build and test QudJP with the same Release configuration used by CI.
 ci-dotnet:

--- a/scripts/check_markdown_reports.py
+++ b/scripts/check_markdown_reports.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 _INLINE_CODE_RE = re.compile(r"(?<!`)`([^`\n]*)`(?!`)")
 _LEADING_ISSUE_REFERENCE_RE = re.compile(r"^#\d+\b")
+_FENCE_DELIMITER_RE = re.compile(r"^\s*(?:```|~~~)")
 _MIN_TABLE_PIPE_COUNT = 2
 
 
@@ -36,7 +37,14 @@ class MarkdownReportIssue:
 def check_file(path: Path) -> list[MarkdownReportIssue]:
     """Check a Markdown report file for known rendering hazards."""
     issues: list[MarkdownReportIssue] = []
+    in_fenced_code = False
     for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if _FENCE_DELIMITER_RE.match(line):
+            in_fenced_code = not in_fenced_code
+            continue
+        if in_fenced_code:
+            continue
+
         stripped = line.lstrip()
         if _LEADING_ISSUE_REFERENCE_RE.match(stripped):
             issues.append(

--- a/scripts/check_markdown_reports.py
+++ b/scripts/check_markdown_reports.py
@@ -1,0 +1,171 @@
+"""Check repository Markdown reports for recurring rendering pitfalls."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+_INLINE_CODE_RE = re.compile(r"(?<!`)`([^`\n]*)`(?!`)")
+_LEADING_ISSUE_REFERENCE_RE = re.compile(r"^#\d+\b")
+_MIN_TABLE_PIPE_COUNT = 2
+
+
+class MarkdownReportError(Exception):
+    """Raised when Markdown report inputs cannot be scanned."""
+
+
+@dataclass(frozen=True)
+class MarkdownReportIssue:
+    """A single Markdown report issue."""
+
+    path: Path
+    line_number: int
+    kind: str
+    detail: str
+
+
+def check_file(path: Path) -> list[MarkdownReportIssue]:
+    """Check a Markdown report file for known rendering hazards."""
+    issues: list[MarkdownReportIssue] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = line.lstrip()
+        if _LEADING_ISSUE_REFERENCE_RE.match(stripped):
+            issues.append(
+                MarkdownReportIssue(
+                    path=path,
+                    line_number=line_number,
+                    kind="leading_issue_reference",
+                    detail="Prefix issue references with prose, for example: Issue `#525`.",
+                ),
+            )
+
+        if not _is_table_row(line):
+            continue
+
+        for match in _INLINE_CODE_RE.finditer(line):
+            if "|" not in match.group(1):
+                continue
+            issues.append(
+                MarkdownReportIssue(
+                    path=path,
+                    line_number=line_number,
+                    kind="raw_pipe_in_table_code_span",
+                    detail="Use HTML code plus an encoded pipe, for example: <code>{{K&#124;</code>.",
+                ),
+            )
+
+    return issues
+
+
+def check_paths(paths: Sequence[Path]) -> list[MarkdownReportIssue]:
+    """Check all Markdown report files under the given paths."""
+    issues: list[MarkdownReportIssue] = []
+    for path in _iter_markdown_files(paths):
+        issues.extend(check_file(path))
+    return issues
+
+
+def git_changed_report_files(base_ref: str, head_ref: str) -> list[Path]:
+    """Return existing changed Markdown report paths between two git refs."""
+    git = shutil.which("git")
+    if git is None:
+        msg = "git executable not found"
+        raise MarkdownReportError(msg)
+    try:
+        result = subprocess.run(  # noqa: S603
+            [git, "diff", "--name-only", f"{base_ref}...{head_ref}", "--", "docs/reports"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip() or str(exc)
+        msg = f"git diff failed for {base_ref}...{head_ref}: {detail}"
+        raise MarkdownReportError(msg) from exc
+    return sorted(
+        Path(line)
+        for line in result.stdout.splitlines()
+        if line.endswith(".md") and Path(line).is_file()
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the Markdown report checker CLI."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", type=Path, help="Markdown files or directories to scan.")
+    parser.add_argument("--base-ref", help="Base git ref for changed-report scanning.")
+    parser.add_argument("--head-ref", help="Head git ref for changed-report scanning.")
+    args = parser.parse_args(argv)
+
+    try:
+        paths = _resolve_cli_paths(args.paths, args.base_ref, args.head_ref)
+        issues = check_paths(paths)
+    except MarkdownReportError as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 2
+
+    if not issues:
+        sys.stdout.write("Markdown report checks passed.\n")
+        return 0
+
+    for issue in issues:
+        sys.stderr.write(
+            f"{issue.path}:{issue.line_number}: {issue.kind}: {issue.detail}",
+        )
+        sys.stderr.write("\n")
+    return 1
+
+
+def _resolve_cli_paths(paths: Sequence[Path], base_ref: str | None, head_ref: str | None) -> list[Path]:
+    """Resolve explicit CLI paths or changed Markdown report paths."""
+    if bool(base_ref) != bool(head_ref):
+        msg = "--base-ref and --head-ref must be provided together"
+        raise MarkdownReportError(msg)
+    if base_ref and head_ref:
+        if paths:
+            msg = "pass explicit paths or --base-ref/--head-ref, not both"
+            raise MarkdownReportError(msg)
+        return git_changed_report_files(base_ref, head_ref)
+    if not paths:
+        msg = "at least one path or --base-ref/--head-ref is required"
+        raise MarkdownReportError(msg)
+    return list(paths)
+
+
+def _is_table_row(line: str) -> bool:
+    """Return whether a line is a pipe-table row in the report style."""
+    stripped = line.lstrip()
+    return stripped.startswith("|") and stripped.count("|") >= _MIN_TABLE_PIPE_COUNT
+
+
+def _iter_markdown_files(paths: Sequence[Path]) -> list[Path]:
+    """Collect Markdown files from explicit file and directory inputs."""
+    files: set[Path] = set()
+    for path in paths:
+        if not path.exists():
+            msg = f"Path not found: {path}"
+            raise MarkdownReportError(msg)
+        if path.is_file():
+            if path.suffix.lower() == ".md":
+                files.add(path)
+            continue
+        if path.is_dir():
+            files.update(path for path in path.rglob("*.md") if path.is_file())
+            continue
+
+        msg = f"Path is not a regular file or directory: {path}"
+        raise MarkdownReportError(msg)
+    return sorted(files, key=str)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_markdown_reports.py
+++ b/scripts/tests/test_check_markdown_reports.py
@@ -1,0 +1,80 @@
+"""Tests for Markdown report quality checks."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.check_markdown_reports import MarkdownReportError, check_paths, main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_reports_raw_pipe_inside_table_code_span(tmp_path: Path) -> None:
+    """Table rows must not contain raw pipes inside inline code spans."""
+    report = tmp_path / "report.md"
+    report.write_text(
+        "| Count | Producer |\n"
+        "| ---: | --- |\n"
+        "| 1 | `_IncrementProgress()` inserts `}}>{{K|` |\n",
+        encoding="utf-8",
+    )
+
+    issues = check_paths([report])
+
+    assert len(issues) == 1
+    assert issues[0].kind == "raw_pipe_in_table_code_span"
+    assert issues[0].line_number == 3
+
+
+def test_accepts_html_code_entity_for_table_pipe(tmp_path: Path) -> None:
+    """HTML code with an encoded pipe is safe in Markdown table cells."""
+    report = tmp_path / "report.md"
+    report.write_text(
+        "| Count | Producer |\n"
+        "| ---: | --- |\n"
+        "| 1 | inserts <code>}}>{{K&#124;</code> |\n",
+        encoding="utf-8",
+    )
+
+    assert check_paths([report]) == []
+
+
+def test_reports_leading_issue_reference_that_can_parse_as_heading(tmp_path: Path) -> None:
+    """Issue references at the start of prose lines must be prefixed with text."""
+    report = tmp_path / "report.md"
+    report.write_text("#459 tracks broad Restore ownership gaps.\n", encoding="utf-8")
+
+    issues = check_paths([report])
+
+    assert len(issues) == 1
+    assert issues[0].kind == "leading_issue_reference"
+    assert issues[0].line_number == 1
+
+
+def test_accepts_issue_references_in_normal_prose(tmp_path: Path) -> None:
+    """Issue references are fine when the line starts as prose."""
+    report = tmp_path / "report.md"
+    report.write_text("Issue `#459` tracks broad Restore ownership gaps.\n", encoding="utf-8")
+
+    assert check_paths([report]) == []
+
+
+def test_main_reports_issues_without_traceback(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The CLI returns a nonzero status and prints stable issue locations."""
+    report = tmp_path / "report.md"
+    report.write_text("#525 is narrower.\n", encoding="utf-8")
+
+    assert main([str(report)]) == 1
+
+    captured = capsys.readouterr()
+    assert "leading_issue_reference" in captured.err
+    assert "report.md:1" in captured.err
+
+
+def test_main_raises_for_missing_paths(tmp_path: Path) -> None:
+    """Missing paths are reported as CLI errors by the caller."""
+    with pytest.raises(MarkdownReportError, match="Path not found"):
+        check_paths([tmp_path / "missing.md"])

--- a/scripts/tests/test_check_markdown_reports.py
+++ b/scripts/tests/test_check_markdown_reports.py
@@ -62,6 +62,22 @@ def test_accepts_issue_references_in_normal_prose(tmp_path: Path) -> None:
     assert check_paths([report]) == []
 
 
+def test_ignores_rendering_hazards_inside_fenced_code(tmp_path: Path) -> None:
+    """Example code blocks may intentionally include otherwise unsafe Markdown."""
+    report = tmp_path / "report.md"
+    report.write_text(
+        "```\n"
+        "#459 tracks broad Restore ownership gaps.\n"
+        "| Count | Producer |\n"
+        "| ---: | --- |\n"
+        "| 1 | `}}>{{K|` |\n"
+        "```\n",
+        encoding="utf-8",
+    )
+
+    assert check_paths([report]) == []
+
+
 def test_main_reports_issues_without_traceback(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """The CLI returns a nonzero status and prints stable issue locations."""
     report = tmp_path / "report.md"


### PR DESCRIPTION
## Summary
- Add a changed-report Markdown checker for raw pipes inside table code spans and leading issue references.
- Wire the checker into CI and just recipes without rewriting historical archived reports.
- Document the markup semantic diagnostics boundary in docs/RULES.md.

## Validation
- uv run pytest scripts/tests/test_check_markdown_reports.py -q
- uv run python scripts/check_markdown_reports.py --base-ref origin/main --head-ref HEAD
- ruff check scripts/check_markdown_reports.py scripts/tests/test_check_markdown_reports.py
- just markdown-report-check
- just python-check
- just python-test
- just pr-check origin/main HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Markdownレポートの品質検証がCI/CDパイプラインに統合されました。不正なMarkdown形式の検出と報告が自動的に行われるようになります。

* **ドキュメント**
  * セマンティック診断に関するマークアップルールのドキュメントが更新されました。

* **テスト**
  * Markdownレポート検証機能の包括的なテストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->