### PR TITLE
docs: record v0.2.42 workshop release

### DIFF
--- a/docs/reports/2026-05-07-workshop-v0.2.42.md
+++ b/docs/reports/2026-05-07-workshop-v0.2.42.md
@@ -1,0 +1,83 @@
+# Workshop Release v0.2.42
+
+## Identity
+
+- Version: `0.2.42`
+- Git commit: `5d2e6955ae4fb07f71bf82c6f721022d521559c5`
+- Git tag: `v0.2.42`
+- Previous release tag/range: `v0.2.41..v0.2.42`
+- Version source: `Mods/QudJP/manifest.json`
+- GitHub Release URL: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.42
+- Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
+- Steam app ID: `333640`
+- Published file ID: `3718988020`
+
+## Changenote
+
+```text
+v0.2.42 / 5d2e6955ae4f
+
+更新内容:
+- Caves of Qud 1.0.4 向けの日本語化 Mod 更新です。
+- インベントリ画面で一部アイテム名が表示されなくなる問題を追加修正しました。
+
+修正:
+- インベントリ行の描画状態はゲーム本体の処理に任せ、翻訳処理は表示テキストだけを更新するようにしました。
+- 0.2.41 で残っていたアイテム名非表示の回帰を修正しました。
+
+既知の問題:
+- 一部の自動生成テキスト、チュートリアル、キャラクター生成画面には未翻訳または不自然な訳が残る場合があります。
+- ゲーム本体のアップデートにより、一部表示やパッチが壊れる可能性があります。
+```
+
+## Artifacts
+
+- Release ZIP: `dist/release-assets/v0.2.42/QudJP-v0.2.42.zip`
+- Release ZIP SHA256: `7b73fb252f254e5358b990b8daf65715c74f8a5e6e08fc446b3e32f113febcf5`
+- GitHub Release asset: `QudJP-v0.2.42.zip`
+- GitHub Release asset SHA256: `7b73fb252f254e5358b990b8daf65715c74f8a5e6e08fc446b3e32f113febcf5`
+- Workshop content folder: `dist/workshop/QudJP/`
+- Workshop VDF: `dist/workshop/workshop_item.vdf`
+- Staged/downloaded DLL SHA256: `d16b8b5073bba24c0dc94c9fd2070faf7823e87ea25bad6bfcf649144631f039`
+- Saved fixed Windows Player.log: `/Users/sankenbisha/Dev/coq-japanese_issue-553/.sisyphus/evidence/win-pc-playerlog-20260507-014055-issue-553-fixed-0.2.42/Player.log`
+
+## Preflight
+
+- [x] `git status --short --branch`
+- [x] Release range established from previous tag, release report, changelog/GitHub release, or explicit user range
+- [x] `Mods/QudJP/manifest.json` version, `v0.2.42` tag, release ZIP name, changenote first line, and report version match
+- [x] `git rev-list -n1 v0.2.42` matches `git rev-parse HEAD`
+- [x] `git merge-base --is-ancestor "$(git rev-list -n1 v0.2.42)" origin/main`
+- [x] Draft GitHub Release created by tag workflow
+- [x] `just download-release-zip 0.2.42`
+- [x] `just workshop-preflight 0.2.42`
+- [x] `just release-zip-check dist/release-assets/v0.2.42/QudJP-v0.2.42.zip`
+- [x] `just build-workshop-upload dist/release-assets/v0.2.42/QudJP-v0.2.42.zip /tmp/qudjp-workshop-changenote.txt`
+
+## Upload
+
+- steamcmd command: `steamcmd +login "$STEAM_USER" +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_release-0.2.42/dist/workshop/workshop_item.vdf +quit`
+- Upload completed at: `2026-05-07 01:54 JST`
+- Steam output summary: `Uploading content`; `Uploading preview image`; `Committing update...Success.`
+- Steam Workshop manifest ID: `8415430360605776191`
+- Steam Web API file size: `19536574`
+- Steam Web API preview URL: `https://images.steamusercontent.com/ugc/15773640086424524965/6FBCC9BB6068E16406D31EDB3206303A382B3F2E/`
+- Steam Web API updated at: `2026-05-07 01:54:49 JST`
+- GitHub Release published at: `2026-05-07 01:55:41 JST`
+
+## Post-Publish Smoke
+
+- [x] Workshop page title, description, preview image, visibility, file size, and changenote checked through Steam Web API and upload VDF evidence
+- [x] Subscribe/resubscribe checked with the documented `steamcmd` Workshop download recipe for app `333640`, item `3718988020`, and `validate`
+- [x] Downloaded Workshop `manifest.json` lists `Version: 0.2.42`
+- [x] Downloaded Workshop DLL SHA256 matches staged DLL SHA256
+- [ ] Mod Manager lists QudJP with expected version and preview
+- [ ] Options screen renders Japanese text and CJK glyphs
+- [ ] One short conversation renders Japanese text and CJK glyphs
+- [ ] Fresh Player.log checked for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`
+
+## Decision
+
+- Result: GO for Steam Workshop upload, public metadata, GitHub Release publication, download validation, downloaded manifest version, and downloaded DLL identity.
+- Notes: The user validated the issue-553 fix on Windows before shipping. Post-publish in-game smoke from the Workshop subscription remains manual.
+- Rollback tag, if needed: `v0.2.41`


### PR DESCRIPTION
## Summary
- Record Steam Workshop v0.2.42 release evidence
- Include upload manifest ID, public metadata, GitHub Release publication, and download validation results

## Verification
- git diff --check
- secretlint docs/reports/2026-05-07-workshop-v0.2.42.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション
* Workshop v0.2.42 のリリースノート文書を追加しました。変更内容、修正、既知の問題、リリースアセット、検証手順を含みます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->