### PR TITLE
[codex] Document retrospective PR workflow lessons

### DIFF
--- a/.codex/skills/qudjp-localization-triage/SKILL.md
+++ b/.codex/skills/qudjp-localization-triage/SKILL.md
@@ -70,6 +70,7 @@ Use this skill to turn runtime untranslated text into the smallest correct QudJP
    - For PR review convergence, confirm thread state with the GitHub review-thread workflow before calling actionable review threads handled.
    - Report `reviewDecision` separately from thread state: if unresolved actionable threads are zero and checks pass but `reviewDecision` still says `CHANGES_REQUESTED`, say the code-side comments appear handled and GitHub approval/decision state is still lagging or blocked.
    - If a CodeRabbit fix changes `ColorAwareTranslationComposer` or `Strip` call sites, run the color-route catalog and strip/restore allowlist tests before the broad gate; those deterministic inventories are part of the color-preservation contract, not incidental snapshots.
+   - When a deterministic inventory or allowlist L1 test fails with `Missing` and `Extra` entries, treat the test failure output as the canonical update source. Do not infer line-number keyed allowlist entries from `rg`, `nl`, or manual file inspection when the test has already reported the current keys.
 
 ## Output
 

--- a/docs/workflows/pr-review.md
+++ b/docs/workflows/pr-review.md
@@ -34,6 +34,24 @@ If the active checkout has unrelated dirty work, either use a separate worktree
 or stage only explicit paths for the PR. Do not commit review fixes from an
 unrelated branch just because the patch applies cleanly.
 
+## Stacked PR Rebase
+
+When a PR was opened on top of another PR branch and the parent PR later lands
+on `main`, rebase the child branch onto `origin/main` before resolving GitHub
+conflicts. If the rebase first tries to replay the already-merged parent commit,
+skip that parent commit after confirming it is present on `origin/main` through
+PR metadata or commit history.
+
+After the rebase, verify that the PR is scoped to the child work only:
+
+```bash
+git diff --stat origin/main...HEAD
+git log --oneline --decorate --graph --max-count=8
+```
+
+Do not keep the old parent commit in the child branch just because it applies;
+that makes GitHub conflict checks and review diffs describe the wrong work.
+
 ## Route-family feedback
 
 For CodeRabbit or reviewer feedback on route ownership, do not stop at the exact

--- a/docs/workflows/pr-review.md
+++ b/docs/workflows/pr-review.md
@@ -37,7 +37,13 @@ unrelated branch just because the patch applies cleanly.
 ## Stacked PR Rebase
 
 When a PR was opened on top of another PR branch and the parent PR later lands
-on `main`, rebase the child branch onto `origin/main` before resolving GitHub
+on `main`, refresh remote refs before using `origin/main`:
+
+```bash
+git fetch origin --prune
+```
+
+Then rebase the child branch onto `origin/main` before resolving GitHub
 conflicts. If the rebase first tries to replay the already-merged parent commit,
 skip that parent commit after confirming it is present on `origin/main` through
 PR metadata or commit history.


### PR DESCRIPTION
## Summary

Retrospective codification from the issue #528 session.

- document the stacked-PR rebase flow after the parent PR lands on `main`
- clarify that line-number keyed deterministic allowlists should use L1 `Missing` / `Extra` failure output as the canonical update source

## Verification

- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * ローカライゼーション・トリアージ用ガイダンスを追加しました：決定的なインベントリ／許可リストの検査で「Missing」や「Extra」が出た場合、そのテスト出力を正と扱う旨を明記しました。
  * スタックPRのリベース手順を追加しました：いつ行うか、origin/mainへのリベース方法、差分・履歴の確認手順を説明しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->