### PR TITLE
Add localization coverage queues

### DIFF
--- a/docs/localization-coverage-map.json
+++ b/docs/localization-coverage-map.json
@@ -1,0 +1,554 @@
+{
+  "schema_version": "1.0",
+  "game_version": "2.0.4",
+  "description": "Executable coverage map for QudJP C# localization discovery, closure gates, and runtime verification boundaries.",
+  "surfaces": [
+    {
+      "id": "static_producer_messages_popups",
+      "label": "Static C# producer sinks: EmitMessage, Popup.Show*, AddPlayerMessage",
+      "category": "csharp_static_inventory",
+      "status": "inventoried_unclosed",
+      "target_surfaces": [
+        "EmitMessage",
+        "Popup.Show*",
+        "AddPlayerMessage"
+      ],
+      "scanner": "scripts/scan_static_producer_inventory.py",
+      "inventory_artifact": "docs/static-producer-inventory.json",
+      "closure_gate": "scripts/static_producer_closure.py",
+      "tests": [
+        "scripts/tests/test_scan_static_producer_inventory.py",
+        "scripts/tests/test_static_producer_closure.py"
+      ],
+      "commands": [
+        "just static-producer-check",
+        "just static-producer-owner-queue"
+      ],
+      "known_limits": [
+        "Covers only EmitMessage, Popup.Show*, and AddPlayerMessage producer families.",
+        "Current-repo owner coverage is represented by a separate closure overlay, not by the raw inventory alone.",
+        "The owner action queue is class-file based for this scanner scope; it does not cover SetText or display-name construction."
+      ],
+      "next_actions": [
+        "Use just static-producer-owner-queue to choose the next decompiled C# source file and producer method.",
+        "Expand covered owner-family registry as owner patch tests land.",
+        "Keep owner_action_queue as the implementation queue for this scanner scope."
+      ]
+    },
+    {
+      "id": "ui_text_construction",
+      "label": "Roslyn player-visible text construction surfaces and owner candidates",
+      "category": "csharp_static_inventory",
+      "status": "classified_queue",
+      "target_surfaces": [
+        "ActivatedAbility",
+        "AddPlayerMessage",
+        "DescriptionReturn",
+        "DisplayNameAssignment",
+        "DisplayNameReturn",
+        "DisplayTextReturn",
+        "Does",
+        "EffectDescriptionReturn",
+        "EmitMessage",
+        "GetDisplayName",
+        "HistoricStringExpander",
+        "JournalAPI",
+        "MessageFrame",
+        "Popup",
+        "Qud UI SetText owner candidates",
+        "Qud/XRL UI direct text owner candidates",
+        "TutorialManagerPopup"
+      ],
+      "scanner": "scripts/tools/TextConstructionInventory/Program.cs",
+      "summary_artifact": "docs/coderabbit/roslyn-text-construction-inventory-summary.md",
+      "closure_gate": "scripts/text_construction_surface_policy.py",
+      "tests": [
+        "scripts/tests/test_roslyn_text_construction_inventory.py",
+        "scripts/tests/test_text_construction_surface_policy.py"
+      ],
+      "commands": [
+        "just text-construction-inventory",
+        "just text-construction-surface-queue",
+        "just roslyn-test"
+      ],
+      "known_limits": [
+        "The full generated inventory is intentionally not committed.",
+        "Generic Attribute, Initializer, OtherInvocation, Other, Assignment, Return, StringBuilderAppend, StringFormat, and ReplaceChain rows are not localization surfaces by themselves.",
+        "SetText and direct text assignment are valuable only after owner class or method context proves player visibility."
+      ],
+      "next_actions": [
+        "Use just text-construction-surface-queue to inspect only player-visible APIs and likely owner candidates.",
+        "Promote candidate-only rows only when a visible owner route or runtime evidence proves player exposure.",
+        "Add surface-specific closure overlays before counting these families as implemented."
+      ]
+    },
+    {
+      "id": "annals_history_patterns",
+      "label": "Annals and HistorySpice generated narrative patterns",
+      "category": "generated_text_inventory",
+      "status": "inventoried_unclosed",
+      "target_surfaces": [
+        "Annals",
+        "HistorySpice",
+        "HistoricStringExpander"
+      ],
+      "scanner": "scripts/extract_annals_patterns.py",
+      "inventory_artifact": "scripts/_artifacts/annals/candidates_pending.json",
+      "tests": [
+        "scripts/tests/test_extract_annals_patterns.py",
+        "scripts/tests/test_merge_annals_patterns.py",
+        "scripts/tests/test_translate_annals_patterns.py",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/AnnalsPatternsAssetReachabilityTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/HistoricNarrativeTranslationPatchesTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2G/HistoricNarrativeTranslationPatchesResolutionTests.cs"
+      ],
+      "commands": [
+        "just annals-pattern-preview",
+        "just annals-pattern-extract-tracked",
+        "just test-l1",
+        "just test-l2",
+        "just test-l2g"
+      ],
+      "known_limits": [
+        "Generated narrative coverage is pattern-based and still has pending candidates.",
+        "HistorySpice component composition and generated names can surface outside fixed Annals patterns."
+      ],
+      "next_actions": [
+        "Keep generated narrative candidates as component/pattern translators, not broad exact leaves.",
+        "Promote pending candidates only with tests that cover generated variants."
+      ]
+    },
+    {
+      "id": "activated_ability_names",
+      "label": "Activated ability and generated ability display names",
+      "category": "generated_text_inventory",
+      "status": "preview_inventory",
+      "target_surfaces": [
+        "AddActivatedAbility",
+        "AddMyActivatedAbility",
+        "SetActivatedAbilityDisplayName",
+        "DisplayNameAssignment"
+      ],
+      "scanner": "scripts/scan_activated_ability_names.py",
+      "tests": [
+        "scripts/tests/test_scan_activated_ability_names.py",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/GameManagerUpdateSelectedAbilityPatchTests.cs"
+      ],
+      "commands": [
+        "uv run pytest scripts/tests/test_scan_activated_ability_names.py -q",
+        "just test-l1",
+        "just test-l2"
+      ],
+      "known_limits": [
+        "The scanner output is not tracked as a repo artifact.",
+        "Generated display-name-source and dynamic-composition rows require owner/generator translation, not exact leaves."
+      ],
+      "next_actions": [
+        "Add a tracked or reproducible summary for real decompiled-source runs.",
+        "Connect dynamic-composition rows to owner closure tests."
+      ]
+    },
+    {
+      "id": "procedural_cooking_effects",
+      "label": "Procedural cooking effect descriptions and details",
+      "category": "domain_inventory",
+      "status": "partial_domain_inventory",
+      "target_surfaces": [
+        "GetDescription",
+        "GetTemplatedDescription",
+        "GetDetails",
+        "GetTriggerDescription",
+        "GetTemplatedTriggerDescription"
+      ],
+      "summary_artifact": "docs/reports/2026-05-03-issue-466-cooking-procedural-inventory.md",
+      "tests": [
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/CookingEffectFragmentTranslatorTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/CookingEffectTranslationPatchTests.cs"
+      ],
+      "commands": [
+        "just test-l1",
+        "just test-l2"
+      ],
+      "known_limits": [
+        "The inventory is a domain report, not a generalized tracked scanner artifact.",
+        "Only audited cooking producer slices should be considered closed."
+      ],
+      "next_actions": [
+        "Convert the cooking report into an executable scanner or domain closure registry if more slices are needed."
+      ]
+    },
+    {
+      "id": "display_name_composition",
+      "label": "Object display names, state suffixes, generated names, and mixed display-name composition",
+      "category": "route_family_tests",
+      "status": "partial_tests_no_inventory",
+      "target_surfaces": [
+        "GetDisplayName",
+        "GetDisplayNameProcess",
+        "DisplayNameRouteTranslator"
+      ],
+      "closure_gate": "Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs",
+      "tests": [
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/GetDisplayNameProcessPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/ZoneDisplayNameTranslationPatchTests.cs"
+      ],
+      "commands": [
+        "just test-l1",
+        "just test-l2"
+      ],
+      "known_limits": [
+        "There is no exhaustive decompiled-source inventory for all display-name producers.",
+        "Runtime-generated title, liquid/container, and blueprint fallback names still require route-family work."
+      ],
+      "next_actions": [
+        "Create a symbol-backed display-name producer inventory.",
+        "Add closure rows for generated name families as they are owner-tested."
+      ]
+    },
+    {
+      "id": "description_effect_detail_routes",
+      "label": "Object, effect, status, tooltip, and long/short description producers",
+      "category": "route_family_tests",
+      "status": "partial_tests_no_inventory",
+      "target_surfaces": [
+        "GetDescription",
+        "GetDetails",
+        "GetShortDescription",
+        "GetLongDescription",
+        "Look tooltip"
+      ],
+      "tests": [
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/DescriptionTextTranslatorTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/ActiveEffectTextTranslatorTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/DescriptionLongDescriptionPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/DescriptionShortDescriptionPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/LookTooltipContentPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/ActiveEffectsOwnerPatchTests.cs"
+      ],
+      "commands": [
+        "just test-l1",
+        "just test-l2"
+      ],
+      "known_limits": [
+        "No complete inventory covers all description-producing methods.",
+        "Tooltip sinks are not safe owners unless a screen-specific producer contract exists."
+      ],
+      "next_actions": [
+        "Promote high-risk description domains to Roslyn inventories before adding broad leaves."
+      ]
+    },
+    {
+      "id": "conversation_routes",
+      "label": "Conversation display text, simple/question templates, and pronoun exchange",
+      "category": "route_family_tests",
+      "status": "partial_tests_no_inventory",
+      "target_surfaces": [
+        "ConversationDisplayText",
+        "ConversationSimpleTemplate",
+        "ConversationQuestionTemplate",
+        "ConversationPronounExchange"
+      ],
+      "tests": [
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/ConversationDisplayTextPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/ConversationTemplateTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/ConversationPronounExchangeTranslationPatchTests.cs"
+      ],
+      "commands": [
+        "just test-l2"
+      ],
+      "known_limits": [
+        "Conversation data/templates do not have a complete tracked inventory.",
+        "Conversation routes may include authored XML/data and runtime-composed text."
+      ],
+      "next_actions": [
+        "Add a conversation-data inventory or classify conversation assets separately from runtime templates."
+      ]
+    },
+    {
+      "id": "journal_quest_routes",
+      "label": "Journal, map notes, accomplishments, notifications, quest log, and generated quest titles",
+      "category": "route_family_tests",
+      "status": "partial_tests_no_inventory",
+      "target_surfaces": [
+        "JournalAPI",
+        "JournalDisplayText",
+        "JournalPatternTranslator",
+        "QuestLog",
+        "GeneratedQuestTitle"
+      ],
+      "tests": [
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/JournalPatternTranslatorTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/JournalTextTranslatorTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/JournalApiAddTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/JournalEntryDisplayTextPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/QuestUiTranslationPatchTests.cs"
+      ],
+      "commands": [
+        "just test-l1",
+        "just test-l2"
+      ],
+      "known_limits": [
+        "No full static inventory covers generated quest title construction.",
+        "Journal surfaces can expose generated names that also need display-name owner coverage."
+      ],
+      "next_actions": [
+        "Inventory generated quest title templates and connect them to journal/quest owner tests."
+      ]
+    },
+    {
+      "id": "chargen_ui_routes",
+      "label": "Character generation UI, subtype selection, chrome, attributes, and structured text",
+      "category": "route_family_tests",
+      "status": "partial_tests_no_inventory",
+      "target_surfaces": [
+        "CharGen",
+        "ChargenStructuredText",
+        "ChargenAttributeDescription"
+      ],
+      "tests": [
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/ChargenStructuredTextTranslatorTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/CharGenLocalizationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/CharGenProducerTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/ChargenAttributeDescriptionTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2G/CharGenProducerTranslationPatchResolutionTests.cs"
+      ],
+      "commands": [
+        "just test-l1",
+        "just test-l2",
+        "just test-l2g"
+      ],
+      "known_limits": [
+        "CharGen has strong route tests but no complete source inventory for all UI text-producing controls."
+      ],
+      "next_actions": [
+        "Add CharGen surface inventory if new runtime gaps appear outside existing owner patches."
+      ]
+    },
+    {
+      "id": "screen_ui_routes",
+      "label": "Screen-specific UI rows and bindings: inventory, equipment, trade, skills, factions, options, saves, books, world map",
+      "category": "route_family_tests",
+      "status": "partial_tests_no_inventory",
+      "target_surfaces": [
+        "InventoryLine",
+        "EquipmentLine",
+        "TradeLine",
+        "SkillsAndPowersLine",
+        "FactionsLine",
+        "Options",
+        "BookScreen",
+        "WorldMap"
+      ],
+      "tests": [
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryLineTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/EquipmentLineTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/TradeLineTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/SkillsAndPowersLineTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/FactionsLineTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/OptionsLocalizationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/BookScreenTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/WorldMapUiTranslationPatchTests.cs"
+      ],
+      "commands": [
+        "just test-l2"
+      ],
+      "known_limits": [
+        "Screen-specific route tests are broad but not generated from a complete UI surface inventory."
+      ],
+      "next_actions": [
+        "Use text-construction inventory to identify screen-specific rows that lack owner tests."
+      ]
+    },
+    {
+      "id": "hud_status_ability_bar_routes",
+      "label": "HUD, player status bar, ability bar, selected ability, target text, and active effects",
+      "category": "route_family_tests",
+      "status": "partial_tests_no_inventory",
+      "target_surfaces": [
+        "PlayerStatusBar",
+        "AbilityBar",
+        "AbilityBarButtonText",
+        "GameManagerUpdateSelectedAbility"
+      ],
+      "tests": [
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/PlayerStatusBarProducerTranslationHelpersTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/PlayerStatusBarProducerTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarAfterRenderTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/AbilityBarButtonTextTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/GameManagerUpdateSelectedAbilityPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2G/PlayerStatusBarProducerTranslationPatchResolutionTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2G/AbilityBarAfterRenderTranslationPatchResolutionTests.cs"
+      ],
+      "commands": [
+        "just test-l1",
+        "just test-l2",
+        "just test-l2g"
+      ],
+      "known_limits": [
+        "HUD/ability bar routes have focused tests but no complete direct text inventory closure."
+      ],
+      "next_actions": [
+        "Cross-check HUD direct text against TextConstructionInventory."
+      ]
+    },
+    {
+      "id": "localization_assets",
+      "label": "Localization XML, JSON dictionaries, scoped dictionaries, token parity, glossary and corpus assets",
+      "category": "asset_validation",
+      "status": "covered_by_validators",
+      "target_surfaces": [
+        "Localization XML",
+        "Dictionaries",
+        "Scoped Dictionaries",
+        "Translation Tokens"
+      ],
+      "validators": [
+        "scripts/diff_localization.py",
+        "scripts/check_translation_tokens.py",
+        "scripts/tests/test_validate_xml.py",
+        "scripts/tests/test_translation_tokens.py",
+        "scripts/tests/test_json_placeholder_parity.py",
+        "scripts/tests/test_json_markup_parity.py"
+      ],
+      "tests": [
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs",
+        "scripts/tests/test_diff_localization.py",
+        "scripts/tests/test_translation_tokens.py"
+      ],
+      "commands": [
+        "just localization-check",
+        "just translation-token-check",
+        "just python-test"
+      ],
+      "known_limits": [
+        "Asset validators do not prove dynamic producer ownership.",
+        "Dictionary coverage is not accepted for procedural or sink-observed text unless the route is proven fixed-leaf safe."
+      ],
+      "next_actions": [
+        "Keep asset validation separate from producer closure queues."
+      ]
+    },
+    {
+      "id": "runtime_observability_triage",
+      "label": "Runtime untranslated triage, final output observability, sink observation, and L3 evidence",
+      "category": "runtime_evidence",
+      "status": "runtime_evidence",
+      "target_surfaces": [
+        "Player.log",
+        "DynamicTextProbe",
+        "SinkObserve",
+        "FinalOutputObservability",
+        "TranslationChecker"
+      ],
+      "scanner": "scripts/triage_untranslated.py",
+      "validators": [
+        "scripts/translation_checker.py",
+        "scripts/triage/cli.py"
+      ],
+      "tests": [
+        "scripts/tests/test_triage_log_parser.py",
+        "scripts/tests/test_triage_classifier.py",
+        "scripts/tests/test_triage_integration.py",
+        "scripts/tests/test_translation_checker.py",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/FinalOutputObservabilityTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/SinkObservationTests.cs"
+      ],
+      "commands": [
+        "python scripts/triage_untranslated.py --log ~/Library/Logs/Freehold\\ Games/CavesOfQud/Player.log",
+        "just python-test"
+      ],
+      "known_limits": [
+        "Runtime evidence is not primary discovery for statically inventoried surfaces.",
+        "Runtime-only rows are priority and verification evidence, not automatic dictionary candidates."
+      ],
+      "next_actions": [
+        "Use runtime-only rows to identify missing inventory surfaces or route-proof gaps."
+      ]
+    },
+    {
+      "id": "renderer_and_sink_boundaries",
+      "label": "UITextSkin, renderer conversion, sink observation, color restoration, and final display boundaries",
+      "category": "runtime_evidence",
+      "status": "boundary_observed",
+      "target_surfaces": [
+        "UITextSkin.SetText",
+        "RTF.FormatToRTF",
+        "Sidebar.FormatToRTF",
+        "ColorAwareTranslationComposer"
+      ],
+      "tests": [
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/UITextSkinTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRestoreOwnershipTests.cs"
+      ],
+      "commands": [
+        "just test-l1",
+        "just test-l2"
+      ],
+      "known_limits": [
+        "Sink-wide translation is intentionally not an owner route.",
+        "Renderer-owned conversion after QudJP hands text off cannot be closed by producer inventory alone."
+      ],
+      "next_actions": [
+        "Keep sink observations as route-gap evidence and promote safe ownership upstream."
+      ]
+    },
+    {
+      "id": "world_generation_and_zone_names",
+      "label": "World generation status, zone names, village/history generated names, and map-note surfaces",
+      "category": "route_family_tests",
+      "status": "partial_tests_no_inventory",
+      "target_surfaces": [
+        "WorldGenerationScreen",
+        "ZoneDisplayName",
+        "ZoneManager",
+        "Village history",
+        "Map notes"
+      ],
+      "tests": [
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/WorldGenerationScreenTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/WorldCreationProgressTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/ZoneDisplayNameTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/ZoneManagerSetActiveZoneTranslationPatchTests.cs",
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/HistoricNarrativeTranslationPatchesTests.cs"
+      ],
+      "commands": [
+        "just test-l2"
+      ],
+      "known_limits": [
+        "Generated village and zone names are not represented by one complete inventory.",
+        "HistorySpice and display-name composition can overlap this surface."
+      ],
+      "next_actions": [
+        "Tie generated village/zone name families to Annals and display-name inventories."
+      ]
+    },
+    {
+      "id": "legacy_candidate_inventory",
+      "label": "Archived legacy candidate inventory and fixed-leaf workflow",
+      "category": "legacy_view",
+      "status": "legacy_view_only",
+      "target_surfaces": [
+        "legacy SetText/Popup/AddPlayerMessage/EmitMessage candidate inventory"
+      ],
+      "inventory_artifact": "docs/archive/candidate-inventory-2026-04-14-reconciled-bridge.json",
+      "scanner": "scripts/legacies/scan_text_producers.py",
+      "tests": [
+        "scripts/tests/test_scan_text_producers.py",
+        "scripts/tests/test_reconcile_inventory_status.py"
+      ],
+      "commands": [
+        "uv run pytest scripts/tests/test_scan_text_producers.py scripts/tests/test_reconcile_inventory_status.py -q"
+      ],
+      "known_limits": [
+        "This is explicitly bridge/view-only and not a source of truth for new implementation work."
+      ],
+      "next_actions": [
+        "Do not use as an implementation dependency; use only as historical comparison when needed."
+      ]
+    }
+  ]
+}

--- a/justfile
+++ b/justfile
@@ -209,10 +209,10 @@ runtime-evidence-check: test-l1
   uv run pytest scripts/tests/test_triage_integration.py -q -k sample_log_smoke
 
 # Run the broad local verification gate.
-check: build test-l1 test-l2 test-l2g python-check python-test localization-check translation-token-check markdown-report-check
+check: build test-l1 test-l2 test-l2g python-check python-test localization-check translation-token-check markdown-report-check localization-coverage-map-check
 
 # Run the CI-like PR gate before pushing broad C#, script, or localization changes.
-pr-check base_ref="origin/main" head_ref="HEAD": ci-dotnet roslyn-build python-check python-test localization-check translation-token-check
+pr-check base_ref="origin/main" head_ref="HEAD": ci-dotnet roslyn-build python-check python-test localization-check translation-token-check localization-coverage-map-check
   {{python}} scripts/release_notes.py check-fragment --base-ref "{{base_ref}}" --head-ref "{{head_ref}}"
   {{python}} scripts/check_markdown_reports.py --base-ref "{{base_ref}}" --head-ref "{{head_ref}}"
 
@@ -243,12 +243,12 @@ roslyn-build: roslyn-build-annals roslyn-build-static-producer roslyn-build-sema
 
 # Run focused pytest coverage for repo-local Roslyn analysis tools.
 roslyn-test:
-  uv run pytest scripts/tests/test_extract_annals_patterns.py scripts/tests/test_roslyn_extractor_smoke.py scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_roslyn_text_construction_inventory.py scripts/tests/test_scan_static_producer_inventory.py -q
+  uv run pytest scripts/tests/test_extract_annals_patterns.py scripts/tests/test_roslyn_extractor_smoke.py scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_roslyn_text_construction_inventory.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_static_producer_closure.py scripts/tests/test_text_construction_surface_policy.py -q
 
 # Run Ruff for Roslyn Python files and basedpyright for the typed static-producer gate.
 roslyn-python-check:
-  ruff check scripts/extract_annals_patterns.py scripts/roslyn_semantic_probe.py scripts/scan_static_producer_inventory.py scripts/tests/test_extract_annals_patterns.py scripts/tests/test_roslyn_extractor_smoke.py scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_roslyn_text_construction_inventory.py scripts/tests/test_scan_static_producer_inventory.py
-  uvx basedpyright scripts/roslyn_semantic_probe.py scripts/scan_static_producer_inventory.py scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_roslyn_extractor_smoke.py
+  ruff check scripts/extract_annals_patterns.py scripts/roslyn_semantic_probe.py scripts/scan_static_producer_inventory.py scripts/static_producer_closure.py scripts/text_construction_surface_policy.py scripts/tests/test_extract_annals_patterns.py scripts/tests/test_roslyn_extractor_smoke.py scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_roslyn_text_construction_inventory.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_static_producer_closure.py scripts/tests/test_text_construction_surface_policy.py
+  uvx basedpyright scripts/roslyn_semantic_probe.py scripts/scan_static_producer_inventory.py scripts/static_producer_closure.py scripts/text_construction_surface_policy.py scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_static_producer_closure.py scripts/tests/test_text_construction_surface_policy.py scripts/tests/test_roslyn_extractor_smoke.py
 
 # Run build, focused tests, and static checks for Roslyn analysis tooling.
 roslyn-check: roslyn-build roslyn-test roslyn-python-check
@@ -267,6 +267,12 @@ semantic-probe-check: roslyn-build-semantic-probe
 semantic-probe-real-smoke:
   QUDJP_RUN_SEMANTIC_PROBE_REAL=1 uv run pytest scripts/tests/test_roslyn_semantic_probe.py -q -m semantic_probe_real
 
+# Validate the executable localization coverage map.
+localization-coverage-map-check:
+  uv run pytest scripts/tests/test_localization_coverage_map.py -q
+  ruff check scripts/localization_coverage_map.py scripts/tests/test_localization_coverage_map.py
+  uvx basedpyright scripts/localization_coverage_map.py scripts/tests/test_localization_coverage_map.py
+
 # Generate static producer inventory to a disposable local output.
 static-producer-preview source_root=decompiled_root output="/tmp/qudjp-static-producer-inventory.json":
   {{python}} scripts/scan_static_producer_inventory.py --source-root {{quote(source_root)}} --output {{quote(output)}}
@@ -278,9 +284,13 @@ static-producer-regenerate-tracked source_root=decompiled_root:
 
 # Run the static producer scanner's focused validation gate.
 static-producer-check: roslyn-build-static-producer
-  uv run pytest scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_roslyn_extractor_smoke.py -q
-  ruff check scripts/scan_static_producer_inventory.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_roslyn_extractor_smoke.py
-  uvx basedpyright scripts/scan_static_producer_inventory.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_roslyn_extractor_smoke.py
+  uv run pytest scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_static_producer_closure.py scripts/tests/test_roslyn_extractor_smoke.py -q
+  ruff check scripts/scan_static_producer_inventory.py scripts/static_producer_closure.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_static_producer_closure.py scripts/tests/test_roslyn_extractor_smoke.py
+  uvx basedpyright scripts/scan_static_producer_inventory.py scripts/static_producer_closure.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_static_producer_closure.py scripts/tests/test_roslyn_extractor_smoke.py
+
+# Print the static producer owner work queue grouped by decompiled C# source file.
+static-producer-owner-queue limit="30":
+  {{python}} scripts/static_producer_closure.py --limit {{quote(limit)}}
 
 # Extract Annals candidate patterns to a disposable local output.
 annals-pattern-preview source_root=decompiled_annals_root include="Resheph*.cs" output="/tmp/qudjp-annals-candidates.json":
@@ -299,6 +309,11 @@ text-construction-inventory source_root=decompiled_root output="/tmp/roslyn-text
   else
     dotnet run --project scripts/tools/TextConstructionInventory/TextConstructionInventory.csproj -- --source-root {{quote(source_root)}} --output {{quote(output)}}
   fi
+
+# Generate and classify player-visible text-construction surfaces for C# owner work.
+text-construction-surface-queue source_root=decompiled_root output="/tmp/roslyn-text-construction-inventory.json" limit="50":
+  just text-construction-inventory {{quote(source_root)}} {{quote(output)}} ""
+  {{python}} scripts/text_construction_surface_policy.py --inventory {{quote(output)}} --limit {{quote(limit)}}
 
 # Verify agent-loop tools and dotfiles script availability.
 tool-check:

--- a/scripts/localization_coverage_map.py
+++ b/scripts/localization_coverage_map.py
@@ -1,0 +1,227 @@
+"""Validator for the executable QudJP localization coverage map."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Final, NotRequired, TypedDict, cast
+
+SCHEMA_VERSION: Final = "1.0"
+GAME_VERSION: Final = "2.0.4"
+MAP_PATH: Final = Path("docs/localization-coverage-map.json")
+
+REQUIRED_STATUSES: Final = {
+    "covered_by_validators",
+    "classified_queue",
+    "inventoried_unclosed",
+    "preview_inventory",
+    "partial_domain_inventory",
+    "partial_tests_no_inventory",
+    "runtime_evidence",
+    "boundary_observed",
+    "legacy_view_only",
+}
+
+REQUIRED_CATEGORIES: Final = {
+    "asset_validation",
+    "csharp_static_inventory",
+    "domain_inventory",
+    "generated_text_inventory",
+    "legacy_view",
+    "route_family_tests",
+    "runtime_evidence",
+}
+
+REQUIRED_SURFACE_IDS: Final = {
+    "activated_ability_names",
+    "annals_history_patterns",
+    "chargen_ui_routes",
+    "conversation_routes",
+    "description_effect_detail_routes",
+    "display_name_composition",
+    "hud_status_ability_bar_routes",
+    "journal_quest_routes",
+    "legacy_candidate_inventory",
+    "localization_assets",
+    "procedural_cooking_effects",
+    "renderer_and_sink_boundaries",
+    "runtime_observability_triage",
+    "screen_ui_routes",
+    "static_producer_messages_popups",
+    "ui_text_construction",
+    "world_generation_and_zone_names",
+}
+
+
+class CoverageSurface(TypedDict):
+    """One localization coverage-map lane."""
+
+    id: str
+    label: str
+    category: str
+    status: str
+    target_surfaces: list[str]
+    scanner: NotRequired[str]
+    inventory_artifact: NotRequired[str]
+    summary_artifact: NotRequired[str]
+    closure_gate: NotRequired[str]
+    tests: NotRequired[list[str]]
+    validators: NotRequired[list[str]]
+    commands: list[str]
+    known_limits: list[str]
+    next_actions: list[str]
+
+
+class CoverageMap(TypedDict):
+    """Machine-readable localization coverage map."""
+
+    schema_version: str
+    game_version: str
+    description: NotRequired[str]
+    surfaces: list[CoverageSurface]
+
+
+REQUIRED_FIELDS: Final = (
+    "id",
+    "label",
+    "category",
+    "status",
+    "target_surfaces",
+    "known_limits",
+    "next_actions",
+)
+
+
+def load_map(path: Path = MAP_PATH) -> CoverageMap:
+    """Load the localization coverage map."""
+    return cast("CoverageMap", json.loads(path.read_text(encoding="utf-8")))
+
+
+def validate_map(repo_root: Path, path: Path = MAP_PATH) -> list[str]:
+    """Validate that the coverage map is complete enough to drive agent work."""
+    document = load_map(repo_root / path)
+    errors: list[str] = []
+
+    if document.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"unexpected schema_version: {document.get('schema_version')!r}")
+    if document.get("game_version") != GAME_VERSION:
+        errors.append(f"unexpected game_version: {document.get('game_version')!r}")
+
+    surfaces = document["surfaces"]
+    ids = [surface.get("id", "") for surface in surfaces]
+    duplicate_ids = sorted({surface_id for surface_id in ids if ids.count(surface_id) > 1})
+    errors.extend(f"duplicate surface id: {surface_id}" for surface_id in duplicate_ids)
+
+    missing_required = sorted(REQUIRED_SURFACE_IDS - set(ids))
+    errors.extend(f"missing required surface: {surface_id}" for surface_id in missing_required)
+
+    for surface in surfaces:
+        errors.extend(_validate_surface(repo_root, surface))
+
+    statuses = {str(surface.get("status", "")) for surface in surfaces}
+    if "inventoried_unclosed" not in statuses:
+        errors.append("coverage map must explicitly include at least one inventoried_unclosed surface")
+    if not statuses <= REQUIRED_STATUSES:
+        errors.append("unknown statuses: " + ", ".join(sorted(statuses - REQUIRED_STATUSES)))
+
+    return errors
+
+
+def _validate_surface(repo_root: Path, surface: CoverageSurface) -> list[str]:
+    errors: list[str] = []
+    surface_id = surface.get("id", "<missing-id>")
+
+    errors.extend(f"{surface_id}: missing {field}" for field in REQUIRED_FIELDS if field not in surface)
+    errors.extend(_validate_surface_enums(surface_id, surface))
+    errors.extend(_validate_surface_lists(surface_id, surface))
+    errors.extend(_validate_surface_paths(repo_root, surface_id, surface))
+    errors.extend(_validate_surface_status_contract(surface_id, surface))
+
+    return errors
+
+
+def _validate_surface_enums(surface_id: str, surface: CoverageSurface) -> list[str]:
+    errors: list[str] = []
+    category = surface.get("category", "")
+    status = surface.get("status", "")
+
+    if category not in REQUIRED_CATEGORIES:
+        errors.append(f"{surface_id}: unknown category {category!r}")
+    if status not in REQUIRED_STATUSES:
+        errors.append(f"{surface_id}: unknown status {status!r}")
+
+    return errors
+
+
+def _validate_surface_lists(surface_id: str, surface: CoverageSurface) -> list[str]:
+    errors: list[str] = []
+    required_lists = (
+        ("target_surfaces", surface.get("target_surfaces")),
+        ("known_limits", surface.get("known_limits")),
+        ("next_actions", surface.get("next_actions")),
+    )
+
+    errors.extend(
+        f"{surface_id}: {field} must be a non-empty list"
+        for field, values in required_lists
+        if not _non_empty_list(values)
+    )
+    if not _non_empty_list(surface.get("commands")):
+        errors.append(f"{surface_id}: commands must be a non-empty list")
+
+    return errors
+
+
+def _validate_surface_paths(repo_root: Path, surface_id: str, surface: CoverageSurface) -> list[str]:
+    errors: list[str] = []
+    single_paths = (
+        ("scanner", surface.get("scanner")),
+        ("inventory_artifact", surface.get("inventory_artifact")),
+        ("summary_artifact", surface.get("summary_artifact")),
+        ("closure_gate", surface.get("closure_gate")),
+    )
+    list_paths = (
+        ("tests", surface.get("tests", [])),
+        ("validators", surface.get("validators", [])),
+    )
+
+    for field, value in single_paths:
+        if value is not None:
+            _append_existing_path_error(errors, repo_root, surface_id, field, value)
+
+    for field, values in list_paths:
+        for value in values:
+            _append_existing_path_error(errors, repo_root, surface_id, field, value)
+
+    return errors
+
+
+def _validate_surface_status_contract(surface_id: str, surface: CoverageSurface) -> list[str]:
+    errors: list[str] = []
+    status = surface.get("status", "")
+    category = surface.get("category", "")
+    if status in {"inventoried_unclosed", "covered_by_validators"} and not (
+        surface.get("inventory_artifact") or surface.get("closure_gate") or surface.get("validators")
+    ):
+        errors.append(f"{surface_id}: status {status} needs inventory_artifact, closure_gate, or validators")
+
+    if status == "legacy_view_only" and category != "legacy_view":
+        errors.append(f"{surface_id}: legacy_view_only status must use legacy_view category")
+
+    return errors
+
+
+def _non_empty_list(value: list[str] | None) -> bool:
+    return value is not None and len(value) > 0
+
+
+def _append_existing_path_error(
+    errors: list[str],
+    repo_root: Path,
+    surface_id: str,
+    field: str,
+    value: str,
+) -> None:
+    path = repo_root / value
+    if not path.exists():
+        errors.append(f"{surface_id}: {field} path does not exist: {value}")

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -1,0 +1,390 @@
+"""Current-repo closure overlay for the static producer inventory."""
+
+from __future__ import annotations
+
+import json
+import sys
+from argparse import ArgumentParser
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Final, Literal, TypedDict, cast
+
+if TYPE_CHECKING:
+    from scripts.scan_static_producer_inventory import FamilyPayload, InventoryPayload
+
+REPO_ROOT: Final = Path(__file__).resolve().parents[1]
+DEFAULT_INVENTORY_PATH: Final = REPO_ROOT / "docs" / "static-producer-inventory.json"
+COVERED_BY_OWNER_PATCH: Final = "covered_by_owner_patch"
+OWNER_ACTION_STATUSES: Final = frozenset({"owner_patch_required", "needs_family_review"})
+OutputFormat = Literal["text", "json"]
+
+
+class OwnerActionQueueEntry(TypedDict):
+    """Actionable static-producer owner work for one producer family."""
+
+    source_file: str
+    producer_family_id: str
+    type_name: str
+    member_name: str
+    member_start_line: int
+    family_closure_status: str
+    callsite_count: int
+    text_argument_count: int
+    surface_counts: dict[str, int]
+    closure_status_counts: dict[str, int]
+    representative_lines: list[int]
+
+
+class SourceFileQueueEntry(TypedDict):
+    """Actionable static-producer owner work grouped by decompiled C# source file."""
+
+    source_file: str
+    family_count: int
+    callsite_count: int
+    text_argument_count: int
+    family_statuses: dict[str, int]
+    surface_counts: dict[str, int]
+    families: list[OwnerActionQueueEntry]
+
+
+@dataclass(frozen=True)
+class EvidenceFile:
+    """A source or test file that must contain evidence for a covered family."""
+
+    path: str
+    required_substrings: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CoveredOwnerFamily:
+    """A producer family that is closed by current owner-patch tests."""
+
+    family_id: str
+    inventory_statuses: tuple[str, ...]
+    evidence_files: tuple[EvidenceFile, ...]
+
+
+COVERED_OWNER_FAMILIES: Final = (
+    CoveredOwnerFamily(
+        family_id="XRL.UI/TradeUI.cs::XRL.UI.TradeUI.PerformOffer",
+        inventory_statuses=("needs_family_review",),
+        evidence_files=(
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/TradeUiPopupTranslationPatch.cs",
+                ("TryTranslatePerformOfferTradeWaterMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/PopupShowTranslationPatch.cs",
+                ("TryTranslatePerformOfferTradeWaterMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L1/TradeUiPopupTranslationPatchTests.cs",
+                (
+                    "TranslatePopupText_TranslatesPerformOfferTradeWaterMessages_WithoutDictionaryEntry",
+                    "TranslatePopupText_UsesOwnerTemplateForPerformOfferTradeWaterMessage_IgnoresDictionaryEntriesAndPreservesColorTags",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupShowTranslationPatchTests.cs",
+                (
+                    "Prefix_TranslatesPerformOfferTradeWaterMessage_WithoutDictionaryEntry",
+                    "Prefix_UsesPerformOfferTradeWaterTemplate_IgnoresDictionaryEntriesAndPreservesColorTags",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                ("typeof(TradeUiPopupTranslationPatch)", "XRL.UI.Popup|Show|"),
+            ),
+        ),
+    ),
+    CoveredOwnerFamily(
+        family_id="XRL.World.Parts/PetEitherOr.cs::XRL.World.Parts.PetEitherOr.explode",
+        inventory_statuses=("owner_patch_required",),
+        evidence_files=(
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/PetEitherOrExplodeTranslationPatch.cs",
+                ("TryTranslateQueuedMessage", "PetEitherOr.Explode"),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/CombatAndLogMessageQueuePatch.cs",
+                ("PetEitherOrExplodeTranslationPatch.TryTranslateQueuedMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/WorldPartsProducerTranslationPatchTests.cs",
+                (
+                    "PetEitherOrExplodePatch_TranslatesQueuedExplodeMessages_WhenPatched",
+                    "PetEitherOrExplodePatch_DoesNotTranslateQueuedExplodeMessage_WhenOwnerPatchIsAbsent",
+                    "PetEitherOrExplodePatch_PreservesColoredDynamicCaptures_WhenOwnerPatched",
+                    "PetEitherOrExplodePatch_DoesNotTranslateDirectMarkedQueuedMessage_WhenOwnerPatched",
+                    "PetEitherOrExplodePatch_DoesNotTranslateEmptyQueuedMessage_WhenOwnerPatched",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                ("typeof(PetEitherOrExplodeTranslationPatch)", '"explode"'),
+            ),
+        ),
+    ),
+    CoveredOwnerFamily(
+        family_id="XRL.World/Zone.cs::XRL.World.Zone.WindChange",
+        inventory_statuses=("owner_patch_required",),
+        evidence_files=(
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/ZoneWindChangeTranslationPatch.cs",
+                ("TryTranslateQueuedMessage", "Zone.WindChange"),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/CombatAndLogMessageQueuePatch.cs",
+                ("ZoneWindChangeTranslationPatch.TryTranslateQueuedMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/WorldPartsProducerTranslationPatchTests.cs",
+                (
+                    "ZoneWindChangePatch_TranslatesQueuedWindMessages_WhenOwnerPatched",
+                    "ZoneWindChangePatch_DoesNotTranslateQueuedWindMessage_WhenOwnerPatchIsAbsent",
+                    "ZoneWindChangePatch_PreservesColorTags_WhenOwnerPatched",
+                    "ZoneWindChangePatch_DoesNotTranslateUnknownWindComponents_WhenOwnerPatched",
+                    "ZoneWindChangePatch_DoesNotTranslateDirectMarkedQueuedMessage_WhenOwnerPatched",
+                    "ZoneWindChangePatch_DoesNotTranslateEmptyQueuedMessage_WhenOwnerPatched",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                ("typeof(ZoneWindChangeTranslationPatch)", '"WindChange"'),
+            ),
+        ),
+    ),
+)
+COVERED_OWNER_FAMILY_IDS: Final = frozenset(family.family_id for family in COVERED_OWNER_FAMILIES)
+
+
+def load_inventory(path: Path) -> InventoryPayload:
+    """Load a static producer inventory JSON payload."""
+    return cast("InventoryPayload", json.loads(path.read_text(encoding="utf-8")))
+
+
+def covered_family_ids() -> frozenset[str]:
+    """Return family ids that current tests close as owner-patch covered."""
+    return COVERED_OWNER_FAMILY_IDS
+
+
+def family_closure_status(family: FamilyPayload) -> str:
+    """Return current-repo closure status for an inventory family."""
+    if family["producer_family_id"] in covered_family_ids():
+        return COVERED_BY_OWNER_PATCH
+    return family["family_closure_status"]
+
+
+def owner_action_queue(inventory: InventoryPayload) -> list[FamilyPayload]:
+    """Return producer families that still need owner-route implementation work."""
+    return [
+        family
+        for family in inventory["families"]
+        if family_closure_status(family) in OWNER_ACTION_STATUSES
+    ]
+
+
+def owner_action_queue_entries(inventory: InventoryPayload) -> list[OwnerActionQueueEntry]:
+    """Return actionable owner work as method-level queue entries."""
+    return sorted(
+        (_owner_action_queue_entry(family) for family in owner_action_queue(inventory)),
+        key=lambda entry: (
+            entry["source_file"],
+            entry["member_start_line"],
+            entry["producer_family_id"],
+        ),
+    )
+
+
+def owner_action_queue_by_file(inventory: InventoryPayload) -> list[SourceFileQueueEntry]:
+    """Return actionable owner work grouped by decompiled C# source file."""
+    grouped: dict[str, list[OwnerActionQueueEntry]] = {}
+    for entry in owner_action_queue_entries(inventory):
+        grouped.setdefault(entry["source_file"], []).append(entry)
+
+    source_entries = [_source_file_queue_entry(source_file, families) for source_file, families in grouped.items()]
+    return sorted(
+        source_entries,
+        key=lambda entry: (
+            -entry["family_count"],
+            -entry["text_argument_count"],
+            -entry["callsite_count"],
+            entry["source_file"],
+        ),
+    )
+
+
+def format_owner_action_queue(
+    inventory: InventoryPayload,
+    *,
+    limit: int | None = 30,
+) -> str:
+    """Format the class-file owner action queue for agent handoff."""
+    source_entries = owner_action_queue_by_file(inventory)
+    family_total = sum(entry["family_count"] for entry in source_entries)
+    callsite_total = sum(entry["callsite_count"] for entry in source_entries)
+    text_argument_total = sum(entry["text_argument_count"] for entry in source_entries)
+
+    lines = [
+        "".join(
+            (
+                "owner action queue: ",
+                f"{family_total} families, {callsite_total} callsites, ",
+                f"{text_argument_total} text arguments across {len(source_entries)} source files",
+            )
+        )
+    ]
+
+    displayed_entries = source_entries if limit is None else source_entries[:limit]
+    for index, source_entry in enumerate(displayed_entries, start=1):
+        lines.append(
+            "".join(
+                (
+                    f"{index}. {source_entry['source_file']}: ",
+                    f"{source_entry['family_count']} families, ",
+                    f"{source_entry['callsite_count']} callsites, ",
+                    f"{source_entry['text_argument_count']} text arguments; ",
+                    f"statuses={_format_counter(source_entry['family_statuses'])}; ",
+                    f"surfaces={_format_counter(source_entry['surface_counts'])}",
+                )
+            )
+        )
+        lines.extend(
+            "".join(
+                (
+                    f"   - line {family['member_start_line']} ",
+                    f"{family['type_name']}.{family['member_name']} ",
+                    f"[{family['family_closure_status']}], ",
+                    f"{family['text_argument_count']} text args, ",
+                    f"surfaces={_format_counter(family['surface_counts'])}",
+                )
+            )
+            for family in source_entry["families"][:3]
+        )
+
+    if limit is not None and len(source_entries) > limit:
+        lines.append(f"... {len(source_entries) - limit} more source files omitted")
+
+    return "\n".join(lines)
+
+
+def validate_covered_owner_families(
+    inventory: InventoryPayload,
+    repo_root: Path = REPO_ROOT,
+) -> list[str]:
+    """Validate that covered-owner registry entries still have source and test evidence."""
+    errors: list[str] = []
+    families = {family["producer_family_id"]: family for family in inventory["families"]}
+    seen: set[str] = set()
+
+    for covered in COVERED_OWNER_FAMILIES:
+        if covered.family_id in seen:
+            errors.append(f"duplicate covered family id: {covered.family_id}")
+            continue
+        seen.add(covered.family_id)
+
+        family = families.get(covered.family_id)
+        if family is None:
+            errors.append(f"covered family missing from inventory: {covered.family_id}")
+            continue
+
+        if family["family_closure_status"] not in covered.inventory_statuses:
+            expected = ", ".join(covered.inventory_statuses)
+            actual = family["family_closure_status"]
+            errors.append(f"{covered.family_id}: expected raw inventory status in [{expected}], got {actual}")
+
+        for evidence in covered.evidence_files:
+            path = repo_root / evidence.path
+            if not path.is_file():
+                errors.append(f"{covered.family_id}: evidence file missing: {evidence.path}")
+                continue
+
+            text = path.read_text(encoding="utf-8")
+            errors.extend(
+                f"{covered.family_id}: {evidence.path} missing {required!r}"
+                for required in evidence.required_substrings
+                if required not in text
+            )
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print or serialize the current static-producer owner action queue."""
+    parser = ArgumentParser(description="Summarize static producer owner-route work by decompiled C# file.")
+    _ = parser.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY_PATH)
+    _ = parser.add_argument("--format", choices=("text", "json"), default="text")
+    _ = parser.add_argument("--limit", type=int, default=30, help="maximum source files for text output; 0 means all")
+    args = parser.parse_args(argv)
+
+    inventory_path = cast("Path", args.inventory)
+    output_format = cast("OutputFormat", args.format)
+    limit_arg = cast("int", args.limit)
+    limit = None if limit_arg == 0 else limit_arg
+
+    inventory = load_inventory(inventory_path)
+    evidence_errors = validate_covered_owner_families(inventory)
+    if evidence_errors:
+        _ = sys.stderr.write("\n".join(evidence_errors) + "\n")
+        return 1
+
+    if output_format == "json":
+        source_entries = owner_action_queue_by_file(inventory)
+        payload = {
+            "schema_version": "1.0",
+            "inventory": str(inventory_path),
+            "source_file_count": len(source_entries),
+            "family_count": sum(entry["family_count"] for entry in source_entries),
+            "source_files": source_entries,
+        }
+        _ = sys.stdout.write(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+        return 0
+
+    _ = sys.stdout.write(format_owner_action_queue(inventory, limit=limit) + "\n")
+    return 0
+
+
+def _owner_action_queue_entry(family: FamilyPayload) -> OwnerActionQueueEntry:
+    return {
+        "source_file": family["file"],
+        "producer_family_id": family["producer_family_id"],
+        "type_name": family["type_name"],
+        "member_name": family["member_name"],
+        "member_start_line": family["member_start_line"],
+        "family_closure_status": family_closure_status(family),
+        "callsite_count": family["callsite_count"],
+        "text_argument_count": family["text_argument_count"],
+        "surface_counts": dict(family["surface_counts"]),
+        "closure_status_counts": dict(family["closure_status_counts"]),
+        "representative_lines": [call["line"] for call in family["representative_calls"]],
+    }
+
+
+def _source_file_queue_entry(
+    source_file: str,
+    families: list[OwnerActionQueueEntry],
+) -> SourceFileQueueEntry:
+    family_statuses: dict[str, int] = {}
+    surface_counts: dict[str, int] = {}
+    for family in families:
+        family_statuses[family["family_closure_status"]] = family_statuses.get(family["family_closure_status"], 0) + 1
+        for surface, count in family["surface_counts"].items():
+            surface_counts[surface] = surface_counts.get(surface, 0) + count
+
+    return {
+        "source_file": source_file,
+        "family_count": len(families),
+        "callsite_count": sum(family["callsite_count"] for family in families),
+        "text_argument_count": sum(family["text_argument_count"] for family in families),
+        "family_statuses": family_statuses,
+        "surface_counts": surface_counts,
+        "families": families,
+    }
+
+
+def _format_counter(counter: dict[str, int]) -> str:
+    return ",".join(f"{key}:{counter[key]}" for key in sorted(counter))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_localization_coverage_map.py
+++ b/scripts/tests/test_localization_coverage_map.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.localization_coverage_map import (
+    REQUIRED_SURFACE_IDS,
+    load_map,
+    validate_map,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAP_PATH = REPO_ROOT / "docs" / "localization-coverage-map.json"
+
+
+def test_localization_coverage_map_is_valid_and_complete() -> None:
+    """Coverage map must stay machine-valid and include every required surface lane."""
+    errors = validate_map(REPO_ROOT)
+
+    assert errors == []
+
+
+def test_localization_coverage_map_keeps_runtime_and_sink_boundary_lanes_explicit() -> None:
+    """The map must keep runtime and sink-boundary lanes separate from static coverage."""
+    document = load_map(MAP_PATH)
+    surfaces = {surface["id"]: surface for surface in document["surfaces"]}
+
+    assert set(surfaces) >= REQUIRED_SURFACE_IDS
+    assert "blueprint_xml_data_sources" not in surfaces
+    assert surfaces["runtime_observability_triage"]["status"] == "runtime_evidence"
+    assert surfaces["renderer_and_sink_boundaries"]["status"] == "boundary_observed"
+
+
+def test_localization_coverage_map_does_not_treat_legacy_inventory_as_source_of_truth() -> None:
+    """Legacy bridge artifacts must remain explicitly view-only."""
+    document = load_map(MAP_PATH)
+    legacy = next(surface for surface in document["surfaces"] if surface["id"] == "legacy_candidate_inventory")
+
+    assert legacy["status"] == "legacy_view_only"
+    assert legacy["category"] == "legacy_view"
+    assert "not a source of truth" in " ".join(legacy["known_limits"])

--- a/scripts/tests/test_static_producer_closure.py
+++ b/scripts/tests/test_static_producer_closure.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.static_producer_closure import (
+    COVERED_BY_OWNER_PATCH,
+    COVERED_OWNER_FAMILIES,
+    covered_family_ids,
+    family_closure_status,
+    format_owner_action_queue,
+    load_inventory,
+    owner_action_queue,
+    owner_action_queue_by_file,
+    validate_covered_owner_families,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRACKED_INVENTORY = REPO_ROOT / "docs" / "static-producer-inventory.json"
+
+
+def test_covered_owner_registry_has_unique_family_ids() -> None:
+    """Covered-family registry entries must be unique."""
+    family_ids = [family.family_id for family in COVERED_OWNER_FAMILIES]
+
+    assert len(family_ids) == len(set(family_ids))
+
+
+def test_covered_owner_families_have_current_source_and_test_evidence() -> None:
+    """Covered families must point at current source and test evidence."""
+    inventory = load_inventory(TRACKED_INVENTORY)
+
+    errors = validate_covered_owner_families(inventory, REPO_ROOT)
+
+    assert errors == []
+
+
+def test_covered_owner_families_are_removed_from_owner_action_queue() -> None:
+    """Covered owner families must not remain in the owner implementation queue."""
+    inventory = load_inventory(TRACKED_INVENTORY)
+    raw_families = {family["producer_family_id"]: family for family in inventory["families"]}
+
+    for family_id in covered_family_ids():
+        assert raw_families[family_id]["family_closure_status"] in {
+            "owner_patch_required",
+            "needs_family_review",
+        }
+        assert family_closure_status(raw_families[family_id]) == COVERED_BY_OWNER_PATCH
+
+    queued_family_ids = {family["producer_family_id"] for family in owner_action_queue(inventory)}
+
+    assert queued_family_ids.isdisjoint(covered_family_ids())
+
+
+def test_uncovered_high_volume_owner_family_remains_in_owner_action_queue() -> None:
+    """Uncovered high-volume owner families must stay actionable."""
+    inventory = load_inventory(TRACKED_INVENTORY)
+    queued_family_ids = {family["producer_family_id"] for family in owner_action_queue(inventory)}
+
+    assert "XRL.World.Parts/Combat.cs::XRL.World.Parts.Combat.MeleeAttackWithWeaponInternal" in queued_family_ids
+
+
+def test_owner_action_queue_groups_actionable_work_by_source_file() -> None:
+    """Static producer work queue must expose class-file starting points."""
+    inventory = load_inventory(TRACKED_INVENTORY)
+    source_entries = owner_action_queue_by_file(inventory)
+    combat_entry = next(entry for entry in source_entries if entry["source_file"] == "XRL.World.Parts/Combat.cs")
+
+    assert source_entries == sorted(
+        source_entries,
+        key=lambda entry: (
+            -entry["family_count"],
+            -entry["text_argument_count"],
+            -entry["callsite_count"],
+            entry["source_file"],
+        ),
+    )
+    assert combat_entry["family_count"] > 0
+    assert combat_entry["text_argument_count"] > 0
+    assert any(
+        family["producer_family_id"]
+        == "XRL.World.Parts/Combat.cs::XRL.World.Parts.Combat.MeleeAttackWithWeaponInternal"
+        for family in combat_entry["families"]
+    )
+
+
+def test_owner_action_queue_text_summary_names_source_files_and_methods() -> None:
+    """Text output must be useful as an agent handoff queue."""
+    inventory = load_inventory(TRACKED_INVENTORY)
+
+    summary = format_owner_action_queue(inventory, limit=5)
+
+    assert "owner action queue:" in summary
+    assert ".cs:" in summary
+    assert "surfaces=" in summary
+    assert "line " in summary

--- a/scripts/tests/test_text_construction_surface_policy.py
+++ b/scripts/tests/test_text_construction_surface_policy.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.text_construction_surface_policy import (
+    TextConstructionFamily,
+    TextConstructionInventory,
+    build_surface_queue,
+    classify_family,
+    format_surface_queue,
+    queue_payload,
+    valuable_surface_queue,
+)
+
+
+def test_policy_treats_known_visible_apis_as_player_visible() -> None:
+    """Known display/log/journal/description APIs are valuable localization surfaces."""
+    inventory = _inventory(
+        [
+            _family("Demo.cs::TextRoutes.Popup()", "Demo.cs", "Popup", {"Popup": 1}),
+            _family("Demo.cs::TextRoutes.Message()", "Demo.cs", "Message", {"MessageFrame": 1}),
+            _family(
+                "XRL.World.Effects/Asleep.cs::Asleep.GetDescription()",
+                "XRL.World.Effects/Asleep.cs",
+                "GetDescription",
+                {"EffectDescriptionReturn": 1},
+            ),
+        ]
+    )
+
+    entries = valuable_surface_queue(inventory)
+
+    assert [entry["classification"] for entry in entries] == [
+        "player_visible_api",
+        "player_visible_api",
+        "player_visible_api",
+    ]
+    assert {tuple(entry["player_visible_surfaces"]) for entry in entries} == {
+        ("Popup",),
+        ("MessageFrame",),
+        ("EffectDescriptionReturn",),
+    }
+
+
+def test_policy_promotes_ui_and_semantic_assignments_without_promoting_internal_text() -> None:
+    """Assignments are valuable only when their owner context is likely player-visible."""
+    inventory = _inventory(
+        [
+            _family(
+                "Qud.UI/InventoryLine.cs::InventoryLine.setData(object)",
+                "Qud.UI/InventoryLine.cs",
+                "setData",
+                {"SetText": 1},
+            ),
+            _family(
+                "XRL.World.ZoneBuilders/VillageBase.cs::VillageBase.Build()",
+                "XRL.World.ZoneBuilders/VillageBase.cs",
+                "Build",
+                {"DisplayNameAssignment": 1},
+            ),
+            _family(
+                "Overlay.MapEditor/MapEditorView.cs::MapEditorView.Render()",
+                "Overlay.MapEditor/MapEditorView.cs",
+                "Render",
+                {"DirectTextAssignment": 1},
+            ),
+            _family("Internal.cs::Internal.Fields", "Internal.cs", "Fields", {"Attribute": 1, "Initializer": 1}),
+        ]
+    )
+
+    entries = build_surface_queue(inventory)
+    classifications = {entry["family_id"]: entry["classification"] for entry in entries}
+
+    assert classifications["Qud.UI/InventoryLine.cs::InventoryLine.setData(object)"] == "player_visible_owner_candidate"
+    assert (
+        classifications["XRL.World.ZoneBuilders/VillageBase.cs::VillageBase.Build()"]
+        == "player_visible_owner_candidate"
+    )
+    assert classifications["Overlay.MapEditor/MapEditorView.cs::MapEditorView.Render()"] == "candidate_only"
+    assert classifications["Internal.cs::Internal.Fields"] == "non_target"
+
+
+def test_policy_keeps_debug_or_wish_routes_out_of_valuable_queue() -> None:
+    """Debug-like visible APIs are not normal gameplay localization coverage."""
+    inventory = _inventory(
+        [
+            _family(
+                "XRL.Wish/WishManager.cs::WishManager.HandleWish(string)",
+                "XRL.Wish/WishManager.cs",
+                "HandleWish",
+                {"Popup": 1},
+            ),
+            _family(
+                "XRL.World.Parts/WishMenu.cs::WishMenu.Show()",
+                "XRL.World.Parts/WishMenu.cs",
+                "Show",
+                {"Popup": 1},
+            ),
+            _family(
+                "XRL.World/StatWishHandler.cs::StatWishHandler.HandleWish(string)",
+                "XRL.World/StatWishHandler.cs",
+                "HandleWish",
+                {"AddPlayerMessage": 1},
+            ),
+            _family(
+                "XRL.World.Capabilities/Wishing.cs::Wishing.HandleWish(GameObject,string)",
+                "XRL.World.Capabilities/Wishing.cs",
+                "HandleWish",
+                {"Popup": 1, "AddPlayerMessage": 1},
+            ),
+            _family(
+                "XRL.World.Parts/Combat.cs::Combat.Attack()",
+                "XRL.World.Parts/Combat.cs",
+                "Attack",
+                {"MessageFrame": 1},
+            ),
+        ]
+    )
+
+    entries = build_surface_queue(inventory)
+    classifications = {entry["family_id"]: entry["classification"] for entry in entries}
+
+    assert (
+        classifications["XRL.World.Capabilities/Wishing.cs::Wishing.HandleWish(GameObject,string)"]
+        == "candidate_only"
+    )
+    assert classifications["XRL.Wish/WishManager.cs::WishManager.HandleWish(string)"] == "candidate_only"
+    assert classifications["XRL.World.Parts/WishMenu.cs::WishMenu.Show()"] == "candidate_only"
+    assert classifications["XRL.World/StatWishHandler.cs::StatWishHandler.HandleWish(string)"] == "candidate_only"
+    assert classifications["XRL.World.Parts/Combat.cs::Combat.Attack()"] == "player_visible_api"
+    assert [entry["source_file"] for entry in valuable_surface_queue(inventory)] == ["XRL.World.Parts/Combat.cs"]
+
+
+def test_queue_payload_defaults_to_valuable_surfaces_only() -> None:
+    """The handoff queue must not mix valuable localization surfaces with generic text noise."""
+    inventory = _inventory(
+        [
+            _family("Qud.UI/TradeLine.cs::TradeLine.setData(object)", "Qud.UI/TradeLine.cs", "setData", {"SetText": 2}),
+            _family("Internal.cs::Internal.Config", "Internal.cs", "Config", {"Initializer": 3}),
+        ]
+    )
+
+    payload = queue_payload(inventory, inventory_path=Path("inventory.json"))
+
+    assert payload["counts"] == {"player_visible_owner_candidate": 1}
+    assert [entry["source_file"] for entry in payload["entries"]] == ["Qud.UI/TradeLine.cs"]
+
+
+def test_text_summary_names_reason_and_action_for_agent_handoff() -> None:
+    """Text output must explain why a surface is worth translating."""
+    inventory = _inventory(
+        [
+            _family(
+                "Qud.UI/InventoryLine.cs::InventoryLine.setData(object)",
+                "Qud.UI/InventoryLine.cs",
+                "setData",
+                {"SetText": 1},
+            ),
+        ]
+    )
+
+    summary = format_surface_queue(inventory, inventory_path=Path("inventory.json"))
+
+    assert "text construction surface queue:" in summary
+    assert "[player_visible_owner_candidate]" in summary
+    assert "Qud.UI/InventoryLine.cs" in summary
+    assert "reason:" in summary
+    assert "action:" in summary
+
+
+def test_classify_family_keeps_generic_string_construction_as_candidate_only() -> None:
+    """StringBuilder/StringFormat alone is not a localization surface."""
+    result = classify_family(
+        _family("Demo.cs::Builder.Build()", "Demo.cs", "Build", {"StringBuilderAppend": 1, "StringFormat": 1})
+    )
+
+    assert result["classification"] == "candidate_only"
+    assert result["construction_only_surfaces"] == ["StringBuilderAppend", "StringFormat"]
+
+
+def _inventory(families: list[TextConstructionFamily]) -> TextConstructionInventory:
+    return {
+        "schema_version": "1.0",
+        "game_version": "2.0.4",
+        "totals": {},
+        "families": families,
+    }
+
+
+def _family(
+    family_id: str,
+    file_path: str,
+    member_name: str,
+    surface_counts: dict[str, int],
+) -> TextConstructionFamily:
+    return {
+        "family_id": family_id,
+        "file": file_path,
+        "namespace": None,
+        "type_name": family_id.split("::", maxsplit=1)[1].split(".", maxsplit=1)[0],
+        "member_name": member_name,
+        "member_signature": f"{member_name}()",
+        "member_kind": "method",
+        "member_start_line": 10,
+        "text_construction_count": sum(surface_counts.values()),
+        "shape_counts": {"static_literal": sum(surface_counts.values())},
+        "context_counts": {"invocation_argument": sum(surface_counts.values())},
+        "surface_counts": surface_counts,
+        "first_lines": [10],
+    }

--- a/scripts/text_construction_surface_policy.py
+++ b/scripts/text_construction_surface_policy.py
@@ -1,0 +1,428 @@
+"""Classify Roslyn text-construction surfaces by localization value."""
+
+from __future__ import annotations
+
+import json
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Final, Literal, TypedDict, cast
+
+Classification = Literal[
+    "player_visible_api",
+    "player_visible_owner_candidate",
+    "candidate_only",
+    "non_target",
+]
+OutputFormat = Literal["text", "json"]
+
+PLAYER_VISIBLE_API_SURFACES: Final = {
+    "ActivatedAbility",
+    "AddPlayerMessage",
+    "Description",
+    "DescriptionReturn",
+    "DisplayNameReturn",
+    "DisplayTextReturn",
+    "Does",
+    "EffectDescriptionReturn",
+    "EmitMessage",
+    "GetDisplayName",
+    "HistoricStringExpander",
+    "JournalAPI",
+    "MessageFrame",
+    "Popup",
+    "TutorialManagerPopup",
+}
+CONTEXTUAL_OWNER_SURFACES: Final = {
+    "DescriptionAssignment",
+    "DirectTextAssignment",
+    "DisplayNameAssignment",
+    "SetText",
+}
+CONSTRUCTION_ONLY_SURFACES: Final = {
+    "Assignment",
+    "ReplaceBuilder",
+    "ReplaceChain",
+    "Return",
+    "StringBuilderAppend",
+    "StringFormat",
+}
+NON_TARGET_SURFACES: Final = {
+    "Attribute",
+    "Initializer",
+    "Other",
+    "OtherInvocation",
+}
+UI_OWNER_FILE_PREFIXES: Final = (
+    "Qud.UI/",
+    "XRL.UI/",
+    "XRL.CharacterBuilds.Qud.UI/",
+)
+GAMEPLAY_OWNER_FILE_PREFIXES: Final = (
+    "Qud.API/",
+    "XRL.Annals/",
+    "XRL.World/",
+    "XRL.World.Effects/",
+    "XRL.World.Parts/",
+    "XRL.World.Parts.Mutation/",
+    "XRL.World.Skills.Cooking/",
+    "XRL.World.ZoneBuilders/",
+)
+NON_PLAYER_FILE_PREFIXES: Final = (
+    "Overlay.MapEditor/",
+    "UnityStandardAssets.",
+    "XRL.Wish/",
+)
+NON_PLAYER_FILE_NAMES: Final = (
+    "UAP_",
+    "uGUI",
+)
+LOW_VALUE_FILE_PARTS: Final = (
+    "/ObjectFinderTests.cs",
+    "/StatWishHandler.cs",
+    "/WishMenu.cs",
+    "/Wishing.cs",
+    "Debug",
+    "MetricsManager.cs",
+    "Test",
+    "WorkshopUploader",
+)
+CLASSIFICATION_ORDER: Final = {
+    "player_visible_api": 0,
+    "player_visible_owner_candidate": 1,
+    "candidate_only": 2,
+    "non_target": 3,
+}
+VALUABLE_CLASSIFICATIONS: Final = frozenset({"player_visible_api", "player_visible_owner_candidate"})
+
+
+class TextConstructionFamily(TypedDict):
+    """Family record emitted by TextConstructionInventory."""
+
+    family_id: str
+    file: str
+    namespace: str | None
+    type_name: str
+    member_name: str
+    member_signature: str
+    member_kind: str
+    member_start_line: int
+    text_construction_count: int
+    shape_counts: dict[str, int]
+    context_counts: dict[str, int]
+    surface_counts: dict[str, int]
+    first_lines: list[int]
+
+
+class TextConstructionInventory(TypedDict):
+    """TextConstructionInventory JSON payload."""
+
+    schema_version: str
+    game_version: str
+    totals: dict[str, object]
+    families: list[TextConstructionFamily]
+
+
+class SurfaceQueueEntry(TypedDict):
+    """One classified text-construction family for localization planning."""
+
+    classification: Classification
+    family_id: str
+    source_file: str
+    type_name: str
+    member_name: str
+    member_signature: str
+    member_start_line: int
+    text_construction_count: int
+    player_visible_surfaces: list[str]
+    contextual_surfaces: list[str]
+    construction_only_surfaces: list[str]
+    non_target_surfaces: list[str]
+    first_lines: list[int]
+    reason: str
+    action: str
+
+
+class SurfaceQueuePayload(TypedDict):
+    """Serialized classified surface queue."""
+
+    schema_version: str
+    inventory: str
+    counts: dict[str, int]
+    entries: list[SurfaceQueueEntry]
+
+
+class ClassifiedSurface(TypedDict):
+    """Internal classification result."""
+
+    classification: Classification
+    player_visible_surfaces: list[str]
+    contextual_surfaces: list[str]
+    construction_only_surfaces: list[str]
+    non_target_surfaces: list[str]
+    reason: str
+    action: str
+
+
+def load_inventory(path: Path) -> TextConstructionInventory:
+    """Load a TextConstructionInventory JSON payload."""
+    return cast("TextConstructionInventory", json.loads(path.read_text(encoding="utf-8")))
+
+
+def classify_family(family: TextConstructionFamily) -> ClassifiedSurface:
+    """Classify whether a family is a valuable localization surface."""
+    surfaces = set(family["surface_counts"])
+    player_visible_surfaces = sorted(surfaces & PLAYER_VISIBLE_API_SURFACES)
+    contextual_surfaces = sorted(surfaces & CONTEXTUAL_OWNER_SURFACES)
+    construction_only_surfaces = sorted(surfaces & CONSTRUCTION_ONLY_SURFACES)
+    non_target_surfaces = sorted(surfaces & NON_TARGET_SURFACES)
+
+    if player_visible_surfaces and _is_low_value_source_file(family["file"]):
+        return {
+            "classification": "candidate_only",
+            "player_visible_surfaces": player_visible_surfaces,
+            "contextual_surfaces": contextual_surfaces,
+            "construction_only_surfaces": construction_only_surfaces,
+            "non_target_surfaces": non_target_surfaces,
+            "reason": "debug, test, metrics, workshop, wish, or tool-like source is not normal gameplay coverage",
+            "action": "promote only if runtime evidence shows this route matters to ordinary player localization",
+        }
+
+    if player_visible_surfaces:
+        return {
+            "classification": "player_visible_api",
+            "player_visible_surfaces": player_visible_surfaces,
+            "contextual_surfaces": contextual_surfaces,
+            "construction_only_surfaces": construction_only_surfaces,
+            "non_target_surfaces": non_target_surfaces,
+            "reason": "known player-visible API or route-return surface",
+            "action": "trace owner route, add or extend owner translator, and test the route",
+        }
+
+    if contextual_surfaces and _is_player_visible_owner_candidate(family):
+        return {
+            "classification": "player_visible_owner_candidate",
+            "player_visible_surfaces": [],
+            "contextual_surfaces": contextual_surfaces,
+            "construction_only_surfaces": construction_only_surfaces,
+            "non_target_surfaces": non_target_surfaces,
+            "reason": "text assignment occurs in a likely player-visible owner class or method",
+            "action": "confirm screen/owner field, then patch the screen-specific route if needed",
+        }
+
+    if contextual_surfaces or construction_only_surfaces:
+        return {
+            "classification": "candidate_only",
+            "player_visible_surfaces": [],
+            "contextual_surfaces": contextual_surfaces,
+            "construction_only_surfaces": construction_only_surfaces,
+            "non_target_surfaces": non_target_surfaces,
+            "reason": "string construction exists, but player visibility is not proven by this surface",
+            "action": "promote only if a visible owner route or runtime evidence proves player exposure",
+        }
+
+    return {
+        "classification": "non_target",
+        "player_visible_surfaces": [],
+        "contextual_surfaces": [],
+        "construction_only_surfaces": [],
+        "non_target_surfaces": non_target_surfaces,
+        "reason": "attribute, initializer, generic invocation, or other non-surface text",
+        "action": "do not use for localization coverage unless another route promotes it",
+    }
+
+
+def build_surface_queue(inventory: TextConstructionInventory) -> list[SurfaceQueueEntry]:
+    """Classify every text-construction family and return a stable queue."""
+    return sorted(
+        (_queue_entry(family) for family in inventory["families"]),
+        key=lambda entry: (
+            CLASSIFICATION_ORDER[entry["classification"]],
+            -entry["text_construction_count"],
+            entry["source_file"],
+            entry["member_start_line"],
+            entry["family_id"],
+        ),
+    )
+
+
+def valuable_surface_queue(inventory: TextConstructionInventory) -> list[SurfaceQueueEntry]:
+    """Return only families worth considering for localization ownership."""
+    return [
+        entry
+        for entry in build_surface_queue(inventory)
+        if entry["classification"] in VALUABLE_CLASSIFICATIONS
+    ]
+
+
+def queue_payload(
+    inventory: TextConstructionInventory,
+    *,
+    inventory_path: Path,
+    include: str = "valuable",
+) -> SurfaceQueuePayload:
+    """Build a JSON-serializable classified queue payload."""
+    entries = _filter_entries(build_surface_queue(inventory), include)
+    counts: dict[str, int] = {}
+    for entry in entries:
+        counts[entry["classification"]] = counts.get(entry["classification"], 0) + 1
+
+    return {
+        "schema_version": "1.0",
+        "inventory": str(inventory_path),
+        "counts": counts,
+        "entries": entries,
+    }
+
+
+def format_surface_queue(
+    inventory: TextConstructionInventory,
+    *,
+    inventory_path: Path,
+    include: str = "valuable",
+    limit: int | None = 50,
+) -> str:
+    """Format classified player-visible surface candidates for agent handoff."""
+    payload = queue_payload(inventory, inventory_path=inventory_path, include=include)
+    entries = payload["entries"] if limit is None else payload["entries"][:limit]
+    total_entries = len(payload["entries"])
+    lines = [
+        f"text construction surface queue: {total_entries} entries; counts={_format_counter(payload['counts'])}"
+    ]
+
+    for index, entry in enumerate(entries, start=1):
+        surfaces = (
+            entry["player_visible_surfaces"]
+            or entry["contextual_surfaces"]
+            or entry["construction_only_surfaces"]
+        )
+        lines.append(
+            "".join(
+                (
+                    f"{index}. [{entry['classification']}] {entry['source_file']}:",
+                    f"{entry['member_start_line']} {entry['type_name']}.{entry['member_signature']} ",
+                    f"surfaces={','.join(surfaces)} ",
+                    f"count={entry['text_construction_count']}",
+                )
+            )
+        )
+        lines.append(f"   reason: {entry['reason']}")
+        lines.append(f"   action: {entry['action']}")
+
+    if limit is not None and total_entries > limit:
+        lines.append(f"... {total_entries - limit} more entries omitted")
+
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Classify a TextConstructionInventory JSON file."""
+    parser = ArgumentParser(description="Classify player-visible text-construction surfaces.")
+    _ = parser.add_argument("--inventory", type=Path, required=True)
+    _ = parser.add_argument("--format", choices=("text", "json"), default="text")
+    _ = parser.add_argument(
+        "--include",
+        choices=("valuable", "all", "candidate-only", "non-target"),
+        default="valuable",
+    )
+    _ = parser.add_argument("--limit", type=int, default=50, help="maximum text rows; 0 means all")
+    args = parser.parse_args(argv)
+
+    inventory_path = cast("Path", args.inventory)
+    inventory = load_inventory(inventory_path)
+    include = cast("str", args.include)
+    output_format = cast("OutputFormat", args.format)
+    limit_arg = cast("int", args.limit)
+    limit = None if limit_arg == 0 else limit_arg
+
+    if output_format == "json":
+        payload = queue_payload(inventory, inventory_path=inventory_path, include=include)
+        _ = sys.stdout.write(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+        return 0
+
+    text = format_surface_queue(inventory, inventory_path=inventory_path, include=include, limit=limit)
+    _ = sys.stdout.write(text + "\n")
+    return 0
+
+
+def _queue_entry(family: TextConstructionFamily) -> SurfaceQueueEntry:
+    classified = classify_family(family)
+    return {
+        "classification": classified["classification"],
+        "family_id": family["family_id"],
+        "source_file": family["file"],
+        "type_name": family["type_name"],
+        "member_name": family["member_name"],
+        "member_signature": family["member_signature"],
+        "member_start_line": family["member_start_line"],
+        "text_construction_count": family["text_construction_count"],
+        "player_visible_surfaces": classified["player_visible_surfaces"],
+        "contextual_surfaces": classified["contextual_surfaces"],
+        "construction_only_surfaces": classified["construction_only_surfaces"],
+        "non_target_surfaces": classified["non_target_surfaces"],
+        "first_lines": family["first_lines"],
+        "reason": classified["reason"],
+        "action": classified["action"],
+    }
+
+
+def _is_player_visible_owner_candidate(family: TextConstructionFamily) -> bool:
+    file_path = family["file"]
+    if file_path.startswith(NON_PLAYER_FILE_NAMES) or _is_low_value_source_file(file_path):
+        return False
+    if _has_prefix(file_path, UI_OWNER_FILE_PREFIXES):
+        return True
+    if _has_prefix(file_path, GAMEPLAY_OWNER_FILE_PREFIXES):
+        return _member_name_suggests_visible_text(family["member_name"]) or _has_semantic_assignment_surface(family)
+    return False
+
+
+def _has_semantic_assignment_surface(family: TextConstructionFamily) -> bool:
+    surfaces = set(family["surface_counts"])
+    return bool(surfaces & {"DescriptionAssignment", "DisplayNameAssignment"})
+
+
+def _member_name_suggests_visible_text(member_name: str) -> bool:
+    visible_terms = (
+        "Description",
+        "DisplayName",
+        "DisplayText",
+        "GetDetails",
+        "GetTabString",
+        "Render",
+        "SetData",
+        "Show",
+        "UpdateView",
+    )
+    return any(term in member_name for term in visible_terms)
+
+
+def _filter_entries(entries: list[SurfaceQueueEntry], include: str) -> list[SurfaceQueueEntry]:
+    match include:
+        case "valuable":
+            return [entry for entry in entries if entry["classification"] in VALUABLE_CLASSIFICATIONS]
+        case "candidate-only":
+            return [entry for entry in entries if entry["classification"] == "candidate_only"]
+        case "non-target":
+            return [entry for entry in entries if entry["classification"] == "non_target"]
+        case "all":
+            return entries
+        case _:
+            msg = f"unsupported include mode: {include}"
+            raise ValueError(msg)
+
+
+def _has_prefix(value: str, prefixes: tuple[str, ...]) -> bool:
+    return any(value.startswith(prefix) for prefix in prefixes)
+
+
+def _is_low_value_source_file(file_path: str) -> bool:
+    return _has_prefix(file_path, NON_PLAYER_FILE_PREFIXES) or any(part in file_path for part in LOW_VALUE_FILE_PARTS)
+
+
+def _format_counter(counter: dict[str, int]) -> str:
+    return ",".join(f"{key}:{counter[key]}" for key in sorted(counter))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a machine-readable C# localization coverage map that excludes blueprint XML merge data from static-analysis surfaces
- add static producer closure tooling and owner-action queue tests for issue-493 style coverage work
- add text-construction surface classification so valuable player-visible surfaces can drive static-analysis patch work

## Review flow
- separate-instance reviews completed
- initial review blocker around Wish/debug routes entering the valuable queue was fixed
- focused re-review approved
- simplify pass completed after approval

## Verification
- uv run pytest scripts/tests/test_static_producer_closure.py scripts/tests/test_text_construction_surface_policy.py -q
- ruff check scripts/static_producer_closure.py scripts/text_construction_surface_policy.py scripts/tests/test_static_producer_closure.py scripts/tests/test_text_construction_surface_policy.py
- uvx basedpyright scripts/static_producer_closure.py scripts/text_construction_surface_policy.py scripts/tests/test_static_producer_closure.py scripts/tests/test_text_construction_surface_policy.py
- just text-construction-surface-queue "/Users/toarupen/dev/coq-decompiled_stable" /tmp/qudjp-simplify-text-policy.json 3
- just localization-coverage-map-check
- just static-producer-check
- just roslyn-check
- just python-check
- just python-test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ローカライゼーションの包括的なカバレッジ管理と検証ツール、テキスト構築サーフェスのキュー生成・分類機能を追加しました。

* **ドキュメント**
  * ローカライゼーションカバレッジマップのデータ定義を追加しました。

* **テスト**
  * カバレッジマップ、静的プロデューサー閉包、テキスト構築サーフェス分類など、多数の検証テストを追加し品質保証を強化しました。

* **作業改善**
  * 検証・チェック対象を拡大し、既存の検証フローに新しいマップ・キュー検査を組み込みました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->