### PR TITLE
Document Workshop release guardrails

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -11,9 +11,16 @@ When asked to update the Steam Workshop item, do this first:
 1. Read this file, `steam/workshop_metadata.json`, and
    `steam/changenote_template.txt`.
 2. Confirm the target Workshop item is `3718988020`.
-3. Prepare and merge a release PR that updates `Mods/QudJP/manifest.json`,
+3. Establish what "current changes" means before choosing the release version.
+   Do not reuse the newest existing tag just because it exists. Compare the
+   previous shipped tag with `origin/main`, including `Mods/QudJP/Localization/`,
+   `Mods/QudJP/Assemblies/`, `docs/release-notes/unreleased/`, `CHANGELOG.md`,
+   and `Mods/QudJP/manifest.json`. If `origin/main` contains unreleased
+   user-visible localization or runtime changes, prepare the next version so
+   the shipped ZIP and Workshop changenote describe the same content.
+4. Prepare and merge a release PR that updates `Mods/QudJP/manifest.json`,
    `CHANGELOG.md`, and release-note fragments.
-4. After the release PR is merged, update local `main` and inspect tags,
+5. After the release PR is merged, update local `main` and inspect tags,
    release range, and head identity:
 
    ```bash
@@ -23,26 +30,30 @@ When asked to update the Steam Workshop item, do this first:
    git tag --sort=-creatordate | head -20
    git describe --tags --abbrev=0 --match 'v[0-9]*'
    git log --oneline <previous-tag>..HEAD
+   git diff --name-only <previous-tag>..HEAD -- \
+     Mods/QudJP/Localization Mods/QudJP/Assemblies docs/release-notes CHANGELOG.md Mods/QudJP/manifest.json
    git rev-parse --short=12 HEAD
    ```
 
-5. Create and push the release tag from `main` according to the Tag and Release
+6. Create and push the release tag from `main` according to the Tag and Release
    Policy below. The tag, manifest version, GitHub Release ZIP, staged Workshop
    content, and changenote must all identify the same release.
-6. Wait for the tag-triggered `Release` GitHub Actions workflow to create a
+7. Wait for the tag-triggered `Release` GitHub Actions workflow to create a
    draft GitHub Release with `QudJP-vX.Y.Z.zip` and
    `QudJP-vX.Y.Z.zip.sha256`.
-7. Draft a user-facing changenote from the accumulated commits. Keep internal
+8. Draft a user-facing changenote from the accumulated commits. Keep internal
    implementation names secondary; lead with visible translation, UI, runtime,
-   and packaging changes.
-8. Download and verify the GitHub Release ZIP with the local release ZIP
+   and packaging changes. If the release includes localization changes, the
+   first substantive section of the Steam changenote must describe those
+   translation changes in user-facing terms before pipeline or tooling notes.
+9. Download and verify the GitHub Release ZIP with the local release ZIP
    download recipe.
-9. Generate `dist/workshop/QudJP/` and `dist/workshop/workshop_item.vdf` with
+10. Generate `dist/workshop/QudJP/` and `dist/workshop/workshop_item.vdf` with
    the Workshop staging recipe, passing the downloaded GitHub Release ZIP
    explicitly.
-10. Stop before running `steamcmd` unless the user explicitly confirms upload
+11. Stop before running `steamcmd` unless the user explicitly confirms upload
    credentials and permission to publish.
-11. After Steam upload and smoke checks, publish the draft GitHub Release and
+12. After Steam upload and smoke checks, publish the draft GitHub Release and
     commit the Workshop release evidence report outside the release tag.
 
 Use `just` recipes for release commands so local runs match the repo task

--- a/docs/reports/2026-05-06-workshop-v0.2.3.md
+++ b/docs/reports/2026-05-06-workshop-v0.2.3.md
@@ -1,0 +1,93 @@
+# Workshop Release v0.2.3
+
+## Identity
+
+- Version: `0.2.3`
+- Git commit: `4ad565bff3dd05cbee851bc967662f7dcdf7314d`
+- Git tag: `v0.2.3`
+- Previous release tag/range: `v0.2.2..v0.2.3`
+- Version source: `Mods/QudJP/manifest.json` `Version = 0.2.3`
+- GitHub Release URL: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.3
+- Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
+- Steam app ID: `333640`
+- Published file ID: `3718988020`
+
+## Changenote
+
+```text
+v0.2.3 / 4ad565bff3dd
+
+更新内容:
+- Steam Workshop 配布前に使う GitHub Release ZIP の生成・検証フローを追加しました。
+- 新しく作成される GitHub Release が Latest として扱われるようにしました。
+- Workshop upload 前の release artifact download path を文書化し、検証しました。
+
+既知の問題:
+- このリリースは release pipeline の検証リリースです。ゲーム内の翻訳内容は v0.2.2 から manifest version 以外変更ありません。
+- 一部の自動生成テキスト、チュートリアル、キャラクター生成画面には未翻訳または不自然な訳が残る場合があります。
+- ゲーム本体のアップデートにより、一部表示やパッチが壊れる可能性があります。
+```
+
+## Artifacts
+
+- Release ZIP: `dist/release-assets/v0.2.3/QudJP-v0.2.3.zip`
+- Release ZIP SHA256: `8d1324a348654549427b9618dee42e40d4b5644edce3499ec34e68833a93612a`
+- GitHub Release asset: `QudJP-v0.2.3.zip`
+- GitHub Release asset SHA256: `8d1324a348654549427b9618dee42e40d4b5644edce3499ec34e68833a93612a`
+- Workshop content folder: `dist/workshop/QudJP/`
+- Workshop VDF: `dist/workshop/workshop_item.vdf`
+- Steam manifest ID: `1227492540843208769`
+
+## Preflight
+
+- [x] `git status --short --branch`
+- [x] Release range established from previous tag, release report, changelog/GitHub release, or explicit user range
+- [x] `Mods/QudJP/manifest.json` version, `v0.2.3` tag, release ZIP name, changenote first line, and report version match
+- [x] `git rev-list -n1 v0.2.3` matches `git rev-parse HEAD` in `.worktrees/release-v0.2.3`
+- [x] `git merge-base --is-ancestor "$(git rev-list -n1 v0.2.3)" origin/main`
+- [ ] Draft GitHub Release created by tag workflow
+- [x] Draft GitHub Release created manually from the locally verified tag artifact
+- [x] `just download-release-zip 0.2.3`
+- [x] `just workshop-preflight 0.2.3`
+- [x] `just release-zip-check dist/release-assets/v0.2.3/QudJP-v0.2.3.zip`
+- [x] `just build-workshop-upload dist/release-assets/v0.2.3/QudJP-v0.2.3.zip /tmp/qudjp-workshop-changenote.txt`
+
+Notes:
+
+- The tag-triggered GitHub Release workflow for `v0.2.3` failed before artifact creation because the tag-era workflow did not install `ast-grep`; the failing job reported `FileNotFoundError: [Errno 2] No such file or directory: 'ast-grep'`.
+- The local preflight was run from a detached worktree at `v0.2.3^{}` to keep `HEAD`, release tag, manifest version, release ZIP, and staged content aligned.
+- A draft GitHub Release was created manually from the locally verified `v0.2.3` ZIP because the tag-triggered workflow could not produce assets for the already-created tag.
+- `just download-release-zip 0.2.3` downloaded the draft asset to `dist/release-assets/v0.2.3/` and verified `QudJP-v0.2.3.zip: OK`.
+- `dist/workshop/workshop_item.vdf` was checked before upload: `appid=333640`, `publishedfileid=3718988020`, staged manifest `Version=0.2.3`, and changenote literal newlines were present without escaped `\n` sequences.
+- `validate_xml.py` reported the existing baseline warning in `Conversations.jp.xml`: empty `text` element.
+
+## Upload
+
+- steamcmd command: `/opt/homebrew/bin/steamcmd +login <steam_account> +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_stable/dist/workshop/workshop_item.vdf +quit`
+- Upload completed at: 2026-05-06 20:58 JST
+- Steam output summary: `Uploading content`; `Uploaded new content ( ManifestID 1227492540843208769 )`; `Uploading preview image`; `Upload finished for workshop item 3718988020 : OK`; `Committing update...Success`.
+- GitHub Release published at: 2026-05-06 20:59 JST, https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.3
+
+## Post-Publish Smoke
+
+- [x] Workshop page title, description, preview image, visibility, file size, and changenote checked
+- [x] Subscribe/resubscribe checked with `steamcmd +workshop_download_item 333640 3718988020 validate`
+- [x] Downloaded Workshop `manifest.json` lists `Version: 0.2.3`
+- [ ] Mod Manager lists QudJP with expected version and preview
+- [ ] Options screen renders Japanese text and CJK glyphs
+- [ ] One short conversation renders Japanese text and CJK glyphs
+- [ ] Fresh Player.log checked for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`
+
+Notes:
+
+- Steam Web API returned `publishedfileid=3718988020`, `title=Caves of Qud Japanese Mod`, `file_size=19580613`, `hcontent_file=1227492540843208769`, `visibility=0`, and `time_updated=2026-05-06 20:58:27 JST`.
+- Steam Workshop changelog page rendered the `v0.2.3 / 4ad565bff3dd` changenote with literal line breaks converted to HTML `<br>` elements.
+- Steam download validation with cached credentials downloaded item `3718988020` successfully to the local Steam Workshop cache; downloaded size was `19580613` bytes.
+- Downloaded `manifest.json` lists `Id: QudJP`, `Title: Caves of Qud 日本語化`, and `Version: 0.2.3`.
+- Full in-game smoke remains pending.
+
+## Decision
+
+- Result: GO for Steam Workshop upload, public metadata, download availability, downloaded manifest version, and GitHub Release publication.
+- Notes: Release tag, release ZIP, Workshop staging, Workshop upload, public metadata check, Workshop download validation, and GitHub Release publication are complete. Full in-game Mod Manager/options/conversation smoke still needs manual confirmation.
+- Rollback tag, if needed: `v0.2.2`

--- a/docs/reports/2026-05-06-workshop-v0.2.3.md
+++ b/docs/reports/2026-05-06-workshop-v0.2.3.md
@@ -63,7 +63,7 @@ Notes:
 
 ## Upload
 
-- steamcmd command: `/opt/homebrew/bin/steamcmd +login <steam_account> +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_stable/dist/workshop/workshop_item.vdf +quit`
+- steamcmd command: `/opt/homebrew/bin/steamcmd +login <steam_account> +workshop_build_item <repo-root>/dist/workshop/workshop_item.vdf +quit`
 - Upload completed at: 2026-05-06 20:58 JST
 - Steam output summary: `Uploading content`; `Uploaded new content ( ManifestID 1227492540843208769 )`; `Uploading preview image`; `Upload finished for workshop item 3718988020 : OK`; `Committing update...Success`.
 - GitHub Release published at: 2026-05-06 20:59 JST, https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.3

--- a/docs/reports/2026-05-06-workshop-v0.2.3.md
+++ b/docs/reports/2026-05-06-workshop-v0.2.3.md
@@ -43,7 +43,7 @@ v0.2.3 / 4ad565bff3dd
 - [x] `git status --short --branch`
 - [x] Release range established from previous tag, release report, changelog/GitHub release, or explicit user range
 - [x] `Mods/QudJP/manifest.json` version, `v0.2.3` tag, release ZIP name, changenote first line, and report version match
-- [x] `git rev-list -n1 v0.2.3` matches `git rev-parse HEAD` in `.worktrees/release-v0.2.3`
+- [x] `git rev-list -n1 v0.2.3` matches `git rev-parse HEAD` in the detached release worktree
 - [x] `git merge-base --is-ancestor "$(git rev-list -n1 v0.2.3)" origin/main`
 - [ ] Draft GitHub Release created by tag workflow
 - [x] Draft GitHub Release created manually from the locally verified tag artifact

--- a/docs/reports/2026-05-06-workshop-v0.2.4.md
+++ b/docs/reports/2026-05-06-workshop-v0.2.4.md
@@ -33,12 +33,12 @@ v0.2.4 / 91cc85cf108f
 
 ## Artifacts
 
-- Release ZIP: `.worktrees/qudjp-v0.2.4-release/dist/release-assets/v0.2.4/QudJP-v0.2.4.zip`
+- Release ZIP: `<repo-root>/dist/release-assets/v0.2.4/QudJP-v0.2.4.zip`
 - Release ZIP SHA256: `de5f41efa462dd0222d1d775b1aa056b126134eec85f161a3e2028a61a8518bd`
 - GitHub Release asset: `QudJP-v0.2.4.zip`
 - GitHub Release asset SHA256: `de5f41efa462dd0222d1d775b1aa056b126134eec85f161a3e2028a61a8518bd`
-- Workshop content folder: `.worktrees/qudjp-v0.2.4-release/dist/workshop/QudJP/`
-- Workshop VDF: `.worktrees/qudjp-v0.2.4-release/dist/workshop/workshop_item.vdf`
+- Workshop content folder: `<repo-root>/dist/workshop/QudJP/`
+- Workshop VDF: `<repo-root>/dist/workshop/workshop_item.vdf`
 - Steam manifest ID: `753250701823019763`
 
 ## Preflight
@@ -64,7 +64,7 @@ Notes:
 
 ## Upload
 
-- steamcmd command: `/opt/homebrew/bin/steamcmd +login <steam_account> +workshop_build_item <release-worktree>/dist/workshop/workshop_item.vdf +quit`
+- steamcmd command: `/opt/homebrew/bin/steamcmd +login <steam_account> +workshop_build_item <repo-root>/dist/workshop/workshop_item.vdf +quit`
 - Upload completed at: 2026-05-06 22:35 JST
 - Steam output summary: `Uploading content`; `Uploaded new content ( ManifestID 753250701823019763 )`; `Uploading preview image`; `Upload finished for workshop item 3718988020 : OK`; `Committing update...Success`.
 - GitHub Release published at: 2026-05-06 22:35 JST, https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.4

--- a/docs/reports/2026-05-06-workshop-v0.2.4.md
+++ b/docs/reports/2026-05-06-workshop-v0.2.4.md
@@ -64,7 +64,7 @@ Notes:
 
 ## Upload
 
-- steamcmd command: `/opt/homebrew/bin/steamcmd +login <steam_account> +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_stable/.worktrees/qudjp-v0.2.4-release/dist/workshop/workshop_item.vdf +quit`
+- steamcmd command: `/opt/homebrew/bin/steamcmd +login <steam_account> +workshop_build_item <release-worktree>/dist/workshop/workshop_item.vdf +quit`
 - Upload completed at: 2026-05-06 22:35 JST
 - Steam output summary: `Uploading content`; `Uploaded new content ( ManifestID 753250701823019763 )`; `Uploading preview image`; `Upload finished for workshop item 3718988020 : OK`; `Committing update...Success`.
 - GitHub Release published at: 2026-05-06 22:35 JST, https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.4

--- a/docs/reports/2026-05-06-workshop-v0.2.4.md
+++ b/docs/reports/2026-05-06-workshop-v0.2.4.md
@@ -1,0 +1,94 @@
+# Workshop Release v0.2.4
+
+## Identity
+
+- Version: `0.2.4`
+- Git commit: `91cc85cf108f7dedbcc637b7ebe4953977ef6ca4`
+- Git tag: `v0.2.4`
+- Previous release tag/range: `v0.2.3..v0.2.4`
+- Version source: `Mods/QudJP/manifest.json` `Version = 0.2.4`
+- GitHub Release URL: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.4
+- Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
+- Steam app ID: `333640`
+- Published file ID: `3718988020`
+
+## Changenote
+
+```text
+v0.2.4 / 91cc85cf108f
+
+翻訳追加・改善:
+- hookah、mutation、liquid container、statue、combat message など、生成される実行時テキストの日本語表示を改善しました。
+- combat log、popup、world mod text、missile targeting UI の Fire / Reload などの表示を改善しました。
+- generated display names、quest titles、shrine prayer、targeting commands、effect details、combat log messages などの日本語表示範囲を広げました。
+- seated、prone、engulfed、enclosed、piloting、marked、cleaved、dominated、time-dilated などの状態・表示名テキストを改善しました。
+
+更新内容:
+- shipped mod display name を Caves of Qud Japanese Mod に統一しました。
+
+既知の問題:
+- 一部の自動生成テキスト、チュートリアル、キャラクター生成画面には未翻訳または不自然な訳が残る場合があります。
+- ゲーム本体のアップデートにより、一部表示やパッチが壊れる可能性があります。
+```
+
+## Artifacts
+
+- Release ZIP: `.worktrees/qudjp-v0.2.4-release/dist/release-assets/v0.2.4/QudJP-v0.2.4.zip`
+- Release ZIP SHA256: `de5f41efa462dd0222d1d775b1aa056b126134eec85f161a3e2028a61a8518bd`
+- GitHub Release asset: `QudJP-v0.2.4.zip`
+- GitHub Release asset SHA256: `de5f41efa462dd0222d1d775b1aa056b126134eec85f161a3e2028a61a8518bd`
+- Workshop content folder: `.worktrees/qudjp-v0.2.4-release/dist/workshop/QudJP/`
+- Workshop VDF: `.worktrees/qudjp-v0.2.4-release/dist/workshop/workshop_item.vdf`
+- Steam manifest ID: `753250701823019763`
+
+## Preflight
+
+- [x] `git status --short --branch`
+- [x] Release range established from previous tag, release report, changelog/GitHub release, or explicit user range
+- [x] `Mods/QudJP/manifest.json` version, `v0.2.4` tag, release ZIP name, changenote first line, and report version match
+- [x] `git rev-list -n1 v0.2.4` matches `origin/main`
+- [x] `git merge-base --is-ancestor "$(git rev-list -n1 v0.2.4)" origin/main`
+- [x] Draft GitHub Release created by tag workflow
+- [x] `just download-release-zip 0.2.4`
+- [x] `just workshop-preflight 0.2.4`
+- [x] `just release-zip-check dist/release-assets/v0.2.4/QudJP-v0.2.4.zip`
+- [x] `just build-workshop-upload dist/release-assets/v0.2.4/QudJP-v0.2.4.zip /tmp/qudjp-workshop-changenote-v0.2.4.txt`
+
+Notes:
+
+- Release PR: https://github.com/ToaruPen/coq-japanese_stable/pull/543
+- Release workflow: https://github.com/ToaruPen/coq-japanese_stable/actions/runs/25437805259
+- `dist/workshop/workshop_item.vdf` was checked before upload: `appid=333640`, `publishedfileid=3718988020`, staged manifest `Version=0.2.4`, and changenote literal newlines were present without escaped `\n` sequences.
+- The rendered Workshop changenote leads with translation additions and improvements, including generated runtime text, combat logs, popups, targeting labels, display names, quest titles, shrine prayer messages, effect details, and generated status/display-name text.
+- `validate_xml.py` reported the existing baseline warning in `Conversations.jp.xml`: empty `text` element.
+
+## Upload
+
+- steamcmd command: `/opt/homebrew/bin/steamcmd +login <steam_account> +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_stable/.worktrees/qudjp-v0.2.4-release/dist/workshop/workshop_item.vdf +quit`
+- Upload completed at: 2026-05-06 22:35 JST
+- Steam output summary: `Uploading content`; `Uploaded new content ( ManifestID 753250701823019763 )`; `Uploading preview image`; `Upload finished for workshop item 3718988020 : OK`; `Committing update...Success`.
+- GitHub Release published at: 2026-05-06 22:35 JST, https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.4
+
+## Post-Publish Smoke
+
+- [x] Workshop page title, description, preview image, visibility, file size, and changenote checked
+- [x] Subscribe/resubscribe checked with `steamcmd +workshop_download_item 333640 3718988020 validate`
+- [x] Downloaded Workshop `manifest.json` lists `Version: 0.2.4`
+- [ ] Mod Manager lists QudJP with expected version and preview
+- [ ] Options screen renders Japanese text and CJK glyphs
+- [ ] One short conversation renders Japanese text and CJK glyphs
+- [ ] Fresh Player.log checked for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`
+
+Notes:
+
+- Steam Web API returned `publishedfileid=3718988020`, `title=Caves of Qud Japanese Mod`, `file_size=19536883`, `hcontent_file=753250701823019763`, `visibility=0`, and `time_updated=2026-05-06 22:35:02 JST`.
+- Steam Workshop changelog page rendered the `v0.2.4 / 91cc85cf108f` changenote. The first section is `翻訳追加・改善`, and it lists generated runtime text, combat logs, popups, targeting UI labels, generated display names, quest titles, shrine prayer messages, effect details, and generated status/display-name text.
+- Steam download validation with cached credentials downloaded item `3718988020` successfully to the local Steam Workshop cache; downloaded size was `19536883` bytes.
+- Downloaded `manifest.json` lists `Id: QudJP`, `Title: Caves of Qud Japanese Mod`, and `Version: 0.2.4`.
+- Full in-game smoke remains pending.
+
+## Decision
+
+- Result: GO for Steam Workshop upload, public metadata, download availability, downloaded manifest version, and GitHub Release publication.
+- Notes: Release PR, release tag, tag-triggered GitHub Release, release ZIP verification, local preflight, Workshop staging, Workshop upload, public metadata check, Workshop download validation, and GitHub Release publication are complete. Full in-game Mod Manager/options/conversation smoke still needs manual confirmation.
+- Rollback tag, if needed: `v0.2.3`


### PR DESCRIPTION
## Summary
- add release-guide guardrails for shipping current changes and unreleased localization work
- record Workshop release evidence for v0.2.3 and v0.2.4

## Verification
- npx secretlint docs/release.md docs/reports/2026-05-06-workshop-v0.2.3.md docs/reports/2026-05-06-workshop-v0.2.4.md
- uv run python scripts/check_markdown_reports.py docs/reports/2026-05-06-workshop-v0.2.3.md docs/reports/2026-05-06-workshop-v0.2.4.md
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation（ドキュメント）**
  * リリース手順を再構成し、変更内容の特定を早期に行う「Agent Quick Path」ステップを追加、手順を再番号化しました（差分確認手順の例を追記）。
  * v0.2.3およびv0.2.4のワークショップリリース報告書を新規追加し、翻訳改善やUI改善、事前確認・アップロード・公開後の検証手順と決定・ロールバック記録を含めました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->