### PR TITLE
[codex] Add static producer closure workflow

### DIFF
--- a/.codex/skills/qudjp-static-producer-closure/SKILL.md
+++ b/.codex/skills/qudjp-static-producer-closure/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: qudjp-static-producer-closure
+description: Use in QudJP when closing issue-493 style static producer owner queue entries from docs/static-producer-inventory.json and scripts/static_producer_closure.py, including auditing existing patches, proving all callsite shapes, adding focused tests, and registering covered owner families.
+---
+
+# QudJP Static Producer Closure
+
+Use this skill to close one small batch from the `static_producer_messages_popups`
+lane in `docs/localization-coverage-map.json`.
+
+This skill is not a general translation triage guide. Pair it with
+`qudjp-localization-triage` for route ownership decisions and
+`roslyn-static-analysis` for scanner or coverage-map changes.
+
+## Scope
+
+Target only the static producer inventory lane:
+
+- inventory: `docs/static-producer-inventory.json`
+- closure overlay: `scripts/static_producer_closure.py`
+- queue command: `just static-producer-owner-queue`
+- validation gate: `just static-producer-check`
+- target surfaces: `EmitMessage`, `Popup.Show*`, `AddPlayerMessage`
+
+Do not use legacy scanners or archived audits as source of truth. Do not
+regenerate tracked inventory unless the task explicitly owns that artifact.
+
+## Core Rule
+
+Never close a family because a patch class exists.
+
+Close a family only after every inventoried callsite shape is accounted for by
+owner-route behavior, tests, and dictionary/translator coverage, or explicitly
+split/deferred with a reason.
+
+## Batch Workflow
+
+1. **Choose a batch from the queue.**
+   - Run `just static-producer-owner-queue` or
+     `uv run python scripts/static_producer_closure.py --format json --limit 0`.
+   - Prefer one producer family, or a small source-file batch whose families
+     share one owner/test pattern.
+   - Avoid broad `needs_family_review` families until you can split the fixed,
+     generated, runtime-required, and sink-observed shapes.
+
+2. **List every inventory shape before judging coverage.**
+   - Query `docs/static-producer-inventory.json` for the exact
+     `producer_family_id`.
+   - Record all lines, target surfaces, closure statuses, and expressions.
+   - Inspect the matching decompiled source under `~/dev/coq-decompiled_stable/`.
+   - Useful extraction commands:
+
+     ```bash
+     jq -r '.callsites[]
+       | select(.producer_family_id=="FAMILY_ID")
+       | [.line,.target_surface,.closure_status,.expression]
+       | @tsv' docs/static-producer-inventory.json
+
+     uv run python scripts/static_producer_closure.py --format json --limit 0 \
+       | jq '.source_files[].families[]
+         | select(.producer_family_id=="FAMILY_ID")'
+     ```
+
+3. **Audit existing coverage.**
+   - Search repo patches, tests, and localization assets.
+   - Verify the owner patch guard can see every relevant emitted shape.
+   - Verify the real repo dictionary or translator handles every emitted shape.
+     A temporary test dictionary is useful for unit isolation, but it is not
+     enough for closure evidence when production coverage depends on shipped
+     assets.
+   - For families that mix `AddPlayerMessage` and `Popup.Show*`, audit each
+     surface separately. A queue patch can close queued messages only; it does
+     not prove popup callsites in the same owner method.
+   - For `AddPlayerMessage`, prove the generic queue alone does not translate
+     owner-specific traffic.
+   - For `Popup.Show*`, use a narrow owner helper before generic popup fallback
+     for generated or owner-specific sentences.
+
+4. **Classify the result.**
+   - `covered_by_owner_patch`: all inventoried shapes are covered by existing
+     or newly added owner-route tests and production dictionary/translator
+     coverage.
+   - `needs_family_review`: mixed fixed, generated, runtime, or policy shapes
+     still need splitting before implementation.
+   - `runtime_required`: static evidence cannot prove the emitted shape.
+   - `owner_patch_required`: owner-route behavior is still missing.
+
+   For a `needs_family_review` family, report a split table before proposing
+   implementation:
+   - `messages_candidate`: fixed literals or popup/menu text to review outside
+     owner-patch closure.
+   - `owner_patch_required`: generated owner-route shapes that can become a
+     focused batch.
+   - `runtime_required`: shapes that need runtime evidence or deeper producer
+     tracing.
+   - deferred or policy-only shapes, with the reason they are not counted.
+   Do not add the full mixed family id to `COVERED_OWNER_FAMILIES`; close only
+   a smaller coherent route after tests prove that route.
+
+5. **Use Red-Green-Refactor for changes.**
+   - If behavior or closure status changes, add a failing test first.
+   - For existing patches, add missing evidence tests before adding the family
+     to `COVERED_OWNER_FAMILIES`.
+   - For new owner patches, add focused L2 dummy-target tests and L2G target
+     resolution when the patch targets game C#.
+   - Use L1 tests for pure translator or regex helpers.
+
+6. **Minimum evidence before closure overlay registration.**
+   Every `CoveredOwnerFamily` entry should point to evidence for:
+   - owner patch source or owner helper,
+   - queue/popup handoff linkage when applicable,
+   - L2 behavior tests for representative successful shapes,
+   - negative coverage for queue-only or owner-absent traffic when applicable,
+   - direct marker and empty input handling,
+   - color/capture preservation when the family can carry markup,
+   - L2G target/signature resolution for Harmony patches.
+
+7. **Verify and report.**
+   - Run the focused L1/L2/L2G tests touched by the batch.
+   - For focused C# test filters, use direct `dotnet test`; the `just test-l2`
+     and `just test-l2g` recipes do not forward arbitrary filter arguments.
+
+     ```bash
+     dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj \
+       --filter 'TestCategory=L2&FullyQualifiedName~NameFragment' --no-restore
+     ```
+
+   - Run `just static-producer-check`.
+   - Re-run the owner queue and report the family/count delta.
+   - Mention any shapes that remain deferred rather than counting them as
+     closed.
+
+## Common Pitfalls
+
+- Do not register coverage from substring evidence alone; evidence files must
+  contain tests that exercise the inventoried shapes.
+- Do not let a temporary pattern dictionary prove production coverage.
+- Do not treat a sink or generic popup/message fallback as owner coverage.
+- Do not close a mixed `needs_family_review` family without first naming the
+  deferred shapes.
+- Do not quote queue counts from memory; use current command output.
+
+## Output
+
+When reporting a batch, include:
+
+- selected family or source file,
+- inventory callsite shapes reviewed,
+- owner-route decision and deferred shapes,
+- implementation or closure overlay changes,
+- tests/checks run,
+- queue delta,
+- remaining risk.

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
@@ -560,8 +560,7 @@ public sealed class CombatAndLogMessageQueuePatchTests
     [Test]
     public void GameObjectHeal_TranslatesHealMessage_WhenPatched()
     {
-        WritePatternDictionary(
-            ("^You heal for (\\d+) hit points?\\.$", "あなたは{0}HP回復した。"));
+        UseRepositoryPatternDictionary();
 
         var harmonyId = CreateHarmonyId();
         var harmony = new Harmony(harmonyId);
@@ -581,6 +580,118 @@ public sealed class CombatAndLogMessageQueuePatchTests
             target.Heal(5, message: true);
 
             Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("あなたは5HP回復した。"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void GameObjectHeal_TranslatesHpLossMessage_WhenPatched()
+    {
+        UseRepositoryPatternDictionary();
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(typeof(DummyGameObjectHealTarget), nameof(DummyGameObjectHealTarget.Heal), typeof(int), typeof(bool), typeof(bool), typeof(bool)),
+                typeof(GameObjectHealTranslationPatch));
+
+            var target = new DummyGameObjectHealTarget
+            {
+                MessageToSend = "You lose 1 hit point.",
+            };
+
+            target.Heal(-1, message: true);
+
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("あなたは1HP失った。"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void GameObjectHeal_DoesNotTranslateQueueOnlyTraffic_WhenOwnerAbsent()
+    {
+        WritePatternDictionary(
+            ("^You heal for (\\d+) hit points?\\.$", "あなたは{0}HP回復した。"));
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+
+            DummyMessageQueue.AddPlayerMessage("You heal for 5 hit points.", null, Capitalize: false);
+
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("You heal for 5 hit points."));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void GameObjectHeal_DoesNotRetranslateDirectMarkedQueuedMessage_WhenOwnerPatched()
+    {
+        WritePatternDictionary(
+            ("^You heal for (\\d+) hit points?\\.$", "あなたは{0}HP回復した。"));
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(typeof(DummyGameObjectHealTarget), nameof(DummyGameObjectHealTarget.Heal), typeof(int), typeof(bool), typeof(bool), typeof(bool)),
+                typeof(GameObjectHealTranslationPatch));
+
+            var source = MessageFrameTranslator.MarkDirectTranslation("You heal for 5 hit points.");
+            var target = new DummyGameObjectHealTarget
+            {
+                MessageToSend = source,
+            };
+
+            target.Heal(5, message: true);
+
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("You heal for 5 hit points."));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void GameObjectHeal_LeavesEmptyMessageUnchanged_WhenOwnerPatched()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(typeof(DummyGameObjectHealTarget), nameof(DummyGameObjectHealTarget.Heal), typeof(int), typeof(bool), typeof(bool), typeof(bool)),
+                typeof(GameObjectHealTranslationPatch));
+
+            var target = new DummyGameObjectHealTarget
+            {
+                MessageToSend = string.Empty,
+            };
+
+            target.Heal(5, message: true);
+
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(string.Empty));
         }
         finally
         {

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -66,6 +66,34 @@ class CoveredOwnerFamily:
 
 COVERED_OWNER_FAMILIES: Final = (
     CoveredOwnerFamily(
+        family_id="XRL.World/GameObject.cs::XRL.World.GameObject.Heal",
+        inventory_statuses=("owner_patch_required",),
+        evidence_files=(
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/GameObjectHealTranslationPatch.cs",
+                ("TryTranslateQueuedMessage", '"Heal"'),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/CombatAndLogMessageQueuePatch.cs",
+                ("GameObjectHealTranslationPatch.TryTranslateQueuedMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+                (
+                    "GameObjectHeal_TranslatesHealMessage_WhenPatched",
+                    "GameObjectHeal_TranslatesHpLossMessage_WhenPatched",
+                    "GameObjectHeal_DoesNotTranslateQueueOnlyTraffic_WhenOwnerAbsent",
+                    "GameObjectHeal_DoesNotRetranslateDirectMarkedQueuedMessage_WhenOwnerPatched",
+                    "GameObjectHeal_LeavesEmptyMessageUnchanged_WhenOwnerPatched",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                ("typeof(GameObjectHealTranslationPatch)", '"Heal"'),
+            ),
+        ),
+    ),
+    CoveredOwnerFamily(
         family_id="XRL.UI/TradeUI.cs::XRL.UI.TradeUI.PerformOffer",
         inventory_statuses=("needs_family_review",),
         evidence_files=(

--- a/scripts/tests/test_static_producer_closure.py
+++ b/scripts/tests/test_static_producer_closure.py
@@ -51,6 +51,20 @@ def test_covered_owner_families_are_removed_from_owner_action_queue() -> None:
     assert queued_family_ids.isdisjoint(covered_family_ids())
 
 
+def test_game_object_heal_owner_family_is_closed_by_current_owner_tests() -> None:
+    """GameObject.Heal has current owner-route evidence and must stay out of the queue."""
+    inventory = load_inventory(TRACKED_INVENTORY)
+    raw_families = {family["producer_family_id"]: family for family in inventory["families"]}
+    family_id = "XRL.World/GameObject.cs::XRL.World.GameObject.Heal"
+
+    assert raw_families[family_id]["family_closure_status"] == "owner_patch_required"
+    assert family_closure_status(raw_families[family_id]) == COVERED_BY_OWNER_PATCH
+    assert family_id not in {
+        family["producer_family_id"]
+        for family in owner_action_queue(inventory)
+    }
+
+
 def test_uncovered_high_volume_owner_family_remains_in_owner_action_queue() -> None:
     """Uncovered high-volume owner families must stay actionable."""
     inventory = load_inventory(TRACKED_INVENTORY)


### PR DESCRIPTION
## Summary
- Add a repo-local `qudjp-static-producer-closure` skill for issue-493 static producer owner queue work.
- Register the existing `GameObject.Heal` owner-route coverage in `scripts/static_producer_closure.py` with focused evidence checks.
- Strengthen `GameObjectHeal` L2 tests around repository dictionary coverage, queue-only traffic, direct marker handling, and empty messages.

## Context
This builds on the owner action queue introduced by PR #552 and prepares repeatable batch work for #493 before starting larger closure passes in a new session.

Related: #493
Builds on: #552

## Validation
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~CombatAndLogMessageQueuePatchTests.GameObjectHeal" --no-restore`
- `just static-producer-check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * ゲームメッセージの翻訳検証テストを強化しました。ヒール関連の翻訳カバレッジを拡張し、HP損失の翻訳やキューに入ったメッセージの処理を検証しています。

* **ドキュメント**
  * 静的プロデューサーの完了ワークフロー仕様を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->