### PR TITLE
Fix 0.2.43 inventory TMP release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,7 @@ jobs:
           version="${{ steps.identity.outputs.version }}"
           release_zip="dist/QudJP-v${version}.zip"
           python scripts/release_identity.py --tag "v${version}" --release-zip "$release_zip" --main-ref origin/main
+          python scripts/verify_release_dll.py "$release_zip"
           (cd dist && sha256sum "QudJP-v${version}.zip" > "QudJP-v${version}.zip.sha256")
 
       - name: Render GitHub Release notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.2.43] - 2026-05-07
+
+### Fixed
+
+- インベントリ画面のアイテム名が消える問題について、ローカル検証では
+  `0.2.42` 時点で解決していた修正が、CI/CD の release artifact 生成不備により
+  Steam Workshop 版 DLL へ反映されていなかった問題を修正しました。
+- インベントリ項目の折り畳みや更新時に、非アクティブな行が表示中の
+  アイテム名 replacement を誤って無効化する経路を修正しました。
+- インベントリ項目の折り畳み時に、保持済みアイテム名 replacement の位置・
+  色・透明度・表示状態が元の行に追従するようにしました。
+- Steam Workshop へ出荷する DLL に TextMeshPro / InventoryLine 表示修正が
+  含まれていない場合、release 検証で失敗するガードを追加しました。
+
+---
+
 ## [0.2.42] - 2026-05-07
 
 ### Fixed
@@ -201,6 +217,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+[0.2.43]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.43
+[0.2.42]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.42
 [0.2.41]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.41
 [0.2.4]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.4
 [0.2.3]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.3

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineRenderProbePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineRenderProbePatchTests.cs
@@ -84,6 +84,27 @@ public sealed class InventoryLineRenderProbePatchTests
     }
 
     [NUnit.Framework.Test]
+    public void InventoryLineFontFixer_AllowsWrappedTextSkinTmpFields()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "UI",
+            "InventoryLineFontFixer.cs");
+        var source = File.ReadAllText(sourcePath);
+
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Not.Contain("textSkin is not Component"));
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Contain("Access(textSkin, \"_tmp\") as TextMeshProUGUI"));
+    }
+
+    [NUnit.Framework.Test]
     public void DelayedInventoryLineRepairScheduler_RearmsOnlyWhenLineTextChanges()
     {
         var sourcePath = Path.Combine(

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineRenderProbePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineRenderProbePatchTests.cs
@@ -1,0 +1,104 @@
+using System.IO;
+
+namespace QudJP.Tests.L1;
+
+[NUnit.Framework.TestFixture]
+[NUnit.Framework.Category("L1")]
+public sealed class InventoryLineRenderProbePatchTests
+{
+    [NUnit.Framework.Test]
+    public void InventoryLineRenderProbePatch_DoesNotScheduleReplacementOverlay()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "Patches",
+            "InventoryLineRenderProbePatch.cs");
+        var source = File.ReadAllText(sourcePath);
+
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Not.Contain("DelayedInventoryLineRepairScheduler.ScheduleRepair("));
+    }
+
+    [NUnit.Framework.Test]
+    public void InventoryLineTranslationPatch_ForcesPrimaryFontAfterFinalItemText()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "Patches",
+            "InventoryLineTranslationPatch.cs");
+        var source = File.ReadAllText(sourcePath);
+
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Contain("InventoryLineFontFixer.TryForcePrimaryFontOnTextSkin(itemTextSkin, translatedDisplayName)"));
+    }
+
+    [NUnit.Framework.Test]
+    public void InventoryLineActiveTextRefreshPatch_RefreshesAfterLineBecomesActive()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "Patches",
+            "InventoryLineActiveTextRefreshPatch.cs");
+
+        NUnit.Framework.Assert.That(File.Exists(sourcePath), NUnit.Framework.Is.True);
+        var source = File.ReadAllText(sourcePath);
+
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("\"LateUpdate\""));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("InventoryLineFontFixer.IsActiveItemLine(__instance)"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("InventoryLineFontFixer.HasActiveReplacementForCurrentItemText(__instance)"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("InventoryLineFontFixer.TryRefreshActiveItemLine(__instance)"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("DelayedInventoryLineRepairScheduler.ScheduleRepairForCurrentText("));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Not.Contain("TextShellReplacementRenderer"));
+    }
+
+    [NUnit.Framework.Test]
+    public void InventoryLineFontFixer_TreatsZeroCharactersAsRefreshFailure()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "UI",
+            "InventoryLineFontFixer.cs");
+        var source = File.ReadAllText(sourcePath);
+
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Contain("return tmp.textInfo.characterCount > 0;"));
+    }
+
+    [NUnit.Framework.Test]
+    public void DelayedInventoryLineRepairScheduler_RearmsOnlyWhenLineTextChanges()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "UI",
+            "DelayedInventoryLineRepairScheduler.cs");
+        var source = File.ReadAllText(sourcePath);
+
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("LastScheduledTextByLine"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("ScheduleRepairForCurrentText"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("AttemptCounts.TryRemove(lineId, out _)"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Not.Contain("ScheduleRepair(__instance, resetAttempts: true)"));
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryReplacementHardeningTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryReplacementHardeningTests.cs
@@ -1,5 +1,6 @@
 #if HAS_TMP
 using TMPro;
+#endif
 
 namespace QudJP.Tests.L1;
 
@@ -10,6 +11,7 @@ public sealed class InventoryReplacementHardeningTests
     [NUnit.Framework.TestCase(true, true, 0, TextShellReplacementRenderer.ReplacementRenderAction.AttemptReplacement)]
     [NUnit.Framework.TestCase(false, true, 0, TextShellReplacementRenderer.ReplacementRenderAction.PreserveActiveReplacement)]
     [NUnit.Framework.TestCase(true, false, 0, TextShellReplacementRenderer.ReplacementRenderAction.PreserveActiveReplacement)]
+    [NUnit.Framework.TestCase(true, false, 3, TextShellReplacementRenderer.ReplacementRenderAction.PreserveActiveReplacement)]
     [NUnit.Framework.TestCase(false, false, 0, TextShellReplacementRenderer.ReplacementRenderAction.PreserveActiveReplacement)]
     [NUnit.Framework.TestCase(true, true, 3, TextShellReplacementRenderer.ReplacementRenderAction.DisableReplacement)]
     public void DecideRenderActionForTests_ReturnsExpectedAction(
@@ -26,6 +28,7 @@ public sealed class InventoryReplacementHardeningTests
             NUnit.Framework.Is.EqualTo(expectedAction));
     }
 
+#if HAS_TMP
     [NUnit.Framework.Test]
     public void GetReplacementOverflowModeForTests_UsesOverflow()
     {
@@ -46,6 +49,7 @@ public sealed class InventoryReplacementHardeningTests
     {
         return TmpTextRepairer.CanAttemptRepairForTests(enabled, activeInHierarchy, text, objectName);
     }
+#endif
 
     [NUnit.Framework.TestCase("QudJPReplacementText", ExpectedResult = true)]
     [NUnit.Framework.TestCase("Text", ExpectedResult = false)]
@@ -53,5 +57,20 @@ public sealed class InventoryReplacementHardeningTests
     {
         return TextShellReplacementRenderer.IsReplacementTextNameForTests(objectName);
     }
+
+    [NUnit.Framework.TestCase("current", "original", ExpectedResult = "original")]
+    [NUnit.Framework.TestCase("current", "", ExpectedResult = "current")]
+    public string ResolvePreservedReplacementTextForTests_KeepsCurrentTextWhenOriginalIsEmpty(
+        string currentReplacementText,
+        string originalText)
+    {
+        return TextShellReplacementRenderer.ResolvePreservedReplacementTextForTests(currentReplacementText, originalText);
+    }
+
+    [NUnit.Framework.TestCase(true, ExpectedResult = true)]
+    [NUnit.Framework.TestCase(false, ExpectedResult = false)]
+    public bool ResolvePreservedReplacementActiveSelfForTests_FollowsOriginalActiveSelf(bool originalActiveSelf)
+    {
+        return TextShellReplacementRenderer.ResolvePreservedReplacementActiveSelfForTests(originalActiveSelf);
+    }
 }
-#endif

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryReplacementHardeningTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryReplacementHardeningTests.cs
@@ -67,10 +67,29 @@ public sealed class InventoryReplacementHardeningTests
         return TextShellReplacementRenderer.ResolvePreservedReplacementTextForTests(currentReplacementText, originalText);
     }
 
-    [NUnit.Framework.TestCase(true, ExpectedResult = true)]
-    [NUnit.Framework.TestCase(false, ExpectedResult = false)]
-    public bool ResolvePreservedReplacementActiveSelfForTests_FollowsOriginalActiveSelf(bool originalActiveSelf)
+    [NUnit.Framework.TestCase(true, true, ExpectedResult = true)]
+    [NUnit.Framework.TestCase(false, true, ExpectedResult = false)]
+    [NUnit.Framework.TestCase(true, false, ExpectedResult = false)]
+    [NUnit.Framework.TestCase(false, false, ExpectedResult = false)]
+    public bool ResolvePreservedReplacementActiveSelfForTests_RequiresVisibleOriginal(
+        bool originalActiveSelf,
+        bool originalActiveInHierarchy)
     {
-        return TextShellReplacementRenderer.ResolvePreservedReplacementActiveSelfForTests(originalActiveSelf);
+        return TextShellReplacementRenderer.ResolvePreservedReplacementActiveSelfForTests(
+            originalActiveSelf,
+            originalActiveInHierarchy);
+    }
+
+    [NUnit.Framework.TestCase(true, true, ExpectedResult = true)]
+    [NUnit.Framework.TestCase(false, true, ExpectedResult = false)]
+    [NUnit.Framework.TestCase(true, false, ExpectedResult = false)]
+    [NUnit.Framework.TestCase(false, false, ExpectedResult = false)]
+    public bool ShouldRestoreOriginalAfterFailedPreservedReuseForTests_RequiresVisibleOriginal(
+        bool originalActiveSelf,
+        bool originalActiveInHierarchy)
+    {
+        return TextShellReplacementRenderer.ShouldRestoreOriginalAfterFailedPreservedReuseForTests(
+            originalActiveSelf,
+            originalActiveInHierarchy);
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryReplacementHardeningTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryReplacementHardeningTests.cs
@@ -69,15 +69,25 @@ public sealed class InventoryReplacementHardeningTests
 
     [NUnit.Framework.TestCase(true, true, ExpectedResult = true)]
     [NUnit.Framework.TestCase(false, true, ExpectedResult = false)]
-    [NUnit.Framework.TestCase(true, false, ExpectedResult = false)]
+    [NUnit.Framework.TestCase(true, false, ExpectedResult = true)]
     [NUnit.Framework.TestCase(false, false, ExpectedResult = false)]
-    public bool ResolvePreservedReplacementActiveSelfForTests_RequiresVisibleOriginal(
+    public bool ResolvePreservedReplacementActiveSelfForTests_PreservesOriginalActiveSelf(
         bool originalActiveSelf,
         bool originalActiveInHierarchy)
     {
         return TextShellReplacementRenderer.ResolvePreservedReplacementActiveSelfForTests(
             originalActiveSelf,
             originalActiveInHierarchy);
+    }
+
+    [NUnit.Framework.Test]
+    public void ResolvePreservedReplacementActiveSelfForTests_KeepsReplacementActiveSelfAcrossCollapsedParent()
+    {
+        NUnit.Framework.Assert.That(
+            TextShellReplacementRenderer.ResolvePreservedReplacementActiveSelfForTests(
+                originalActiveSelf: true,
+                originalActiveInHierarchy: false),
+            NUnit.Framework.Is.True);
     }
 
     [NUnit.Framework.TestCase(true, true, ExpectedResult = true)]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/TranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/TranslatorTests.cs
@@ -42,8 +42,12 @@ public sealed class TranslatorTests
         Assert.That(translated, Is.EqualTo("こんにちは"));
     }
 
-    [Test]
-    public void Translate_RepositoryDictionary_TranslatesLowercaseRemoveAction()
+    [TestCase("mark important", "重要にする")]
+    [TestCase("mark unimportant", "重要マークを外す")]
+    [TestCase("add notes", "メモを追加")]
+    [TestCase("remove notes", "メモを削除")]
+    [TestCase("remove", "外す")]
+    public void Translate_RepositoryDictionary_TranslatesLowercaseInventoryActionDisplay(string source, string expected)
     {
         Translator.SetDictionaryDirectoryForTests(Path.Combine(
             TestProjectPaths.GetRepositoryRoot(),
@@ -52,9 +56,9 @@ public sealed class TranslatorTests
             "Localization",
             "Dictionaries"));
 
-        var translated = Translator.Translate("remove");
+        var translated = Translator.Translate(source);
 
-        Assert.That(translated, Is.EqualTo("外す"));
+        Assert.That(translated, Is.EqualTo(expected));
     }
 
     [Test]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/TranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/TranslatorTests.cs
@@ -43,6 +43,21 @@ public sealed class TranslatorTests
     }
 
     [Test]
+    public void Translate_RepositoryDictionary_TranslatesLowercaseRemoveAction()
+    {
+        Translator.SetDictionaryDirectoryForTests(Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Localization",
+            "Dictionaries"));
+
+        var translated = Translator.Translate("remove");
+
+        Assert.That(translated, Is.EqualTo("外す"));
+    }
+
+    [Test]
     public void Translate_UsesExactDictionaryKeys_WithoutRouteAwareness()
     {
         WriteDictionary(

--- a/Mods/QudJP/Assemblies/QudJP.csproj
+++ b/Mods/QudJP/Assemblies/QudJP.csproj
@@ -64,6 +64,11 @@
     <DefineConstants>$(DefineConstants);HAS_TMP</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="!Exists('$(ManagedDir)/Unity.TextMeshPro.dll')">
+    <UseUnityReferenceStubs>true</UseUnityReferenceStubs>
+    <DefineConstants>$(DefineConstants);HAS_TMP;UNITY_REFERENCE_STUBS</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup Condition="Exists('$(ManagedDir)/Unity.TextMeshPro.dll')">
     <Reference Include="Unity.TextMeshPro">
       <HintPath>$(ManagedDir)/Unity.TextMeshPro.dll</HintPath>
@@ -89,5 +94,14 @@
       <HintPath>$(ManagedDir)/UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>false</Private>
     </Reference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseUnityReferenceStubs)' == 'true'">
+    <ProjectReference Include="ReferenceStubs/UnityEngine.CoreModule/UnityEngine.CoreModule.csproj" Private="false" />
+    <ProjectReference Include="ReferenceStubs/UnityEngine.TextRenderingModule/UnityEngine.TextRenderingModule.csproj" Private="false" />
+    <ProjectReference Include="ReferenceStubs/UnityEngine.TextCoreFontEngineModule/UnityEngine.TextCoreFontEngineModule.csproj" Private="false" />
+    <ProjectReference Include="ReferenceStubs/UnityEngine.TextCoreTextEngineModule/UnityEngine.TextCoreTextEngineModule.csproj" Private="false" />
+    <ProjectReference Include="ReferenceStubs/UnityEngine.UI/UnityEngine.UI.csproj" Private="false" />
+    <ProjectReference Include="ReferenceStubs/Unity.TextMeshPro/Unity.TextMeshPro.csproj" Private="false" />
   </ItemGroup>
 </Project>

--- a/Mods/QudJP/Assemblies/ReferenceStubs/Unity.TextMeshPro/AssemblyInfo.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/Unity.TextMeshPro/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Reflection;
+
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/Mods/QudJP/Assemblies/ReferenceStubs/Unity.TextMeshPro/TmpStubs.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/Unity.TextMeshPro/TmpStubs.cs
@@ -91,7 +91,7 @@ public class TMP_FontAsset : Object
 public class TMP_Text : UnityEngine.UI.Graphic
 {
     public string text { get; set; } = string.Empty;
-    public TMP_TextInfo textInfo { get; set; } = new TMP_TextInfo();
+    public TMP_TextInfo textInfo { get; } = new TMP_TextInfo();
     public TMP_FontAsset? font { get; set; }
     public Material? fontSharedMaterial { get; set; }
     public Material? fontMaterial { get; set; }
@@ -117,10 +117,10 @@ public class TMP_Text : UnityEngine.UI.Graphic
     public int maxVisibleCharacters { get; set; }
     public int maxVisibleLines { get; set; }
     public int pageToDisplay { get; set; }
-    public float preferredWidth { get; set; }
-    public float preferredHeight { get; set; }
+    public float preferredWidth { get; }
+    public float preferredHeight { get; }
     public float alpha { get; set; }
-    public CanvasRenderer canvasRenderer { get; set; } = new CanvasRenderer();
+    public CanvasRenderer canvasRenderer { get; } = new CanvasRenderer();
 
     public void ForceMeshUpdate(bool ignoreActiveState = false, bool forceTextReparsing = false)
     {

--- a/Mods/QudJP/Assemblies/ReferenceStubs/Unity.TextMeshPro/TmpStubs.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/Unity.TextMeshPro/TmpStubs.cs
@@ -92,7 +92,6 @@ public class TMP_Text : UnityEngine.UI.Graphic
 {
     public string text { get; set; } = string.Empty;
     public TMP_TextInfo textInfo { get; set; } = new TMP_TextInfo();
-    public RectTransform rectTransform { get; set; } = new RectTransform();
     public TMP_FontAsset? font { get; set; }
     public Material? fontSharedMaterial { get; set; }
     public Material? fontMaterial { get; set; }

--- a/Mods/QudJP/Assemblies/ReferenceStubs/Unity.TextMeshPro/TmpStubs.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/Unity.TextMeshPro/TmpStubs.cs
@@ -33,24 +33,24 @@ public enum AtlasPopulationMode
 
 public class TMP_TextInfo
 {
-    public int characterCount { get; set; }
-    public int pageCount { get; set; }
-    public int materialCount { get; set; }
-    public TMP_MeshInfo[] meshInfo { get; set; } = [];
-    public TMP_CharacterInfo[] characterInfo { get; set; } = [];
+    public int characterCount;
+    public int pageCount;
+    public int materialCount;
+    public TMP_MeshInfo[] meshInfo = [];
+    public TMP_CharacterInfo[] characterInfo = [];
 }
 
 public struct TMP_MeshInfo
 {
-    public int vertexCount { get; set; }
+    public int vertexCount;
 }
 
 public struct TMP_CharacterInfo
 {
-    public bool isVisible { get; set; }
-    public int character { get; set; }
-    public Vector3 bottomLeft { get; set; }
-    public Vector3 topRight { get; set; }
+    public bool isVisible;
+    public char character;
+    public Vector3 bottomLeft;
+    public Vector3 topRight;
 }
 
 public class TMP_FontAsset : Object
@@ -88,7 +88,7 @@ public class TMP_FontAsset : Object
     }
 }
 
-public class TMP_Text : Behaviour
+public class TMP_Text : UnityEngine.UI.Graphic
 {
     public string text { get; set; } = string.Empty;
     public TMP_TextInfo textInfo { get; set; } = new TMP_TextInfo();
@@ -163,7 +163,7 @@ public class TMP_SubMeshUI : Behaviour
 public class TMP_InputField : Behaviour
 {
     public TMP_Text? textComponent { get; set; }
-    public TMP_Text? placeholder { get; set; }
+    public UnityEngine.UI.Graphic? placeholder { get; set; }
 }
 
 public static class TMP_Settings

--- a/Mods/QudJP/Assemblies/ReferenceStubs/Unity.TextMeshPro/TmpStubs.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/Unity.TextMeshPro/TmpStubs.cs
@@ -1,0 +1,173 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.TextCore.LowLevel;
+
+namespace TMPro;
+
+public enum TextOverflowModes
+{
+    Overflow = 0,
+}
+
+public enum TextWrappingModes
+{
+    Normal = 0,
+    NoWrap = 1,
+}
+
+public enum FontStyles
+{
+    Normal = 0,
+}
+
+public enum TextAlignmentOptions
+{
+    TopLeft = 257,
+}
+
+public enum AtlasPopulationMode
+{
+    Static = 0,
+    Dynamic = 1,
+}
+
+public class TMP_TextInfo
+{
+    public int characterCount { get; set; }
+    public int pageCount { get; set; }
+    public int materialCount { get; set; }
+    public TMP_MeshInfo[] meshInfo { get; set; } = [];
+    public TMP_CharacterInfo[] characterInfo { get; set; } = [];
+}
+
+public struct TMP_MeshInfo
+{
+    public int vertexCount { get; set; }
+}
+
+public struct TMP_CharacterInfo
+{
+    public bool isVisible { get; set; }
+    public int character { get; set; }
+    public Vector3 bottomLeft { get; set; }
+    public Vector3 topRight { get; set; }
+}
+
+public class TMP_FontAsset : Object
+{
+    public Material material { get; set; } = new Material();
+    public int atlasTextureCount { get; set; }
+    public AtlasPopulationMode atlasPopulationMode { get; set; }
+    public bool isMultiAtlasTexturesEnabled { get; set; }
+    public Font? sourceFontFile { get; set; }
+    public List<TMP_FontAsset>? fallbackFontAssetTable { get; set; }
+
+    public static TMP_FontAsset CreateFontAsset(
+        string fontFilePath,
+        int faceIndex,
+        int samplingPointSize,
+        int atlasPadding,
+        GlyphRenderMode renderMode,
+        int atlasWidth,
+        int atlasHeight)
+    {
+        _ = faceIndex;
+        _ = samplingPointSize;
+        _ = atlasPadding;
+        _ = renderMode;
+        _ = atlasWidth;
+        _ = atlasHeight;
+        return new TMP_FontAsset { name = fontFilePath };
+    }
+
+    public bool TryAddCharacters(string characters) => true;
+    public bool TryAddCharacters(string characters, out string missingCharacters)
+    {
+        missingCharacters = string.Empty;
+        return true;
+    }
+}
+
+public class TMP_Text : Behaviour
+{
+    public string text { get; set; } = string.Empty;
+    public TMP_TextInfo textInfo { get; set; } = new TMP_TextInfo();
+    public RectTransform rectTransform { get; set; } = new RectTransform();
+    public TMP_FontAsset? font { get; set; }
+    public Material? fontSharedMaterial { get; set; }
+    public Material? fontMaterial { get; set; }
+    public Color color { get; set; }
+    public bool maskable { get; set; }
+    public bool raycastTarget { get; set; }
+    public bool havePropertiesChanged { get; set; }
+    public bool richText { get; set; }
+    public bool isRightToLeftText { get; set; }
+    public TextOverflowModes overflowMode { get; set; }
+    public TextWrappingModes textWrappingMode { get; set; }
+    public FontStyles fontStyle { get; set; }
+    public TextAlignmentOptions alignment { get; set; }
+    public Vector4 margin { get; set; }
+    public float fontSize { get; set; }
+    public float fontSizeMin { get; set; }
+    public float fontSizeMax { get; set; }
+    public bool enableAutoSizing { get; set; }
+    public float characterSpacing { get; set; }
+    public float wordSpacing { get; set; }
+    public float lineSpacing { get; set; }
+    public float paragraphSpacing { get; set; }
+    public int maxVisibleCharacters { get; set; }
+    public int maxVisibleLines { get; set; }
+    public int pageToDisplay { get; set; }
+    public float preferredWidth { get; set; }
+    public float preferredHeight { get; set; }
+    public float alpha { get; set; }
+    public CanvasRenderer canvasRenderer { get; set; } = new CanvasRenderer();
+
+    public void ForceMeshUpdate(bool ignoreActiveState = false, bool forceTextReparsing = false)
+    {
+    }
+
+    public void SetAllDirty()
+    {
+    }
+
+    public void UpdateMeshPadding()
+    {
+    }
+
+    public void RecalculateClipping()
+    {
+    }
+
+    public void RecalculateMasking()
+    {
+    }
+}
+
+public class TextMeshProUGUI : TMP_Text
+{
+}
+
+public class TextMeshPro : TMP_Text
+{
+}
+
+public class TMP_SubMeshUI : Behaviour
+{
+    public TMP_FontAsset? fontAsset { get; set; }
+    public Material? sharedMaterial { get; set; }
+    public TMP_Text? textComponent { get; set; }
+    public bool maskable { get; set; }
+}
+
+public class TMP_InputField : Behaviour
+{
+    public TMP_Text? textComponent { get; set; }
+    public TMP_Text? placeholder { get; set; }
+}
+
+public static class TMP_Settings
+{
+    public static TMP_FontAsset? defaultFontAsset { get; set; }
+    public static List<TMP_FontAsset>? fallbackFontAssets { get; set; }
+}

--- a/Mods/QudJP/Assemblies/ReferenceStubs/Unity.TextMeshPro/Unity.TextMeshPro.csproj
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/Unity.TextMeshPro/Unity.TextMeshPro.csproj
@@ -12,5 +12,6 @@
     <ProjectReference Include="../UnityEngine.CoreModule/UnityEngine.CoreModule.csproj" Private="false" />
     <ProjectReference Include="../UnityEngine.TextRenderingModule/UnityEngine.TextRenderingModule.csproj" Private="false" />
     <ProjectReference Include="../UnityEngine.TextCoreFontEngineModule/UnityEngine.TextCoreFontEngineModule.csproj" Private="false" />
+    <ProjectReference Include="../UnityEngine.UI/UnityEngine.UI.csproj" Private="false" />
   </ItemGroup>
 </Project>

--- a/Mods/QudJP/Assemblies/ReferenceStubs/Unity.TextMeshPro/Unity.TextMeshPro.csproj
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/Unity.TextMeshPro/Unity.TextMeshPro.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <AssemblyName>Unity.TextMeshPro</AssemblyName>
+    <RootNamespace>TMPro</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../UnityEngine.CoreModule/UnityEngine.CoreModule.csproj" Private="false" />
+    <ProjectReference Include="../UnityEngine.TextRenderingModule/UnityEngine.TextRenderingModule.csproj" Private="false" />
+    <ProjectReference Include="../UnityEngine.TextCoreFontEngineModule/UnityEngine.TextCoreFontEngineModule.csproj" Private="false" />
+  </ItemGroup>
+</Project>

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.CoreModule/AssemblyInfo.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.CoreModule/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Reflection;
+
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.CoreModule/UnityEngine.CoreModule.csproj
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.CoreModule/UnityEngine.CoreModule.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <AssemblyName>UnityEngine.CoreModule</AssemblyName>
+    <RootNamespace>UnityEngine</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.CoreModule/UnityEngineStubs.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.CoreModule/UnityEngineStubs.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections;
+
+namespace UnityEngine;
+
+public class Object
+{
+    public string name { get; set; } = string.Empty;
+    public HideFlags hideFlags { get; set; }
+
+    public int GetInstanceID() => 0;
+
+    public static void DontDestroyOnLoad(Object target)
+    {
+    }
+}
+
+[Flags]
+public enum HideFlags
+{
+    None = 0,
+    HideAndDontSave = 61,
+}
+
+public class Component : Object
+{
+    public GameObject gameObject { get; set; } = null!;
+    public Transform transform { get; set; } = null!;
+
+    public T? GetComponent<T>() where T : Component => default;
+    public Component? GetComponent(string type) => null;
+    public T? GetComponentInChildren<T>(bool includeInactive = false) where T : Component => default;
+    public T[] GetComponents<T>() where T : Component => Array.Empty<T>();
+    public T[] GetComponentsInChildren<T>(bool includeInactive = false) where T : Component => Array.Empty<T>();
+}
+
+public class Behaviour : Component
+{
+    public bool enabled { get; set; }
+    public bool isActiveAndEnabled { get; set; }
+}
+
+public class MonoBehaviour : Behaviour
+{
+    public Coroutine? StartCoroutine(IEnumerator routine) => null;
+}
+
+public sealed class Coroutine
+{
+}
+
+public class GameObject : Object
+{
+    public GameObject()
+    {
+        transform = new Transform { gameObject = this };
+        transform.transform = transform;
+    }
+
+    public GameObject(string name)
+        : this()
+    {
+        this.name = name;
+    }
+
+    public GameObject(string name, params Type[] components)
+        : this(name)
+    {
+        _ = components;
+    }
+
+    public bool activeSelf { get; set; }
+    public bool activeInHierarchy { get; set; }
+    public int layer { get; set; }
+    public Transform transform { get; set; }
+
+    public void SetActive(bool value)
+    {
+        activeSelf = value;
+    }
+
+    public T AddComponent<T>() where T : Component, new() => AttachComponent(new T());
+    public Component? AddComponent(Type componentType)
+    {
+        var component = Activator.CreateInstance(componentType) as Component;
+        return component is null ? null : AttachComponent(component);
+    }
+
+    private T AttachComponent<T>(T component) where T : Component
+    {
+        component.gameObject = this;
+        component.transform = component as Transform ?? transform;
+        return component;
+    }
+
+    public T? GetComponent<T>() where T : Component => default;
+    public Component? GetComponent(string type) => null;
+    public T? GetComponentInChildren<T>(bool includeInactive = false) where T : Component => default;
+    public T[] GetComponentsInChildren<T>(bool includeInactive = false) where T : Component => Array.Empty<T>();
+}
+
+public class Transform : Component
+{
+    public Transform? parent { get; set; }
+    public Transform root => this;
+    public int childCount { get; set; }
+    public Vector3 localPosition { get; set; }
+    public Vector3 localScale { get; set; }
+    public Quaternion localRotation { get; set; }
+
+    public Transform? Find(string name) => null;
+    public Transform GetChild(int index) => new Transform();
+    public int GetSiblingIndex() => 0;
+    public Vector3 TransformPoint(Vector3 position) => position;
+    public void SetParent(Transform parent, bool worldPositionStays = true)
+    {
+        this.parent = parent;
+    }
+
+    public void SetAsLastSibling()
+    {
+    }
+}
+
+public class RectTransform : Transform
+{
+    public Rect rect { get; set; }
+    public Vector2 anchorMin { get; set; }
+    public Vector2 anchorMax { get; set; }
+    public Vector2 anchoredPosition { get; set; }
+    public Vector2 sizeDelta { get; set; }
+    public Vector2 pivot { get; set; }
+    public Vector2 offsetMin { get; set; }
+    public Vector2 offsetMax { get; set; }
+}
+
+public struct Rect
+{
+    public float width { get; set; }
+    public float height { get; set; }
+    public Vector2 center { get; set; }
+}
+
+public struct Vector2
+{
+    public float x { get; set; }
+    public float y { get; set; }
+
+    public Vector2(float x, float y)
+    {
+        this.x = x;
+        this.y = y;
+    }
+}
+
+public struct Vector3
+{
+    public float x { get; set; }
+    public float y { get; set; }
+    public float z { get; set; }
+
+    public Vector3(float x, float y, float z = 0)
+    {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    public static implicit operator Vector3(Vector2 value) => new(value.x, value.y);
+}
+
+public struct Vector4
+{
+    public float x { get; set; }
+    public float y { get; set; }
+    public float z { get; set; }
+    public float w { get; set; }
+}
+
+public struct Quaternion
+{
+    public float x { get; set; }
+    public float y { get; set; }
+    public float z { get; set; }
+    public float w { get; set; }
+}
+
+public struct Color
+{
+    public float r { get; set; }
+    public float g { get; set; }
+    public float b { get; set; }
+    public float a { get; set; }
+}
+
+public class Material : Object
+{
+    public bool HasProperty(string name) => false;
+    public Color GetColor(string name) => default;
+    public int GetInt(string name) => 0;
+    public float GetFloat(string name) => 0;
+}
+
+public class CanvasRenderer : Component
+{
+    public bool cull { get; set; }
+}
+
+public class CanvasGroup : Component
+{
+    public float alpha { get; set; }
+}
+
+public static class Canvas
+{
+    public static void ForceUpdateCanvases()
+    {
+    }
+}
+
+public static class Resources
+{
+    public static T[] FindObjectsOfTypeAll<T>() where T : Object => Array.Empty<T>();
+}
+
+public static class Debug
+{
+    public static void Log(object message)
+    {
+    }
+
+    public static void LogWarning(object message)
+    {
+    }
+
+    public static void LogError(object message)
+    {
+    }
+}
+
+public static class Time
+{
+    public static int frameCount { get; set; }
+}
+
+public sealed class WaitForEndOfFrame
+{
+}

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextCoreFontEngineModule/AssemblyInfo.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextCoreFontEngineModule/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Reflection;
+
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextCoreFontEngineModule/GlyphRenderMode.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextCoreFontEngineModule/GlyphRenderMode.cs
@@ -1,0 +1,6 @@
+namespace UnityEngine.TextCore.LowLevel;
+
+public enum GlyphRenderMode
+{
+    SDFAA = 4169,
+}

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextCoreFontEngineModule/UnityEngine.TextCoreFontEngineModule.csproj
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextCoreFontEngineModule/UnityEngine.TextCoreFontEngineModule.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <AssemblyName>UnityEngine.TextCoreFontEngineModule</AssemblyName>
+    <RootNamespace>UnityEngine.TextCore.LowLevel</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextCoreTextEngineModule/AssemblyInfo.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextCoreTextEngineModule/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Reflection;
+
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextCoreTextEngineModule/Placeholder.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextCoreTextEngineModule/Placeholder.cs
@@ -1,0 +1,5 @@
+namespace UnityEngine.TextCore.Text;
+
+public sealed class Placeholder
+{
+}

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextCoreTextEngineModule/UnityEngine.TextCoreTextEngineModule.csproj
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextCoreTextEngineModule/UnityEngine.TextCoreTextEngineModule.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <AssemblyName>UnityEngine.TextCoreTextEngineModule</AssemblyName>
+    <RootNamespace>UnityEngine.TextCore.Text</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextRenderingModule/AssemblyInfo.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextRenderingModule/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Reflection;
+
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextRenderingModule/Font.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextRenderingModule/Font.cs
@@ -1,0 +1,8 @@
+namespace UnityEngine;
+
+public class Font : Object
+{
+    public static Font CreateDynamicFontFromOSFont(string fontname, int size) => new Font { name = fontname };
+    public static Font CreateDynamicFontFromOSFont(string[] fontnames, int size) =>
+        new Font { name = fontnames.Length == 0 ? string.Empty : fontnames[0] };
+}

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextRenderingModule/UnityEngine.TextRenderingModule.csproj
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.TextRenderingModule/UnityEngine.TextRenderingModule.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <AssemblyName>UnityEngine.TextRenderingModule</AssemblyName>
+    <RootNamespace>UnityEngine</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../UnityEngine.CoreModule/UnityEngine.CoreModule.csproj" Private="false" />
+  </ItemGroup>
+</Project>

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.UI/AssemblyInfo.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.UI/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Reflection;
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.UI/UiStubs.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.UI/UiStubs.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace UnityEngine.UI;
+
+public class Text : Behaviour
+{
+    public string text { get; set; } = string.Empty;
+    public Font? font { get; set; }
+    public RectTransform rectTransform { get; set; } = new RectTransform();
+}
+
+public static class LayoutRebuilder
+{
+    public static void ForceRebuildLayoutImmediate(RectTransform layoutRoot)
+    {
+    }
+}

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.UI/UiStubs.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.UI/UiStubs.cs
@@ -4,13 +4,13 @@ namespace UnityEngine.UI;
 
 public class Graphic : Behaviour
 {
+    public RectTransform rectTransform { get; } = new RectTransform();
 }
 
 public class Text : Graphic
 {
     public string text { get; set; } = string.Empty;
     public Font? font { get; set; }
-    public RectTransform rectTransform { get; set; } = new RectTransform();
 }
 
 public static class LayoutRebuilder

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.UI/UiStubs.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.UI/UiStubs.cs
@@ -2,7 +2,11 @@ using UnityEngine;
 
 namespace UnityEngine.UI;
 
-public class Text : Behaviour
+public class Graphic : Behaviour
+{
+}
+
+public class Text : Graphic
 {
     public string text { get; set; } = string.Empty;
     public Font? font { get; set; }

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.UI/UnityEngine.UI.csproj
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.UI/UnityEngine.UI.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <AssemblyName>UnityEngine.UI</AssemblyName>
+    <RootNamespace>UnityEngine.UI</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../UnityEngine.CoreModule/UnityEngine.CoreModule.csproj" Private="false" />
+    <ProjectReference Include="../UnityEngine.TextRenderingModule/UnityEngine.TextRenderingModule.csproj" Private="false" />
+  </ItemGroup>
+</Project>

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryLineActiveTextRefreshPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryLineActiveTextRefreshPatch.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class InventoryLineActiveTextRefreshPatch
+{
+    private const string TargetTypeName = "Qud.UI.InventoryLine";
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = AccessTools.TypeByName(TargetTypeName);
+        var method = targetType is null ? null : AccessTools.Method(targetType, "LateUpdate");
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: Failed to resolve InventoryLine.LateUpdate(). Active text refresh patch will not apply.");
+        }
+
+        return method;
+    }
+
+    public static void Postfix(object __instance)
+    {
+        try
+        {
+#if HAS_TMP
+            if (InventoryLineFontFixer.IsActiveItemLine(__instance)
+                && !InventoryLineFontFixer.HasActiveReplacementForCurrentItemText(__instance)
+                && !InventoryLineFontFixer.TryRefreshActiveItemLine(__instance))
+            {
+                DelayedInventoryLineRepairScheduler.ScheduleRepairForCurrentText(
+                    __instance,
+                    InventoryLineFontFixer.GetActiveItemLineText(__instance));
+            }
+#else
+            _ = __instance;
+#endif
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: InventoryLineActiveTextRefreshPatch.Postfix failed: {0}", ex);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryLineRenderProbePatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryLineRenderProbePatch.cs
@@ -52,7 +52,6 @@ public static class InventoryLineRenderProbePatch
         {
 #if HAS_TMP
             _ = InventoryLineFontFixer.TryApplyPrimaryFontToItemRow(__instance, data);
-            DelayedInventoryLineRepairScheduler.ScheduleRepair(__instance);
 #else
             _ = __instance;
             _ = data;

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs
@@ -106,12 +106,16 @@ public static class InventoryLineTranslationPatch
         if (displayName is null) { displayName = string.Empty; }
         var itemRoute = ObservabilityHelpers.ComposeContext(Context, "field=text");
         var translatedDisplayName = TranslateVisibleText(displayName, itemRoute, "InventoryLine.ItemName");
+        var itemTextSkin = GetMemberValue(instance, "text");
         OwnerTextSetter.SetTranslatedText(
-            GetMemberValue(instance, "text"),
+            itemTextSkin,
             displayName,
             translatedDisplayName,
             Context,
             typeof(InventoryLineTranslationPatch));
+#if HAS_TMP
+        _ = InventoryLineFontFixer.TryForcePrimaryFontOnTextSkin(itemTextSkin, translatedDisplayName);
+#endif
 
         var weight = go is null ? 0 : GetIntMemberValue(go, "Weight");
         var weightSource = $"[{weight.ToString(CultureInfo.InvariantCulture)} lbs.]";

--- a/Mods/QudJP/Assemblies/src/UI/DelayedInventoryLineRepairScheduler.cs
+++ b/Mods/QudJP/Assemblies/src/UI/DelayedInventoryLineRepairScheduler.cs
@@ -13,6 +13,7 @@ internal static class DelayedInventoryLineRepairScheduler
     private const int MaxAttemptsPerLine = 2;
 
     private static readonly ConcurrentDictionary<int, int> AttemptCounts = new();
+    private static readonly ConcurrentDictionary<int, string> LastScheduledTextByLine = new();
     private static readonly ConcurrentDictionary<int, byte> Scheduled = new();
 
     private static RepairHost? host;
@@ -50,6 +51,25 @@ internal static class DelayedInventoryLineRepairScheduler
 
         _ = AttemptCounts.AddOrUpdate(lineId, 1, static (_, current) => current + 1);
         runner.StartCoroutine(RunRepair(component, lineId));
+    }
+
+    internal static void ScheduleRepairForCurrentText(object? lineInstance, string? currentText)
+    {
+        var textKey = currentText ?? string.Empty;
+        if (textKey.Length == 0 || lineInstance is not Component component)
+        {
+            return;
+        }
+
+        var lineId = component.GetInstanceID();
+        if (LastScheduledTextByLine.TryGetValue(lineId, out var previousText)
+            && !string.Equals(previousText, textKey, System.StringComparison.Ordinal))
+        {
+            AttemptCounts.TryRemove(lineId, out _);
+        }
+
+        LastScheduledTextByLine[lineId] = textKey;
+        ScheduleRepair(component);
     }
 
     internal static void ScheduleVisibleInventoryRepairs()

--- a/Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs
@@ -140,11 +140,6 @@ internal static class InventoryLineFontFixer
         return TextShellReplacementRenderer.HasActiveReplacementForCurrentItemText(inventoryLineInstance);
     }
 
-    internal static bool TryRefreshActiveItemLineDelayed(object? inventoryLineInstance)
-    {
-        return TryRefreshActiveItemLine(inventoryLineInstance);
-    }
-
     internal static int TryApplyPrimaryFontToAllTextChildren(object? inventoryLineInstance)
     {
         if (inventoryLineInstance is not Component component)

--- a/Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs
@@ -3,12 +3,16 @@ using TMPro;
 using UnityEngine;
 #endif
 using System;
+using System.Threading;
 
 namespace QudJP;
 
 internal static class InventoryLineFontFixer
 {
 #if HAS_TMP
+    private const int MaxDiagnostics = 128;
+    private static int diagnosticsCount;
+
     internal static bool TryApplyPrimaryFontToItemRow(object? inventoryLineInstance, object? data)
     {
         if (inventoryLineInstance is null || data is null)
@@ -21,22 +25,124 @@ internal static class InventoryLineFontFixer
             return false;
         }
 
-        var textSkin = GetPropertyOrFieldValue(inventoryLineInstance, "text");
-        if (textSkin is not Component component)
-        {
-            return false;
-        }
-
-        var tmp = component.GetComponent<TextMeshProUGUI>();
-        if (tmp is null)
-        {
-            return false;
-        }
-
         var displayName = TryGetStringPropertyOrField(data, "displayName");
-        _ = FontManager.TryWarmPrimaryFontCharactersForUi(displayName);
-        FontManager.ApplyToText(tmp);
+        var textSkin = GetPropertyOrFieldValue(inventoryLineInstance, "text");
+        return TryForcePrimaryFontOnTextSkin(textSkin, displayName);
+    }
+
+    internal static bool TryForcePrimaryFontOnTextSkin(object? textSkin, string? finalText)
+    {
+        if (textSkin is not Component)
+        {
+            return false;
+        }
+
+        if (!TryGetTextMeshPro(textSkin, out var tmp) || tmp is null)
+        {
+            LogDiagnostics(textSkin, null, finalText, applied: false);
+            return false;
+        }
+
+        if (tmp.gameObject is null || !tmp.gameObject.activeInHierarchy || !tmp.isActiveAndEnabled)
+        {
+            return false;
+        }
+
+        InvokeIfPresent(textSkin, "Apply");
+        _ = FontManager.TryWarmPrimaryFontCharactersForUi(finalText);
+        FontManager.ForcePrimaryFont(tmp);
+        if (tmp.font is not null)
+        {
+            tmp.fontSharedMaterial = tmp.font.material;
+        }
+
+        if (tmp.maxVisibleCharacters <= 0)
+        {
+            tmp.maxVisibleCharacters = int.MaxValue;
+        }
+
+        if (tmp.maxVisibleLines <= 0)
+        {
+            tmp.maxVisibleLines = int.MaxValue;
+        }
+
+        if (tmp.pageToDisplay <= 0)
+        {
+            tmp.pageToDisplay = 1;
+        }
+
+        var currentText = tmp.text;
+        tmp.UpdateMeshPadding();
+        InvokeIfPresent(tmp, "SetAllDirty");
+        InvokeIfPresent(tmp, "SetVerticesDirty");
+        InvokeIfPresent(tmp, "SetLayoutDirty");
+        InvokeIfPresent(tmp, "SetMaterialDirty");
+        InvokeIfPresent(tmp, "RecalculateClipping");
+        InvokeIfPresent(tmp, "RecalculateMasking");
+        tmp.havePropertiesChanged = true;
+        tmp.text = currentText;
+        ForceUpdateCanvases();
+        tmp.ForceMeshUpdate(ignoreActiveState: true, forceTextReparsing: true);
+        LogDiagnostics(textSkin, tmp, finalText, applied: true);
+        return tmp.textInfo.characterCount > 0;
+    }
+
+    internal static bool IsActiveItemLine(object? inventoryLineInstance)
+    {
+        if (inventoryLineInstance is not Component component
+            || component.gameObject is null
+            || !component.gameObject.activeInHierarchy)
+        {
+            return false;
+        }
+
+        if (GetPropertyOrFieldValue(inventoryLineInstance, "categoryMode") is GameObject categoryMode
+            && categoryMode.activeSelf)
+        {
+            return false;
+        }
+
+        if (GetPropertyOrFieldValue(inventoryLineInstance, "itemMode") is GameObject itemMode
+            && !itemMode.activeSelf)
+        {
+            return false;
+        }
+
         return true;
+    }
+
+    internal static bool TryRefreshActiveItemLine(object? inventoryLineInstance)
+    {
+        if (!IsActiveItemLine(inventoryLineInstance))
+        {
+            return false;
+        }
+
+        return TryForcePrimaryFontOnTextSkin(
+            GetPropertyOrFieldValue(inventoryLineInstance, "text"),
+            GetActiveItemLineText(inventoryLineInstance));
+    }
+
+    internal static string? GetActiveItemLineText(object? inventoryLineInstance)
+    {
+        var textSkin = GetPropertyOrFieldValue(inventoryLineInstance, "text");
+        var currentText = TryGetStringPropertyOrField(textSkin, "text");
+        if (currentText is null)
+        {
+            currentText = TryGetStringPropertyOrField(textSkin, "Text");
+        }
+
+        return currentText;
+    }
+
+    internal static bool HasActiveReplacementForCurrentItemText(object? inventoryLineInstance)
+    {
+        return TextShellReplacementRenderer.HasActiveReplacementForCurrentItemText(inventoryLineInstance);
+    }
+
+    internal static bool TryRefreshActiveItemLineDelayed(object? inventoryLineInstance)
+    {
+        return TryRefreshActiveItemLine(inventoryLineInstance);
     }
 
     internal static int TryApplyPrimaryFontToAllTextChildren(object? inventoryLineInstance)
@@ -123,6 +229,124 @@ internal static class InventoryLineFontFixer
         var nonPublicField = type.GetField(memberName, System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
 #pragma warning restore S3011
         return nonPublicField?.GetValue(instance);
+    }
+
+    private static bool TryGetTextMeshPro(object? textSkin, out TextMeshProUGUI? tmp)
+    {
+        tmp = null;
+        if (textSkin is null)
+        {
+            return false;
+        }
+
+        if (textSkin is Component component)
+        {
+            tmp = component.GetComponent<TextMeshProUGUI>();
+            if (tmp is not null)
+            {
+                return true;
+            }
+        }
+
+        tmp = Access(textSkin, "_tmp") as TextMeshProUGUI
+            ?? Access(textSkin, "tmp") as TextMeshProUGUI;
+        return tmp is not null;
+    }
+
+    private static void LogDiagnostics(object? textSkin, TextMeshProUGUI? tmp, string? finalText, bool applied)
+    {
+        var count = Interlocked.Increment(ref diagnosticsCount);
+        if (count > MaxDiagnostics)
+        {
+            return;
+        }
+
+        try
+        {
+            var textInfo = tmp?.textInfo;
+            var rect = tmp?.rectTransform?.rect;
+            Debug.Log(
+                "[QudJP] InventoryLineFontFixer/v1: "
+                + $"applied={applied} "
+                + $"textSkin='{textSkin?.GetType().FullName ?? "<null>"}' "
+                + $"tmp='{tmp?.GetType().FullName ?? "<null>"}' "
+                + $"font='{tmp?.font?.name ?? "<null>"}' "
+                + $"source='{finalText ?? string.Empty}' "
+                + $"tmpText='{tmp?.text ?? string.Empty}' "
+                + $"charCount={textInfo?.characterCount.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "<null>"} "
+                + $"pageCount={textInfo?.pageCount.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "<null>"} "
+                + $"tmpAlpha={tmp?.alpha.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "<null>"} "
+                + $"fontSize={tmp?.fontSize.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "<null>"} "
+                + $"maxChars={tmp?.maxVisibleCharacters.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "<null>"} "
+                + $"maxLines={tmp?.maxVisibleLines.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "<null>"} "
+                + $"pageToDisplay={tmp?.pageToDisplay.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "<null>"} "
+                + $"richText={tmp?.richText.ToString() ?? "<null>"} "
+                + $"enabled={tmp?.enabled.ToString() ?? "<null>"} "
+                + $"activeAndEnabled={tmp?.isActiveAndEnabled.ToString() ?? "<null>"} "
+                + $"activeSelf={tmp?.gameObject?.activeSelf.ToString() ?? "<null>"} "
+                + $"activeInHierarchy={tmp?.gameObject?.activeInHierarchy.ToString() ?? "<null>"} "
+                + $"cull={ReadCanvasCull(tmp)} "
+                + $"rect={rect?.width.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "<null>"}x{rect?.height.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "<null>"}");
+        }
+        catch (Exception ex)
+        {
+            Debug.LogWarning($"[QudJP] InventoryLineFontFixer diagnostics failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static string ReadCanvasCull(TextMeshProUGUI? tmp)
+    {
+        if (tmp is null)
+        {
+            return "<null>";
+        }
+
+        var canvasRendererProperty = tmp.GetType().GetProperty("canvasRenderer");
+        var canvasRenderer = canvasRendererProperty?.GetValue(tmp);
+        if (canvasRenderer is null)
+        {
+            return "<null>";
+        }
+
+        var cullProperty = canvasRenderer.GetType().GetProperty("cull");
+        var cull = cullProperty?.GetValue(canvasRenderer);
+        return cull?.ToString() ?? "<null>";
+    }
+
+    private static void InvokeIfPresent(object target, string methodName)
+    {
+        try
+        {
+            _ = target.GetType().GetMethod(methodName, Type.EmptyTypes)?.Invoke(target, Array.Empty<object>());
+        }
+        catch (Exception ex)
+        {
+            Debug.LogWarning($"[QudJP] InventoryLineFontFixer: {methodName} failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static void ForceUpdateCanvases()
+    {
+        try
+        {
+            var canvasType = Type.GetType("UnityEngine.Canvas, UnityEngine.CoreModule", throwOnError: false);
+            if (canvasType is null)
+            {
+                canvasType = Type.GetType("UnityEngine.Canvas, UnityEngine", throwOnError: false);
+            }
+
+            var method = canvasType?.GetMethod(
+                "ForceUpdateCanvases",
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static,
+                binder: null,
+                types: Type.EmptyTypes,
+                modifiers: null);
+            method?.Invoke(null, null);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogWarning($"[QudJP] InventoryLineFontFixer: ForceUpdateCanvases failed: {ex.GetType().Name}: {ex.Message}");
+        }
     }
 #endif
 }

--- a/Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs
@@ -32,11 +32,6 @@ internal static class InventoryLineFontFixer
 
     internal static bool TryForcePrimaryFontOnTextSkin(object? textSkin, string? finalText)
     {
-        if (textSkin is not Component)
-        {
-            return false;
-        }
-
         if (!TryGetTextMeshPro(textSkin, out var tmp) || tmp is null)
         {
             LogDiagnostics(textSkin, null, finalText, applied: false);
@@ -48,7 +43,10 @@ internal static class InventoryLineFontFixer
             return false;
         }
 
-        InvokeIfPresent(textSkin, "Apply");
+        if (textSkin is not null)
+        {
+            InvokeIfPresent(textSkin, "Apply");
+        }
         _ = FontManager.TryWarmPrimaryFontCharactersForUi(finalText);
         FontManager.ForcePrimaryFont(tmp);
         if (tmp.font is not null)
@@ -324,7 +322,12 @@ internal static class InventoryLineFontFixer
     {
         try
         {
-            var canvasType = Type.GetType("UnityEngine.Canvas, UnityEngine.CoreModule", throwOnError: false);
+            var canvasType = Type.GetType("UnityEngine.Canvas, UnityEngine.UIModule", throwOnError: false);
+            if (canvasType is null)
+            {
+                canvasType = Type.GetType("UnityEngine.Canvas, UnityEngine.CoreModule", throwOnError: false);
+            }
+
             if (canvasType is null)
             {
                 canvasType = Type.GetType("UnityEngine.Canvas, UnityEngine", throwOnError: false);

--- a/Mods/QudJP/Assemblies/src/UI/TextShellReplacementRenderer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/TextShellReplacementRenderer.cs
@@ -45,9 +45,16 @@ internal static class TextShellReplacementRenderer
         return string.IsNullOrEmpty(originalText) ? currentReplacementText : originalText;
     }
 
-    internal static bool ResolvePreservedReplacementActiveSelfForTests(bool originalActiveSelf)
+    internal static bool ResolvePreservedReplacementActiveSelfForTests(bool originalActiveSelf, bool originalActiveInHierarchy)
     {
-        return originalActiveSelf;
+        return originalActiveSelf && originalActiveInHierarchy;
+    }
+
+    internal static bool ShouldRestoreOriginalAfterFailedPreservedReuseForTests(
+        bool originalActiveSelf,
+        bool originalActiveInHierarchy)
+    {
+        return originalActiveSelf && originalActiveInHierarchy;
     }
 
     private static ReplacementRenderAction DecideRenderAction(
@@ -107,7 +114,10 @@ internal static class TextShellReplacementRenderer
                     continue;
                 }
 
-                continue;
+                if (!TryRestoreOriginalAfterFailedPreservedReuse(original.transform.parent, original))
+                {
+                    continue;
+                }
             }
 
             if (renderAction == ReplacementRenderAction.DisableReplacement)
@@ -224,6 +234,43 @@ internal static class TextShellReplacementRenderer
 
         logLine = builder.ToString();
         return replaced;
+    }
+
+    internal static bool HasActiveReplacementForCurrentItemText(object? componentInstance)
+    {
+        if (componentInstance is not Component component)
+        {
+            return false;
+        }
+
+        var texts = component.GetComponentsInChildren<TextMeshProUGUI>(includeInactive: true);
+        for (var index = 0; index < texts.Length; index++)
+        {
+            var original = texts[index];
+            var relativePath = BuildRelativePath(component.transform, original.transform);
+            if (!IsTextShellLeaf(relativePath) || string.IsNullOrEmpty(original.text))
+            {
+                continue;
+            }
+
+            var replacementTransform = original.transform.parent?.Find(ReplacementObjectName);
+            var replacement = replacementTransform?.GetComponent<TextMeshProUGUI>();
+            if (replacement is null
+                || !replacement.enabled
+                || !replacement.gameObject.activeInHierarchy
+                || !string.Equals(replacement.text, original.text, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            replacement.ForceMeshUpdate(ignoreActiveState: true, forceTextReparsing: false);
+            if (replacement.textInfo.characterCount > 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     internal static TextOverflowModes GetReplacementOverflowModeForTests()
@@ -462,6 +509,21 @@ internal static class TextShellReplacementRenderer
         return true;
     }
 
+    private static bool TryRestoreOriginalAfterFailedPreservedReuse(Transform? shell, TextMeshProUGUI original)
+    {
+        if (!ShouldRestoreOriginalAfterFailedPreservedReuseForTests(
+            original.gameObject.activeSelf,
+            original.gameObject.activeInHierarchy))
+        {
+            return false;
+        }
+
+        TryDisableReplacement(shell);
+        original.enabled = true;
+        original.ForceMeshUpdate(ignoreActiveState: true, forceTextReparsing: true);
+        return original.textInfo.characterCount == 0;
+    }
+
     private static void TrySyncPreservedReplacementState(Transform? shell, TextMeshProUGUI original)
     {
         if (shell is null)
@@ -484,8 +546,11 @@ internal static class TextShellReplacementRenderer
         var currentReplacementText = replacement.text;
         SyncReplacement(replacement, original);
         replacement.text = ResolvePreservedReplacementTextForTests(currentReplacementText, original.text);
-        replacement.gameObject.SetActive(ResolvePreservedReplacementActiveSelfForTests(original.gameObject.activeSelf));
-        replacement.enabled = !string.IsNullOrEmpty(replacement.text);
+        var replacementActive = ResolvePreservedReplacementActiveSelfForTests(
+            original.gameObject.activeSelf,
+            original.gameObject.activeInHierarchy);
+        replacement.gameObject.SetActive(replacementActive);
+        replacement.enabled = replacementActive && !string.IsNullOrEmpty(replacement.text);
         replacement.havePropertiesChanged = true;
         replacement.SetAllDirty();
         if (replacement.gameObject.activeInHierarchy)
@@ -1322,6 +1387,12 @@ internal static class TextShellReplacementRenderer
         return null;
     }
 #else
+    internal static bool HasActiveReplacementForCurrentItemText(object? componentInstance)
+    {
+        _ = componentInstance;
+        return false;
+    }
+
     internal static int TryRenderReplacementTexts(object? componentInstance, out string? logLine)
     {
         _ = componentInstance;

--- a/Mods/QudJP/Assemblies/src/UI/TextShellReplacementRenderer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/TextShellReplacementRenderer.cs
@@ -13,7 +13,8 @@ namespace QudJP;
 
 internal static class TextShellReplacementRenderer
 {
-#if HAS_TMP
+    private const string ReplacementObjectName = "QudJPReplacementText";
+
     internal enum ReplacementRenderAction
     {
         AttemptReplacement,
@@ -21,7 +22,50 @@ internal static class TextShellReplacementRenderer
         DisableReplacement,
     }
 
-    private const string ReplacementObjectName = "QudJPReplacementText";
+    internal static bool ShouldPreserveActiveReplacementForTests(bool originalEnabled, bool originalActiveInHierarchy)
+    {
+        return !originalEnabled || !originalActiveInHierarchy;
+    }
+
+    internal static ReplacementRenderAction DecideRenderActionForTests(
+        bool originalEnabled,
+        bool originalActiveInHierarchy,
+        int originalCharacterCount)
+    {
+        return DecideRenderAction(originalEnabled, originalActiveInHierarchy, originalCharacterCount);
+    }
+
+    internal static bool IsReplacementTextNameForTests(string objectName)
+    {
+        return string.Equals(objectName, ReplacementObjectName, StringComparison.Ordinal);
+    }
+
+    internal static string ResolvePreservedReplacementTextForTests(string currentReplacementText, string originalText)
+    {
+        return string.IsNullOrEmpty(originalText) ? currentReplacementText : originalText;
+    }
+
+    internal static bool ResolvePreservedReplacementActiveSelfForTests(bool originalActiveSelf)
+    {
+        return originalActiveSelf;
+    }
+
+    private static ReplacementRenderAction DecideRenderAction(
+        bool originalEnabled,
+        bool originalActiveInHierarchy,
+        int originalCharacterCount)
+    {
+        if (originalEnabled && originalActiveInHierarchy && originalCharacterCount == 0)
+        {
+            return ReplacementRenderAction.AttemptReplacement;
+        }
+
+        return ShouldPreserveActiveReplacementForTests(originalEnabled, originalActiveInHierarchy)
+            ? ReplacementRenderAction.PreserveActiveReplacement
+            : ReplacementRenderAction.DisableReplacement;
+    }
+
+#if HAS_TMP
     private const string LegacyReplacementObjectName = "QudJPReplacementLegacyText";
     private static readonly ConcurrentDictionary<string, byte> FailureProbeLogged = new();
     private static readonly ConcurrentDictionary<string, byte> DisableProbeLogged = new();
@@ -51,14 +95,23 @@ internal static class TextShellReplacementRenderer
             }
 
             original.ForceMeshUpdate(ignoreActiveState: true, forceTextReparsing: true);
-            if (!original.enabled || !original.gameObject.activeInHierarchy || original.textInfo.characterCount > 0)
+            var renderAction = DecideRenderAction(
+                original.enabled,
+                original.gameObject.activeInHierarchy,
+                original.textInfo.characterCount);
+            if (renderAction == ReplacementRenderAction.PreserveActiveReplacement)
             {
-                if (!original.enabled
-                    && TryReuseActiveReplacement(original.transform.parent, relativePath, builder, ref replaced))
+                TrySyncPreservedReplacementState(original.transform.parent, original);
+                if (TryReuseActiveReplacement(original.transform.parent, relativePath, builder, ref replaced))
                 {
                     continue;
                 }
 
+                continue;
+            }
+
+            if (renderAction == ReplacementRenderAction.DisableReplacement)
+            {
                 if (TryBuildDisableProbe(component, relativePath, original, out var disableLog)
                     && disableLog is not null
                     && disableLog.Length > 0)
@@ -173,27 +226,9 @@ internal static class TextShellReplacementRenderer
         return replaced;
     }
 
-    internal static bool ShouldPreserveActiveReplacementForTests(bool originalEnabled, bool originalActiveInHierarchy)
-    {
-        return !originalEnabled || !originalActiveInHierarchy;
-    }
-
-    internal static ReplacementRenderAction DecideRenderActionForTests(
-        bool originalEnabled,
-        bool originalActiveInHierarchy,
-        int originalCharacterCount)
-    {
-        return DecideRenderAction(originalEnabled, originalActiveInHierarchy, originalCharacterCount);
-    }
-
     internal static TextOverflowModes GetReplacementOverflowModeForTests()
     {
         return TextOverflowModes.Overflow;
-    }
-
-    internal static bool IsReplacementTextNameForTests(string objectName)
-    {
-        return string.Equals(objectName, ReplacementObjectName, StringComparison.Ordinal);
     }
 
     internal static bool TryBuildReplacementLifecycleSnapshot(
@@ -427,6 +462,38 @@ internal static class TextShellReplacementRenderer
         return true;
     }
 
+    private static void TrySyncPreservedReplacementState(Transform? shell, TextMeshProUGUI original)
+    {
+        if (shell is null)
+        {
+            return;
+        }
+
+        var replacementTransform = shell.Find(ReplacementObjectName);
+        if (replacementTransform is null)
+        {
+            return;
+        }
+
+        var replacement = replacementTransform.GetComponent<TextMeshProUGUI>();
+        if (replacement is null)
+        {
+            return;
+        }
+
+        var currentReplacementText = replacement.text;
+        SyncReplacement(replacement, original);
+        replacement.text = ResolvePreservedReplacementTextForTests(currentReplacementText, original.text);
+        replacement.gameObject.SetActive(ResolvePreservedReplacementActiveSelfForTests(original.gameObject.activeSelf));
+        replacement.enabled = !string.IsNullOrEmpty(replacement.text);
+        replacement.havePropertiesChanged = true;
+        replacement.SetAllDirty();
+        if (replacement.gameObject.activeInHierarchy)
+        {
+            replacement.ForceMeshUpdate(ignoreActiveState: true, forceTextReparsing: true);
+        }
+    }
+
     private static bool TryRecoverDegradedReplacement(TextMeshProUGUI replacement)
     {
         if (!replacement.enabled || !replacement.gameObject.activeInHierarchy || string.IsNullOrEmpty(replacement.text))
@@ -483,21 +550,6 @@ internal static class TextShellReplacementRenderer
         TryInvokeLifecycleMethod(replacement, "RecalculateClipping");
         TryInvokeLifecycleMethod(replacement, "RecalculateMasking");
         TryForceCanvasUpdate();
-    }
-
-    private static ReplacementRenderAction DecideRenderAction(
-        bool originalEnabled,
-        bool originalActiveInHierarchy,
-        int originalCharacterCount)
-    {
-        if (originalEnabled && originalActiveInHierarchy && originalCharacterCount == 0)
-        {
-            return ReplacementRenderAction.AttemptReplacement;
-        }
-
-        return ShouldPreserveActiveReplacementForTests(originalEnabled, originalActiveInHierarchy)
-            ? ReplacementRenderAction.PreserveActiveReplacement
-            : ReplacementRenderAction.DisableReplacement;
     }
 
     private static void TryDisableLegacyReplacement(Transform? parent)

--- a/Mods/QudJP/Assemblies/src/UI/TextShellReplacementRenderer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/TextShellReplacementRenderer.cs
@@ -114,7 +114,7 @@ internal static class TextShellReplacementRenderer
                     continue;
                 }
 
-                if (!TryRestoreOriginalAfterFailedPreservedReuse(original.transform.parent, original))
+                if (!RestoreOriginalAndCheckIfStillEmpty(original.transform.parent, original))
                 {
                     continue;
                 }
@@ -509,7 +509,7 @@ internal static class TextShellReplacementRenderer
         return true;
     }
 
-    private static bool TryRestoreOriginalAfterFailedPreservedReuse(Transform? shell, TextMeshProUGUI original)
+    private static bool RestoreOriginalAndCheckIfStillEmpty(Transform? shell, TextMeshProUGUI original)
     {
         if (!ShouldRestoreOriginalAfterFailedPreservedReuseForTests(
             original.gameObject.activeSelf,

--- a/Mods/QudJP/Assemblies/src/UI/TextShellReplacementRenderer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/TextShellReplacementRenderer.cs
@@ -1,5 +1,6 @@
-#if HAS_TMP
 using System;
+
+#if HAS_TMP
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Diagnostics;
@@ -47,7 +48,8 @@ internal static class TextShellReplacementRenderer
 
     internal static bool ResolvePreservedReplacementActiveSelfForTests(bool originalActiveSelf, bool originalActiveInHierarchy)
     {
-        return originalActiveSelf && originalActiveInHierarchy;
+        _ = originalActiveInHierarchy;
+        return originalActiveSelf;
     }
 
     internal static bool ShouldRestoreOriginalAfterFailedPreservedReuseForTests(
@@ -546,11 +548,11 @@ internal static class TextShellReplacementRenderer
         var currentReplacementText = replacement.text;
         SyncReplacement(replacement, original);
         replacement.text = ResolvePreservedReplacementTextForTests(currentReplacementText, original.text);
-        var replacementActive = ResolvePreservedReplacementActiveSelfForTests(
+        var replacementActiveSelf = ResolvePreservedReplacementActiveSelfForTests(
             original.gameObject.activeSelf,
             original.gameObject.activeInHierarchy);
-        replacement.gameObject.SetActive(replacementActive);
-        replacement.enabled = replacementActive && !string.IsNullOrEmpty(replacement.text);
+        replacement.gameObject.SetActive(replacementActiveSelf);
+        replacement.enabled = replacementActiveSelf && !string.IsNullOrEmpty(replacement.text);
         replacement.havePropertiesChanged = true;
         replacement.SetAllDirty();
         if (replacement.gameObject.activeInHierarchy)

--- a/Mods/QudJP/Localization/Dictionaries/ui-inventory-actions.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-inventory-actions.ja.json
@@ -30,7 +30,7 @@
       "text": "メモを削除"
     },
     {
-      "key": "Remove",
+      "key": "remove",
       "context": "XRL.World.IInventoryActionsEvent",
       "text": "外す"
     },

--- a/Mods/QudJP/Localization/Dictionaries/ui-inventory-actions.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-inventory-actions.ja.json
@@ -10,22 +10,22 @@
   },
   "entries": [
     {
-      "key": "Mark Important",
+      "key": "mark important",
       "context": "XRL.World.IInventoryActionsEvent",
-      "text": "重要にマーク"
+      "text": "重要にする"
     },
     {
-      "key": "Mark Unimportant",
+      "key": "mark unimportant",
       "context": "XRL.World.IInventoryActionsEvent",
       "text": "重要マークを外す"
     },
     {
-      "key": "Add Notes",
+      "key": "add notes",
       "context": "XRL.World.IInventoryActionsEvent",
       "text": "メモを追加"
     },
     {
-      "key": "Remove Notes",
+      "key": "remove notes",
       "context": "XRL.World.IInventoryActionsEvent",
       "text": "メモを削除"
     },

--- a/Mods/QudJP/Localization/Dictionaries/ui-messagelog-leaf.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-messagelog-leaf.ja.json
@@ -158,7 +158,7 @@
         },
         {
             "key": "You embark for the caves of Qud.",
-            "text": "あなたはクッドの洞窟へ旅立った。"
+            "text": "クッドの洞窟へ旅立つ。"
         },
         {
             "key": "You can't see!",

--- a/Mods/QudJP/Localization/Dictionaries/ui-messagelog-world.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-messagelog-world.ja.json
@@ -137,7 +137,7 @@
         {
             "key": "You embark for the caves of Qud.",
             "context": "XRL.Messages.MessageQueue",
-            "text": "クッドの洞窟へ向かう。"
+            "text": "クッドの洞窟へ旅立つ。"
         },
         {
             "key": " [toggled off]",

--- a/Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json
@@ -167,20 +167,8 @@
             "text": "落とす"
         },
         {
-            "key": "mark important",
-            "text": "重要にする"
-        },
-        {
             "key": "learn",
             "text": "習得"
-        },
-        {
-            "key": "add Notes",
-            "text": "メモを追加"
-        },
-        {
-            "key": "add notes",
-            "text": "メモを追加"
         },
         {
             "key": "View final messages",

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.2.42",
+  "Version": "0.2.43",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/release-notes/unreleased/inventory-action-labels.md
+++ b/docs/release-notes/unreleased/inventory-action-labels.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Corrected inventory action labels such as remove, notes, and important markers.

--- a/docs/release-notes/unreleased/inventory-action-labels.md
+++ b/docs/release-notes/unreleased/inventory-action-labels.md
@@ -1,3 +1,4 @@
 ### Fixed
 
 - Corrected inventory action labels such as remove, notes, and important markers.
+- Unified the Japanese text for embarking for the caves of Qud.

--- a/justfile
+++ b/justfile
@@ -130,6 +130,11 @@ release-zip-check release_zip="":
       )
   print(f"{zip_path}: required release files present")
   PY
+  if [ -n "{{release_zip}}" ]; then \
+    {{python}} scripts/verify_release_dll.py "{{release_zip}}"; \
+  else \
+    {{python}} scripts/verify_release_dll.py "$(ls -t dist/QudJP-v*.zip | head -1)"; \
+  fi
 
 # Run the Workshop shipping preflight for an already-tagged release.
 workshop-preflight version:

--- a/justfile
+++ b/justfile
@@ -78,23 +78,32 @@ build-release:
 release-zip-check release_zip="":
   #!/usr/bin/env bash
   set -euo pipefail
-  export QUDJP_RELEASE_ZIP="{{release_zip}}"
+  if [ -n "{{release_zip}}" ]; then
+    chosen_zip="{{release_zip}}"
+  else
+    chosen_zip="$({{python}} - <<'PY'
+  from pathlib import Path
+
+  release_archives = sorted(
+      Path("dist").glob("QudJP-v*.zip"),
+      key=lambda path: (path.stat().st_mtime, path.name),
+  )
+  if not release_archives:
+      raise SystemExit("dist/: no QudJP-v*.zip release archive found")
+  print(release_archives[-1])
+  PY
+  )"
+  fi
+  export QUDJP_RELEASE_ZIP="$chosen_zip"
   {{python}} - <<'PY'
   import os
   import zipfile
   from pathlib import Path
 
   requested = os.environ.get("QUDJP_RELEASE_ZIP", "")
-  if requested:
-      zip_path = Path(requested)
-  else:
-      release_archives = sorted(
-          Path("dist").glob("QudJP-v*.zip"),
-          key=lambda path: (path.stat().st_mtime, path.name),
-      )
-      if not release_archives:
-          raise SystemExit("dist/: no QudJP-v*.zip release archive found")
-      zip_path = release_archives[-1]
+  if not requested:
+      raise SystemExit("QUDJP_RELEASE_ZIP is empty")
+  zip_path = Path(requested)
 
   required = {
       "QudJP/manifest.json",
@@ -130,11 +139,7 @@ release-zip-check release_zip="":
       )
   print(f"{zip_path}: required release files present")
   PY
-  if [ -n "{{release_zip}}" ]; then \
-    {{python}} scripts/verify_release_dll.py "{{release_zip}}"; \
-  else \
-    {{python}} scripts/verify_release_dll.py "$(ls -t dist/QudJP-v*.zip | head -1)"; \
-  fi
+  {{python}} scripts/verify_release_dll.py "$chosen_zip"
 
 # Run the Workshop shipping preflight for an already-tagged release.
 workshop-preflight version:

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -282,6 +282,7 @@ def build_release() -> None:
     )
     missing_markers = verify_release_dll(output_path)
     if missing_markers:
+        output_path.unlink(missing_ok=True)
         msg = "release DLL missing required marker(s): " + ", ".join(missing_markers)
         raise ValueError(msg)
 

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -26,6 +26,11 @@ import sys
 import zipfile
 from pathlib import Path
 
+try:
+    from scripts.verify_release_dll import verify_release_dll
+except ModuleNotFoundError:
+    from verify_release_dll import verify_release_dll
+
 _LOCALIZATION_ASSET_SUFFIXES = {".json", ".txt", ".xml"}
 
 
@@ -275,6 +280,10 @@ def build_release() -> None:
         localization_files,
         legal_files=legal_files,
     )
+    missing_markers = verify_release_dll(output_path)
+    if missing_markers:
+        msg = "release DLL missing required marker(s): " + ", ".join(missing_markers)
+        raise ValueError(msg)
 
     print(f"\nCreated: {output_path}")  # noqa: T201
     print(f"Contents ({len(members)} files):")  # noqa: T201

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -513,11 +513,40 @@ class TestBuildReleaseImport:
             patch("scripts.build_release.build_dll", return_value=dll),
             patch("scripts.build_release.collect_localization_files", return_value=[]),
             patch("scripts.build_release.create_zip", return_value=[]) as create_zip_mock,
+            patch("scripts.build_release.verify_release_dll", return_value=[]) as verify_release_dll_mock,
         ):
             build_release()
 
         create_zip_mock.assert_called_once()
-        assert create_zip_mock.call_args.args[0] == tmp_path / "dist" / "QudJP-v1.2.3.zip"
+        output_path = tmp_path / "dist" / "QudJP-v1.2.3.zip"
+        assert create_zip_mock.call_args.args[0] == output_path
+        verify_release_dll_mock.assert_called_once_with(output_path)
+
+    def test_build_release_rejects_release_dll_missing_required_markers(self, tmp_path: Path) -> None:
+        """Release ZIP creation fails when the packaged DLL lacks required markers."""
+        mod_dir = tmp_path / "Mods" / "QudJP"
+        loc_dir = mod_dir / "Localization"
+        mod_dir.mkdir(parents=True)
+        loc_dir.mkdir()
+        manifest = mod_dir / "manifest.json"
+        manifest.write_text(json.dumps({"Version": "1.2.3"}), encoding="utf-8")
+        dll = mod_dir / "Assemblies" / "QudJP.dll"
+        dll.parent.mkdir()
+        dll.write_bytes(b"dll")
+        license_file = tmp_path / "LICENSE"
+        license_file.write_text("license", encoding="utf-8")
+        notice_file = tmp_path / "NOTICE.md"
+        notice_file.write_text("notice", encoding="utf-8")
+
+        with (
+            patch("scripts.build_release._find_project_root", return_value=tmp_path),
+            patch("scripts.build_release.build_dll", return_value=dll),
+            patch("scripts.build_release.collect_localization_files", return_value=[]),
+            patch("scripts.build_release.create_zip", return_value=[]),
+            patch("scripts.build_release.verify_release_dll", return_value=["InventoryLineFontFixer"]),
+            pytest.raises(ValueError, match="release DLL missing required marker\\(s\\): InventoryLineFontFixer"),
+        ):
+            build_release()
 
     def test_build_dll_raises_on_missing_dll(self, tmp_path: Path) -> None:
         """build_dll raises FileNotFoundError when DLL is absent after build."""

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -467,6 +467,12 @@ class TestCreateZip:
             )
 
 
+def _write_marker_reject_fixture_zip(output_path: Path, *_args: object, **_kwargs: object) -> list[str]:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(b"zip")
+    return []
+
+
 class TestBuildReleaseImport:
     """Smoke test: module imports without error."""
 
@@ -542,11 +548,12 @@ class TestBuildReleaseImport:
             patch("scripts.build_release._find_project_root", return_value=tmp_path),
             patch("scripts.build_release.build_dll", return_value=dll),
             patch("scripts.build_release.collect_localization_files", return_value=[]),
-            patch("scripts.build_release.create_zip", return_value=[]),
+            patch("scripts.build_release.create_zip", side_effect=_write_marker_reject_fixture_zip),
             patch("scripts.build_release.verify_release_dll", return_value=["InventoryLineFontFixer"]),
             pytest.raises(ValueError, match="release DLL missing required marker\\(s\\): InventoryLineFontFixer"),
         ):
             build_release()
+        assert not (tmp_path / "dist" / "QudJP-v1.2.3.zip").exists()
 
     def test_build_dll_raises_on_missing_dll(self, tmp_path: Path) -> None:
         """build_dll raises FileNotFoundError when DLL is absent after build."""

--- a/scripts/tests/test_verify_release_dll.py
+++ b/scripts/tests/test_verify_release_dll.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import zipfile
+from typing import TYPE_CHECKING
+
+from scripts.verify_release_dll import verify_release_dll
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_verify_release_dll_accepts_required_markers(tmp_path: Path) -> None:
+    """Accept a DLL that contains all required runtime markers."""
+    dll = tmp_path / "QudJP.dll"
+    dll.write_bytes(
+        b"\0".join(
+            [
+                b"Unity.TextMeshPro",
+                b"TextMeshProUguiFontPatch",
+                b"TmpInputFieldFontPatch",
+                b"InventoryLineFontFixer",
+                b"DelayedInventoryLineRepairScheduler",
+                b"ShouldPreserveActiveReplacementForTests",
+            ],
+        ),
+    )
+
+    assert verify_release_dll(dll) == []
+
+
+def test_verify_release_dll_reports_missing_markers(tmp_path: Path) -> None:
+    """Report every missing required runtime marker."""
+    dll = tmp_path / "QudJP.dll"
+    dll.write_bytes(b"Unity.TextMeshPro")
+
+    assert verify_release_dll(dll) == [
+        "TextMeshProUguiFontPatch",
+        "TmpInputFieldFontPatch",
+        "InventoryLineFontFixer",
+        "DelayedInventoryLineRepairScheduler",
+        "ShouldPreserveActiveReplacementForTests",
+    ]
+
+
+def test_verify_release_dll_reads_release_zip(tmp_path: Path) -> None:
+    """Read QudJP.dll from a release ZIP before checking markers."""
+    release_zip = tmp_path / "QudJP-v0.0.0.zip"
+    with zipfile.ZipFile(release_zip, "w") as archive:
+        archive.writestr(
+            "QudJP/Assemblies/QudJP.dll",
+            b"\0".join(
+                [
+                    b"Unity.TextMeshPro",
+                    b"TextMeshProUguiFontPatch",
+                    b"TmpInputFieldFontPatch",
+                    b"InventoryLineFontFixer",
+                    b"DelayedInventoryLineRepairScheduler",
+                    b"ShouldPreserveActiveReplacementForTests",
+                ],
+            ),
+        )
+
+    assert verify_release_dll(release_zip) == []

--- a/scripts/translation_token_duplicate_baseline.json
+++ b/scripts/translation_token_duplicate_baseline.json
@@ -118,7 +118,7 @@
         },
         {
           "path": "Dictionaries/ui-popup.ja.json",
-          "entry_index": 383,
+          "entry_index": 380,
           "text": "……"
         }
       ]
@@ -1358,34 +1358,6 @@
     {
       "scope": "cross_file",
       "path": "Dictionaries",
-      "key": "You embark for the caves of Qud.",
-      "entry_count": 3,
-      "texts": [
-        "あなたはクッドの洞窟へ旅立った。",
-        "クッドの洞窟へ向かう。",
-        "クッドの洞窟へ旅立つ。"
-      ],
-      "occurrences": [
-        {
-          "path": "Dictionaries/ui-messagelog-leaf.ja.json",
-          "entry_index": 40,
-          "text": "あなたはクッドの洞窟へ旅立った。"
-        },
-        {
-          "path": "Dictionaries/ui-messagelog-world.ja.json",
-          "entry_index": 29,
-          "text": "クッドの洞窟へ向かう。"
-        },
-        {
-          "path": "Dictionaries/ui-popup.ja.json",
-          "entry_index": 90,
-          "text": "クッドの洞窟へ旅立つ。"
-        }
-      ]
-    },
-    {
-      "scope": "cross_file",
-      "path": "Dictionaries",
       "key": "You entered into a covenant with Resheph to help prepare Qud for the Coven's return.",
       "entry_count": 2,
       "texts": [
@@ -1959,7 +1931,7 @@
       "occurrences": [
         {
           "path": "Dictionaries/ui-popup.ja.json",
-          "entry_index": 79,
+          "entry_index": 76,
           "text": "液体を採取"
         },
         {
@@ -2256,7 +2228,7 @@
         },
         {
           "path": "Dictionaries/ui-popup.ja.json",
-          "entry_index": 109,
+          "entry_index": 106,
           "text": "操作する"
         }
       ]

--- a/scripts/verify_release_dll.py
+++ b/scripts/verify_release_dll.py
@@ -1,0 +1,62 @@
+"""Verify that a QudJP release DLL contains required runtime feature markers."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import zipfile
+from pathlib import Path
+
+_REQUIRED_DLL_MARKERS = (
+    b"Unity.TextMeshPro",
+    b"TextMeshProUguiFontPatch",
+    b"TmpInputFieldFontPatch",
+    b"InventoryLineFontFixer",
+    b"DelayedInventoryLineRepairScheduler",
+    b"ShouldPreserveActiveReplacementForTests",
+)
+
+
+def _read_dll(path: Path) -> bytes:
+    if path.suffix.lower() == ".zip":
+        with zipfile.ZipFile(path) as archive:
+            try:
+                return archive.read("QudJP/Assemblies/QudJP.dll")
+            except KeyError as exc:
+                msg = f"{path}: missing QudJP/Assemblies/QudJP.dll"
+                raise FileNotFoundError(msg) from exc
+
+    return path.read_bytes()
+
+
+def verify_release_dll(path: Path) -> list[str]:
+    """Return release DLL marker names missing from a DLL or release ZIP."""
+    data = _read_dll(path)
+    return [
+        marker.decode("ascii")
+        for marker in _REQUIRED_DLL_MARKERS
+        if marker not in data
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the release DLL marker verifier CLI."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, help="QudJP.dll or QudJP release ZIP")
+    args = parser.parse_args(argv)
+
+    missing = verify_release_dll(args.path)
+    if missing:
+        print(  # noqa: T201
+            f"{args.path}: release DLL is missing required marker(s): "
+            + ", ".join(missing),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"{args.path}: required release DLL markers present")  # noqa: T201
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- fix the InventoryLine TMP replacement path so inactive item rows preserve active replacement text instead of disabling it during collapse/refresh
- include bounded hardening for #556 by re-syncing preserved replacement text state with the owning original row during collapse/refresh
- make CI release builds include the TMP/InventoryLine hardening even when game Managed DLLs are unavailable on the runner
- add a release DLL marker gate so Workshop artifacts fail validation if the required TMP/InventoryLine code is missing
- keep the pure InventoryLine hardening tests active in no-game CI builds
- bump the mod manifest and changelog to `0.2.43`

## Cause
The inventory item-name disappearance had been fixed in local `0.2.42` validation, but the GitHub Actions release environment did not have `Unity.TextMeshPro.dll`. As a result, the release/Workshop DLL was built without `HAS_TMP`, so the local fix was not actually present in the shipped Workshop artifact. This PR adds reference stubs for CI-time compilation and validates release ZIP DLL contents before shipping.

## #556 Scope
#556 is included as bounded hardening, not treated as fully runtime-confirmed yet. The preserve/reuse path now re-syncs an existing replacement from the current original row before reuse, so preserved item names follow the row's rect/style/alpha/text and `activeSelf` state instead of keeping stale replacement state. Runtime confirmation is still required before closing #556.

## Runtime Evidence
- mac log saved: `.sisyphus/evidence/runtime-confirmed-0.2.43-20260507-030321/mac-Player.log`
- win log saved: `.sisyphus/evidence/runtime-confirmed-0.2.43-20260507-030321/win-Player.log`
- local validation DLL/ZIP contained required release DLL markers

## Follow-up
- #556 should stay open until the new bounded hardening is validated in-game.

## Verification
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj -c Release -p:GameDir=/tmp/qudjp-no-game-dir`
- `python3 scripts/verify_release_dll.py Mods/QudJP/Assemblies/QudJP.dll`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj -c Release -p:GameDir=/tmp/qudjp-no-game-dir --filter "FullyQualifiedName~InventoryReplacementHardeningTests"` (12 tests)
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~InventoryReplacementHardeningTests"` (17 tests)
- `uv run pytest scripts/tests/test_build_release.py scripts/tests/test_verify_release_dll.py -q` (41 tests)
- `ruff check scripts/build_release.py scripts/tests/test_build_release.py scripts/tests/test_verify_release_dll.py scripts/verify_release_dll.py`
- `uv run pytest scripts/tests/`
- `just test-l1`
- `python3 scripts/build_release.py`
- `python3 scripts/verify_release_dll.py dist/QudJP-v0.2.43.zip`
- `just release-zip-check dist/QudJP-v0.2.43.zip`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * インベントリ折りたたみ／更新時のアイテム名置換が正しく保持されるよう修正（位置・色・不透明度・表示状態を維持）
  * 置換が誤って無効化される問題を修正  
  * Steam Workshop向けリリースでのアイテム名修正が確実に反映されるよう修正
* **改善／運用**
  * リリース工程にDLL内容の検証を追加し、不完全なアーティファクトの公開を防止（TextMeshPro非搭載環境への配慮あり）
* **ローカリゼーション**
  * インベントリ操作ラベルの日本語辞書を整理・追加（小文字キー対応など）
* **テスト**
  * 置換ロジックとリリース検証まわりのテストを拡充し、検証カバレッジを強化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->