### PR TITLE
[codex] Codify QudJP review and localization triage rules

### DIFF
--- a/.codex/skills/qudjp-localization-triage/SKILL.md
+++ b/.codex/skills/qudjp-localization-triage/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: qudjp-localization-triage
+description: Use when working in QudJP on untranslated or incorrectly translated Caves of Qud runtime text, player.log triage, owner-route vs sink-route decisions, generated/composed names, HistorySpice text, dictionary leaf additions, or localization patches that need decompiled producer tracing and focused verification.
+---
+
+# QudJP Localization Triage
+
+## Overview
+
+Use this skill to turn runtime untranslated text into the smallest correct QudJP localization change. Route text at the producer or owner when possible, use dictionary leaves only for fixed literals, and leave sink fallback as observability rather than the primary solution.
+
+## Workflow
+
+1. Establish current evidence.
+   - Read repo instructions first, including scoped `AGENTS.md` files for C# patches, localization assets, or scripts.
+   - Use fresh `~/Library/Logs/Freehold Games/CavesOfQud/Player.log` when the user asks about live gameplay output.
+   - Treat `Player.log` as route evidence, not just an untranslated-string list. Use `scripts/triage_untranslated.py` or equivalent parsing to preserve sink, route, category, and producer context before assigning work.
+   - Classify each finding as untranslated fixed literal, generated template, generated name, composed route, already-Japanese runtime noise, or intentional pass-through.
+   - Group broad runtime surfaces by owner route or route family before deciding backlog scope. Do not collapse sink-adjacent families such as `UITextSkinTranslationPatch`, `GetDisplayName*`, `Popup*`, and generic message sinks into one undifferentiated "untranslated" bucket.
+   - When an observed English source looks like a stable label but contains a domain noun, Title Case phrase, number, object name, mutation/effect name, date, festival, dish, faction, or village term, treat it as generated until the producer proves it is a fixed literal.
+   - When the user's surface name is broad, such as chargen, inspect adjacent runtime probes that share the text family or UI route, then state which screens are primary and which are follow-up risk.
+   - If the requested text is absent from the current log, say it is absent in that log. Use adjacent logs/routes only as risk evidence, not proof that the requested text is still failing.
+   - When PR review comments are part of the request, pair this skill with `github:gh-address-comments` or `post-pr-convergence`; CodeRabbit/check pass alone is not enough if unresolved review threads may remain.
+   - Treat an actionable CodeRabbit comment as a representative symptom for the whole route family, not only the exact line or literal named in the comment. Before editing, enumerate sibling owner tokens, parser branches, punctuation/casing variants, scoped dictionary homes, and owner-vs-sink boundaries that share the same contract.
+   - When reading CodeRabbit state, compare `headRefOid`, check/status context, review decision, and the commit range named in the latest review body. `latestReviews` may retain comments from older force-pushed commits, while the current CodeRabbit status context can already be passing.
+   - Do not rely on unresolved review threads alone. Inspect the latest review bodies for actionable non-threaded notes such as duplicate-comment summaries, and treat current-head actionable body text as open review work.
+
+2. Trace the source before choosing a fix.
+   - Use `rg` for literal strings, symbol names, files, and quick dictionary searches.
+   - Use `just sg-cs '<pattern>'` for decompiled C# producers when call shape, argument structure, wrappers, assignments, overloads, or attributes matter.
+   - Use `just sg-cs '<pattern>' Mods/QudJP/Assemblies/src` to compare existing patch patterns in repo-owned C#.
+   - When a decision depends on C# producer/sink ownership, do not stop at literal `rg`. Run at least one `just sg-cs` query that matches the relevant call shape, such as `AddMyActivatedAbility($$$ARGS)`, `ExpandString($$$ARGS)`, `AddEntityListItem($$$ARGS)`, `SetText($$$ARGS)`, or `MessagePatternTranslator.Translate($$$ARGS)`. If `rg` is sufficient because the source is a plain data file or fixed asset literal, state that explicitly in the evidence summary.
+   - For generated ability names, effect names, mutation labels, and similar UI labels, trace the method or object data that composes the visible name before adding any dictionary entry.
+   - For generated or composed text, record the route shape before choosing a fix: fixed frame with generated noun, generated name only, generated sentence from reusable grammar templates, or final sink-only display with no known owner route yet.
+   - For Annals / HistorySpice / village history text, inspect both the decompiled event builder under `~/dev/coq-decompiled_stable/XRL.Annals/` and the live `Base/HistorySpice.json` source when available. Title Case dish, festival, gospel, or sacred/profane phrases are usually composed outputs, not fixed leaves.
+   - Treat `~/dev/coq-decompiled_stable/` as read-only evidence and never commit it.
+
+3. Choose the ownership surface.
+   - Prefer owner/source patches for generated UI text, status/inspect text, chargen framework data, journal/game-summary text, conversations, and other composed routes.
+   - Use scoped dictionaries for route-specific fixed leaves or domain-specific leaf text.
+   - Use broad dictionary entries only when the literal is stable and not context-sensitive.
+   - Do not promote an observed generated name to an exact leaf merely because it appears unchanged in one `Player.log`. Prefer a generator helper that derives the translation from the owning data source, such as mutation DisplayName, effect metadata, object display names, or other shipped XML.
+   - For generated HistorySpice names, prefer component leaves plus a reconstruction translator over whole observed phrases. Add whole exact leaves only after proving the phrase is authored as a stable fixed literal.
+   - Do not add or keep sink translation as the intended fix when a producer route can own the text.
+   - Treat generic popup and message sinks as observation or last-resort fallback, not as the primary fix for owner-specific generated sentences. If a popup or message reaches a shared helper with route-specific captures, add a narrow owner helper before delegating to the shared path.
+   - Treat zero unresolved rows for a sink or composed route as a closeout candidate only after the owner route has been classified. A sink count reaching zero does not prove the upstream family is owned.
+   - If a route cannot be owned safely, document why and preserve observability.
+
+4. Fix with tests first when behavior changes.
+   - Add or extend L1 translator tests for pure translation helpers and dictionary-driven templates.
+   - Add L2 Harmony/dummy-target tests for owner patches and route observability.
+   - Add L2G resolution tests when upstream game signatures or member contracts matter.
+   - New translation families must cover exact match, fallback to English, empty input, color tags, and `\x01` marker behavior.
+   - For producer or queue-gated patches that translate before a generic sink, also prove owner-absent or queue-only traffic stays unchanged, pass-through traffic is not recorded as an owner hit, and transformed owner traffic is recorded on the intended route family.
+   - When articles, generated names, quantities, or placeholder-like fragments can appear, include those emitted shapes in tests instead of replacing them with dictionary leaves.
+   - For generated/composed text, use this test matrix where applicable: fixed frame plus generated noun, generated noun alone, known observed sample, at least one non-observed variant, English fallback for unknown component, empty input, color tags, and `\x01` marker preservation.
+   - For generated-name fixes, test at least one non-observed variant or a derivation path from the upstream data source so the test does not simply bless the single runtime sample.
+   - After adding an owner/generator fix, search the fresh log for the same raw source across UI owner routes, message patterns, journal patterns, description patterns, and final-output probes. Route the shared translation helper through every surface that can expose the same source.
+   - For PR review work, scope edge-test additions to the families or files named by unresolved actionable review threads unless the user explicitly asks for a broader audit.
+   - For CodeRabbit route-ownership feedback, add tests for the named family plus any sibling token or parser branch discovered in the family audit. A fix for one token, such as `Fire`, should also check adjacent owner tokens such as `Reload` before closing the thread.
+   - Tests should assert the Japanese output, not only that output differs from English.
+
+5. Verify using `just` recipes where available.
+   - Build: `just build`
+   - C# tests: `just test-l1`, `just test-l2`, `just test-l2g`
+   - Localization checks: `just localization-check`, `just translation-token-check`
+   - Broad local gate: `just check`
+   - Sync only when the user wants local game deployment: `just sync-mod`
+   - Before committing PR review fixes, confirm the checkout branch matches the PR head branch. If unrelated dirty work is present, use a separate worktree or stage only explicit paths.
+   - For PR review convergence, confirm thread state with the GitHub review-thread workflow before calling actionable review threads handled.
+   - Report `reviewDecision` separately from thread state: if unresolved actionable threads are zero and checks pass but `reviewDecision` still says `CHANGES_REQUESTED`, say the code-side comments appear handled and GitHub approval/decision state is still lagging or blocked.
+   - If a CodeRabbit fix changes `ColorAwareTranslationComposer` or `Strip` call sites, run the color-route catalog and strip/restore allowlist tests before the broad gate; those deterministic inventories are part of the color-preservation contract, not incidental snapshots.
+
+## Output
+
+When reporting back, include:
+
+- what runtime text or route was investigated
+- source-of-truth evidence used, including player.log and decompiled producer paths when relevant
+- owner-route grouping used for broad runtime buckets, especially when closing or deferring an issue
+- whether the fix is owner/source, scoped dictionary, broad leaf, or intentional pass-through
+- for generated/composed text, the producer evidence and whether the fix uses upstream data derivation, component-leaf reconstruction, or a justified exact leaf
+- tests and checks run
+- remaining runtime risk or surfaces the user still needs to verify in-game
+
+For PR review convergence requests, report PR/thread evidence instead of runtime route evidence:
+
+- check state
+- unresolved actionable review-thread count
+- `reviewDecision` or approval state, reported separately
+- edge-test families/files named by unresolved actionable threads
+- local `just` checks run
+
+Do not report sink success as final coverage if the owner route is still missing.

--- a/.codex/skills/qudjp-localization-triage/agents/openai.yaml
+++ b/.codex/skills/qudjp-localization-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "QudJP Localization Triage"
+  short_description: "QudJP runtime localization route triage"
+  default_prompt: "Use $qudjp-localization-triage to trace QudJP untranslated runtime text to the correct owner route and tests."

--- a/Mods/QudJP/Assemblies/AGENTS.md
+++ b/Mods/QudJP/Assemblies/AGENTS.md
@@ -38,6 +38,9 @@ just test-l2g
 - If structural search is intentionally skipped for C# route work, state the reason in the work note or PR summary.
 - Constraints:
   - one patch class per file in `src/Patches/`
-  - do not instantiate real game types in tests; use dummy targets with matching signatures
+  - do not instantiate real game types in L1/L2 tests; use dummy targets with matching signatures
+  - L2G may use a minimal real game type invocation only for an upstream member
+    contract that cannot be proven by target/signature resolution and
+    DummyTarget behavior tests; follow `docs/test-architecture.md`
   - runtime Harmony comes from the game; tests use HarmonyLib NuGet `2.4.2`
   - producer or queue-gated translation patches must follow the route-contract test checklist in `docs/RULES.md`

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -60,13 +60,27 @@ L2 層は 2 つのカテゴリに分かれます。
 **制約**:
 - `Assembly-CSharp.dll` の型を参照してよい
 - `using UnityEngine` を含めない
-- `Assembly-CSharp.dll` の型をテスト内で直接 instantiate しない
+- 実ゲーム型の instantiate は原則禁止し、下記の限定例外だけを認める
 - 画面表示や TMP/UGUI の実描画結果は L3 に残す
+
+**実ゲーム型 instantiate の限定例外**:
+L2G で upstream の実メンバー契約や実プロパティ経路そのものが
+レビュー・Issue の対象になっており、target/signature 解決と DummyTarget
+だけでは経路を証明できない場合に限り、最小の実型呼び出しを許可します。
+その場合も、次をすべて満たす必要があります。
+
+- `GameObjectFactory`、Unity ECall、フルゲーム bootstrap、実描画に入らない
+- 必要な field/property だけを reflection や軽量インスタンスで設定する
+- static singleton や global state を触る場合は必ず復元する
+- DummyTarget では不十分な理由をテスト名またはコメントで明示する
+- assertion は「英語と違う」ではなく、期待する日本語出力を固定する
 
 **推奨例**:
 - `AccessTools.Method("XRL.UI.Look:GenerateTooltipContent")` の解決確認
 - `ConsoleLib.Console.Markup` の static API 解決確認
 - private `TargetMethod()` の反射呼び出し検証
+- `GameObject.One` / `one` のように実ゲーム型上の display-name
+  contract が対象の場合の、Unity 非依存な最小呼び出し
 
 ### L2 — DummyTarget (`[Category("L2")]`)
 
@@ -141,6 +155,8 @@ dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCa
 - L1 では `Assembly-CSharp.dll` を使わない
 - L2 では `UnityEngine` 実ランタイムに依存しない
 - L2 では `Assembly-CSharp.dll` の型を直接 instantiate しない
+- L2G でも実ゲーム型 instantiate は原則禁止し、上記の限定例外に
+  該当する contract proof だけに絞る
 - L3 だけが実レンダリングの最終保証を担う
 
 ---

--- a/docs/workflows/pr-review.md
+++ b/docs/workflows/pr-review.md
@@ -62,10 +62,17 @@ gh pr view <number> --json headRefOid,reviewDecision,statusCheckRollup,latestRev
 The CodeRabbit status context is named `CodeRabbit`. Treat it as current only
 when it belongs to the PR head you are reporting.
 
-Use review-thread state, not only review bodies, to decide whether actionable
-comments remain. The practical convergence check is:
+Inspect the latest review bodies in addition to thread state. CodeRabbit can
+put actionable non-inline notes, such as duplicate-comment summaries, in a
+review body without leaving a separate unresolved review thread. Treat a
+current-head review body with actionable text as open review work even when the
+review-thread count is zero.
+
+Use review-thread state, latest review bodies, and current checks together to
+decide whether actionable comments remain. The practical convergence check is:
 
 - unresolved actionable review threads are zero
+- latest current-head review bodies contain no actionable non-threaded notes
 - checks on the current head pass
 - the current `CodeRabbit` status context is `SUCCESS`
 


### PR DESCRIPTION
## Summary

- move QudJP localization triage guidance into a repo-local Codex skill
- document PR review convergence checks for actionable latest review-body notes, not only unresolved review threads
- clarify the narrow L2G exception for minimal real game type invocation when proving upstream member contracts

## Validation

- skill-creator quick validation for `.codex/skills/qudjp-localization-triage`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * QudJP ローカライゼーション トリアージワークフローの新しいスキルドキュメントを追加しました。
  * テストアーキテクチャガイドラインを強化し、実装ルールをより明確にしました。
  * PR レビュー ワークフローの判定基準を改善し、レビュー内容の確認プロセスを拡張しました。

* **新機能**
  * QudJP ローカライゼーション トリアージ用の新しいインターフェース定義を導入しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->