### PR TITLE
Fix inventory font diagnostics fallback

### DIFF
--- a/Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs
@@ -283,10 +283,17 @@ internal static class InventoryLineFontFixer
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Trace.TraceWarning(
-                "QudJP: InventoryLineFontFixer diagnostics failed: {0}: {1}",
-                ex.GetType().Name,
-                ex.Message);
+            try
+            {
+                System.Diagnostics.Trace.TraceWarning(
+                    "QudJP: InventoryLineFontFixer diagnostics failed: {0}: {1}",
+                    ex.GetType().Name,
+                    ex.Message);
+            }
+            catch
+            {
+                // Diagnostics must never interrupt inventory row translation.
+            }
         }
     }
 

--- a/Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs
@@ -283,7 +283,10 @@ internal static class InventoryLineFontFixer
         }
         catch (Exception ex)
         {
-            Debug.LogWarning($"[QudJP] InventoryLineFontFixer diagnostics failed: {ex.GetType().Name}: {ex.Message}");
+            System.Diagnostics.Trace.TraceWarning(
+                "QudJP: InventoryLineFontFixer diagnostics failed: {0}: {1}",
+                ex.GetType().Name,
+                ex.Message);
         }
     }
 


### PR DESCRIPTION
## Summary\n- keep inventory font diagnostics failures from aborting later inventory row translation work\n- preserves the v0.2.45 release manifest and shipping content\n\n## Verification\n- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --filter FullyQualifiedName~InventoryLinePostfix_TranslatesCategoryAndItemRows_AfterOriginalSetData\n- python3 scripts/verify_release_dll.py Mods/QudJP/Assemblies/QudJP.dll\n- synced rebased Release DLL d31518038db240a824cfa9607ea4515705932e907cb0b97ee8965aac4bbeba42 to macOS and ts-win-main\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 診断収集時のエラー報告を改善し、警告として記録されるようにしました。
  * 診断報告処理自体の失敗が在庫行の表示や翻訳処理を中断しないようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->