### PR TITLE
Record v0.2.41 Workshop release evidence

### DIFF
--- a/docs/reports/2026-05-07-workshop-v0.2.41.md
+++ b/docs/reports/2026-05-07-workshop-v0.2.41.md
@@ -1,0 +1,78 @@
+# Workshop Release v0.2.41
+
+## Identity
+
+- Version: `0.2.41`
+- Git commit: `d1a06389e609dc9a94dc2a9add2952f2dbb9122d`
+- Git tag: `v0.2.41`
+- Previous release tag/range: `v0.2.4..v0.2.41`
+- Version source: `Mods/QudJP/manifest.json`
+- GitHub Release URL: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.41
+- Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
+- Steam app ID: `333640`
+- Published file ID: `3718988020`
+
+## Changenote
+
+```text
+v0.2.41 更新
+
+更新内容:
+- 生成された村の帆布テント名とサイバネティクス端末の身体部位サフィックスを日本語化しました。
+- インベントリ画面で一部アイテム名が表示されなくなる問題を修正しました。
+- README、NOTICE、Steam Workshop 説明文の対応ゲーム表記を Caves of Qud 1.0.4 対応として明確化しました。
+
+既知の問題:
+- 一部の自動生成テキスト、チュートリアル、キャラクター生成画面には未翻訳または不自然な訳が残る場合があります。
+- ゲーム本体のアップデートにより、一部表示やパッチが壊れる可能性があります。
+```
+
+## Artifacts
+
+- Release ZIP: `dist/release-assets/v0.2.41/QudJP-v0.2.41.zip`
+- Release ZIP SHA256: `175592b43bb18d2257af0d33d20bd5ffdf8404a23e643df24e1ac40c5a2df8d9`
+- GitHub Release asset: `QudJP-v0.2.41.zip`
+- GitHub Release asset SHA256: `175592b43bb18d2257af0d33d20bd5ffdf8404a23e643df24e1ac40c5a2df8d9`
+- Workshop content folder: `dist/workshop/QudJP/`
+- Workshop VDF: `dist/workshop/workshop_item.vdf`
+- Staged/downloaded DLL SHA256: `53abf25aba0cf2c532d6f1d8fdf8897ea6831472b39b41dae4d68ae2d44b960d`
+
+## Preflight
+
+- [x] `git status --short --branch`
+- [x] Release range established from previous tag, release report, changelog/GitHub release, or explicit user range
+- [x] `Mods/QudJP/manifest.json` version, `v0.2.41` tag, release ZIP name, changenote first line, and report version match
+- [x] `git rev-list -n1 v0.2.41` matches `git rev-parse HEAD`
+- [x] `git merge-base --is-ancestor "$(git rev-list -n1 v0.2.41)" origin/main`
+- [x] Draft GitHub Release created by tag workflow
+- [x] `just download-release-zip 0.2.41`
+- [x] `just workshop-preflight 0.2.41`
+- [x] `just release-zip-check dist/release-assets/v0.2.41/QudJP-v0.2.41.zip`
+- [x] `just build-workshop-upload dist/release-assets/v0.2.41/QudJP-v0.2.41.zip /tmp/qudjp-workshop-changenote.txt`
+
+## Upload
+
+- steamcmd command: `steamcmd +login "$STEAM_USER" +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_stable/dist/workshop/workshop_item.vdf +quit`
+- Upload completed at: `2026-05-07 01:17 JST`
+- Steam output summary: `Uploading content`; `Uploading preview image`; `Committing update...Success.`
+- Steam Workshop manifest ID: `8738543480054806837`
+- Steam Web API file size: `19538110`
+- Steam Web API preview URL: `https://images.steamusercontent.com/ugc/15773640086424524965/6FBCC9BB6068E16406D31EDB3206303A382B3F2E/`
+- GitHub Release published at: `2026-05-07 01:18 JST`
+
+## Post-Publish Smoke
+
+- [x] Workshop page title, description, preview image, visibility, file size, and changenote checked through Steam Web API and upload VDF evidence
+- [x] Subscribe/resubscribe checked with `steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit`
+- [x] Downloaded Workshop `manifest.json` lists `Version: 0.2.41`
+- [x] Downloaded Workshop DLL SHA256 matches staged DLL SHA256
+- [ ] Mod Manager lists QudJP with expected version and preview
+- [ ] Options screen renders Japanese text and CJK glyphs
+- [ ] One short conversation renders Japanese text and CJK glyphs
+- [ ] Fresh Player.log checked for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`
+
+## Decision
+
+- Result: GO for Steam Workshop upload, public metadata, GitHub Release publication, download validation, downloaded manifest version, and downloaded DLL identity.
+- Notes: The first upload attempt failed after `just workshop-preflight` was run in parallel with Workshop staging generation; the Python test fixture in preflight overwrote `dist/workshop/`. The staging directory was regenerated from the verified GitHub Release ZIP before the successful upload. Manual in-game smoke remains pending.
+- Rollback tag, if needed: `v0.2.4`


### PR DESCRIPTION
## Summary

- Record Steam Workshop v0.2.41 release evidence after upload.
- Capture manifest ID, GitHub Release asset details, download validation, and remaining manual smoke items.

## Verification

- Steam Workshop upload succeeded for item `3718988020`.
- Steam Web API reports content manifest `8738543480054806837` and file size `19538110`.
- `steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit` succeeded.
- Downloaded Workshop `manifest.json` lists `Version: 0.2.41`.
- Downloaded Workshop DLL SHA256 matches staged DLL SHA256.
- GitHub Release `v0.2.41` is published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * v0.2.41リリースの詳細なワークショップリポートを追加しました。リリースメタデータ、成果物の詳細、プリフライトチェックリスト、アップロード情報、本番環境後の検証チェック、及び最終決定セクションを含みます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->