### PR TITLE
[codex] Fix generated canvas and cybernetics labels

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs
@@ -219,6 +219,25 @@ public sealed class GetDisplayNameRouteTranslatorTests
     }
 
     [Test]
+    public void TranslatePreservingColors_UsesShippedGeneratedCanvasTentComponents()
+    {
+        var repositoryDictionaryPath = Path.GetFullPath(
+            Path.Combine(TestContext.CurrentContext.TestDirectory, "../../../../../Localization/Dictionaries"));
+        Translator.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(repositoryDictionaryPath);
+
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            "dragonfly chitin tent",
+            nameof(GetDisplayNamePatch));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.EqualTo("トンボのキチン質の天幕"));
+            Assert.That(Translator.GetMissingKeyHitCountForTests("dragonfly chitin tent"), Is.EqualTo(0));
+        });
+    }
+
+    [Test]
     public void TranslatePreservingColors_PrefersTrimmedExactLookupBeforeProperNameModifierHeuristic()
     {
         WriteDictionary(("Water Containers", "水容器"));

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CyberneticsTerminalTextTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CyberneticsTerminalTextTranslationPatchTests.cs
@@ -82,6 +82,35 @@ public sealed partial class Issue201OtherUiBindingPatchTests
     }
 
     [Test]
+    public void CyberneticsTerminalTextTranspiler_TranslatesBodySlotSuffixes()
+    {
+        WriteCyberneticsDictionary(("translucent skin", "透明皮膚"));
+
+        RunWithCyberneticsTerminalTextTranspiler(() =>
+        {
+            var screen = new CyberneticsScreen();
+            screen.MainText = "Please choose a target body part.";
+            screen.Options.Add("{{Y|皮膚用断熱材}} (Back)");
+            screen.Options.Add("translucent skin (Back)");
+            screen.Options.Add("made-up cyberware (Back)");
+            screen.Options.Add("Back");
+            screen.Update();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(screen.Options[0], Is.EqualTo("{{Y|皮膚用断熱材}}（背中）"));
+                Assert.That(screen.Options[1], Is.EqualTo("透明皮膚（背中）"));
+                Assert.That(screen.Options[2], Is.EqualTo("made-up cyberware (Back)"));
+                Assert.That(screen.Options[3], Is.EqualTo("Back"));
+                Assert.That(screen.RenderedText, Does.Contain("{{Y|皮膚用断熱材}}（背中）"));
+                Assert.That(
+                    DynamicTextObservability.GetRouteFamilyHitCountForTests(nameof(CyberneticsTerminalTextTranslator), "CyberneticsTerminal.OptionText"),
+                    Is.GreaterThan(0));
+            });
+        });
+    }
+
+    [Test]
     public void CyberneticsTerminalTextTranspiler_LeavesNonCyberneticsScreenUntouched()
     {
         WriteCyberneticsDictionary(

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/GetDisplayNameProcessPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/GetDisplayNameProcessPatchTests.cs
@@ -770,10 +770,14 @@ public sealed class GetDisplayNameProcessPatchTests
             "{\"entries\":[" +
             "{\"key\":\"tortoise\",\"context\":\"GetDisplayName.GeneratedCanvasTent.Component\",\"text\":\"亀\"}," +
             "{\"key\":\"keratin\",\"context\":\"GetDisplayName.GeneratedCanvasTent.Component\",\"text\":\"ケラチン質\"}," +
+            "{\"key\":\"dragonfly\",\"context\":\"GetDisplayName.GeneratedCanvasTent.Component\",\"text\":\"トンボ\"}," +
+            "{\"key\":\"chitin\",\"context\":\"GetDisplayName.GeneratedCanvasTent.Component\",\"text\":\"キチン質\"}," +
             "{\"key\":\"tent\",\"context\":\"GetDisplayName.GeneratedCanvasTent.Component\",\"text\":\"天幕\"}," +
             "{\"key\":\"salt kraken\",\"text\":\"ソルト・クラーケン\"}," +
             "{\"key\":\"tortoise\",\"text\":\"亀ではない\"}," +
             "{\"key\":\"keratin\",\"text\":\"ケラチンではない\"}," +
+            "{\"key\":\"dragonfly\",\"text\":\"トンボではない\"}," +
+            "{\"key\":\"chitin\",\"text\":\"キチンではない\"}," +
             "{\"key\":\"tent\",\"text\":\"テントではない\"}" +
             "]}\n");
 
@@ -782,13 +786,19 @@ public sealed class GetDisplayNameProcessPatchTests
             var processor = new DummyDisplayNameProcessor();
             var result = processor.ProcessFor("tortoise keratin tent");
             var multiWordCreatureResult = processor.ProcessFor("salt kraken keratin tent");
+            var observedRuntimeResult = processor.ProcessFor("dragonfly chitin tent");
+            var nonObservedCombinationResult = processor.ProcessFor("tortoise chitin tent");
 
             Assert.Multiple(() =>
             {
                 Assert.That(result, Is.EqualTo("亀のケラチン質の天幕"));
                 Assert.That(multiWordCreatureResult, Is.EqualTo("ソルト・クラーケンのケラチン質の天幕"));
+                Assert.That(observedRuntimeResult, Is.EqualTo("トンボのキチン質の天幕"));
+                Assert.That(nonObservedCombinationResult, Is.EqualTo("亀のキチン質の天幕"));
                 Assert.That(Translator.GetMissingKeyHitCountForTests("tortoise keratin tent"), Is.EqualTo(0));
                 Assert.That(Translator.GetMissingKeyHitCountForTests("salt kraken keratin tent"), Is.EqualTo(0));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("dragonfly chitin tent"), Is.EqualTo(0));
+                Assert.That(Translator.GetMissingKeyHitCountForTests("tortoise chitin tent"), Is.EqualTo(0));
             });
         });
     }

--- a/Mods/QudJP/Assemblies/src/Patches/CyberneticsTerminalTextTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/CyberneticsTerminalTextTranslator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
@@ -68,6 +69,10 @@ internal static class CyberneticsTerminalTextTranslator
         "^Error: Condition inadequate for installation\\n  \\-(?<item>.+)\\n\\nPlease supply a replacement\\.$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex CyberneticsSlotPattern = new Regex(
+        "^(?<label>.+?) (?<slotSegment>\\((?<slot>Face|Body|Head|Back|Feet|Arm|Hands)\\))$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private static readonly Regex ReminderPattern = new Regex(
         "Remember, Aristocrat, your base license tier is (?<tier>\\{\\{C\\|\\d+\\}\\})\\.",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -91,6 +96,23 @@ internal static class CyberneticsTerminalTextTranslator
     private static readonly Regex UninstallingLinePattern = new Regex(
         "Uninstalling (?<item>.+?)(?<suffix>\\.+\\n)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex JapaneseCharacterPattern =
+        new Regex("[\\p{IsHiragana}\\p{IsKatakana}\\p{IsCJKUnifiedIdeographs}]", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex AsciiLetterPattern =
+        new Regex("[A-Za-z]", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly IReadOnlyDictionary<string, string> SlotNames = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["Face"] = "顔",
+        ["Body"] = "胴",
+        ["Head"] = "頭",
+        ["Back"] = "背中",
+        ["Feet"] = "足",
+        ["Arm"] = "腕",
+        ["Hands"] = "手",
+    };
 
     private static readonly MethodInfo? LeetMethod = ResolveLeetMethod();
 
@@ -170,6 +192,11 @@ internal static class CyberneticsTerminalTextTranslator
             return exact;
         }
 
+        if (TryTranslateCyberneticsSlot(source, out var slotTranslated))
+        {
+            return slotTranslated;
+        }
+
         var knownLeet = TranslateKnownLeet(source);
         if (!string.Equals(knownLeet, source, StringComparison.Ordinal))
         {
@@ -225,6 +252,57 @@ internal static class CyberneticsTerminalTextTranslator
         }
 
         return source;
+    }
+
+    private static bool TryTranslateCyberneticsSlot(string source, out string translated)
+    {
+        translated = source;
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out _))
+        {
+            return false;
+        }
+
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
+        var match = CyberneticsSlotPattern.Match(stripped);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var sourceLabel = match.Groups["label"].Value;
+        if (!StringHelpers.TryGetTranslationExactOrLowerAscii(sourceLabel, out var translatedLabel)
+            && !TryUseAlreadyLocalizedCyberneticsLabel(sourceLabel, out translatedLabel))
+        {
+            return false;
+        }
+
+        var sourceSlot = match.Groups["slot"].Value;
+        if (!SlotNames.TryGetValue(sourceSlot, out var translatedSlot))
+        {
+            return false;
+        }
+
+        var translatedSlotSegment = string.Concat("（", translatedSlot, "）");
+        var restoredLabel = spans.Count == 0
+            ? translatedLabel
+            : ColorAwareTranslationComposer.RestoreCapture(translatedLabel, spans, match.Groups["label"]);
+        var restoredSlotSegment = spans.Count == 0
+            ? translatedSlotSegment
+            : ColorAwareTranslationComposer.RestoreCapture(translatedSlotSegment, spans, match.Groups["slotSegment"]);
+        translated = string.Concat(restoredLabel, restoredSlotSegment);
+        return true;
+    }
+
+    private static bool TryUseAlreadyLocalizedCyberneticsLabel(string sourceLabel, out string translatedLabel)
+    {
+        if (JapaneseCharacterPattern.IsMatch(sourceLabel) && !AsciiLetterPattern.IsMatch(sourceLabel))
+        {
+            translatedLabel = sourceLabel;
+            return true;
+        }
+
+        translatedLabel = sourceLabel;
+        return false;
     }
 
     private static string ApplyRegexTemplates(string source)

--- a/Mods/QudJP/Localization/Dictionaries/ui-displayname-atomic.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-displayname-atomic.ja.json
@@ -26,6 +26,8 @@
     { "key": "クリスティールの大剣", "text": "クリスティールの大剣" },
     { "key": "無垢のクリスティール短剣", "text": "無垢のクリスティール短剣" },
     { "key": "CanvasWall", "context": "GetDisplayName.BlueprintFallback", "text": "帆布壁" },
+    { "key": "chitin", "context": "GetDisplayName.GeneratedCanvasTent.Component", "text": "キチン質" },
+    { "key": "dragonfly", "context": "GetDisplayName.GeneratedCanvasTent.Component", "text": "トンボ" },
     { "key": "keratin", "context": "GetDisplayName.GeneratedCanvasTent.Component", "text": "ケラチン質" },
     { "key": "tent", "context": "GetDisplayName.GeneratedCanvasTent.Component", "text": "天幕" },
     { "key": "tortoise", "context": "GetDisplayName.GeneratedCanvasTent.Component", "text": "亀" },

--- a/docs/release-notes/unreleased/issue-515-517-generated-displayname-cybernetics.md
+++ b/docs/release-notes/unreleased/issue-515-517-generated-displayname-cybernetics.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Translate generated village canvas tent display names and cybernetics terminal body-slot suffixes.


### PR DESCRIPTION
## Summary

Fixes #515
Fixes #517

- Translate cybernetics terminal option labels with body-slot suffixes such as `{{Y|皮膚用断熱材}} (Back)` through the cybernetics terminal owner route.
- Add scoped generated-canvas component leaves for `dragonfly` and `chitin` so generated names such as `dragonfly chitin tent` translate through `DisplayName.GeneratedCanvasTent` component reconstruction instead of a whole exact leaf.
- Add regression coverage for shipped dictionary components, observed generated canvas names, a non-observed generated canvas combination, and cybernetics terminal slot suffix behavior.

## Root Cause

The cybernetics terminal route translated exact terminal text and templates but did not handle `name (Slot)` option labels. Generated village canvas names are composed by village generation as `species + skin + tent`, and the existing route lacked component leaves for the observed `dragonfly chitin tent` case.

## Verification

- `just build`
- `just test-l1`
- `just test-l2`
- `python3.12 scripts/release_notes.py check-fragment --base-ref origin/main --head-ref HEAD`
- `just localization-check`
- `just translation-token-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 生成されたビレッジキャンバステント表示名の日本語翻訳を修正
  * サイバネティクスターミナルのボディスロットサフィックス翻訳に対応

* **Tests**
  * 翻訳機能の検証テストを追加

* **Documentation**
  * リリースノートを更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->