### PR TITLE
Clarify v0.2.43 release report audit

### DIFF
--- a/docs/reports/2026-05-07-workshop-v0.2.43.md
+++ b/docs/reports/2026-05-07-workshop-v0.2.43.md
@@ -4,7 +4,7 @@
 
 - Version: `0.2.43`
 - Git commit: `49e16affae680f71e65dd8d89d165fc85a40910a`
-- Git tag: `v0.2.43`
+- Git tag: `v0.2.43` (annotated tag; peels to release commit `49e16affae680f71e65dd8d89d165fc85a40910a`)
 - Previous release tag/range: `v0.2.42..v0.2.43`
 - Version source: `Mods/QudJP/manifest.json`
 - GitHub Release URL: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.43
@@ -48,7 +48,7 @@ v0.2.43 / 49e16affae68
 - [x] `git status --short --branch`
 - [x] Release range established from previous tag, release report, changelog/GitHub release, or explicit user range
 - [x] `Mods/QudJP/manifest.json` version, `v0.2.43` tag, release ZIP name, changenote first line, and report version match
-- [x] `git rev-list -n1 v0.2.43` matches `git rev-parse HEAD`
+- [x] `git rev-list -n1 v0.2.43` matches release commit `49e16affae680f71e65dd8d89d165fc85a40910a`
 - [x] `git merge-base --is-ancestor "$(git rev-list -n1 v0.2.43)" origin/main`
 - [x] Draft GitHub Release created by tag workflow
 - [x] `just download-release-zip 0.2.43`
@@ -75,5 +75,5 @@ v0.2.43 / 49e16affae68
 ## Decision
 
 - Result: GO
-- Notes: Steam Workshop page renders `Caves of Qud Japanese Mod`, Caves of Qud app ID `333640`, preview image, Japanese description with `Caves of Qud 1.0.4`, and changelog entry `v0.2.43 / 49e16affae68`. The release ZIP was downloaded from the GitHub draft release, checksum-verified, used for Workshop staging, uploaded successfully, and the draft GitHub Release was published after the Steam changelog appeared. In-game subscription and fresh runtime smoke were not repeated during this release pass; the user had already confirmed the PR build had no inventory display regression before release.
+- Notes: Steam Workshop page renders `Caves of Qud Japanese Mod`, Caves of Qud app ID `333640`, preview image, Japanese description with `Caves of Qud 1.0.4`, and changelog entry `v0.2.43 / 49e16affae68`. The release ZIP was downloaded from the GitHub draft release, checksum-verified, used for Workshop staging, uploaded successfully, and the draft GitHub Release was published after the Steam changelog appeared. Audit update: rechecked the remote `v0.2.43` tag and GitHub Release publication; the tag peels to `49e16affae680f71e65dd8d89d165fc85a40910a`, and the GitHub Release is public with `publishedAt` `2026-05-06T20:58:28Z`. In-game subscription and fresh runtime smoke were not repeated during this release pass; the user had already confirmed the PR build had no inventory display regression before release.
 - Rollback tag, if needed: `v0.2.42`


### PR DESCRIPTION
## Summary
- clarify that `v0.2.43` is an annotated tag that peels to the documented release commit
- make the preflight tag check refer to the release commit instead of the post-release report branch HEAD
- add an audit note reconciling the GitHub Release publication timestamp with the release decision notes

## Tests
- `just markdown-report-check origin/main HEAD`
- `git diff --check`
- `git rev-list -n1 v0.2.43` equals `49e16affae680f71e65dd8d89d165fc85a40910a`
- `gh release view v0.2.43 --json isDraft,publishedAt,tagName,url`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * v0.2.43リリースの検証プロセスをアップデートしました。

* **Chores**
  * Git タグメタデータの設定を改善しました。
  * リリース確認の監査手順を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->