### PR TITLE
Fix inventory line item rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.2.42] - 2026-05-07
+
+### Fixed
+
+- インベントリ画面でアイテム名が表示されなくなる問題を追加修正しました。
+
+---
+
 ## [0.2.41] - 2026-05-07
 
 ### Changed

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryLineTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryLineTranslationPatchTests.cs
@@ -39,7 +39,7 @@ public sealed partial class Issue201StatusScreensBatch2Tests
     }
 
     [Test]
-    public void InventoryLinePrefix_TranslatesCategoryAndItemRows_WhenPatched()
+    public void InventoryLinePostfix_TranslatesCategoryAndItemRows_AfterOriginalSetData()
     {
         WriteDictionary(
             ("Weapons", "武器"),
@@ -53,7 +53,7 @@ public sealed partial class Issue201StatusScreensBatch2Tests
         {
             harmony.Patch(
                 original: RequireMethod(typeof(DummyInventoryLineTarget), nameof(DummyInventoryLineTarget.setData)),
-                prefix: new HarmonyMethod(RequireMethod(typeof(InventoryLineTranslationPatch), nameof(InventoryLineTranslationPatch.Prefix))));
+                postfix: new HarmonyMethod(RequireMethod(typeof(InventoryLineTranslationPatch), nameof(InventoryLineTranslationPatch.Postfix))));
 
             var categoryTarget = new DummyInventoryLineTarget();
             categoryTarget.setData(new DummyInventoryLineDataTarget
@@ -76,10 +76,12 @@ public sealed partial class Issue201StatusScreensBatch2Tests
             Assert.Multiple(() =>
             {
                 Assert.That(categoryTarget.categoryLabel.Text, Is.EqualTo("武器"));
+                Assert.That(categoryTarget.OriginalExecuted, Is.True);
                 Assert.That(categoryTarget.categoryWeightText.Text, Does.Contain("3 個"));
                 Assert.That(categoryTarget.categoryWeightText.Text, Does.Contain("17 lbs."));
                 Assert.That(categoryTarget.categoryExpandLabel.Text, Is.EqualTo("[-]"));
                 Assert.That(itemTarget.text.Text, Is.EqualTo("レーザーライフル"));
+                Assert.That(itemTarget.OriginalExecuted, Is.True);
                 Assert.That(itemTarget.itemWeightText.Text, Is.EqualTo("[7 lbs.]"));
                 Assert.That(Translator.GetMissingKeyHitCountForTests("lbs."), Is.EqualTo(0));
                 Assert.That(
@@ -111,7 +113,7 @@ public sealed partial class Issue201StatusScreensBatch2Tests
     }
 
     [Test]
-    public void InventoryLinePrefix_DoesNotUseDisplayNameRouteForItemNames_WhenPatched()
+    public void InventoryLinePostfix_DoesNotUseDisplayNameRouteForItemNames_WhenPatched()
     {
         WriteDictionary(
             ("items", "個"));
@@ -126,7 +128,7 @@ public sealed partial class Issue201StatusScreensBatch2Tests
         {
             harmony.Patch(
                 original: RequireMethod(typeof(DummyInventoryLineTarget), nameof(DummyInventoryLineTarget.setData)),
-                prefix: new HarmonyMethod(RequireMethod(typeof(InventoryLineTranslationPatch), nameof(InventoryLineTranslationPatch.Prefix))));
+                postfix: new HarmonyMethod(RequireMethod(typeof(InventoryLineTranslationPatch), nameof(InventoryLineTranslationPatch.Postfix))));
 
             var itemTarget = new DummyInventoryLineTarget();
             itemTarget.setData(new DummyInventoryLineDataTarget
@@ -138,6 +140,7 @@ public sealed partial class Issue201StatusScreensBatch2Tests
 
             Assert.Multiple(() =>
             {
+                Assert.That(itemTarget.OriginalExecuted, Is.True);
                 Assert.That(itemTarget.text.Text, Is.EqualTo("water flask [empty]"));
                 Assert.That(
                     DynamicTextObservability.GetRouteFamilyHitCountForTests(
@@ -153,7 +156,7 @@ public sealed partial class Issue201StatusScreensBatch2Tests
     }
 
     [Test]
-    public void InventoryLinePrefix_FallsBackToOriginal_OnUnsupportedInput()
+    public void InventoryLinePostfix_LeavesUnsupportedInputOnOriginalPath()
     {
         var harmonyId = CreateHarmonyId();
         var harmony = new Harmony(harmonyId);
@@ -161,12 +164,16 @@ public sealed partial class Issue201StatusScreensBatch2Tests
         {
             harmony.Patch(
                 original: RequireMethod(typeof(DummyInventoryLineTarget), nameof(DummyInventoryLineTarget.setData)),
-                prefix: new HarmonyMethod(RequireMethod(typeof(InventoryLineTranslationPatch), nameof(InventoryLineTranslationPatch.Prefix))));
+                postfix: new HarmonyMethod(RequireMethod(typeof(InventoryLineTranslationPatch), nameof(InventoryLineTranslationPatch.Postfix))));
 
             var target = new DummyInventoryLineTarget();
             target.setData(new DummyFallbackInventoryLineDataTarget());
 
-            Assert.That(target.OriginalExecuted, Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(target.OriginalExecuted, Is.True);
+                Assert.That(target.text.Text, Is.EqualTo("inventory fallback"));
+            });
         }
         finally
         {

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs
@@ -34,64 +34,39 @@ public static class InventoryLineTranslationPatch
         return method;
     }
 
-    public static bool Prefix(object? __instance, object? data)
+    public static void Postfix(object? __instance, object? data)
     {
         try
         {
             if (__instance is null || data is null)
             {
-                return true;
+                return;
             }
 
             var categoryMember = GetMemberValue(data, "category");
             if (categoryMember is null)
             {
-                return true;
+                return;
             }
 
             var category = Convert.ToBoolean(categoryMember, CultureInfo.InvariantCulture);
-            var context = GetMemberValue(__instance, "context");
-            var previousData = context is null ? null : GetMemberValue(context, "data");
-            if (context is not null)
-            {
-                SetMemberValue(context, "data", data);
-            }
-
-            if (!ReferenceEquals(previousData, data))
-            {
-                _ = UITextSkinReflectionAccessor.SetCurrentText(GetMemberValue(__instance, "hotkeyText"), string.Empty, Context);
-            }
-
-            TrySetEnabled(GetMemberValue(__instance, "dotImage"), category);
-            TryResetHotkey(__instance);
-
             if (category)
             {
-                ApplyCategoryMode(__instance, data);
+                ApplyCategoryTranslations(__instance, data);
             }
             else
             {
-                ApplyItemMode(__instance, data);
+                ApplyItemTranslations(__instance, data);
             }
-
-            TryInvokeParameterless(__instance, "UpdateHotkey");
-            return false;
         }
         catch (Exception ex)
         {
-            Trace.TraceError("QudJP: InventoryLineTranslationPatch.Prefix failed: {0}", ex);
-            return true;
+            Trace.TraceError("QudJP: InventoryLineTranslationPatch.Postfix failed: {0}", ex);
         }
     }
 
-    private static void ApplyCategoryMode(object instance, object data)
+    private static void ApplyCategoryTranslations(object instance, object data)
     {
-        TrySetActive(GetMemberValue(instance, "hotkeySpacer"), active: false);
-        TrySetActive(GetMemberValue(instance, "categoryMode"), active: true);
-        TrySetActive(GetMemberValue(instance, "itemMode"), active: false);
-        SetMemberValue(instance, "tooltipGo", null);
-        SetMemberValue(instance, "tooltipCompareGo", null);
-
         var categoryName = GetStringMemberValue(data, "categoryName");
         if (categoryName is null) { categoryName = string.Empty; }
         var categoryRoute = ObservabilityHelpers.ComposeContext(Context, "field=categoryLabel");
@@ -102,10 +77,6 @@ public static class InventoryLineTranslationPatch
             translatedCategoryName,
             Context,
             typeof(InventoryLineTranslationPatch));
-
-        var categoryExpanded = GetBoolMemberValue(data, "categoryExpanded");
-        var expanderText = categoryExpanded ? "[-]" : "[+]";
-        _ = UITextSkinReflectionAccessor.SetCurrentText(GetMemberValue(instance, "categoryExpandLabel"), expanderText, Context);
 
         var amount = GetIntMemberValue(data, "categoryAmount");
         var weight = GetIntMemberValue(data, "categoryWeight");
@@ -121,21 +92,11 @@ public static class InventoryLineTranslationPatch
             translatedWeight,
             Context,
             typeof(InventoryLineTranslationPatch));
-
-        _ = UITextSkinReflectionAccessor.SetCurrentText(GetMemberValue(instance, "itemWeightText"), string.Empty, Context);
     }
 
-    private static void ApplyItemMode(object instance, object data)
+    private static void ApplyItemTranslations(object instance, object data)
     {
-        TrySetActive(GetMemberValue(instance, "hotkeySpacer"), active: true);
-        TrySetActive(GetMemberValue(instance, "categoryMode"), active: false);
-        TrySetActive(GetMemberValue(instance, "itemMode"), active: true);
-
         var go = GetMemberValue(data, "go");
-        SetMemberValue(instance, "tooltipGo", go);
-
-        _ = UITextSkinReflectionAccessor.SetCurrentText(GetMemberValue(instance, "categoryWeightText"), string.Empty, Context);
-
         var displayName = GetStringMemberValue(data, "displayName");
         if (displayName is null)
         {
@@ -162,13 +123,6 @@ public static class InventoryLineTranslationPatch
             translatedWeight,
             Context,
             typeof(InventoryLineTranslationPatch));
-
-        var renderable = go is null ? null : InvokeMethod(go, "RenderForUI", "Inventory");
-        var icon = GetMemberValue(instance, "icon");
-        if (icon is not null)
-        {
-            _ = AccessTools.Method(icon.GetType(), "FromRenderable")?.Invoke(icon, new[] { renderable });
-        }
     }
 
     private static string TranslateVisibleText(string source, string route, string family)
@@ -240,58 +194,6 @@ public static class InventoryLineTranslationPatch
         return field?.GetValue(null);
     }
 
-    private static void TryResetHotkey(object instance)
-    {
-        var field = AccessTools.Field(instance.GetType(), "hotkey");
-        if (field is null)
-        {
-            return;
-        }
-
-        var fieldType = field.FieldType;
-        var defaultValue = fieldType.IsValueType ? Activator.CreateInstance(fieldType) : null;
-        field.SetValue(instance, defaultValue);
-    }
-
-    private static void TrySetActive(object? target, bool active)
-    {
-        if (target is null)
-        {
-            return;
-        }
-
-        if (AccessTools.Method(target.GetType(), "SetActive", new[] { typeof(bool) }) is MethodInfo method)
-        {
-            _ = method.Invoke(target, new object[] { active });
-            return;
-        }
-
-        SetMemberValue(target, "activeSelf", active);
-        SetMemberValue(target, "Active", active);
-    }
-
-    private static void TrySetEnabled(object? target, bool enabled)
-    {
-        if (target is null)
-        {
-            return;
-        }
-
-        SetMemberValue(target, "enabled", enabled);
-        SetMemberValue(target, "Enabled", enabled);
-    }
-
-    private static void TryInvokeParameterless(object instance, string methodName)
-    {
-        _ = AccessTools.Method(instance.GetType(), methodName)?.Invoke(instance, null);
-    }
-
-    private static object? InvokeMethod(object instance, string methodName, params object?[]? args)
-    {
-        var method = AccessTools.Method(instance.GetType(), methodName);
-        return method?.Invoke(instance, args);
-    }
-
     private static object? GetMemberValue(object instance, string memberName)
     {
         var type = instance.GetType();
@@ -310,29 +212,10 @@ public static class InventoryLineTranslationPatch
         return GetMemberValue(instance, memberName) as string;
     }
 
-    private static bool GetBoolMemberValue(object instance, string memberName)
-    {
-        var value = GetMemberValue(instance, memberName);
-        return value is not null && Convert.ToBoolean(value, CultureInfo.InvariantCulture);
-    }
-
     private static int GetIntMemberValue(object instance, string memberName)
     {
         var value = GetMemberValue(instance, memberName);
         return value is null ? 0 : Convert.ToInt32(value, CultureInfo.InvariantCulture);
     }
 
-    private static void SetMemberValue(object instance, string memberName, object? value)
-    {
-        var type = instance.GetType();
-        var property = AccessTools.Property(type, memberName);
-        if (property is not null && property.CanWrite)
-        {
-            property.SetValue(instance, value);
-            return;
-        }
-
-        var field = AccessTools.Field(type, memberName);
-        field?.SetValue(instance, value);
-    }
 }

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.2.41",
+  "Version": "0.2.42",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}


### PR DESCRIPTION
## Summary

- changes `InventoryLineTranslationPatch` from a full Prefix replacement to a narrow Postfix pass
- lets the game-owned `InventoryLine.setData` state setup run before QudJP rewrites translated fields
- bumps the mod manifest and changelog to `0.2.42`

Closes #553.

## Runtime evidence

- Windows verification build was synced as local `Mods/QudJP` version `0.2.42`.
- Player.log confirms the local mod DLL was loaded from `AppData\\LocalLow\\Freehold Games\\CavesOfQud\\Mods\\QudJP\\Assemblies\\QudJP.dll`.
- The fixed log contains `InventoryLineReplacementDisable/v1` probes again.
- `GetDisplayNameRouteTranslator` is absent from the fixed log.

Evidence directory:
`.sisyphus/evidence/win-pc-playerlog-20260507-014055-issue-553-fixed-0.2.42/`

## Verification

- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~InventoryLine"`
- `just test-l1`
- `just test-l2`
- `just test-l2g`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~TargetMethodResolution"`
- `just build`
