### PR TITLE
docs: record v0.2.43 workshop release

### DIFF
--- a/docs/reports/2026-05-07-workshop-v0.2.43.md
+++ b/docs/reports/2026-05-07-workshop-v0.2.43.md
@@ -1,0 +1,79 @@
+# Workshop Release v0.2.43
+
+## Identity
+
+- Version: `0.2.43`
+- Git commit: `49e16affae680f71e65dd8d89d165fc85a40910a`
+- Git tag: `v0.2.43`
+- Previous release tag/range: `v0.2.42..v0.2.43`
+- Version source: `Mods/QudJP/manifest.json`
+- GitHub Release URL: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.43
+- Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
+- Steam app ID: `333640`
+- Published file ID: `3718988020`
+
+## Changenote
+
+```text
+v0.2.43 / 49e16affae68
+
+更新内容:
+- Steam Workshop版に、0.2.42時点でローカル検証済みだったインベントリ表示修正が正しく含まれるようにしました。
+- release artifact生成時に、TextMeshPro / InventoryLine表示修正がDLLへ含まれていない場合は検証で失敗するガードを追加しました。
+
+翻訳追加・改善:
+- インベントリ操作の remove、メモ、重要マーク関連ラベルの日本語訳を、実際のゲーム内表示キーに合わせて修正しました。
+- 「You embark for the caves of Qud.」の日本語訳を「クッドの洞窟へ旅立つ。」に統一しました。
+
+修正:
+- インベントリ画面でアイテム名が消える、折り畳みや更新時に表示名がズレる、または保持済み表示が無効化される問題を修正しました。
+- インベントリ項目の折り畳み時に、保持済みアイテム名の位置・色・透明度・表示状態が元の行に追従するようにしました。
+
+既知の問題:
+- 一部の自動生成テキスト、チュートリアル、キャラクター生成画面には未翻訳または不自然な訳が残る場合があります。
+- ゲーム本体のアップデートにより、一部表示やパッチが壊れる可能性があります。
+```
+
+## Artifacts
+
+- Release ZIP: `dist/release-assets/v0.2.43/QudJP-v0.2.43.zip`
+- Release ZIP SHA256: `da5876c02d574fb33ab5fe838febfa24c0757de70b2e1bc7948d2489c4503602`
+- GitHub Release asset: `QudJP-v0.2.43.zip`
+- GitHub Release asset SHA256: `da5876c02d574fb33ab5fe838febfa24c0757de70b2e1bc7948d2489c4503602`
+- Workshop content folder: `dist/workshop/QudJP/`
+- Workshop VDF: `dist/workshop/workshop_item.vdf`
+
+## Preflight
+
+- [x] `git status --short --branch`
+- [x] Release range established from previous tag, release report, changelog/GitHub release, or explicit user range
+- [x] `Mods/QudJP/manifest.json` version, `v0.2.43` tag, release ZIP name, changenote first line, and report version match
+- [x] `git rev-list -n1 v0.2.43` matches `git rev-parse HEAD`
+- [x] `git merge-base --is-ancestor "$(git rev-list -n1 v0.2.43)" origin/main`
+- [x] Draft GitHub Release created by tag workflow
+- [x] `just download-release-zip 0.2.43`
+- [x] `just workshop-preflight 0.2.43`
+- [x] `just release-zip-check dist/release-assets/v0.2.43/QudJP-v0.2.43.zip`
+- [x] `just build-workshop-upload dist/release-assets/v0.2.43/QudJP-v0.2.43.zip /tmp/qudjp-workshop-changenote.txt`
+
+## Upload
+
+- steamcmd command: `steamcmd +login "$STEAM_USER" +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_release-v0.2.43/dist/workshop/workshop_item.vdf +quit`
+- Upload completed at: `2026-05-07 05:58 JST`
+- Steam output summary: cached login succeeded; content, preview image, and update commit completed with `Success`.
+- GitHub Release published at: `2026-05-06T20:58:28Z`
+
+## Post-Publish Smoke
+
+- [x] Workshop page title, description, preview image, visibility, file size, and changenote checked
+- [ ] Subscribe/resubscribe checked
+- [ ] Mod Manager lists QudJP with expected version and preview
+- [ ] Options screen renders Japanese text and CJK glyphs
+- [ ] One short conversation renders Japanese text and CJK glyphs
+- [ ] Fresh Player.log checked for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`
+
+## Decision
+
+- Result: GO
+- Notes: Steam Workshop page renders `Caves of Qud Japanese Mod`, Caves of Qud app ID `333640`, preview image, Japanese description with `Caves of Qud 1.0.4`, and changelog entry `v0.2.43 / 49e16affae68`. The release ZIP was downloaded from the GitHub draft release, checksum-verified, used for Workshop staging, uploaded successfully, and the draft GitHub Release was published after the Steam changelog appeared. In-game subscription and fresh runtime smoke were not repeated during this release pass; the user had already confirmed the PR build had no inventory display regression before release.
+- Rollback tag, if needed: `v0.2.42`


### PR DESCRIPTION
## Summary
- record v0.2.43 Workshop upload evidence
- note GitHub Release publication and remaining manual runtime smoke items

## Verification
- git diff --cached --check before commit
- Steam Workshop page/changelog checked after upload
- GitHub Release v0.2.43 is published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * Workshop Release v0.2.43 のリリースドキュメントを公開しました。バージョン情報、変更内容、翻訳、バグ修正、既知の問題、リリース成果物の一覧、および検証ステップが記載されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->