### PR TITLE
[codex] Separate dev sync display from release builds

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,10 +11,16 @@ default:
 build:
   dotnet build Mods/QudJP/Assemblies/QudJP.csproj
 
+# Build the QudJP assembly for local development.
+build-dev: build
+
 # Clean and rebuild the shipped QudJP assembly without incremental artifacts.
 rebuild:
   dotnet clean Mods/QudJP/Assemblies/QudJP.csproj
   dotnet build Mods/QudJP/Assemblies/QudJP.csproj --no-incremental
+
+# Clean and rebuild the QudJP assembly for local development.
+rebuild-dev: rebuild
 
 # Run fast C# L1 tests.
 test-l1:
@@ -183,9 +189,17 @@ download-release-zip version:
 sync-mod:
   {{python}} scripts/sync_mod.py
 
+# Sync the built mod into the local game install as a local dev build.
+sync-mod-dev:
+  {{python}} scripts/sync_mod.py --dev
+
 # Preview the local mod sync without copying files.
 sync-mod-dry-run:
   {{python}} scripts/sync_mod.py --dry-run
+
+# Preview the local dev sync without copying files.
+sync-mod-dev-dry-run:
+  {{python}} scripts/sync_mod.py --dev --dry-run
 
 # Sync the built mod without copying fonts.
 sync-mod-exclude-fonts:
@@ -195,13 +209,25 @@ sync-mod-exclude-fonts:
 sync-mod-to destination:
   {{python}} scripts/sync_mod.py --destination {{quote(destination)}}
 
+# Sync the built mod to an explicit Mods/QudJP destination as a local dev build.
+sync-mod-dev-to destination:
+  {{python}} scripts/sync_mod.py --dev --destination {{quote(destination)}}
+
 # Rebuild and sync the local mod into the game install.
 deploy-mod: rebuild sync-mod
+
+# Rebuild and sync the local dev mod into the game install.
+deploy-dev: rebuild-dev sync-mod-dev
 
 # Rebuild and sync the local mod to an explicit Mods/QudJP destination.
 deploy-mod-to destination:
   just rebuild
   just sync-mod-to {{quote(destination)}}
+
+# Rebuild and sync the local dev mod to an explicit Mods/QudJP destination.
+deploy-dev-to destination:
+  just rebuild-dev
+  just sync-mod-dev-to {{quote(destination)}}
 
 # Run the Phase F runtime evidence verification commands.
 runtime-evidence-check: test-l1

--- a/justfile
+++ b/justfile
@@ -11,10 +11,16 @@ default:
 build:
   dotnet build Mods/QudJP/Assemblies/QudJP.csproj
 
+# Build the QudJP assembly for local development.
+build-dev: build
+
 # Clean and rebuild the shipped QudJP assembly without incremental artifacts.
 rebuild:
   dotnet clean Mods/QudJP/Assemblies/QudJP.csproj
   dotnet build Mods/QudJP/Assemblies/QudJP.csproj --no-incremental
+
+# Clean and rebuild the QudJP assembly for local development.
+rebuild-dev: rebuild
 
 # Run fast C# L1 tests.
 test-l1:
@@ -193,9 +199,17 @@ download-release-zip version:
 sync-mod:
   {{python}} scripts/sync_mod.py
 
+# Sync the built mod into the local game install as a local dev build.
+sync-mod-dev:
+  {{python}} scripts/sync_mod.py --dev
+
 # Preview the local mod sync without copying files.
 sync-mod-dry-run:
   {{python}} scripts/sync_mod.py --dry-run
+
+# Preview the local dev sync without copying files.
+sync-mod-dev-dry-run:
+  {{python}} scripts/sync_mod.py --dev --dry-run
 
 # Sync the built mod without copying fonts.
 sync-mod-exclude-fonts:
@@ -205,13 +219,25 @@ sync-mod-exclude-fonts:
 sync-mod-to destination:
   {{python}} scripts/sync_mod.py --destination {{quote(destination)}}
 
+# Sync the built mod to an explicit Mods/QudJP destination as a local dev build.
+sync-mod-dev-to destination:
+  {{python}} scripts/sync_mod.py --dev --destination {{quote(destination)}}
+
 # Rebuild and sync the local mod into the game install.
 deploy-mod: rebuild sync-mod
+
+# Rebuild and sync the local dev mod into the game install.
+deploy-dev: rebuild-dev sync-mod-dev
 
 # Rebuild and sync the local mod to an explicit Mods/QudJP destination.
 deploy-mod-to destination:
   just rebuild
   just sync-mod-to {{quote(destination)}}
+
+# Rebuild and sync the local dev mod to an explicit Mods/QudJP destination.
+deploy-dev-to destination:
+  just rebuild-dev
+  just sync-mod-dev-to {{quote(destination)}}
 
 # Run the Phase F runtime evidence verification commands.
 runtime-evidence-check: test-l1

--- a/scripts/sync_mod.py
+++ b/scripts/sync_mod.py
@@ -1,6 +1,7 @@
 """Sync QudJP mod files to the Caves of Qud game directory."""
 
 import argparse
+import json
 import os
 import platform
 import shutil
@@ -37,6 +38,8 @@ _RSYNC_EXCLUDES: tuple[str, ...] = ("*",)
 _LOCAL_ONLY_FILES: tuple[Path, ...] = (Path("workshop.json"),)
 _LOCALIZATION_ASSET_SUFFIXES = {".json", ".txt", ".xml"}
 _WINDOWS_DRIVE_PREFIX_LENGTH = 2
+DEFAULT_DEV_VERSION_SUFFIX = "-dev"
+DEFAULT_DEV_TITLE_SUFFIX = " (local dev)"
 
 _MACOS_MODS_SUFFIX = (
     Path("Library")
@@ -215,16 +218,84 @@ def _iter_sync_files(source: Path, *, exclude_fonts: bool) -> list[Path]:
     return file_paths
 
 
+def _rewrite_manifest_metadata(
+    manifest_data: dict[str, object],
+    *,
+    version_suffix: str | None,
+    title_suffix: str | None,
+) -> dict[str, object]:
+    """Return manifest data with local-only display metadata applied."""
+    rewritten = dict(manifest_data)
+
+    if version_suffix:
+        version = rewritten.get("Version")
+        if not isinstance(version, str) or not version:
+            msg = "manifest.json must contain a non-empty string Version"
+            raise ValueError(msg)
+        rewritten["Version"] = (
+            version if version.endswith(version_suffix) else f"{version}{version_suffix}"
+        )
+
+    if title_suffix:
+        title = rewritten.get("Title")
+        if isinstance(title, str) and title and not title.endswith(title_suffix):
+            rewritten["Title"] = f"{title}{title_suffix}"
+
+    return rewritten
+
+
+def _write_manifest_metadata(
+    source_manifest: Path,
+    destination_manifest: Path,
+    *,
+    version_suffix: str | None,
+    title_suffix: str | None,
+) -> None:
+    """Write destination manifest metadata without mutating the source manifest."""
+    manifest_data = json.loads(source_manifest.read_text(encoding="utf-8"))
+    if not isinstance(manifest_data, dict):
+        msg = "manifest.json must contain a JSON object"
+        raise TypeError(msg)
+
+    rewritten = _rewrite_manifest_metadata(
+        manifest_data,
+        version_suffix=version_suffix,
+        title_suffix=title_suffix,
+    )
+    destination_manifest.parent.mkdir(parents=True, exist_ok=True)
+    destination_manifest.write_text(
+        f"{json.dumps(rewritten, ensure_ascii=False, indent=2)}\n",
+        encoding="utf-8",
+    )
+
+
+def _append_stdout_line(
+    result: subprocess.CompletedProcess[str],
+    line: str,
+) -> subprocess.CompletedProcess[str]:
+    """Return a completed process result with one extra stdout line."""
+    stdout = f"{result.stdout.rstrip()}\n{line}\n" if result.stdout else f"{line}\n"
+    return subprocess.CompletedProcess(
+        args=result.args,
+        returncode=result.returncode,
+        stdout=stdout,
+        stderr=result.stderr,
+    )
+
+
 def _run_python_sync(
     source: Path,
     destination: Path,
     *,
     dry_run: bool,
     exclude_fonts: bool,
+    manifest_version_suffix: str | None,
+    manifest_title_suffix: str | None,
 ) -> subprocess.CompletedProcess[str]:
     """Synchronize files with a pure-Python copy fallback."""
     file_paths = _iter_sync_files(source, exclude_fonts=exclude_fonts)
     lines = ["Using Python copy fallback."]
+    rewrite_manifest = bool(manifest_version_suffix or manifest_title_suffix)
 
     if dry_run:
         action = "replace" if destination.exists() else "create"
@@ -233,6 +304,8 @@ def _run_python_sync(
             f"Would copy {file_path.relative_to(source)}"
             for file_path in file_paths
         )
+        if rewrite_manifest:
+            lines.append("Would rewrite manifest.json display metadata")
         return subprocess.CompletedProcess(
             args=["python-copy"],
             returncode=0,
@@ -250,7 +323,15 @@ def _run_python_sync(
         relative_path = file_path.relative_to(source)
         target_path = destination / relative_path
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(file_path, target_path)
+        if relative_path == Path("manifest.json") and rewrite_manifest:
+            _write_manifest_metadata(
+                file_path,
+                target_path,
+                version_suffix=manifest_version_suffix,
+                title_suffix=manifest_title_suffix,
+            )
+        else:
+            shutil.copy2(file_path, target_path)
 
     lines.append(f"Copied {len(file_paths)} files to {destination}")
     return subprocess.CompletedProcess(
@@ -317,6 +398,8 @@ def run_sync(
     *,
     dry_run: bool = False,
     exclude_fonts: bool = False,
+    manifest_version_suffix: str | None = None,
+    manifest_title_suffix: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Execute sync to copy mod files into the game directory.
 
@@ -325,6 +408,10 @@ def run_sync(
         destination: Destination directory to sync to.
         dry_run: If True, perform a dry run without copying.
         exclude_fonts: If True, exclude Fonts/ directory.
+        manifest_version_suffix: Optional local-only Version suffix to apply at
+            destination.
+        manifest_title_suffix: Optional local-only Title suffix to apply at
+            destination.
 
     Returns:
         Completed process result from rsync or the Python fallback.
@@ -337,6 +424,7 @@ def run_sync(
         msg = f"Source directory not found: {source}"
         raise FileNotFoundError(msg)
 
+    rewrite_manifest = bool(manifest_version_suffix or manifest_title_suffix)
     preserved = {} if dry_run else _capture_local_only_files(destination)
     try:
         if shutil.which("rsync") is None:
@@ -345,6 +433,8 @@ def run_sync(
                 destination,
                 dry_run=dry_run,
                 exclude_fonts=exclude_fonts,
+                manifest_version_suffix=manifest_version_suffix,
+                manifest_title_suffix=manifest_title_suffix,
             )
 
         cmd = build_rsync_command(
@@ -353,7 +443,20 @@ def run_sync(
             dry_run=dry_run,
             exclude_fonts=exclude_fonts,
         )
-        return subprocess.run(cmd, capture_output=True, text=True, check=True)  # noqa: S603 -- trusted rsync call
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)  # noqa: S603 -- trusted rsync call
+        if rewrite_manifest and dry_run:
+            return _append_stdout_line(
+                result,
+                "Would rewrite manifest.json display metadata",
+            )
+        if rewrite_manifest and not dry_run:
+            _write_manifest_metadata(
+                source / "manifest.json",
+                destination / "manifest.json",
+                version_suffix=manifest_version_suffix,
+                title_suffix=manifest_title_suffix,
+            )
+        return result
     finally:
         if preserved:
             _restore_local_only_files(destination, preserved)
@@ -382,6 +485,24 @@ def main(argv: list[str] | None = None) -> int:
         help="Exclude Fonts/ directory from sync.",
     )
     parser.add_argument(
+        "--dev",
+        action="store_true",
+        help=(
+            "Mark the synced destination manifest as a local development build "
+            "without changing the source manifest."
+        ),
+    )
+    parser.add_argument(
+        "--dev-version-suffix",
+        default=DEFAULT_DEV_VERSION_SUFFIX,
+        help="Version suffix used with --dev. Defaults to -dev.",
+    )
+    parser.add_argument(
+        "--dev-title-suffix",
+        default=DEFAULT_DEV_TITLE_SUFFIX,
+        help="Title suffix used with --dev. Defaults to ' (local dev)'.",
+    )
+    parser.add_argument(
         "--destination",
         "--dest",
         type=Path,
@@ -406,14 +527,18 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     source = project_root / "Mods" / "QudJP"
+    manifest_version_suffix = args.dev_version_suffix if args.dev else None
+    manifest_title_suffix = args.dev_title_suffix if args.dev else None
     try:
         result = run_sync(
             source,
             destination,
             dry_run=args.dry_run,
             exclude_fonts=args.exclude_fonts,
+            manifest_version_suffix=manifest_version_suffix,
+            manifest_title_suffix=manifest_title_suffix,
         )
-    except FileNotFoundError as exc:
+    except (FileNotFoundError, TypeError, ValueError) as exc:
         print(f"Error: {exc}", file=sys.stderr)  # noqa: T201
         return 1
     except subprocess.CalledProcessError as exc:

--- a/scripts/sync_mod.py
+++ b/scripts/sync_mod.py
@@ -1,6 +1,7 @@
 """Sync QudJP mod files to the Caves of Qud game directory."""
 
 import argparse
+import json
 import os
 import platform
 import shutil
@@ -37,6 +38,8 @@ _RSYNC_EXCLUDES: tuple[str, ...] = ("*",)
 _LOCAL_ONLY_FILES: tuple[Path, ...] = (Path("workshop.json"),)
 _LOCALIZATION_ASSET_SUFFIXES = {".json", ".txt", ".xml"}
 _WINDOWS_DRIVE_PREFIX_LENGTH = 2
+DEFAULT_DEV_VERSION_SUFFIX = "-dev"
+DEFAULT_DEV_TITLE_SUFFIX = " (local dev)"
 
 _MACOS_MODS_SUFFIX = (
     Path("Library")
@@ -215,16 +218,88 @@ def _iter_sync_files(source: Path, *, exclude_fonts: bool) -> list[Path]:
     return file_paths
 
 
+def _rewrite_manifest_metadata(
+    manifest_data: dict[str, object],
+    *,
+    version_suffix: str | None,
+    title_suffix: str | None,
+) -> dict[str, object]:
+    """Return manifest data with local-only display metadata applied."""
+    rewritten = dict(manifest_data)
+
+    if version_suffix:
+        version = rewritten.get("Version")
+        if not isinstance(version, str) or not version:
+            msg = "manifest.json must contain a non-empty string Version"
+            raise ValueError(msg)
+        rewritten["Version"] = (
+            version if version.endswith(version_suffix) else f"{version}{version_suffix}"
+        )
+
+    if title_suffix:
+        title = rewritten.get("Title")
+        if not isinstance(title, str) or not title:
+            msg = "manifest.json must contain a non-empty string Title"
+            raise ValueError(msg)
+        rewritten["Title"] = (
+            title if title.endswith(title_suffix) else f"{title}{title_suffix}"
+        )
+
+    return rewritten
+
+
+def _write_manifest_metadata(
+    source_manifest: Path,
+    destination_manifest: Path,
+    *,
+    version_suffix: str | None,
+    title_suffix: str | None,
+) -> None:
+    """Write destination manifest metadata without mutating the source manifest."""
+    manifest_data = json.loads(source_manifest.read_text(encoding="utf-8"))
+    if not isinstance(manifest_data, dict):
+        msg = "manifest.json must contain a JSON object"
+        raise TypeError(msg)
+
+    rewritten = _rewrite_manifest_metadata(
+        manifest_data,
+        version_suffix=version_suffix,
+        title_suffix=title_suffix,
+    )
+    destination_manifest.parent.mkdir(parents=True, exist_ok=True)
+    destination_manifest.write_text(
+        f"{json.dumps(rewritten, ensure_ascii=False, indent=2)}\n",
+        encoding="utf-8",
+    )
+
+
+def _append_stdout_line(
+    result: subprocess.CompletedProcess[str],
+    line: str,
+) -> subprocess.CompletedProcess[str]:
+    """Return a completed process result with one extra stdout line."""
+    stdout = f"{result.stdout.rstrip()}\n{line}\n" if result.stdout else f"{line}\n"
+    return subprocess.CompletedProcess(
+        args=result.args,
+        returncode=result.returncode,
+        stdout=stdout,
+        stderr=result.stderr,
+    )
+
+
 def _run_python_sync(
     source: Path,
     destination: Path,
     *,
     dry_run: bool,
     exclude_fonts: bool,
+    manifest_version_suffix: str | None,
+    manifest_title_suffix: str | None,
 ) -> subprocess.CompletedProcess[str]:
     """Synchronize files with a pure-Python copy fallback."""
     file_paths = _iter_sync_files(source, exclude_fonts=exclude_fonts)
     lines = ["Using Python copy fallback."]
+    rewrite_manifest = bool(manifest_version_suffix or manifest_title_suffix)
 
     if dry_run:
         action = "replace" if destination.exists() else "create"
@@ -233,6 +308,8 @@ def _run_python_sync(
             f"Would copy {file_path.relative_to(source)}"
             for file_path in file_paths
         )
+        if rewrite_manifest:
+            lines.append("Would rewrite manifest.json display metadata")
         return subprocess.CompletedProcess(
             args=["python-copy"],
             returncode=0,
@@ -250,7 +327,15 @@ def _run_python_sync(
         relative_path = file_path.relative_to(source)
         target_path = destination / relative_path
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(file_path, target_path)
+        if relative_path == Path("manifest.json") and rewrite_manifest:
+            _write_manifest_metadata(
+                file_path,
+                target_path,
+                version_suffix=manifest_version_suffix,
+                title_suffix=manifest_title_suffix,
+            )
+        else:
+            shutil.copy2(file_path, target_path)
 
     lines.append(f"Copied {len(file_paths)} files to {destination}")
     return subprocess.CompletedProcess(
@@ -317,6 +402,8 @@ def run_sync(
     *,
     dry_run: bool = False,
     exclude_fonts: bool = False,
+    manifest_version_suffix: str | None = None,
+    manifest_title_suffix: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Execute sync to copy mod files into the game directory.
 
@@ -325,17 +412,29 @@ def run_sync(
         destination: Destination directory to sync to.
         dry_run: If True, perform a dry run without copying.
         exclude_fonts: If True, exclude Fonts/ directory.
+        manifest_version_suffix: Optional local-only Version suffix to apply at
+            destination.
+        manifest_title_suffix: Optional local-only Title suffix to apply at
+            destination.
 
     Returns:
         Completed process result from rsync or the Python fallback.
 
     Raises:
-        FileNotFoundError: If source directory does not exist.
+        FileNotFoundError: If source directory does not exist, or if dev
+            manifest rewriting is enabled but source manifest.json is missing.
         subprocess.CalledProcessError: If rsync fails.
     """
     if not source.is_dir():
         msg = f"Source directory not found: {source}"
         raise FileNotFoundError(msg)
+
+    rewrite_manifest = bool(manifest_version_suffix or manifest_title_suffix)
+    if rewrite_manifest and not dry_run:
+        source_manifest = source / "manifest.json"
+        if not source_manifest.is_file():
+            msg = f"manifest.json not found: {source_manifest}"
+            raise FileNotFoundError(msg)
 
     preserved = {} if dry_run else _capture_local_only_files(destination)
     try:
@@ -345,6 +444,8 @@ def run_sync(
                 destination,
                 dry_run=dry_run,
                 exclude_fonts=exclude_fonts,
+                manifest_version_suffix=manifest_version_suffix,
+                manifest_title_suffix=manifest_title_suffix,
             )
 
         cmd = build_rsync_command(
@@ -353,7 +454,20 @@ def run_sync(
             dry_run=dry_run,
             exclude_fonts=exclude_fonts,
         )
-        return subprocess.run(cmd, capture_output=True, text=True, check=True)  # noqa: S603 -- trusted rsync call
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)  # noqa: S603 -- trusted rsync call
+        if rewrite_manifest and dry_run:
+            return _append_stdout_line(
+                result,
+                "Would rewrite manifest.json display metadata",
+            )
+        if rewrite_manifest and not dry_run:
+            _write_manifest_metadata(
+                source / "manifest.json",
+                destination / "manifest.json",
+                version_suffix=manifest_version_suffix,
+                title_suffix=manifest_title_suffix,
+            )
+        return result
     finally:
         if preserved:
             _restore_local_only_files(destination, preserved)
@@ -382,6 +496,24 @@ def main(argv: list[str] | None = None) -> int:
         help="Exclude Fonts/ directory from sync.",
     )
     parser.add_argument(
+        "--dev",
+        action="store_true",
+        help=(
+            "Mark the synced destination manifest as a local development build "
+            "without changing the source manifest."
+        ),
+    )
+    parser.add_argument(
+        "--dev-version-suffix",
+        default=DEFAULT_DEV_VERSION_SUFFIX,
+        help="Version suffix used with --dev. Defaults to -dev.",
+    )
+    parser.add_argument(
+        "--dev-title-suffix",
+        default=DEFAULT_DEV_TITLE_SUFFIX,
+        help="Title suffix used with --dev. Defaults to ' (local dev)'.",
+    )
+    parser.add_argument(
         "--destination",
         "--dest",
         type=Path,
@@ -392,6 +524,12 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     args = parser.parse_args(argv)
+
+    if not args.dev and (
+        args.dev_version_suffix != DEFAULT_DEV_VERSION_SUFFIX
+        or args.dev_title_suffix != DEFAULT_DEV_TITLE_SUFFIX
+    ):
+        parser.error("--dev-version-suffix and --dev-title-suffix require --dev")
 
     try:
         project_root = _find_project_root()
@@ -406,14 +544,18 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     source = project_root / "Mods" / "QudJP"
+    manifest_version_suffix = args.dev_version_suffix if args.dev else None
+    manifest_title_suffix = args.dev_title_suffix if args.dev else None
     try:
         result = run_sync(
             source,
             destination,
             dry_run=args.dry_run,
             exclude_fonts=args.exclude_fonts,
+            manifest_version_suffix=manifest_version_suffix,
+            manifest_title_suffix=manifest_title_suffix,
         )
-    except FileNotFoundError as exc:
+    except (FileNotFoundError, TypeError, ValueError) as exc:
         print(f"Error: {exc}", file=sys.stderr)  # noqa: T201
         return 1
     except subprocess.CalledProcessError as exc:

--- a/scripts/tests/test_sync_mod.py
+++ b/scripts/tests/test_sync_mod.py
@@ -1,5 +1,6 @@
 """Tests for the sync_mod module."""
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -9,6 +10,8 @@ import pytest
 from scripts.sync_mod import (
     _RSYNC_EXCLUDES,
     _RSYNC_INCLUDES,
+    DEFAULT_DEV_TITLE_SUFFIX,
+    DEFAULT_DEV_VERSION_SUFFIX,
     build_rsync_command,
     main,
     resolve_default_destination,
@@ -16,6 +19,8 @@ from scripts.sync_mod import (
 )
 
 LOCALIZATION_DOC_NAMES = ("AGENTS.md", "CLAUDE.md", "README.md")
+SAMPLE_RELEASE_VERSION = "1.2.3"
+SAMPLE_MOD_TITLE = "Caves of Qud Japanese Mod"
 
 
 class TestBuildRsyncCommand:
@@ -263,6 +268,178 @@ class TestRunSync:
         assert not (destination / "src.cs").exists()
         assert not (destination / "stale.txt").exists()
 
+    def test_python_fallback_rewrites_dev_manifest_only_at_destination(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Dev sync rewrites manifest display fields without mutating source."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        source.mkdir()
+        source_manifest = source / "manifest.json"
+        source_manifest.write_text(
+            json.dumps(
+                {
+                    "Id": "QudJP",
+                    "Title": SAMPLE_MOD_TITLE,
+                    "Version": SAMPLE_RELEASE_VERSION,
+                },
+            ),
+            encoding="utf-8",
+        )
+
+        with patch("scripts.sync_mod.shutil.which", return_value=None):
+            run_sync(
+                source,
+                destination,
+                manifest_version_suffix=DEFAULT_DEV_VERSION_SUFFIX,
+                manifest_title_suffix=DEFAULT_DEV_TITLE_SUFFIX,
+            )
+
+        assert json.loads(source_manifest.read_text(encoding="utf-8")) == {
+            "Id": "QudJP",
+            "Title": SAMPLE_MOD_TITLE,
+            "Version": SAMPLE_RELEASE_VERSION,
+        }
+        assert json.loads((destination / "manifest.json").read_text(encoding="utf-8")) == {
+            "Id": "QudJP",
+            "Title": f"{SAMPLE_MOD_TITLE}{DEFAULT_DEV_TITLE_SUFFIX}",
+            "Version": f"{SAMPLE_RELEASE_VERSION}{DEFAULT_DEV_VERSION_SUFFIX}",
+        }
+
+    def test_python_fallback_dev_manifest_suffix_is_idempotent(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Dev sync does not duplicate an existing destination-only suffix."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        source.mkdir()
+        (source / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "Title": f"{SAMPLE_MOD_TITLE}{DEFAULT_DEV_TITLE_SUFFIX}",
+                    "Version": f"{SAMPLE_RELEASE_VERSION}{DEFAULT_DEV_VERSION_SUFFIX}",
+                },
+            ),
+            encoding="utf-8",
+        )
+
+        with patch("scripts.sync_mod.shutil.which", return_value=None):
+            run_sync(
+                source,
+                destination,
+                manifest_version_suffix=DEFAULT_DEV_VERSION_SUFFIX,
+                manifest_title_suffix=DEFAULT_DEV_TITLE_SUFFIX,
+            )
+
+        assert json.loads((destination / "manifest.json").read_text(encoding="utf-8")) == {
+            "Title": f"{SAMPLE_MOD_TITLE}{DEFAULT_DEV_TITLE_SUFFIX}",
+            "Version": f"{SAMPLE_RELEASE_VERSION}{DEFAULT_DEV_VERSION_SUFFIX}",
+        }
+
+    def test_python_fallback_dry_run_reports_dev_manifest_without_writing(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Dry-run dev sync reports the manifest rewrite but writes nothing."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        source.mkdir()
+        (source / "manifest.json").write_text(
+            json.dumps({"Version": SAMPLE_RELEASE_VERSION}),
+            encoding="utf-8",
+        )
+
+        with patch("scripts.sync_mod.shutil.which", return_value=None):
+            result = run_sync(
+                source,
+                destination,
+                dry_run=True,
+                manifest_version_suffix=DEFAULT_DEV_VERSION_SUFFIX,
+                manifest_title_suffix=DEFAULT_DEV_TITLE_SUFFIX,
+            )
+
+        assert result.returncode == 0
+        assert "Would rewrite manifest.json display metadata" in result.stdout
+        assert not destination.exists()
+
+    def test_rsync_rewrites_dev_manifest_after_sync(self, tmp_path: Path) -> None:
+        """Rsync mode applies dev manifest metadata after rsync copies files."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        source.mkdir()
+        destination.mkdir()
+        (source / "manifest.json").write_text(
+            json.dumps({"Title": SAMPLE_MOD_TITLE, "Version": SAMPLE_RELEASE_VERSION}),
+            encoding="utf-8",
+        )
+
+        def fake_rsync(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            (destination / "manifest.json").write_text(
+                json.dumps({"Title": SAMPLE_MOD_TITLE, "Version": SAMPLE_RELEASE_VERSION}),
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(
+                args=["rsync"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+
+        with (
+            patch("scripts.sync_mod.shutil.which", return_value="/usr/bin/rsync"),
+            patch("scripts.sync_mod.subprocess.run", side_effect=fake_rsync),
+        ):
+            run_sync(
+                source,
+                destination,
+                manifest_version_suffix=DEFAULT_DEV_VERSION_SUFFIX,
+                manifest_title_suffix=DEFAULT_DEV_TITLE_SUFFIX,
+            )
+
+        assert json.loads((destination / "manifest.json").read_text(encoding="utf-8")) == {
+            "Title": f"{SAMPLE_MOD_TITLE}{DEFAULT_DEV_TITLE_SUFFIX}",
+            "Version": f"{SAMPLE_RELEASE_VERSION}{DEFAULT_DEV_VERSION_SUFFIX}",
+        }
+
+    def test_rsync_dry_run_reports_dev_manifest_without_writing(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Rsync dry-run reports the manifest rewrite but writes nothing."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        source.mkdir()
+        (source / "manifest.json").write_text(
+            json.dumps({"Version": SAMPLE_RELEASE_VERSION}),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("scripts.sync_mod.shutil.which", return_value="/usr/bin/rsync"),
+            patch(
+                "scripts.sync_mod.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=["rsync"],
+                    returncode=0,
+                    stdout="Would copy manifest.json\n",
+                    stderr="",
+                ),
+            ),
+        ):
+            result = run_sync(
+                source,
+                destination,
+                dry_run=True,
+                manifest_version_suffix=DEFAULT_DEV_VERSION_SUFFIX,
+                manifest_title_suffix=DEFAULT_DEV_TITLE_SUFFIX,
+            )
+
+        assert "Would copy manifest.json" in result.stdout
+        assert "Would rewrite manifest.json display metadata" in result.stdout
+        assert not destination.exists()
+
     def test_python_fallback_preserves_local_workshop_json(
         self,
         tmp_path: Path,
@@ -426,3 +603,34 @@ class TestMain:
         assert result == 0
         assert mock_run.call_args.args[0] == source
         assert mock_run.call_args.args[1] == destination
+
+    def test_dev_flag_forwards_manifest_suffixes(self, tmp_path: Path) -> None:
+        """--dev forwards local-only manifest suffixes to run_sync."""
+        project_root = tmp_path / "repo"
+        source = project_root / "Mods" / "QudJP"
+        source.mkdir(parents=True)
+        destination = tmp_path / "custom-dest"
+
+        with (
+            patch("scripts.sync_mod._find_project_root", return_value=project_root),
+            patch(
+                "scripts.sync_mod.run_sync",
+                return_value=subprocess.CompletedProcess(
+                    args=["sync"],
+                    returncode=0,
+                    stdout="",
+                    stderr="",
+                ),
+            ) as mock_run,
+        ):
+            result = main(["--dev", "--dest", str(destination)])
+
+        assert result == 0
+        assert (
+            mock_run.call_args.kwargs["manifest_version_suffix"]
+            == DEFAULT_DEV_VERSION_SUFFIX
+        )
+        assert (
+            mock_run.call_args.kwargs["manifest_title_suffix"]
+            == DEFAULT_DEV_TITLE_SUFFIX
+        )

--- a/scripts/tests/test_sync_mod.py
+++ b/scripts/tests/test_sync_mod.py
@@ -1,5 +1,6 @@
 """Tests for the sync_mod module."""
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -9,6 +10,8 @@ import pytest
 from scripts.sync_mod import (
     _RSYNC_EXCLUDES,
     _RSYNC_INCLUDES,
+    DEFAULT_DEV_TITLE_SUFFIX,
+    DEFAULT_DEV_VERSION_SUFFIX,
     build_rsync_command,
     main,
     resolve_default_destination,
@@ -16,6 +19,8 @@ from scripts.sync_mod import (
 )
 
 LOCALIZATION_DOC_NAMES = ("AGENTS.md", "CLAUDE.md", "README.md")
+SAMPLE_RELEASE_VERSION = "1.2.3"
+SAMPLE_MOD_TITLE = "Caves of Qud Japanese Mod"
 
 
 class TestBuildRsyncCommand:
@@ -263,6 +268,222 @@ class TestRunSync:
         assert not (destination / "src.cs").exists()
         assert not (destination / "stale.txt").exists()
 
+    def test_python_fallback_rewrites_dev_manifest_only_at_destination(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Dev sync rewrites manifest display fields without mutating source."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        source.mkdir()
+        source_manifest = source / "manifest.json"
+        source_manifest.write_text(
+            json.dumps(
+                {
+                    "Id": "QudJP",
+                    "Title": SAMPLE_MOD_TITLE,
+                    "Version": SAMPLE_RELEASE_VERSION,
+                },
+            ),
+            encoding="utf-8",
+        )
+
+        with patch("scripts.sync_mod.shutil.which", return_value=None):
+            run_sync(
+                source,
+                destination,
+                manifest_version_suffix=DEFAULT_DEV_VERSION_SUFFIX,
+                manifest_title_suffix=DEFAULT_DEV_TITLE_SUFFIX,
+            )
+
+        assert json.loads(source_manifest.read_text(encoding="utf-8")) == {
+            "Id": "QudJP",
+            "Title": SAMPLE_MOD_TITLE,
+            "Version": SAMPLE_RELEASE_VERSION,
+        }
+        assert json.loads((destination / "manifest.json").read_text(encoding="utf-8")) == {
+            "Id": "QudJP",
+            "Title": f"{SAMPLE_MOD_TITLE}{DEFAULT_DEV_TITLE_SUFFIX}",
+            "Version": f"{SAMPLE_RELEASE_VERSION}{DEFAULT_DEV_VERSION_SUFFIX}",
+        }
+
+    def test_python_fallback_dev_manifest_suffix_is_idempotent(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Dev sync does not duplicate an existing destination-only suffix."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        source.mkdir()
+        (source / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "Title": f"{SAMPLE_MOD_TITLE}{DEFAULT_DEV_TITLE_SUFFIX}",
+                    "Version": f"{SAMPLE_RELEASE_VERSION}{DEFAULT_DEV_VERSION_SUFFIX}",
+                },
+            ),
+            encoding="utf-8",
+        )
+
+        with patch("scripts.sync_mod.shutil.which", return_value=None):
+            run_sync(
+                source,
+                destination,
+                manifest_version_suffix=DEFAULT_DEV_VERSION_SUFFIX,
+                manifest_title_suffix=DEFAULT_DEV_TITLE_SUFFIX,
+            )
+
+        assert json.loads((destination / "manifest.json").read_text(encoding="utf-8")) == {
+            "Title": f"{SAMPLE_MOD_TITLE}{DEFAULT_DEV_TITLE_SUFFIX}",
+            "Version": f"{SAMPLE_RELEASE_VERSION}{DEFAULT_DEV_VERSION_SUFFIX}",
+        }
+
+    def test_python_fallback_requires_title_when_dev_title_suffix_is_set(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Dev title rewrite fails when manifest Title is missing."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        source.mkdir()
+        (source / "manifest.json").write_text(
+            json.dumps({"Version": SAMPLE_RELEASE_VERSION}),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("scripts.sync_mod.shutil.which", return_value=None),
+            pytest.raises(ValueError, match="non-empty string Title"),
+        ):
+            run_sync(
+                source,
+                destination,
+                manifest_version_suffix=DEFAULT_DEV_VERSION_SUFFIX,
+                manifest_title_suffix=DEFAULT_DEV_TITLE_SUFFIX,
+            )
+
+    def test_python_fallback_requires_manifest_when_dev_rewrite_is_enabled(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Dev manifest rewrite fails fast when source manifest is missing."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        source.mkdir()
+
+        with (
+            patch("scripts.sync_mod.shutil.which", return_value=None),
+            pytest.raises(FileNotFoundError, match=r"manifest\.json not found"),
+        ):
+            run_sync(
+                source,
+                destination,
+                manifest_version_suffix=DEFAULT_DEV_VERSION_SUFFIX,
+                manifest_title_suffix=DEFAULT_DEV_TITLE_SUFFIX,
+            )
+
+    def test_python_fallback_dry_run_reports_dev_manifest_without_writing(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Dry-run dev sync reports the manifest rewrite but writes nothing."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        source.mkdir()
+        (source / "manifest.json").write_text(
+            json.dumps({"Version": SAMPLE_RELEASE_VERSION}),
+            encoding="utf-8",
+        )
+
+        with patch("scripts.sync_mod.shutil.which", return_value=None):
+            result = run_sync(
+                source,
+                destination,
+                dry_run=True,
+                manifest_version_suffix=DEFAULT_DEV_VERSION_SUFFIX,
+                manifest_title_suffix=DEFAULT_DEV_TITLE_SUFFIX,
+            )
+
+        assert result.returncode == 0
+        assert "Would rewrite manifest.json display metadata" in result.stdout
+        assert not destination.exists()
+
+    def test_rsync_rewrites_dev_manifest_after_sync(self, tmp_path: Path) -> None:
+        """Rsync mode applies dev manifest metadata after rsync copies files."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        source.mkdir()
+        destination.mkdir()
+        (source / "manifest.json").write_text(
+            json.dumps({"Title": SAMPLE_MOD_TITLE, "Version": SAMPLE_RELEASE_VERSION}),
+            encoding="utf-8",
+        )
+
+        def fake_rsync(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            (destination / "manifest.json").write_text(
+                json.dumps({"Title": SAMPLE_MOD_TITLE, "Version": SAMPLE_RELEASE_VERSION}),
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(
+                args=["rsync"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+
+        with (
+            patch("scripts.sync_mod.shutil.which", return_value="/usr/bin/rsync"),
+            patch("scripts.sync_mod.subprocess.run", side_effect=fake_rsync),
+        ):
+            run_sync(
+                source,
+                destination,
+                manifest_version_suffix=DEFAULT_DEV_VERSION_SUFFIX,
+                manifest_title_suffix=DEFAULT_DEV_TITLE_SUFFIX,
+            )
+
+        assert json.loads((destination / "manifest.json").read_text(encoding="utf-8")) == {
+            "Title": f"{SAMPLE_MOD_TITLE}{DEFAULT_DEV_TITLE_SUFFIX}",
+            "Version": f"{SAMPLE_RELEASE_VERSION}{DEFAULT_DEV_VERSION_SUFFIX}",
+        }
+
+    def test_rsync_dry_run_reports_dev_manifest_without_writing(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Rsync dry-run reports the manifest rewrite but writes nothing."""
+        source = tmp_path / "source"
+        destination = tmp_path / "dest"
+        source.mkdir()
+        (source / "manifest.json").write_text(
+            json.dumps({"Version": SAMPLE_RELEASE_VERSION}),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("scripts.sync_mod.shutil.which", return_value="/usr/bin/rsync"),
+            patch(
+                "scripts.sync_mod.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=["rsync"],
+                    returncode=0,
+                    stdout="Would copy manifest.json\n",
+                    stderr="",
+                ),
+            ),
+        ):
+            result = run_sync(
+                source,
+                destination,
+                dry_run=True,
+                manifest_version_suffix=DEFAULT_DEV_VERSION_SUFFIX,
+                manifest_title_suffix=DEFAULT_DEV_TITLE_SUFFIX,
+            )
+
+        assert "Would copy manifest.json" in result.stdout
+        assert "Would rewrite manifest.json display metadata" in result.stdout
+        assert not destination.exists()
+
     def test_python_fallback_preserves_local_workshop_json(
         self,
         tmp_path: Path,
@@ -426,3 +647,41 @@ class TestMain:
         assert result == 0
         assert mock_run.call_args.args[0] == source
         assert mock_run.call_args.args[1] == destination
+
+    def test_dev_flag_forwards_manifest_suffixes(self, tmp_path: Path) -> None:
+        """--dev forwards local-only manifest suffixes to run_sync."""
+        project_root = tmp_path / "repo"
+        source = project_root / "Mods" / "QudJP"
+        source.mkdir(parents=True)
+        destination = tmp_path / "custom-dest"
+
+        with (
+            patch("scripts.sync_mod._find_project_root", return_value=project_root),
+            patch(
+                "scripts.sync_mod.run_sync",
+                return_value=subprocess.CompletedProcess(
+                    args=["sync"],
+                    returncode=0,
+                    stdout="",
+                    stderr="",
+                ),
+            ) as mock_run,
+        ):
+            result = main(["--dev", "--dest", str(destination)])
+
+        assert result == 0
+        assert (
+            mock_run.call_args.kwargs["manifest_version_suffix"]
+            == DEFAULT_DEV_VERSION_SUFFIX
+        )
+        assert (
+            mock_run.call_args.kwargs["manifest_title_suffix"]
+            == DEFAULT_DEV_TITLE_SUFFIX
+        )
+
+    def test_dev_suffix_flags_require_dev_flag(self) -> None:
+        """Custom dev suffix flags fail fast without --dev."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--dev-version-suffix", "-local"])
+
+        assert exc_info.value.code == 2


### PR DESCRIPTION
## Summary

- Add a local development sync mode that rewrites only the deployed manifest display metadata.
- Keep the source `Mods/QudJP/manifest.json` release version unchanged so release ZIP and Workshop preflight continue to use the canonical semver version.
- Add `just` recipes for dev build/sync/deploy entry points alongside the existing release-oriented commands.

## Impact

Local dev deployments can show a distinct Mods screen identity by appending the configured dev suffix to the current manifest version and title, while Workshop/release artifacts keep the plain release version from the source manifest.

## Validation

- `just build-dev`
- `just sync-mod-dev-dry-run`
- `just python-check`
- `uv run pytest scripts/tests/test_build_release.py scripts/tests/test_sync_mod.py -q`
- Temporary destination sync confirmed the source `Version` stayed unchanged while the destination `Version` received the configured dev suffix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 開発向けの別コマンド群を追加（開発ビルド／再ビルド、開発同期、開発デプロイ、宛先指定版を含む）
  * 同期時に出力先マニフェストの表示用バージョン／タイトルを開発用表記に書き換えるオプション（カスタム接尾辞可）を追加
  * dry-run 時に書き換え予定を表示

* **テスト**
  * 開発モードのマニフェスト書き換え、dry-run、idempotence 等の包括的テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->