### PR TITLE
Finalize v0.2.43 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   色・透明度・表示状態が元の行に追従するようにしました。
 - Steam Workshop へ出荷する DLL に TextMeshPro / InventoryLine 表示修正が
   含まれていない場合、release 検証で失敗するガードを追加しました。
+- インベントリ操作の `remove`、メモ、重要マーク関連ラベルの日本語訳を
+  実際のゲーム内表示キーに合わせて修正しました。
+- 「You embark for the caves of Qud.」の日本語訳を
+  `クッドの洞窟へ旅立つ。` に統一しました。
 
 ---
 

--- a/docs/release-notes/unreleased/inventory-action-labels.md
+++ b/docs/release-notes/unreleased/inventory-action-labels.md
@@ -1,4 +1,0 @@
-### Fixed
-
-- Corrected inventory action labels such as remove, notes, and important markers.
-- Unified the Japanese text for embarking for the caves of Qud.


### PR DESCRIPTION
## Summary
- Fold the remaining inventory action and Qud embark localization fragment into the v0.2.43 changelog entry.
- Remove the consumed unreleased fragment before tagging v0.2.43.

## Verification
- just translation-token-check
- just localization-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 修正

* **翻訳の改善**
  * インベントリの削除、メモ、重要マークラベルの日本語翻訳がゲーム内表示に統一されました。
  * 「クッドの洞窟へ旅立つ。」のテキストが日本語で統一されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->