### PR TITLE
Release QudJP v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.2.4] - 2026-05-06
+
+### Changed
+
+- Standardize the shipped mod display name as `Caves of Qud Japanese Mod`.
+
+### Fixed
+
+- Improve Japanese localization for generated hookah, mutation, liquid
+  container, statue, and combat messages.
+- Improve Japanese coverage for combat logs, popups, world mod text, and
+  missile targeting UI labels such as Fire and Reload.
+- Improve Japanese localization for generated runtime text, including generated
+  display names, quest titles, shrine prayer messages, targeting commands,
+  effect details, and combat log messages.
+- Improve Japanese localization for generated status and display-name text,
+  including seated, prone, engulfed, enclosed, piloting, marked, cleaved,
+  dominated, and time-dilated states.
+
+---
+
 ## [0.2.3] - 2026-05-06
 
 ### Changed
@@ -159,6 +180,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+[0.2.4]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.4
 [0.2.3]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.3
 [0.2.2]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.2
 [0.2.1]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.1

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.2.3",
+  "Version": "0.2.4",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/release-notes/unreleased/fix-hookah-generated-text.md
+++ b/docs/release-notes/unreleased/fix-hookah-generated-text.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Improve Japanese localization for generated hookah, mutation, liquid container, statue, and combat messages.

--- a/docs/release-notes/unreleased/issue-497-localization-routes.md
+++ b/docs/release-notes/unreleased/issue-497-localization-routes.md
@@ -1,7 +1,0 @@
-### Fixed
-
-- Improve Japanese coverage for combat logs, popups, world mod text, and missile targeting UI labels such as Fire and Reload.
-
-### Changed
-
-- Standardize the shipped mod display name as `Caves of Qud Japanese Mod`.

--- a/docs/release-notes/unreleased/issue-519-generated-runtime-localization.md
+++ b/docs/release-notes/unreleased/issue-519-generated-runtime-localization.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Improved Japanese localization for generated runtime text, including generated display names, quest titles, shrine prayer messages, targeting commands, effect details, and combat log messages.

--- a/docs/release-notes/unreleased/issue-537-dynamic-dictionary-scope.md
+++ b/docs/release-notes/unreleased/issue-537-dynamic-dictionary-scope.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Improve Japanese localization for generated status and display-name text, including seated, prone, engulfed, enclosed, piloting, marked, cleaved, dominated, and time-dilated states.


### PR DESCRIPTION
## Summary
- bump QudJP manifest to 0.2.4
- add 0.2.4 changelog focused on generated/runtime Japanese localization improvements
- consume released note fragments

## Verification
- just build
- just python-check
- just localization-check
- just translation-token-check
- npx secretlint CHANGELOG.md Mods/QudJP/manifest.json docs/release-notes/unreleased
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **変更点**
  * モッド表示名を「Caves of Qud Japanese Mod」に統一しました

* **バグ修正**
  * 日本語ローカライズの複数の改善を実施
    * 生成テキスト（フックシーシャ、突然変異、液体容器、像）の日本語化
    * 戦闘メッセージ・戦闘ログの改善
    * UI ラベルとポップアップの日本語化
    * 実行時生成テキストとステータス表示の改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->