### PR TITLE
Finalize v0.2.44 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+[0.2.44]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.44
 [0.2.43]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.43
 [0.2.42]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.42
 [0.2.41]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.41

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.2.44] - 2026-05-07
+
+### Fixed
+
+- TextMeshPro のフォント warmup API がゲーム本体のビルド差異で異なる場合でも、
+  QudJP の起動が失敗しないようにしました。
+- アイテム操作ポップアップで `load` / `unload` が日本語化されない問題を修正しました。
+
+---
+
 ## [0.2.43] - 2026-05-07
 
 ### Fixed

--- a/docs/release-notes/unreleased/fix-tmp-font-warmup-and-popup-actions.md
+++ b/docs/release-notes/unreleased/fix-tmp-font-warmup-and-popup-actions.md
@@ -1,4 +1,0 @@
-### Fixed
-
-- Prevent startup failure on game builds where TMP font warmup exposes a different API overload.
-- Translate load and unload item action labels in popup option menus.


### PR DESCRIPTION
## Summary
- add the v0.2.44 CHANGELOG entry
- consume the unreleased release-note fragment for the TMP warmup and popup action fixes

## Tests
- `uv run python scripts/release_notes.py extract-changelog --version 0.2.44 --changelog CHANGELOG.md`
- `uv run python scripts/release_notes.py check-fragment --base-ref origin/main --head-ref HEAD`
- `just markdown-report-check origin/main HEAD`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 起動時に発生するTextMeshProフォント初期化関連の不具合を修正
  * アイテム操作ポップアップの「load/ unload」表記を日本語で正しく表示するよう修正

* **Documentation**
  * バージョン 0.2.44（2026-05-07）をリリースノートに追記
<!-- end of auto-generated comment: release notes by coderabbit.ai -->