### PR TITLE
[codex] Align internal game version docs to 1.0.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Why
 
-QudJP is the Japanese localization mod for Caves of Qud `2.0.4`. The repo contains the shipped DLL, localization assets, and the tooling used to validate and deploy them.
+QudJP is the Japanese localization mod for Caves of Qud `1.0.4`. The repo contains the shipped DLL, localization assets, and the tooling used to validate and deploy them.
 
 ## What
 

--- a/CODERABBIT.md
+++ b/CODERABBIT.md
@@ -1,7 +1,7 @@
 # CodeRabbit Review Knowledge
 
 This root-level document is the CodeRabbit-specific global guideline for QudJP
-changes that depend on local inspection of Caves of Qud 2.0.4 runtime behavior.
+changes that depend on local inspection of Caves of Qud 1.0.4 runtime behavior.
 CodeRabbit may also auto-detect root `AGENTS.md` or `CLAUDE.md`; this file adds
 review rules they do not contain. It must be self-contained for critical
 CodeRabbit review rules because CodeRabbit scopes guideline files by the

--- a/Mods/QudJP/Assemblies/src/Patches/GrammarPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GrammarPatch.cs
@@ -378,7 +378,7 @@ public static class GrammarMakeOrListPatch
     }
 }
 
-// Grammar.SplitOfSentenceList is absent in game version 2.0.4, so this helper stays
+// Grammar.SplitOfSentenceList is absent in game version 1.0.4, so this helper stays
 // test-covered but is not registered as a Harmony patch to avoid TargetMethod failures.
 public static class GrammarSplitOfSentenceListPatch
 {

--- a/Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs
@@ -100,15 +100,15 @@ public static class PopupTranslationPatch
     private static readonly Regex WaterRitualLowReputationPattern =
         new Regex("^You don't have a high enough reputation with (?<value>.+?)\\.$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
-    // ShowBlock parameter count for game version 2.0.4
+    // ShowBlock parameter count for game version 1.0.4
     private const int ShowBlockParameterCount = 8;
 
-    // ShowOptionList parameter count for game version 2.0.4
+    // ShowOptionList parameter count for game version 1.0.4
     private const int ShowOptionListParameterCount = 19;
 
     private const int ShowConversationParameterCount = 7;
 
-    // ShowOptionList argument indices (game version 2.0.4)
+    // ShowOptionList argument indices (game version 1.0.4)
     private const int ShowOptionListIntroIndex = 4;
     private const int ShowOptionListSpacingTextIndex = 9;
     private const int ShowOptionListButtonsIndex = 14;

--- a/Mods/QudJP/Localization/AGENTS.md
+++ b/Mods/QudJP/Localization/AGENTS.md
@@ -35,4 +35,4 @@ hexdump -C <file> | head -1
 - `AddPlayerMessage` remains sink-observed; do not treat it as a fixed-leaf owner or sink-side fallback.
 - Validation must fail on duplicate or broad additions rather than tolerate them at runtime.
 - Preserve markup and placeholders exactly, including `{{...}}`, `&X`, `^x`, `&&`, `^^`, and `=variable.name=`.
-- Verify target object and conversation IDs against game version `2.0.4`.
+- Verify target object and conversation IDs against game version `1.0.4`.

--- a/Mods/QudJP/Localization/Conversations.jp.xml
+++ b/Mods/QudJP/Localization/Conversations.jp.xml
@@ -258,7 +258,7 @@
       <choice GotoID="End">生きて飲め。</choice>
     </start>
     <node ID="Welcome">
-      <!-- Upstream Conversations.xml 2.0.4 keeps Tzedech/Welcome text empty; choices provide the visible content. -->
+      <!-- Upstream Conversations.xml 1.0.4 keeps Tzedech/Welcome text empty; choices provide the visible content. -->
       <text />
       <choice GotoID="Name">私は =name=。君は？</choice>
       <choice GotoID="Upset">何かあったのか？</choice>

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -237,5 +237,5 @@ If a route can emit articles, generated names, quantities, or placeholder-like f
 
 - Do not commit `Assembly-CSharp.dll` or other game binaries.
 - Contributors need a local game install for DLL-assisted work.
-- Blueprint and conversation IDs must match game version `2.0.4`.
+- Blueprint and conversation IDs must match game version `1.0.4`.
 - The shipped mod is the built DLL plus localization assets and fonts, not the C# source tree.

--- a/docs/coderabbit/roslyn-text-construction-inventory-summary.md
+++ b/docs/coderabbit/roslyn-text-construction-inventory-summary.md
@@ -1,7 +1,7 @@
 # Roslyn Text Construction Inventory Summary
 
 This is the CodeRabbit-facing summary for the raw-free Roslyn text construction
-inventory generated from local decompiled Caves of Qud `2.0.4` C# sources.
+inventory generated from local decompiled Caves of Qud `1.0.4` C# sources.
 
 The full generated family inventory is intentionally not committed and should
 not be added to CodeRabbit knowledge-base file patterns. It is a large

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -199,7 +199,7 @@ UI 文字列・アイテム名・能力名など、プロシージャルでな�
 </conversations>
 ```
 
-- ID (`conversation ID`、`node ID`、`choice ID`、`object Name` など) は **ゲームバージョン 2.0.4** の値と完全一致する必要があります。
+- ID (`conversation ID`、`node ID`、`choice ID`、`object Name` など) は **ゲームバージョン 1.0.4** の値と完全一致する必要があります。
 - `=variable.name=` のようなランタイム置換プレースホルダーは保持してください。
 - `<text>` 要素の中身 (およびそれに類する表示テキスト要素) だけを日本語化します。
 
@@ -402,9 +402,9 @@ PR を出すと GitHub Actions (`.github/workflows/ci.yml`) が変更ファイ�
 
 このファイルはゲームの著作物です。`.gitignore` で除外されていますが、意図的に追加しないよう注意してください。同様に、`Mods/QudJP/Assemblies/QudJP.dll` のビルド成果物もコミット対象ではありません。
 
-**ゲームバージョン 2.0.4 に合わせる**
+**ゲームバージョン 1.0.4 に合わせる**
 
-Blueprint ID、Conversation ID、メソッドシグネチャはすべてゲームバージョン 2.0.4 に合わせてください。バージョンが異なると Harmony パッチが当たらなくなります。
+Blueprint ID、Conversation ID、メソッドシグネチャはすべてゲームバージョン 1.0.4 に合わせてください。バージョンが異なると Harmony パッチが当たらなくなります。
 
 **クリーンルーム実装**
 
@@ -441,7 +441,7 @@ Blueprint ID、Conversation ID、メソッドシグネチャはすべてゲー�
 
 Issue を開く際は以下を含めてください:
 
-- **OS とバージョン** (例: Windows 11 / Caves of Qud v2.0.4 / QudJP v0.1.0)
+- **OS とバージョン** (例: Windows 11 / Caves of Qud v1.0.4 / QudJP v0.1.0)
 - **再現手順** — 最小ステップ
 - **期待される挙動 / 実際の挙動**
 - **`Player.log` の該当行** (上述の OS 別パスから抜粋)

--- a/docs/localization-coverage-map.json
+++ b/docs/localization-coverage-map.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "game_version": "2.0.4",
+  "game_version": "1.0.4",
   "description": "Executable coverage map for QudJP C# localization discovery, closure gates, and runtime verification boundaries.",
   "surfaces": [
     {

--- a/docs/release-notes/unreleased/issue-573-game-version-1.0.4.md
+++ b/docs/release-notes/unreleased/issue-573-game-version-1.0.4.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Align internal release metadata and documentation with Caves of Qud 1.0.4.

--- a/docs/reports/2026-05-05-issue-493-static-producer-inventory.md
+++ b/docs/reports/2026-05-05-issue-493-static-producer-inventory.md
@@ -156,7 +156,7 @@ uvx basedpyright scripts/scan_static_producer_inventory.py scripts/tests/test_sc
 The Python entrypoint invokes the Roslyn console scanner and keeps this JSON
 shape stable for current consumers.
 
-In the current decompiled `2.0.4` snapshot, Roslyn semantic enrichment resolved
+In the current decompiled `1.0.4` snapshot, Roslyn semantic enrichment resolved
 or produced candidate symbols for every inventoried callsite:
 
 | `roslyn_symbol_status` | Count |

--- a/docs/reports/2026-05-05-issue-497-dynamic-dictionary-audit.md
+++ b/docs/reports/2026-05-05-issue-497-dynamic-dictionary-audit.md
@@ -22,7 +22,7 @@ patch candidate.
 - `Mods/QudJP/Localization/AGENTS.md` dictionary acceptance rules.
 - Current dictionary rows under `Mods/QudJP/Localization/Dictionaries/`.
 - Static producer evidence in `docs/static-producer-inventory.json`.
-- Decompiled Caves of Qud 2.0.4 source under
+- Decompiled Caves of Qud 1.0.4 source under
   `~/dev/coq-decompiled_stable/`.
 - Structural searches with `just sg-cs` for `AddPlayerMessage`, `EmitMessage`,
   `StartReplace`, `JournalAPI.AddAccomplishment`, and conversation APIs.

--- a/docs/reports/2026-05-06-issue-525-markup-semantic-drift.md
+++ b/docs/reports/2026-05-06-issue-525-markup-semantic-drift.md
@@ -68,7 +68,7 @@ arguments are data-bound values such as `message`, `itemText`, `sb.ToString()`,
 producer callsites and construction routes; it cannot enumerate every runtime
 value without complementary observations or focused fixtures.
 
-Current static bounds from the local decompiled `2.0.4` source:
+Current static bounds from the local decompiled `1.0.4` source:
 
 | Probe | Count | Notes |
 | --- | ---: | --- |

--- a/docs/reports/2026-05-06-issue-537-dynamic-dictionary-scope.md
+++ b/docs/reports/2026-05-06-issue-537-dynamic-dictionary-scope.md
@@ -10,7 +10,7 @@ HistorySpice surfaces that still need owner translators.
 
 - `docs/RULES.md` owner-route and fixed-leaf policy.
 - `Mods/QudJP/Localization/AGENTS.md` dictionary acceptance policy.
-- Decompiled Caves of Qud 2.0.4 source under `~/dev/coq-decompiled_stable/`.
+- Decompiled Caves of Qud 1.0.4 source under `~/dev/coq-decompiled_stable/`.
 - Structural source searches over `XRL.World.Effects`, especially
   `GetDescription()`, `GetDetails()`, `DisplayName = ...`, and `E.AddTag(...)`
   producers.

--- a/docs/reports/2026-05-07-workshop-v0.2.45.md
+++ b/docs/reports/2026-05-07-workshop-v0.2.45.md
@@ -59,16 +59,15 @@ v0.2.45 / 3d88378c621f
 
 ## Upload
 
-- steamcmd command: `/opt/homebrew/bin/steamcmd +login pen4216 +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_stable/.worktrees/issue-566-restore-mac-good/dist/workshop/workshop_item.vdf +quit`
+- steamcmd command: `<STEAMCMD> +login <STEAM_USER> +workshop_build_item <LOCAL_WORKTREE_PATH>/dist/workshop/workshop_item.vdf +quit`
 - Upload completed at: `2026-05-07 12:48 JST`
 - Steam output summary: `Preparing update`, `Uploading content`, `Uploading preview image`, `Committing update...Success.`
-- Steam download validation: `/opt/homebrew/bin/steamcmd +login pen4216 +workshop_download_item 333640 3718988020 validate +quit`
-- Downloaded Workshop content: `/Users/sankenbisha/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020`
-- Downloaded `manifest.json` version: `0.2.45`
+- Steam download validation: `<STEAMCMD> +login <STEAM_USER> +workshop_download_item 333640 3718988020 validate +quit`
+- Downloaded Workshop content: `<WORKSHOP_CONTENT_PATH>/333640/3718988020`
+- Downloaded `manifest.json` version: `<MANIFEST_VERSION>` (matched release version `0.2.45`)
 - Downloaded Workshop manifest ID: `1340249862260182590`
 - Downloaded Workshop size: `19614952`
-- Local macOS Mods DLL SHA256 after final sync: `eee9956246c72ba46b09e0a54b7931e6e58ced0aa338ead9f5e0005b25d5e681`
-- `ts-win-main` Mods DLL SHA256 after final sync: `eee9956246c72ba46b09e0a54b7931e6e58ced0aa338ead9f5e0005b25d5e681`
+- Local/Windows Mods DLL SHA256 after final sync: `eee9956246c72ba46b09e0a54b7931e6e58ced0aa338ead9f5e0005b25d5e681`
 - GitHub Release draft URL: `https://github.com/ToaruPen/coq-japanese_stable/releases/tag/untagged-060f7f2f255d9cc74890`
 - GitHub Release published at: not published during this pass; the requested release-draft gate is complete.
 

--- a/docs/reports/2026-05-07-workshop-v0.2.45.md
+++ b/docs/reports/2026-05-07-workshop-v0.2.45.md
@@ -95,6 +95,6 @@ v0.2.45 / 3d88378c621f
 
 ## Decision
 
-- Result: UPLOADED; DISTRIBUTED CONTENT VERIFIED; PUBLIC PAGE/CLIENT SMOKE INCOMPLETE
-- Notes: Steam accepted the update and `steamcmd` downloaded `0.2.45` content whose DLL matches the staged upload. The GitHub Release draft exists with the verified ZIP assets. Do not publish the GitHub Release draft until the Steam-side warnings, changenote visibility, and game-client smoke are reviewed.
+- Result: UPLOADED; DISTRIBUTED CONTENT VERIFIED; PUBLIC PAGE REVIEWED; CLIENT SMOKE INCOMPLETE
+- Notes: Steam accepted the update and `steamcmd` downloaded `0.2.45` content whose DLL matches the staged upload. The public Workshop changelog visibility was confirmed, and the Steam warning blocks were reviewed as hidden in the fetched page markup. The GitHub Release draft exists with the verified ZIP assets. Do not publish the GitHub Release draft until the remaining Steam client smoke is reviewed.
 - Rollback tag, if needed: `v0.2.44`

--- a/docs/reports/2026-05-07-workshop-v0.2.45.md
+++ b/docs/reports/2026-05-07-workshop-v0.2.45.md
@@ -1,0 +1,101 @@
+# Workshop Release v0.2.45
+
+## Identity
+
+- Version: `0.2.45`
+- Git commit: `3d88378c621fb7bb0613efef1a475f742d5a7e95`
+- Git tag: `v0.2.45`
+- Previous release tag/range: `v0.2.44..v0.2.45`
+- Version source: `Mods/QudJP/manifest.json`
+- GitHub Release URL: `https://github.com/ToaruPen/coq-japanese_stable/releases/tag/untagged-060f7f2f255d9cc74890` (draft created by tag workflow; not published during this smoke pass)
+- Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
+- Steam app ID: `333640`
+- Published file ID: `3718988020`
+
+## Changenote
+
+```text
+v0.2.45 / 3d88378c621f
+
+更新内容:
+- Caves of Qud 1.0.4 向けの QudJP runtime DLL を更新しました。
+- インベントリ画面のアイテム名表示修復を、Windows 環境の Unity API 差異にも耐える形にしました。
+
+翻訳追加・改善:
+- この更新では新規翻訳追加はありません。既存の日本語表示資産を維持しています。
+
+修正:
+- Windows 環境でインベントリ表示の診断処理が失敗した場合でも、後続のアイテム名修復処理が止まらないようにしました。
+- Steam Workshop 用の DLL に TextMeshPro / InventoryLine 表示修正が含まれていることを検証するガードを通過した artifact を配布します。
+
+既知の問題:
+- 一部の自動生成テキスト、チュートリアル、キャラクター生成画面には未翻訳または不自然な訳が残る場合があります。
+- ゲーム本体のアップデートにより、一部表示やパッチが壊れる可能性があります。
+```
+
+## Artifacts
+
+- Release ZIP: `dist/release-assets/v0.2.45/QudJP-v0.2.45.zip`
+- Release ZIP SHA256: `6369ce8c23336c472869917cb782e4e49c32eedf21f6bd9b4a7dbd637661e5be`
+- GitHub Release asset: `qudjp-release-0.2.45`
+- GitHub Release asset SHA256: `6369ce8c23336c472869917cb782e4e49c32eedf21f6bd9b4a7dbd637661e5be`
+- Workshop content folder: `dist/workshop/QudJP/`
+- Workshop VDF: `dist/workshop/workshop_item.vdf`
+- Staged/downloaded Workshop DLL SHA256: `eee9956246c72ba46b09e0a54b7931e6e58ced0aa338ead9f5e0005b25d5e681`
+
+## Preflight
+
+- [x] `git status --short --branch`
+- [x] Release range established from previous tag, release report, changelog/GitHub release, or explicit user range
+- [x] `Mods/QudJP/manifest.json` version, `v0.2.45` tag, release ZIP name, changenote first line, and report version match
+- [x] `git rev-list -n1 v0.2.45` matches `git rev-parse HEAD`
+- [x] `git merge-base --is-ancestor "$(git rev-list -n1 v0.2.45)" origin/main`
+- [x] Draft GitHub Release created by tag workflow
+- [x] Draft GitHub Release creation confirmed from `draft-github-release` job `74745594824`
+- [x] GitHub Actions release artifact downloaded and checksum-verified manually because local `gh` token was invalid
+- [x] `just workshop-preflight 0.2.45`
+- [x] `just release-zip-check dist/release-assets/v0.2.45/QudJP-v0.2.45.zip`
+- [x] `just build-workshop-upload dist/release-assets/v0.2.45/QudJP-v0.2.45.zip /tmp/qudjp-workshop-changenote.txt`
+
+## Upload
+
+- steamcmd command: `/opt/homebrew/bin/steamcmd +login pen4216 +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_stable/.worktrees/issue-566-restore-mac-good/dist/workshop/workshop_item.vdf +quit`
+- Upload completed at: `2026-05-07 12:48 JST`
+- Steam output summary: `Preparing update`, `Uploading content`, `Uploading preview image`, `Committing update...Success.`
+- Steam download validation: `/opt/homebrew/bin/steamcmd +login pen4216 +workshop_download_item 333640 3718988020 validate +quit`
+- Downloaded Workshop content: `/Users/sankenbisha/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020`
+- Downloaded `manifest.json` version: `0.2.45`
+- Downloaded Workshop manifest ID: `1340249862260182590`
+- Downloaded Workshop size: `19614952`
+- Local macOS Mods DLL SHA256 after final sync: `eee9956246c72ba46b09e0a54b7931e6e58ced0aa338ead9f5e0005b25d5e681`
+- `ts-win-main` Mods DLL SHA256 after final sync: `eee9956246c72ba46b09e0a54b7931e6e58ced0aa338ead9f5e0005b25d5e681`
+- GitHub Release draft URL: `https://github.com/ToaruPen/coq-japanese_stable/releases/tag/untagged-060f7f2f255d9cc74890`
+- GitHub Release published at: not published during this pass; the requested release-draft gate is complete.
+
+## Post-Publish Smoke
+
+- [x] Workshop upload command completed successfully.
+- [x] Workshop page title, description, preview image, visibility, file size, and changenote checked from the public page.
+- [x] Clean Workshop download with `steamcmd +workshop_download_item 333640 3718988020 validate` succeeded.
+- [x] Downloaded Workshop `manifest.json` reports `Version: 0.2.45`.
+- [x] Downloaded Workshop DLL SHA256 matches staged Workshop DLL SHA256.
+- [x] Downloaded Workshop DLL passed `scripts/verify_release_dll.py`.
+- [ ] Subscribe/resubscribe checked in the Steam client.
+- [ ] Mod Manager lists QudJP with expected version and preview.
+- [ ] Options screen renders Japanese text and CJK glyphs.
+- [ ] One short conversation renders Japanese text and CJK glyphs.
+- [ ] Fresh Player.log checked for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`.
+
+## Steam Page Observations
+
+- Public Workshop page showed `Caves of Qud Japanese Mod`.
+- Public Workshop page HTML includes Steam `bannedNotification` and `incompatibleNotification` blocks, but they are `display: none` in the fetched markup.
+- Public Workshop changelog page showed `v0.2.45 / 3d88378c621f` as the newest visible entry.
+- Public Workshop changelog entry says `Caves of Qud 1.0.4 向け` in the first update bullet.
+- Public Workshop description included `Caves of Qud 1.0.4 対応`.
+
+## Decision
+
+- Result: UPLOADED; DISTRIBUTED CONTENT VERIFIED; PUBLIC PAGE/CLIENT SMOKE INCOMPLETE
+- Notes: Steam accepted the update and `steamcmd` downloaded `0.2.45` content whose DLL matches the staged upload. The GitHub Release draft exists with the verified ZIP assets. Do not publish the GitHub Release draft until the Steam-side warnings, changenote visibility, and game-client smoke are reviewed.
+- Rollback tag, if needed: `v0.2.44`

--- a/docs/static-producer-inventory.json
+++ b/docs/static-producer-inventory.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "game_version": "2.0.4",
+  "game_version": "1.0.4",
   "target_surfaces": [
     "EmitMessage",
     "Popup.Show*",

--- a/docs/superpowers/plans/2026-03-23-runtime-sites-strategy.md
+++ b/docs/superpowers/plans/2026-03-23-runtime-sites-strategy.md
@@ -504,7 +504,7 @@ Mitigation:
 
 - Prefer stable producer methods over fragile IL surgery.
 - Keep L2/L2G signature validation for new targets.
-- Document the exact 2.0.4 assumptions per new producer patch.
+- Document the exact 1.0.4 assumptions per new producer patch.
 
 ### 3. Pattern-order regressions
 
@@ -564,7 +564,7 @@ In practice, that means:
 
 1. Keep existing sink patches working as observability/fallback layers.
 2. Add new producer patches incrementally rather than replacing the sink safety net in one step.
-3. Validate new producer patches under the current game version (`2.0.4`) and Rosetta runtime flow before calling a cluster "done."
+3. Validate new producer patches under the current game version (`1.0.4`) and Rosetta runtime flow before calling a cluster "done."
 
 ## Validation plan
 

--- a/docs/superpowers/plans/2026-03-26-issue134-plan.md
+++ b/docs/superpowers/plans/2026-03-26-issue134-plan.md
@@ -43,7 +43,7 @@
 | `XRL.World.Parts/Stomach.cs:538` | drinking logic StringBuilder |
 | `XRL.World/GameObject.cs:14597` | `Die(..., Message)` caller param |
 | `XRL.World.Parts/DesalinationPellet.cs:217` | `Examiner.GetIdentifyMessage()` runtime output; part field templatesとは別 |
-| `XRL.World.Parts/Reconstitution.cs:262`, `Spawner.cs:89`, `SwapOnUse.cs:34` | [`docs/phase3d-remaining-audit.md:18-31`](docs/phase3d-remaining-audit.md#L18) にある通り v2.0.4 では XML override 不在の unreachable field。Issue #136 側の除外メモとして維持 |
+| `XRL.World.Parts/Reconstitution.cs:262`, `Spawner.cs:89`, `SwapOnUse.cs:34` | [`docs/phase3d-remaining-audit.md:18-31`](docs/phase3d-remaining-audit.md#L18) にある通り v1.0.4 では XML override 不在の unreachable field。Issue #136 側の除外メモとして維持 |
 
 ## Implementation Steps
 

--- a/docs/superpowers/specs/2026-04-25-issue-404-preacher-prefix-localization-design.md
+++ b/docs/superpowers/specs/2026-04-25-issue-404-preacher-prefix-localization-design.md
@@ -115,5 +115,5 @@ dotnet build Mods/QudJP/Assemblies/QudJP.csproj
 ## Risks
 
 - **Translator drift.** A future contributor who edits these entries without the `Postfix="'}}"` invariant will silently re-introduce the imbalance. Mitigation: the test in step 1 owns the invariant.
-- **Extra Preacher entry surfaces in 2.0.4+ data.** A future game patch could add `Mechanimist Preacher 5`. The Book-set assertion will fail loudly so it is treated as an explicit decision rather than silent omission.
+- **Extra Preacher entry surfaces in 1.0.4+ data.** A future game patch could add `Mechanimist Preacher 5`. The Book-set assertion will fail loudly so it is treated as an explicit decision rather than silent omission.
 - **Translation tone.** `説教者は言う、` is a defensible reading of `The preacher says,`. If the project glossary later prefers `司祭は告げる、` or similar, change in one place; the test only asserts non-ASCII content, not exact wording.

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -55,7 +55,7 @@ L2 層は 2 つのカテゴリに分かれます。
 **このモードで優先して検証するもの**:
 - `HarmonyTargetMethod` / `HarmonyTargetMethods` が実 DLL 上で正しいメソッドを解決できるか
 - 実ゲーム DLL 由来の static メソッドや、Unity ランタイムなしで安全に呼べる処理
-- ILSpy 解析で得たフック候補が現行ゲーム 2.0.4 の実 DLL と一致しているか
+- ILSpy 解析で得たフック候補が現行ゲーム 1.0.4 の実 DLL と一致しているか
 
 **制約**:
 - `Assembly-CSharp.dll` の型を参照してよい
@@ -133,7 +133,7 @@ dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCa
 
 **制約**:
 - 手動実行のみ
-- Caves of Qud v2.0.4 の実行環境が必要
+- Caves of Qud v1.0.4 の実行環境が必要
 
 **手順**:
 

--- a/scripts/legacies/scanner/rule_classifier.py
+++ b/scripts/legacies/scanner/rule_classifier.py
@@ -31,7 +31,7 @@ from scripts.legacies.scanner.inventory import (
     write_inventory_draft_json,
 )
 
-DEFAULT_GAME_VERSION = "2.0.4"
+DEFAULT_GAME_VERSION = "1.0.4"
 DEFAULT_RAW_HITS_PATH = Path(".scanner-cache/raw_hits.jsonl")
 DEFAULT_OUTPUT_PATH = Path(".scanner-cache/inventory_draft.json")
 _INTERPOLATED_STRING_RE = re.compile(r'(?:\$@|@\$|\$)"')

--- a/scripts/localization_coverage_map.py
+++ b/scripts/localization_coverage_map.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Final, NotRequired, TypedDict, cast
 
 SCHEMA_VERSION: Final = "1.0"
-GAME_VERSION: Final = "2.0.4"
+GAME_VERSION: Final = "1.0.4"
 MAP_PATH: Final = Path("docs/localization-coverage-map.json")
 
 REQUIRED_STATUSES: Final = {

--- a/scripts/scan_static_producer_inventory.py
+++ b/scripts/scan_static_producer_inventory.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Final, NotRequired, TypedDict, cast
 
 SCHEMA_VERSION: Final = "1.0"
-GAME_VERSION: Final = "2.0.4"
+GAME_VERSION: Final = "1.0.4"
 DEFAULT_SOURCE_ROOT: Final = Path("~/dev/coq-decompiled_stable").expanduser()
 TARGET_SURFACES: Final = ["EmitMessage", "Popup.Show*", "AddPlayerMessage"]
 ROSLYN_SCANNER_TIMEOUT_SECONDS: Final = 600

--- a/scripts/tests/test_reconcile_inventory_status.py
+++ b/scripts/tests/test_reconcile_inventory_status.py
@@ -31,7 +31,7 @@ def _draft(*sites: InventorySite) -> InventoryDraft:
     """Build a minimal inventory draft for reconciliation tests."""
     return InventoryDraft(
         version="1.0",
-        game_version="2.0.4",
+        game_version="1.0.4",
         scan_date="2026-03-24",
         stats=InventoryStats(
             input_hits=len(sites),

--- a/scripts/tests/test_scan_static_producer_inventory.py
+++ b/scripts/tests/test_scan_static_producer_inventory.py
@@ -141,7 +141,7 @@ def test_cli_writes_deterministic_inventory_without_absolute_source_root(tmp_pat
     assert output_a.read_text(encoding="utf-8") == output_b.read_text(encoding="utf-8")
     payload = cast("dict[str, object]", json.loads(output_a.read_text(encoding="utf-8")))
     assert payload["schema_version"] == "1.0"
-    assert payload["game_version"] == "2.0.4"
+    assert payload["game_version"] == "1.0.4"
     assert payload["target_surfaces"] == ["EmitMessage", "Popup.Show*", "AddPlayerMessage"]
     assert "source_root" not in payload
 

--- a/scripts/tests/test_scanner_cross_reference.py
+++ b/scripts/tests/test_scanner_cross_reference.py
@@ -37,7 +37,7 @@ def _draft(*sites: InventorySite) -> InventoryDraft:
     """Build a minimal inventory draft for cross-reference tests."""
     return InventoryDraft(
         version="1.0",
-        game_version="2.0.4",
+        game_version="1.0.4",
         scan_date="2026-03-22",
         stats=InventoryStats(
             input_hits=len(sites),

--- a/scripts/tests/test_scanner_fixed_leaf_validation.py
+++ b/scripts/tests/test_scanner_fixed_leaf_validation.py
@@ -26,7 +26,7 @@ def _draft(*sites: InventorySite) -> InventoryDraft:
     """Build a minimal inventory draft for validation tests."""
     return InventoryDraft(
         version="1.0",
-        game_version="2.0.4",
+        game_version="1.0.4",
         scan_date="2026-04-11",
         stats=InventoryStats(
             input_hits=len(sites),

--- a/scripts/tests/test_scanner_inventory.py
+++ b/scripts/tests/test_scanner_inventory.py
@@ -115,7 +115,7 @@ class TestInventoryDraftJson:
         """Inventory drafts persist explicit fixed-leaf provenance fields and counts."""
         draft = InventoryDraft(
             version="1.0",
-            game_version="2.0.4",
+            game_version="1.0.4",
             scan_date="2026-04-11",
             stats=InventoryStats(
                 input_hits=2,

--- a/scripts/tests/test_text_construction_surface_policy.py
+++ b/scripts/tests/test_text_construction_surface_policy.py
@@ -181,7 +181,7 @@ def test_classify_family_keeps_generic_string_construction_as_candidate_only() -
 def _inventory(families: list[TextConstructionFamily]) -> TextConstructionInventory:
     return {
         "schema_version": "1.0",
-        "game_version": "2.0.4",
+        "game_version": "1.0.4",
         "totals": {},
         "families": families,
     }

--- a/scripts/tools/StaticProducerInventoryScanner/Program.cs
+++ b/scripts/tools/StaticProducerInventoryScanner/Program.cs
@@ -135,7 +135,7 @@ internal static class InventoryWriter
 internal static class StaticProducerScanner
 {
     private const string SchemaVersion = "1.0";
-    private const string GameVersion = "2.0.4";
+    private const string GameVersion = "1.0.4";
     internal static readonly CSharpParseOptions ParseOptions =
         CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
 

--- a/scripts/tools/TextConstructionInventory/Program.cs
+++ b/scripts/tools/TextConstructionInventory/Program.cs
@@ -90,7 +90,7 @@ return 0;
 internal static class InventoryBuilder
 {
     private const string SchemaVersion = "1.0";
-    private const string GameVersion = "2.0.4";
+    private const string GameVersion = "1.0.4";
 
     public static InventoryDocument Scan(string sourceRoot)
     {

--- a/scripts/validate_xml_warning_baseline.json
+++ b/scripts/validate_xml_warning_baseline.json
@@ -4,7 +4,7 @@
     {
       "path": "Mods/QudJP/Localization/Conversations.jp.xml",
       "warning": "Empty text in element 'text'",
-      "note": "Intentional upstream-preserved Tzedech/Welcome slot; base Conversations.xml 2.0.4 has the same empty <text></text> at line 12869."
+      "note": "Intentional upstream-preserved Tzedech/Welcome slot; base Conversations.xml 1.0.4 has the same empty <text></text> at line 12869."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Align active internal game-version references from 2.0.4 to 1.0.4 across agent docs, contributor docs, CodeRabbit guidance, scanner metadata, and related tests.
- Add the v0.2.45 Workshop release evidence report with the verified 1.0.4 changenote/description wording.
- Add an unreleased release-note fragment for the localization-path metadata change.

## Validation

- `git diff --check`
- `rg -n "2\.0\.4|v2\.0\.4" . -g "!docs/archive/**" -g "!dist/**" -g "!obj/**" -g "!bin/**" -g "!*.dll" -g "!*.zip"` (no matches)
- `just python-check`
- `just python-test-filter 'scan_static_producer_inventory or scanner_inventory or scanner_cross_reference or scanner_fixed_leaf_validation or reconcile_inventory_status or text_construction_surface_policy or localization_coverage_map'`
- `just localization-check`
- `just localization-coverage-map-check`
- `just roslyn-build-static-producer`
- `just roslyn-build-text-construction`
- `just markdown-report-check origin/main HEAD`
- `uv run python scripts/release_notes.py check-fragment --base-ref origin/main --head-ref HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 会話／ポップアップ翻訳のための文法分割処理を追加しました（翻訳表示の改善）。

* **Chores**
  * プロジェクト内の基準ゲーム参照を Caves of Qud v1.0.4 に統一しました（スクリプト・ツール・生成物含む）。

* **Documentation**
  * 多数のドキュメント、報告、ワークショップ資料、リリースメモ等のゲーム版表記を v1.0.4 に更新しました。

* **Bug Fixes**
  * ローカライゼーション検証と互換性関連のワークフロー整備を行いました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->