### PR TITLE
Prepare v0.2.41 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.2.41] - 2026-05-07
+
+### Changed
+
+- README、NOTICE、Steam Workshop 説明文の対応ゲーム表記を Caves of Qud 1.0.4 対応として明確化しました。
+
+### Fixed
+
+- 生成された村の帆布テント名とサイバネティクス端末の身体部位サフィックスを日本語化しました。
+- インベントリ画面で一部アイテム名が表示されなくなる問題を修正しました。
+
+---
+
 ## [0.2.4] - 2026-05-06
 
 ### Changed
@@ -180,6 +193,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+[0.2.41]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.41
 [0.2.4]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.4
 [0.2.3]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.3
 [0.2.2]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.2

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.2.4",
+  "Version": "0.2.41",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/release-notes/unreleased/issue-515-517-generated-displayname-cybernetics.md
+++ b/docs/release-notes/unreleased/issue-515-517-generated-displayname-cybernetics.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Translate generated village canvas tent display names and cybernetics terminal body-slot suffixes.

--- a/docs/release-notes/unreleased/issue-546-inventory-item-names.md
+++ b/docs/release-notes/unreleased/issue-546-inventory-item-names.md
@@ -1,7 +1,0 @@
-### Fixed
-
-- インベントリ画面で一部アイテム名が表示されなくなる問題を修正しました。
-
-### Changed
-
-- README、NOTICE、Steam Workshop 説明文の対応ゲーム表記を Caves of Qud 1.0.4 対応として明確化しました。


### PR DESCRIPTION
## Summary

- Bump QudJP manifest version to 0.2.41.
- Add the v0.2.41 CHANGELOG entry.
- Fold the shipped unreleased release-note fragments.

## Included user-facing changes

- Generated village canvas tent names and cybernetics terminal body-slot suffixes are localized.
- Inventory item names stay visible after the InventoryLine route regression fix.
- README, NOTICE, and Steam Workshop description use the Caves of Qud 1.0.4 runtime version wording.

## Verification

- `just build`
- `uv run python scripts/release_notes.py extract-changelog --version 0.2.41 --output /tmp/qudjp-changelog-entry.md`
- `uv run python scripts/release_notes.py check-fragment --base-ref origin/main --head-ref HEAD`
- `git diff --check`

## After merge

Tag/upload gate remains manual:
- create and push annotated `v0.2.41` only after confirmation
- wait for the tag-triggered GitHub Release ZIP
- build Workshop staging from `dist/release-assets/v0.2.41/QudJP-v0.2.41.zip`
- stop before Steam upload unless explicitly confirmed