### PR TITLE
Fix TMP warmup compatibility and popup load actions

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -125,10 +125,10 @@ public sealed class ColorTagAllowlistCoverageTests
             ["Mods/QudJP/Assemblies/src/Patches/PetEitherOrExplodeTranslationPatch.cs:131:TryTranslate"] = "Delegates capture and boundary restoration to matched owner-route branches.",
             ["Mods/QudJP/Assemblies/src/Patches/PickGameObjectScreenTranslationPatch.cs:115:TranslateProducerText"] = "Strips only for already-localized/direct-route checks before TranslatePreservingColors owns restoration.",
             ["Mods/QudJP/Assemblies/src/Patches/PlayerStatusBarProducerTranslationHelpers.cs:101:TryTranslateFoodWaterPart"] = "Strips only to choose an exact visible-text translation before TranslatePreservingColors owns restoration.",
-            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:1302:IsAlreadyLocalizedPopupText"] = "Predicate only; it compares stripped and original text.",
-            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:261:TranslatePopupTextForRoute"] = "Strips only for direct-marker and already-localized detection before producer routes own restoration.",
-            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:307:TranslatePopupMenuItemTextForRoute"] = "Strips only for direct-marker and already-localized detection before producer routes own restoration.",
-            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:370:TryTranslatePopupProducerText"] = "Delegates capture restoration to template/exact branch helpers.",
+            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:1384:IsAlreadyLocalizedPopupText"] = "Predicate only; it compares stripped and original text.",
+            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:263:TranslatePopupTextForRoute"] = "Strips only for direct-marker and already-localized detection before producer routes own restoration.",
+            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:309:TranslatePopupMenuItemTextForRoute"] = "Strips only for direct-marker and already-localized detection before producer routes own restoration.",
+            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:372:TryTranslatePopupProducerText"] = "Delegates capture restoration to template/exact branch helpers.",
             ["Mods/QudJP/Assemblies/src/Patches/SkillsAndPowersLineTranslationPatch.cs:229:TranslateSkillRightText"] = "Strips only for skill right-text detection before a non-colored exact replacement.",
             ["Mods/QudJP/Assemblies/src/Patches/TradeUiPopupTranslationPatch.cs:296:TryTranslatePerformOfferTradeWaterMessage"] = "Popup sink handoff delegates capture restoration to the PerformOffer owner-template helper.",
             ["Mods/QudJP/Assemblies/src/Patches/TradeUiPopupTranslationPatch.cs:314:TryTranslateHasNothingToTradeMessage"] = "Popup sink handoff delegates capture restoration to the has-nothing owner-template helper.",
@@ -143,7 +143,7 @@ public sealed class ColorTagAllowlistCoverageTests
             ["Mods/QudJP/Assemblies/src/Translation/ColorAwareTranslationComposer.cs:30:Strip"] = "Wrapper method exposes the Strip API; callers are checked where they consume the returned spans.",
             ["Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs:76:Translate"] = "Passes stripped text and spans to TranslateStripped, where template application restores colors.",
             ["Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs:79:Translate"] = "Passes stripped text and spans to TranslateStripped, where template application restores colors.",
-            ["Mods/QudJP/Assemblies/src/UI/FontManager.cs:174:TryWarmPrimaryFontCharactersForUi"] = "UI glyph warmup intentionally strips markup only to add visible characters to the font atlas.",
+            ["Mods/QudJP/Assemblies/src/UI/FontManager.cs:233:TryWarmPrimaryFontCharactersForUi"] = "UI glyph warmup intentionally strips markup only to add visible characters to the font atlas.",
         };
 
     private static readonly SortedDictionary<string, string> NameLikeRestoreCaptureWithoutGuardAllowlist =

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/FontManagerRuntimeWarmupCompatibilityTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/FontManagerRuntimeWarmupCompatibilityTests.cs
@@ -1,0 +1,73 @@
+namespace QudJP.Tests.L1;
+
+[NUnit.Framework.TestFixture]
+[NUnit.Framework.Category("L1")]
+public sealed class FontManagerRuntimeWarmupCompatibilityTests
+{
+    [NUnit.Framework.Test]
+    public void TryWarmFontCharactersForTests_UsesStringOutStringOverload_WhenStringOnlyOverloadIsAbsent()
+    {
+        var fontAsset = new OutStringOnlyFontAsset();
+
+        var warmed = FontManager.TryWarmFontCharactersForTests(fontAsset, "日本語テスト");
+
+        NUnit.Framework.Assert.Multiple(() =>
+        {
+            NUnit.Framework.Assert.That(warmed, NUnit.Framework.Is.True);
+            NUnit.Framework.Assert.That(fontAsset.CapturedCharacters, NUnit.Framework.Is.EqualTo("日本語テスト"));
+        });
+    }
+
+    [NUnit.Framework.Test]
+    public void TryWarmFontCharactersForTests_UsesStringOnlyOverload_WhenThatIsTheAvailableRuntimeApi()
+    {
+        var fontAsset = new StringOnlyFontAsset();
+
+        var warmed = FontManager.TryWarmFontCharactersForTests(fontAsset, "日本語テスト");
+
+        NUnit.Framework.Assert.Multiple(() =>
+        {
+            NUnit.Framework.Assert.That(warmed, NUnit.Framework.Is.True);
+            NUnit.Framework.Assert.That(fontAsset.CapturedCharacters, NUnit.Framework.Is.EqualTo("日本語テスト"));
+        });
+    }
+
+    [NUnit.Framework.Test]
+    public void TryWarmFontCharactersForTests_ReturnsFalse_WhenNoCompatibleOverloadExists()
+    {
+        var warmed = FontManager.TryWarmFontCharactersForTests(new object(), "日本語テスト");
+
+        NUnit.Framework.Assert.That(warmed, NUnit.Framework.Is.False);
+    }
+
+    private sealed class OutStringOnlyFontAsset
+    {
+        public string? CapturedCharacters { get; private set; }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Major Code Smell",
+            "S1144:Unused private types or members should be removed",
+            Justification = "Invoked through the runtime-overload reflection helper under test.")]
+        public bool TryAddCharacters(string characters, out string missingCharacters)
+        {
+            CapturedCharacters = characters;
+            missingCharacters = string.Empty;
+            return true;
+        }
+    }
+
+    private sealed class StringOnlyFontAsset
+    {
+        public string? CapturedCharacters { get; private set; }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Major Code Smell",
+            "S1144:Unused private types or members should be removed",
+            Justification = "Invoked through the runtime-overload reflection helper under test.")]
+        public bool TryAddCharacters(string characters)
+        {
+            CapturedCharacters = characters;
+            return true;
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupPickOptionTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupPickOptionTranslationPatchTests.cs
@@ -26,6 +26,7 @@ public sealed class PopupPickOptionTranslationPatchTests
 
         Translator.ResetForTests();
         Translator.SetDictionaryDirectoryForTests(dictionaryDirectory);
+        ScopedDictionaryLookup.ResetForTests();
         MessagePatternTranslator.ResetForTests();
         MessagePatternTranslator.SetPatternFileForTests(patternFilePath);
         DynamicTextObservability.ResetForTests();
@@ -38,6 +39,7 @@ public sealed class PopupPickOptionTranslationPatchTests
     public void TearDown()
     {
         Translator.ResetForTests();
+        ScopedDictionaryLookup.ResetForTests();
         MessagePatternTranslator.ResetForTests();
         DynamicTextObservability.ResetForTests();
         SinkObservation.ResetForTests();
@@ -236,6 +238,47 @@ public sealed class PopupPickOptionTranslationPatchTests
         });
     }
 
+    [Test]
+    public void Prefix_TranslatesEmbeddedHotkeyLoadAndUnloadOptions()
+    {
+        WriteDictionary(("load", "GLOBAL-LOAD-POISON"), ("unload", "GLOBAL-UNLOAD-POISON"));
+        WriteQudMenuItemDictionary(
+            ("load", "QudMenuItem", "装填"),
+            ("unload", "QudMenuItem", "装填解除"));
+
+        using var patch = PatchPickOption();
+
+        DummyPopupGenericTarget.PickOption(
+            Options: new[]
+            {
+                "l{{hotkey|o}}ad",
+                "{{hotkey|u}}nload",
+            },
+            Buttons: new[]
+            {
+                new DummyPopupMenuItem("{{W|[o]}} {{y|l{{hotkey|o}}ad}}"),
+                new DummyPopupMenuItem("{{W|[u]}} {{y|{{hotkey|u}}nload}}"),
+            });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupGenericTarget.LastPickOptionOptions, Is.EqualTo(new[] { "装填", "装填解除" }));
+            Assert.That(DummyPopupGenericTarget.LastPickOptionButtons, Is.Not.Null);
+            Assert.That(DummyPopupGenericTarget.LastPickOptionButtons![0].text, Is.EqualTo("{{W|[o]}} {{y|装填}}"));
+            Assert.That(DummyPopupGenericTarget.LastPickOptionButtons[1].text, Is.EqualTo("{{W|[u]}} {{y|装填解除}}"));
+            Assert.That(
+                DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                    nameof(PopupPickOptionTranslationPatch),
+                    "Popup.ProducerText.EmbeddedHotkeyLabel"),
+                Is.GreaterThan(0));
+            Assert.That(
+                DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                    nameof(PopupPickOptionTranslationPatch),
+                    "Popup.ProducerMenuItem.HotkeyLabel"),
+                Is.GreaterThan(0));
+        });
+    }
+
     private static IDisposable PatchPickOption()
     {
         var harmonyId = CreateHarmonyId();
@@ -280,6 +323,38 @@ public sealed class PopupPickOptionTranslationPatchTests
         builder.Append("]}");
         File.WriteAllText(
             Path.Combine(dictionaryDirectory, "popup-pickoption.ja.json"),
+            builder.ToString(),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private void WriteQudMenuItemDictionary(params (string key, string context, string text)[] entries)
+    {
+        var scopedDirectory = Path.Combine(dictionaryDirectory, "Scoped");
+        Directory.CreateDirectory(scopedDirectory);
+
+        var builder = new StringBuilder();
+        builder.Append('{');
+        builder.Append("\"entries\":[");
+
+        for (var index = 0; index < entries.Length; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append("{\"key\":\"");
+            builder.Append(EscapeJson(entries[index].key));
+            builder.Append("\",\"context\":\"");
+            builder.Append(EscapeJson(entries[index].context));
+            builder.Append("\",\"text\":\"");
+            builder.Append(EscapeJson(entries[index].text));
+            builder.Append("\"}");
+        }
+
+        builder.Append("]}");
+        File.WriteAllText(
+            Path.Combine(scopedDirectory, "ui-popup-qud-menu-item.ja.json"),
             builder.ToString(),
             new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
     }

--- a/Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs
@@ -13,6 +13,8 @@ public static class PopupTranslationPatch
 {
     private const string TargetTypeName = "XRL.UI.Popup";
     private const string UntilPrefix = "Until ";
+    private const string QudMenuItemContext = "QudMenuItem";
+    private const string QudMenuItemDictionaryFile = "Scoped/ui-popup-qud-menu-item.ja.json";
     private static readonly Regex HotkeyLabelPattern =
         new Regex("^\\[(?<hotkey>[^\\]]+)\\]\\s+(?<label>.+)$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly Regex PlainHotkeyLabelPattern =
@@ -420,6 +422,18 @@ public static class PopupTranslationPatch
         if (IsAlreadyLocalizedPopupTextCore(stripped))
         {
             translated = source;
+            return true;
+        }
+
+        if (TryTranslatePopupPickOptionHotkeyLabel(
+                source,
+                stripped,
+                spans,
+                route,
+                family,
+                out var hotkeyLabelTranslated))
+        {
+            translated = hotkeyLabelTranslated;
             return true;
         }
 
@@ -972,6 +986,74 @@ public static class PopupTranslationPatch
 
         translated = source;
         return false;
+    }
+
+    private static bool TryTranslatePopupPickOptionHotkeyLabel(
+        string source,
+        string stripped,
+        IReadOnlyList<ColorSpan> spans,
+        string route,
+        string family,
+        out string translated)
+    {
+        translated = source;
+        if (!string.Equals(route, nameof(PopupPickOptionTranslationPatch), StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var hotkeyMatch = HotkeyLabelPattern.Match(stripped);
+        if (hotkeyMatch.Success && !int.TryParse(hotkeyMatch.Groups["hotkey"].Value, out _))
+        {
+            var label = hotkeyMatch.Groups["label"].Value;
+            var translatedLabel = ScopedDictionaryLookup.TranslateExactOrLowerAsciiForContext(
+                label,
+                QudMenuItemContext,
+                QudMenuItemDictionaryFile);
+            if (translatedLabel is null || string.Equals(translatedLabel, label, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var hotkey = ColorAwareTranslationComposer.RestoreSlice(
+                "[" + hotkeyMatch.Groups["hotkey"].Value + "]",
+                spans,
+                hotkeyMatch.Index,
+                hotkeyMatch.Groups["hotkey"].Length + 2);
+            var labelWithWrappers = ColorAwareTranslationComposer.RestoreCaptureWholeBoundaryWrappersPreservingTranslatedOwnership(
+                translatedLabel,
+                spans,
+                hotkeyMatch.Groups["label"]);
+            var visibleTranslation = hotkey + " " + labelWithWrappers;
+            translated = ColorAwareTranslationComposer.RestoreWholeSourceBoundaryWrappersPreservingTranslatedOwnership(
+                visibleTranslation,
+                spans,
+                stripped.Length);
+            DynamicTextObservability.RecordTransform(route, family + ".HotkeyLabel", source, translated);
+            return true;
+        }
+
+        if (source.IndexOf("{{hotkey|", StringComparison.Ordinal) < 0
+            || !Regex.IsMatch(stripped, "^[A-Za-z][A-Za-z ]*[A-Za-z]$", RegexOptions.CultureInvariant))
+        {
+            return false;
+        }
+
+        var embeddedTranslated = ScopedDictionaryLookup.TranslateExactOrLowerAsciiForContext(
+            stripped,
+            QudMenuItemContext,
+            QudMenuItemDictionaryFile);
+        if (embeddedTranslated is null || string.Equals(embeddedTranslated, stripped, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        translated = ColorAwareTranslationComposer.RestoreWholeSourceBoundaryWrappersPreservingTranslatedOwnership(
+            embeddedTranslated,
+            spans,
+            stripped.Length);
+        DynamicTextObservability.RecordTransform(route, family + ".EmbeddedHotkeyLabel", source, translated);
+        return true;
     }
 
     private static bool TryTranslateUntilCalendarTimeOfDay(

--- a/Mods/QudJP/Assemblies/src/UI/FontManager.cs
+++ b/Mods/QudJP/Assemblies/src/UI/FontManager.cs
@@ -96,9 +96,9 @@ public static class FontManager
 
             var patchedFontAssetCount = EnsureFallbackOnAllFontAssets(fontAsset);
 
-            if (!fontAsset.TryAddCharacters("日本語テスト"))
+            if (!TryWarmFontCharacters(fontAsset, "日本語テスト"))
             {
-                throw new InvalidOperationException("TryAddCharacters failed for probe string '日本語テスト'");
+                Debug.LogWarning("[QudJP] FontManager: CJK font probe warmup failed for '日本語テスト'. Continuing with runtime fallback.");
             }
 
             Debug.Log($"[QudJP] FontManager: CJK font registered. defaultFontAsset='{fontAsset.name}', patchedAssets={patchedFontAssetCount}.");
@@ -111,6 +111,65 @@ public static class FontManager
 #else
         Trace.TraceInformation("[QudJP] FontManager: TMP unavailable (CI build). Font injection skipped.");
 #endif
+    }
+
+    internal static bool TryWarmFontCharactersForTests(object? fontAsset, string? text)
+    {
+        return TryWarmFontCharacters(fontAsset, text);
+    }
+
+    private static bool TryWarmFontCharacters(object? fontAsset, string? text)
+    {
+        if (fontAsset is null || string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        var fontAssetType = fontAsset.GetType();
+        var stringByReferenceType = typeof(string).MakeByRefType();
+        var overloadWithMissingCharacters = fontAssetType.GetMethod(
+            "TryAddCharacters",
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            types: new[] { typeof(string), stringByReferenceType },
+            modifiers: null);
+        if (TryInvokeBooleanMethod(overloadWithMissingCharacters, fontAsset, new object?[] { text, null }))
+        {
+            return true;
+        }
+
+        var overloadWithCharactersOnly = fontAssetType.GetMethod(
+            "TryAddCharacters",
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            types: new[] { typeof(string) },
+            modifiers: null);
+        return TryInvokeBooleanMethod(overloadWithCharactersOnly, fontAsset, new object?[] { text });
+    }
+
+    private static bool TryInvokeBooleanMethod(MethodInfo? method, object target, object?[] parameters)
+    {
+        if (method is null || method.ReturnType != typeof(bool))
+        {
+            return false;
+        }
+
+        try
+        {
+            return method.Invoke(target, parameters) is true;
+        }
+        catch (TargetInvocationException)
+        {
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (MethodAccessException)
+        {
+            return false;
+        }
     }
 
 #if HAS_TMP
@@ -177,7 +236,7 @@ public static class FontManager
                 return false;
             }
 
-            return fontAsset.TryAddCharacters(stripped, out _);
+            return TryWarmFontCharacters(fontAsset, stripped);
         }
         catch (Exception ex)
         {

--- a/Mods/QudJP/Localization/Dictionaries/Scoped/ui-popup-qud-menu-item.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/Scoped/ui-popup-qud-menu-item.ja.json
@@ -1,0 +1,15 @@
+{
+  "meta": {
+    "id": "ui-popup-qud-menu-item",
+    "lang": "ja",
+    "version": "0.0.1"
+  },
+  "rules": {
+    "protectColorTags": true,
+    "protectHtmlEntities": true
+  },
+  "entries": [
+    { "key": "load", "context": "QudMenuItem", "text": "装填" },
+    { "key": "unload", "context": "QudMenuItem", "text": "装填解除" }
+  ]
+}

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.2.43",
+  "Version": "0.2.44",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/release-notes/unreleased/fix-tmp-font-warmup-and-popup-actions.md
+++ b/docs/release-notes/unreleased/fix-tmp-font-warmup-and-popup-actions.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Prevent startup failure on game builds where TMP font warmup exposes a different API overload.
+- Translate load and unload item action labels in popup option menus.


### PR DESCRIPTION
## Summary
- keep TMP font warmup compatible with both `TryAddCharacters(string, out string)` and `TryAddCharacters(string)` runtime APIs
- route-scope popup `load`/`unload` action translations through a Scoped/QudMenuItem dictionary instead of the global dictionary
- bump mod menu version to 0.2.44 and add an unreleased release-note fragment

## Runtime evidence
- Windows runtime log collected at `.sisyphus/evidence/runtime-logs/ts-win-main/Player-2026-05-07-062830.log` showed local QudJP 0.2.44 loading and the TMP warmup warning path instead of startup failure.

## Review
- Separate reviewer re-reviewed the scoped dictionary change and returned APPROVE with no blocking findings.

## Tests
- `just test-l1`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~PopupPickOptionTranslationPatchTests|FullyQualifiedName~FontManagerRuntimeWarmupCompatibilityTests"`
- `just build`
- `just localization-check`
- `uv run python scripts/release_notes.py check-fragment --base-ref origin/main --head-ref HEAD`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 特定のゲームビルド環境でのスタートアップ失敗を防止しました
  * ポップアップメニューのロード/アンロード項目ラベルの日本語翻訳を追加しました

* **テスト**
  * フォント管理機能の互換性検証テストを追加しました
  * ポップアップ翻訳機能の埋め込みホットキー翻訳テストを追加しました

* **その他**
  * バージョンを 0.2.43 から 0.2.44 に更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->