### PR TITLE
Fix Workshop inventory item-name regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.2.46] - 2026-05-07
+
+### Fixed
+
+- Steam Workshop 版でインベントリのアイテム名修復処理が `UnityEngine.Vector2.get_x()` 例外により止まり、アイテム名が消える問題を修正しました。
+
+---
+
 ## [0.2.45] - 2026-05-07
 
 ### Fixed

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/UnityApiCompatibilityTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/UnityApiCompatibilityTests.cs
@@ -13,6 +13,10 @@ public sealed class UnityApiCompatibilityTests
         @"TransformPoint\s*\(\s*(?!UnityRuntimeCompatibility\s*\.\s*ToVector3\s*\()[\s\S]*?\.\s*rectTransform\s*\.\s*rect\s*\.\s*center\s*\)",
         SourceRegexOptions);
 
+    private static readonly Regex DirectVector2CoordinateAccessPattern = new(
+        @"\b(?:value|vector)\s*\.\s*[xy]\b",
+        SourceRegexOptions);
+
     [NUnit.Framework.Test]
     public void RuntimeDiagnostics_AvoidDirectUnityColorAlphaAccess()
     {
@@ -83,5 +87,31 @@ public sealed class UnityApiCompatibilityTests
         var directColorAlphaPattern = new Regex(@"\.\s*color\s*\.\s*a\b", SourceRegexOptions);
 
         NUnit.Framework.Assert.That("text.color.alpha", NUnit.Framework.Does.Not.Match(directColorAlphaPattern));
+    }
+
+    [NUnit.Framework.TestCase("new Vector3(value.x, value.y, 0f)")]
+    [NUnit.Framework.TestCase("new Vector3(vector.x, vector.y, 0f)")]
+    public void DirectVector2CoordinateAccessPattern_CatchesKnownParameterNames(string source)
+    {
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Match(DirectVector2CoordinateAccessPattern));
+    }
+
+    [NUnit.Framework.Test]
+    public void RuntimeCompatibility_ToVector3AvoidsDirectVector2CoordinateAccess()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "UI",
+            "UnityRuntimeCompatibility.cs");
+        var source = File.ReadAllText(sourcePath);
+
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Not.Match(DirectVector2CoordinateAccessPattern),
+            "UnityEngine.Vector2 x/y access can compile to get_x/get_y calls that are absent in the shipped game runtime.");
     }
 }

--- a/Mods/QudJP/Assemblies/src/UI/UnityRuntimeCompatibility.cs
+++ b/Mods/QudJP/Assemblies/src/UI/UnityRuntimeCompatibility.cs
@@ -1,5 +1,6 @@
 #if HAS_TMP
 using System;
+using System.Diagnostics;
 using System.Reflection;
 using UnityEngine;
 #endif
@@ -11,9 +12,14 @@ internal static class UnityRuntimeCompatibility
 #if HAS_TMP
     private const BindingFlags PublicInstance = BindingFlags.Instance | BindingFlags.Public;
 
-    internal static Vector3 ToVector3(Vector2 value)
+    internal static Vector3 ToVector3(Vector2 vector)
     {
-        return new Vector3(value.x, value.y, 0f);
+        var boxedVector = (object)vector;
+        var vectorType = boxedVector.GetType();
+        var x = TryGetFloatMemberOrDefault(boxedVector, vectorType, "x");
+        var y = TryGetFloatMemberOrDefault(boxedVector, vectorType, "y");
+
+        return new Vector3(x, y, 0f);
     }
 
     internal static float? TryGetColorAlpha(Color color)
@@ -60,6 +66,47 @@ internal static class UnityRuntimeCompatibility
         {
             return null;
         }
+    }
+
+    private static float? TryGetFloatMember(object target, Type targetType, string memberName)
+    {
+        try
+        {
+            var field = targetType.GetField(memberName, PublicInstance);
+            if (field?.FieldType == typeof(float) && field.GetValue(target) is float fieldValue)
+            {
+                return fieldValue;
+            }
+
+            var property = targetType.GetProperty(memberName, PublicInstance);
+            if (property?.PropertyType == typeof(float)
+                && property.GetIndexParameters().Length == 0
+                && property.GetValue(target, null) is float propertyValue)
+            {
+                return propertyValue;
+            }
+
+            return null;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private static float TryGetFloatMemberOrDefault(object target, Type targetType, string memberName)
+    {
+        var value = TryGetFloatMember(target, targetType, memberName);
+        if (value.HasValue)
+        {
+            return value.Value;
+        }
+
+        Trace.TraceWarning(
+            "QudJP: UnityRuntimeCompatibility could not read float member '{0}' on '{1}'. Falling back to 0.",
+            memberName,
+            targetType.FullName);
+        return 0f;
     }
 #endif
 }

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.2.45",
+  "Version": "0.2.46",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/release.md
+++ b/docs/release.md
@@ -338,15 +338,25 @@ After Steam finishes processing the item:
    image, visibility, file size, and change note.
 2. Subscribe to the item from a clean Steam client state or unsubscribe and
    resubscribe if updating an existing item.
-3. Launch the game, enable only QudJP for the smoke pass, and restart.
-4. Confirm the Mod Manager lists QudJP with the expected version and preview.
-5. Confirm the Options screen and one short conversation render Japanese text
+3. Validate the downloaded Workshop item against the staged content:
+
+   ```bash
+   just workshop-download-check X.Y.Z dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip
+   ```
+
+   This verifies that the downloaded `manifest.json` reports the expected
+   version and that the downloaded `Assemblies/QudJP.dll` SHA256 matches the
+   release ZIP DLL. Do not mark the release GO if the public Workshop download
+   still contains an older DLL.
+4. Launch the game, enable only QudJP for the smoke pass, and restart.
+5. Confirm the Mod Manager lists QudJP with the expected version and preview.
+6. Confirm the Options screen and one short conversation render Japanese text
    and CJK glyphs correctly.
-6. Check fresh logs under `~/Library/Logs/Freehold Games/CavesOfQud/` for QudJP
+7. Check fresh logs under `~/Library/Logs/Freehold Games/CavesOfQud/` for QudJP
    build markers, missing glyph warnings, compile errors, or `MODWARN`.
-7. Record the smoke result in the dated release evidence file copied from
+8. Record the smoke result in the dated release evidence file copied from
    `docs/reports/templates/workshop-release.md`.
-8. Publish the draft GitHub Release only after the Steam Workshop upload and
+9. Publish the draft GitHub Release only after the Steam Workshop upload and
    minimum post-publish checks are acceptable.
 
 ## Rollback

--- a/docs/reports/2026-05-07-workshop-v0.2.46.md
+++ b/docs/reports/2026-05-07-workshop-v0.2.46.md
@@ -3,7 +3,7 @@
 ## Identity
 
 - Version: `0.2.46`
-- Git commit: PR commit containing this report, rebased onto `origin/main` after the emergency upload
+- Git commit: `6f52ee7` (`6f52ee786e296b1e70bb6ac872fbdea72fad7146`)
 - Git tag: not created for this emergency Workshop hotfix
 - Previous release tag/range: `v0.2.45..HEAD`
 - Version source: `Mods/QudJP/manifest.json`
@@ -61,7 +61,7 @@ v0.2.46 / 3d88378c621f+worktree-hotfix
 
 ## Upload
 
-- steamcmd command: `steamcmd +login "$STEAM_USER" +workshop_build_item "/Users/sankenbisha/Dev/coq-japanese_stable/.worktrees/fix-workshop-vector2-inventory/dist/workshop/workshop_item.vdf" +quit`
+- steamcmd command: `steamcmd +login "$STEAM_USER" +workshop_build_item "<repo>/dist/workshop/workshop_item.vdf" +quit`
 - Upload completed at: `2026-05-07 20:12:39 JST` according to Steam Web API `time_updated`
 - Steam output summary: `Preparing update`; `Uploading content`; `Uploading preview image`; `Committing update...Success.`
 - Steam Web API: `publishedfileid=3718988020`, `title=Caves of Qud Japanese Mod`, `visibility=0`, `file_size=19618536`, `hcontent_file=2488077146811212590`

--- a/docs/reports/2026-05-07-workshop-v0.2.46.md
+++ b/docs/reports/2026-05-07-workshop-v0.2.46.md
@@ -1,0 +1,85 @@
+# Workshop Release v0.2.46
+
+## Identity
+
+- Version: `0.2.46`
+- Git commit: PR commit containing this report, rebased onto `origin/main` after the emergency upload
+- Git tag: not created for this emergency Workshop hotfix
+- Previous release tag/range: `v0.2.45..HEAD`
+- Version source: `Mods/QudJP/manifest.json`
+- GitHub Release URL: not used for this emergency Workshop hotfix
+- Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
+- Steam app ID: `333640`
+- Published file ID: `3718988020`
+- Follow-up issue: https://github.com/ToaruPen/coq-japanese_stable/issues/574
+- Steam changenote upload identity: `3d88378c621f+worktree-hotfix`
+
+## Changenote
+
+```text
+v0.2.46 / 3d88378c621f+worktree-hotfix
+
+更新内容:
+- インベントリ画面でアイテム名が消えることがある問題の hotfix です。
+
+翻訳追加・改善:
+- なし
+
+修正:
+- Steam Workshop 版で、インベントリのアイテム名修復処理が Unity 実行環境差異による `Vector2.get_x()` 例外で止まる問題を修正しました。
+- 修復経路が例外で中断されないよう、Unity の `Vector2` 座標読み取りを実行時互換の処理に変更しました。
+
+既知の問題:
+- インベントリの元 TextMeshPro 行は、環境によって `charCount=0` のまま補修経路で表示される場合があります。根本原因の調査は follow-up issue で追跡します。
+- 一部の自動生成テキスト、チュートリアル、キャラクター生成画面には未翻訳または不自然な訳が残る場合があります。
+- ゲーム本体のアップデートにより、一部表示やパッチが壊れる可能性があります。
+```
+
+## Artifacts
+
+- Release ZIP: `dist/QudJP-v0.2.46.zip`
+- Release ZIP SHA256: `d5ba54b2bed4913fa0247c8339c8500d8837984d833c964a1113003bdaa58df7`
+- GitHub Release asset: not used
+- GitHub Release asset SHA256: not used
+- Workshop content folder: `dist/workshop/QudJP/`
+- Workshop VDF: `dist/workshop/workshop_item.vdf`
+
+## Preflight
+
+- [x] `git status --short --branch`
+- [x] Release range established from previous tag, release report, changelog/GitHub release, or explicit user range
+- [x] `Mods/QudJP/manifest.json` version, release ZIP name, changenote first line, and report version match
+- [x] focused `UnityApiCompatibilityTests`
+- [x] focused inventory L1 tests
+- [x] `just test-l1`
+- [x] `uv run pytest scripts/tests/test_build_release.py scripts/tests/test_build_workshop_upload.py scripts/tests/test_sync_mod.py -q`
+- [x] `just build-release`
+- [x] `just release-zip-check dist/QudJP-v0.2.46.zip`
+- [x] `just build-workshop-upload dist/QudJP-v0.2.46.zip /tmp/qudjp-workshop-changenote.txt`
+- [x] Workshop staging DLL SHA256 matches downloaded Workshop DLL SHA256: `ca8ad3b9f2f94df472a6e04f6f169ce23afa28c6aca7a1500c82cca699391b0c`
+- [x] Workshop staging VDF uses literal multiline description and changenote text, not escaped `\n` sequences
+
+## Upload
+
+- steamcmd command: `steamcmd +login "$STEAM_USER" +workshop_build_item "/Users/sankenbisha/Dev/coq-japanese_stable/.worktrees/fix-workshop-vector2-inventory/dist/workshop/workshop_item.vdf" +quit`
+- Upload completed at: `2026-05-07 20:12:39 JST` according to Steam Web API `time_updated`
+- Steam output summary: `Preparing update`; `Uploading content`; `Uploading preview image`; `Committing update...Success.`
+- Steam Web API: `publishedfileid=3718988020`, `title=Caves of Qud Japanese Mod`, `visibility=0`, `file_size=19618536`, `hcontent_file=2488077146811212590`
+- GitHub Release published at: not used
+
+## Post-Publish Smoke
+
+- [x] Workshop metadata checked through Steam Web API
+- [x] Subscribe/resubscribe checked with `steamcmd +login anonymous +workshop_download_item 333640 3718988020 validate +quit`
+- [x] `just workshop-download-check 0.2.46 dist/QudJP-v0.2.46.zip`
+- [x] Downloaded Workshop `manifest.json` reports `Version: 0.2.46`
+- [x] Downloaded Workshop DLL SHA256 matches staging DLL SHA256: `ca8ad3b9f2f94df472a6e04f6f169ce23afa28c6aca7a1500c82cca699391b0c`
+- [x] Mod Manager / in-game load checked manually after placing the downloaded Workshop `0.2.46` content
+- [x] Inventory item names visible in-game after placing the downloaded Workshop `0.2.46` content
+- [x] Fresh Player.log checked after downloading Workshop `0.2.46`: no `MissingMethodException`, `Vector2.get_x/get_y`, QudJP compile errors, or `MODWARN`
+
+## Decision
+
+- Result: GO
+- Notes: Emergency Workshop hotfix uploaded from dirty worktree changes instead of the normal clean-tagged GitHub Release flow. The public Workshop item now downloads `manifest.json` version `0.2.46` and the fixed DLL without `Vector2.get_x/get_y` references. Manual in-game smoke confirmed inventory item names are visible, while the original inventory TMP route still reports `charCount=0` and is tracked separately in issue #574.
+- Rollback tag, if needed: `v0.2.45`

--- a/docs/reports/templates/workshop-release.md
+++ b/docs/reports/templates/workshop-release.md
@@ -64,6 +64,7 @@ vX.Y.Z / <short-git-hash>
 
 - [ ] Workshop page title, description, preview image, visibility, file size, and changenote checked
 - [ ] Subscribe/resubscribe checked
+- [ ] `just workshop-download-check X.Y.Z dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip`
 - [ ] Mod Manager lists QudJP with expected version and preview
 - [ ] Options screen renders Japanese text and CJK glyphs
 - [ ] One short conversation renders Japanese text and CJK glyphs

--- a/justfile
+++ b/justfile
@@ -188,13 +188,17 @@ workshop-download-check version expected_dll="" workshop_dir="":
           "${HOME}/.steam/steam/steamapps/workshop/content/333640/3718988020"
           "${HOME}/.local/share/Steam/steamapps/workshop/content/333640/3718988020"
         )
-        resolved_workshop_dir="${workshop_candidates[0]}"
+        resolved_workshop_dir=""
         for candidate in "${workshop_candidates[@]}"; do
           if [ -d "${candidate}" ]; then
             resolved_workshop_dir="${candidate}"
             break
           fi
         done
+        if [ -z "${resolved_workshop_dir}" ]; then
+          printf 'error: Workshop download directory not found; pass workshop_dir explicitly\n' >&2
+          exit 1
+        fi
         ;;
       *)
         printf 'error: pass workshop_dir explicitly on this platform\n' >&2

--- a/justfile
+++ b/justfile
@@ -179,7 +179,28 @@ workshop-download-check version expected_dll="" workshop_dir="":
   set -euo pipefail
   resolved_workshop_dir={{quote(workshop_dir)}}
   if [ -z "${resolved_workshop_dir}" ]; then
-    resolved_workshop_dir="${HOME}/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020"
+    case "$(uname -s)" in
+      Darwin)
+        resolved_workshop_dir="${HOME}/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020"
+        ;;
+      Linux)
+        workshop_candidates=(
+          "${HOME}/.steam/steam/steamapps/workshop/content/333640/3718988020"
+          "${HOME}/.local/share/Steam/steamapps/workshop/content/333640/3718988020"
+        )
+        resolved_workshop_dir="${workshop_candidates[0]}"
+        for candidate in "${workshop_candidates[@]}"; do
+          if [ -d "${candidate}" ]; then
+            resolved_workshop_dir="${candidate}"
+            break
+          fi
+        done
+        ;;
+      *)
+        printf 'error: pass workshop_dir explicitly on this platform\n' >&2
+        exit 1
+        ;;
+    esac
   fi
   resolved_expected_dll={{quote(expected_dll)}}
   if [ -z "${resolved_expected_dll}" ]; then

--- a/justfile
+++ b/justfile
@@ -167,6 +167,20 @@ build-workshop-upload release_zip="" changenote_file="/tmp/qudjp-workshop-change
     {{python}} scripts/build_workshop_upload.py --changenote-file "{{changenote_file}}"; \
   fi
 
+# Verify a downloaded Steam Workshop item against the expected release DLL or ZIP.
+workshop-download-check version expected_dll="" workshop_dir="":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  resolved_workshop_dir={{quote(workshop_dir)}}
+  if [ -z "${resolved_workshop_dir}" ]; then
+    resolved_workshop_dir="${HOME}/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020"
+  fi
+  resolved_expected_dll={{quote(expected_dll)}}
+  if [ -z "${resolved_expected_dll}" ]; then
+    resolved_expected_dll="dist/QudJP-v{{version}}.zip"
+  fi
+  {{python}} scripts/verify_workshop_download.py --workshop-dir "${resolved_workshop_dir}" --expected-version {{quote(version)}} --expected-dll "${resolved_expected_dll}"
+
 # Download and verify the GitHub Release ZIP used for Workshop staging.
 download-release-zip version:
   #!/usr/bin/env bash

--- a/scripts/tests/test_verify_workshop_download.py
+++ b/scripts/tests/test_verify_workshop_download.py
@@ -91,6 +91,27 @@ def test_verify_workshop_download_reports_missing_assembly(tmp_path: Path) -> No
     assert downloaded_dll_sha256 is None
 
 
+def test_verify_workshop_download_reports_unreadable_manifest(tmp_path: Path) -> None:
+    """A manifest with invalid encoding is reported as a validation finding."""
+    expected_dll = tmp_path / "QudJP.dll"
+    expected_dll.write_bytes(b"fixed dll")
+    workshop_dir = tmp_path / "workshop" / "3718988020"
+    (workshop_dir / "Assemblies").mkdir(parents=True)
+    (workshop_dir / "manifest.json").write_bytes(b"\xff")
+    (workshop_dir / "Assemblies" / "QudJP.dll").write_bytes(b"fixed dll")
+
+    findings, downloaded_dll_sha256 = verify_workshop_download(
+        workshop_dir,
+        expected_version="0.2.46",
+        expected_dll=expected_dll,
+    )
+
+    assert len(findings) == 2
+    assert findings[0].startswith("Workshop manifest is not valid JSON or could not be read:")
+    assert findings[1] == "manifest version mismatch: expected 0.2.46, got <missing>"
+    assert downloaded_dll_sha256 == "17af6e82115c251ea6aea5e9900ccfcd0f19ab211fd9f92d9e48b6efd02d19c6"
+
+
 def test_verify_workshop_download_accepts_expected_release_zip(tmp_path: Path) -> None:
     """The expected DLL can be read from the release ZIP used for Workshop staging."""
     release_zip = tmp_path / "QudJP-v0.2.46.zip"

--- a/scripts/tests/test_verify_workshop_download.py
+++ b/scripts/tests/test_verify_workshop_download.py
@@ -27,11 +27,14 @@ def test_verify_workshop_download_accepts_matching_version_and_dll(tmp_path: Pat
     workshop_dir = tmp_path / "workshop" / "3718988020"
     _write_workshop_download(workshop_dir, version="0.2.46", dll_bytes=b"fixed dll")
 
-    assert verify_workshop_download(
+    findings, downloaded_dll_sha256 = verify_workshop_download(
         workshop_dir,
         expected_version="0.2.46",
         expected_dll=expected_dll,
-    ) == []
+    )
+
+    assert findings == []
+    assert downloaded_dll_sha256 == "17af6e82115c251ea6aea5e9900ccfcd0f19ab211fd9f92d9e48b6efd02d19c6"
 
 
 def test_verify_workshop_download_reports_version_and_dll_mismatch(tmp_path: Path) -> None:
@@ -42,7 +45,7 @@ def test_verify_workshop_download_reports_version_and_dll_mismatch(tmp_path: Pat
     workshop_dir = tmp_path / "workshop" / "3718988020"
     _write_workshop_download(workshop_dir, version="0.2.45", dll_bytes=b"old dll")
 
-    findings = verify_workshop_download(
+    findings, downloaded_dll_sha256 = verify_workshop_download(
         workshop_dir,
         expected_version="0.2.46",
         expected_dll=expected_dll,
@@ -52,6 +55,7 @@ def test_verify_workshop_download_reports_version_and_dll_mismatch(tmp_path: Pat
         "manifest version mismatch: expected 0.2.46, got 0.2.45",
         "DLL SHA256 mismatch: downloaded QudJP.dll does not match expected DLL",
     ]
+    assert downloaded_dll_sha256 == "6fa63fac4dbe68a82c66caa07a3d821e10d043e5ca2a1c774d4da9671f1305a9"
 
 
 def test_verify_workshop_download_reports_missing_manifest(tmp_path: Path) -> None:
@@ -59,13 +63,32 @@ def test_verify_workshop_download_reports_missing_manifest(tmp_path: Path) -> No
     expected_dll = tmp_path / "QudJP.dll"
     expected_dll.write_bytes(b"fixed dll")
 
-    findings = verify_workshop_download(
+    findings, downloaded_dll_sha256 = verify_workshop_download(
         tmp_path / "missing-workshop",
         expected_version="0.2.46",
         expected_dll=expected_dll,
     )
 
     assert findings == ["Workshop manifest not found"]
+    assert downloaded_dll_sha256 is None
+
+
+def test_verify_workshop_download_reports_missing_assembly(tmp_path: Path) -> None:
+    """A missing Workshop DLL is reported without crashing."""
+    expected_dll = tmp_path / "QudJP.dll"
+    expected_dll.write_bytes(b"fixed dll")
+    workshop_dir = tmp_path / "workshop" / "3718988020"
+    workshop_dir.mkdir(parents=True)
+    (workshop_dir / "manifest.json").write_text(json.dumps({"Version": "0.2.46"}), encoding="utf-8")
+
+    findings, downloaded_dll_sha256 = verify_workshop_download(
+        workshop_dir,
+        expected_version="0.2.46",
+        expected_dll=expected_dll,
+    )
+
+    assert findings == ["Workshop DLL not found: Assemblies/QudJP.dll"]
+    assert downloaded_dll_sha256 is None
 
 
 def test_verify_workshop_download_accepts_expected_release_zip(tmp_path: Path) -> None:
@@ -76,11 +99,31 @@ def test_verify_workshop_download_accepts_expected_release_zip(tmp_path: Path) -
     workshop_dir = tmp_path / "workshop" / "3718988020"
     _write_workshop_download(workshop_dir, version="0.2.46", dll_bytes=b"fixed dll")
 
-    assert verify_workshop_download(
+    findings, downloaded_dll_sha256 = verify_workshop_download(
         workshop_dir,
         expected_version="0.2.46",
         expected_dll=release_zip,
-    ) == []
+    )
+
+    assert findings == []
+    assert downloaded_dll_sha256 == "17af6e82115c251ea6aea5e9900ccfcd0f19ab211fd9f92d9e48b6efd02d19c6"
+
+
+def test_verify_workshop_download_reports_invalid_expected_release_zip(tmp_path: Path) -> None:
+    """An unreadable release ZIP is reported as a validation finding."""
+    release_zip = tmp_path / "QudJP-v0.2.46.zip"
+    release_zip.write_bytes(b"not a zip")
+    workshop_dir = tmp_path / "workshop" / "3718988020"
+    _write_workshop_download(workshop_dir, version="0.2.46", dll_bytes=b"fixed dll")
+
+    findings, downloaded_dll_sha256 = verify_workshop_download(
+        workshop_dir,
+        expected_version="0.2.46",
+        expected_dll=release_zip,
+    )
+
+    assert findings == [f"expected DLL could not be read from {release_zip}: File is not a zip file"]
+    assert downloaded_dll_sha256 is None
 
 
 def test_verify_workshop_download_rejects_invalid_expected_version(tmp_path: Path) -> None:

--- a/scripts/tests/test_verify_workshop_download.py
+++ b/scripts/tests/test_verify_workshop_download.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.verify_workshop_download import verify_workshop_download
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_workshop_download(root: Path, *, version: str, dll_bytes: bytes) -> None:
+    """Create a minimal downloaded Workshop item fixture."""
+    (root / "Assemblies").mkdir(parents=True)
+    (root / "manifest.json").write_text(json.dumps({"Version": version}), encoding="utf-8")
+    (root / "Assemblies" / "QudJP.dll").write_bytes(dll_bytes)
+
+
+def test_verify_workshop_download_accepts_matching_version_and_dll(tmp_path: Path) -> None:
+    """A downloaded Workshop item is valid when version and DLL hash match."""
+    expected_dll = tmp_path / "expected" / "QudJP.dll"
+    expected_dll.parent.mkdir()
+    expected_dll.write_bytes(b"fixed dll")
+    workshop_dir = tmp_path / "workshop" / "3718988020"
+    _write_workshop_download(workshop_dir, version="0.2.46", dll_bytes=b"fixed dll")
+
+    assert verify_workshop_download(
+        workshop_dir,
+        expected_version="0.2.46",
+        expected_dll=expected_dll,
+    ) == []
+
+
+def test_verify_workshop_download_reports_version_and_dll_mismatch(tmp_path: Path) -> None:
+    """Version and DLL mismatches are both reported so releases cannot hide drift."""
+    expected_dll = tmp_path / "expected" / "QudJP.dll"
+    expected_dll.parent.mkdir()
+    expected_dll.write_bytes(b"fixed dll")
+    workshop_dir = tmp_path / "workshop" / "3718988020"
+    _write_workshop_download(workshop_dir, version="0.2.45", dll_bytes=b"old dll")
+
+    findings = verify_workshop_download(
+        workshop_dir,
+        expected_version="0.2.46",
+        expected_dll=expected_dll,
+    )
+
+    assert findings == [
+        "manifest version mismatch: expected 0.2.46, got 0.2.45",
+        "DLL SHA256 mismatch: downloaded QudJP.dll does not match expected DLL",
+    ]
+
+
+def test_verify_workshop_download_reports_missing_manifest(tmp_path: Path) -> None:
+    """A missing manifest is reported as an actionable release validation failure."""
+    expected_dll = tmp_path / "QudJP.dll"
+    expected_dll.write_bytes(b"fixed dll")
+
+    findings = verify_workshop_download(
+        tmp_path / "missing-workshop",
+        expected_version="0.2.46",
+        expected_dll=expected_dll,
+    )
+
+    assert findings == ["Workshop manifest not found"]
+
+
+def test_verify_workshop_download_accepts_expected_release_zip(tmp_path: Path) -> None:
+    """The expected DLL can be read from the release ZIP used for Workshop staging."""
+    release_zip = tmp_path / "QudJP-v0.2.46.zip"
+    with zipfile.ZipFile(release_zip, "w") as archive:
+        archive.writestr("QudJP/Assemblies/QudJP.dll", b"fixed dll")
+    workshop_dir = tmp_path / "workshop" / "3718988020"
+    _write_workshop_download(workshop_dir, version="0.2.46", dll_bytes=b"fixed dll")
+
+    assert verify_workshop_download(
+        workshop_dir,
+        expected_version="0.2.46",
+        expected_dll=release_zip,
+    ) == []
+
+
+def test_verify_workshop_download_rejects_invalid_expected_version(tmp_path: Path) -> None:
+    """Expected versions must be the same simple semver used by manifest.json."""
+    with pytest.raises(ValueError, match=r"X\.Y\.Z"):
+        verify_workshop_download(
+            tmp_path,
+            expected_version="v0.2.46",
+            expected_dll=tmp_path / "QudJP.dll",
+        )

--- a/scripts/tests/test_verify_workshop_download.py
+++ b/scripts/tests/test_verify_workshop_download.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import scripts.verify_workshop_download as verifier
 from scripts.verify_workshop_download import verify_workshop_download
 
 if TYPE_CHECKING:
@@ -130,6 +131,24 @@ def test_verify_workshop_download_accepts_expected_release_zip(tmp_path: Path) -
     assert downloaded_dll_sha256 == "17af6e82115c251ea6aea5e9900ccfcd0f19ab211fd9f92d9e48b6efd02d19c6"
 
 
+def test_verify_workshop_download_accepts_uppercase_expected_release_zip(tmp_path: Path) -> None:
+    """Release ZIP extension matching is case-insensitive."""
+    release_zip = tmp_path / "QudJP-v0.2.46.ZIP"
+    with zipfile.ZipFile(release_zip, "w") as archive:
+        archive.writestr("QudJP/Assemblies/QudJP.dll", b"fixed dll")
+    workshop_dir = tmp_path / "workshop" / "3718988020"
+    _write_workshop_download(workshop_dir, version="0.2.46", dll_bytes=b"fixed dll")
+
+    findings, downloaded_dll_sha256 = verify_workshop_download(
+        workshop_dir,
+        expected_version="0.2.46",
+        expected_dll=release_zip,
+    )
+
+    assert findings == []
+    assert downloaded_dll_sha256 == "17af6e82115c251ea6aea5e9900ccfcd0f19ab211fd9f92d9e48b6efd02d19c6"
+
+
 def test_verify_workshop_download_reports_invalid_expected_release_zip(tmp_path: Path) -> None:
     """An unreadable release ZIP is reported as a validation finding."""
     release_zip = tmp_path / "QudJP-v0.2.46.zip"
@@ -144,6 +163,32 @@ def test_verify_workshop_download_reports_invalid_expected_release_zip(tmp_path:
     )
 
     assert findings == [f"expected DLL could not be read from {release_zip}: File is not a zip file"]
+    assert downloaded_dll_sha256 is None
+
+
+def test_verify_workshop_download_reports_unreadable_workshop_dll(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Workshop DLL read errors are reported as validation findings."""
+    expected_dll = tmp_path / "QudJP.dll"
+    expected_dll.write_bytes(b"fixed dll")
+    workshop_dir = tmp_path / "workshop" / "3718988020"
+    _write_workshop_download(workshop_dir, version="0.2.46", dll_bytes=b"fixed dll")
+
+    def raise_os_error(_path: object) -> str:
+        msg = "permission denied"
+        raise OSError(msg)
+
+    monkeypatch.setattr(verifier, "_sha256", raise_os_error)
+
+    findings, downloaded_dll_sha256 = verify_workshop_download(
+        workshop_dir,
+        expected_version="0.2.46",
+        expected_dll=expected_dll,
+    )
+
+    assert findings == ["Workshop DLL could not be read: permission denied"]
     assert downloaded_dll_sha256 is None
 
 

--- a/scripts/verify_workshop_download.py
+++ b/scripts/verify_workshop_download.py
@@ -79,8 +79,8 @@ def verify_workshop_download(
 
     try:
         actual_version = _read_manifest_version(manifest_path)
-    except json.JSONDecodeError as exc:
-        findings.append(f"Workshop manifest is not valid JSON: {exc.msg}")
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
+        findings.append(f"Workshop manifest is not valid JSON or could not be read: {exc}")
         actual_version = None
 
     if actual_version != expected_version:

--- a/scripts/verify_workshop_download.py
+++ b/scripts/verify_workshop_download.py
@@ -31,7 +31,7 @@ def _sha256_bytes(payload: bytes) -> str:
 
 def _read_expected_dll(path: Path) -> bytes:
     """Read an expected DLL from a DLL file or QudJP release ZIP."""
-    if path.suffix == ".zip":
+    if path.suffix.casefold() == ".zip":
         with zipfile.ZipFile(path) as archive:
             return archive.read("QudJP/Assemblies/QudJP.dll")
     return path.read_bytes()
@@ -96,11 +96,16 @@ def verify_workshop_download(
 
     try:
         expected_payload = _read_expected_dll(expected_dll)
-    except (FileNotFoundError, KeyError, zipfile.BadZipFile) as exc:
+    except (FileNotFoundError, KeyError, OSError, zipfile.BadZipFile) as exc:
         findings.append(f"expected DLL could not be read from {expected_dll}: {exc}")
         return findings, None
 
-    downloaded_dll_sha256 = _sha256(downloaded_dll)
+    try:
+        downloaded_dll_sha256 = _sha256(downloaded_dll)
+    except OSError as exc:
+        findings.append(f"Workshop DLL could not be read: {exc}")
+        return findings, None
+
     if downloaded_dll_sha256 != _sha256_bytes(expected_payload):
         findings.append("DLL SHA256 mismatch: downloaded QudJP.dll does not match expected DLL")
 

--- a/scripts/verify_workshop_download.py
+++ b/scripts/verify_workshop_download.py
@@ -49,7 +49,7 @@ def verify_workshop_download(
     *,
     expected_version: str,
     expected_dll: Path,
-) -> list[str]:
+) -> tuple[list[str], str | None]:
     """Verify a downloaded Workshop item folder.
 
     Args:
@@ -59,7 +59,8 @@ def verify_workshop_download(
             Workshop DLL must match.
 
     Returns:
-        A list of validation findings. An empty list means the download matches.
+        Validation findings and the downloaded DLL SHA256 when available.
+        An empty findings list means the download matches.
 
     Raises:
         ValueError: If ``expected_version`` is not simple ``X.Y.Z`` semver.
@@ -74,7 +75,7 @@ def verify_workshop_download(
 
     if not manifest_path.is_file():
         findings.append("Workshop manifest not found")
-        return findings
+        return findings, None
 
     try:
         actual_version = _read_manifest_version(manifest_path)
@@ -87,17 +88,23 @@ def verify_workshop_download(
 
     if not expected_dll.is_file():
         findings.append(f"expected DLL not found: {expected_dll}")
-        return findings
+        return findings, None
 
     if not downloaded_dll.is_file():
         findings.append("Workshop DLL not found: Assemblies/QudJP.dll")
-        return findings
+        return findings, None
 
-    expected_payload = _read_expected_dll(expected_dll)
-    if _sha256(downloaded_dll) != _sha256_bytes(expected_payload):
+    try:
+        expected_payload = _read_expected_dll(expected_dll)
+    except (FileNotFoundError, KeyError, zipfile.BadZipFile) as exc:
+        findings.append(f"expected DLL could not be read from {expected_dll}: {exc}")
+        return findings, None
+
+    downloaded_dll_sha256 = _sha256(downloaded_dll)
+    if downloaded_dll_sha256 != _sha256_bytes(expected_payload):
         findings.append("DLL SHA256 mismatch: downloaded QudJP.dll does not match expected DLL")
 
-    return findings
+    return findings, downloaded_dll_sha256
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -115,7 +122,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        findings = verify_workshop_download(
+        findings, downloaded_dll_sha256 = verify_workshop_download(
             args.workshop_dir,
             expected_version=args.expected_version,
             expected_dll=args.expected_dll,
@@ -129,11 +136,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"Error: {finding}", file=sys.stderr)  # noqa: T201
         return 1
 
-    downloaded_dll = args.workshop_dir / "Assemblies" / "QudJP.dll"
     print(  # noqa: T201
         "Workshop download verified: "
         f"version={args.expected_version} "
-        f"dll_sha256={_sha256(downloaded_dll)}",
+        f"dll_sha256={downloaded_dll_sha256}",
     )
     return 0
 

--- a/scripts/verify_workshop_download.py
+++ b/scripts/verify_workshop_download.py
@@ -1,0 +1,142 @@
+"""Verify a downloaded Steam Workshop item against the staged release DLL."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA256 hex digest for a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    """Return the SHA256 hex digest for bytes."""
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _read_expected_dll(path: Path) -> bytes:
+    """Read an expected DLL from a DLL file or QudJP release ZIP."""
+    if path.suffix == ".zip":
+        with zipfile.ZipFile(path) as archive:
+            return archive.read("QudJP/Assemblies/QudJP.dll")
+    return path.read_bytes()
+
+
+def _read_manifest_version(manifest_path: Path) -> str | None:
+    """Read the Version field from a Workshop manifest."""
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    version = data.get("Version")
+    return version if isinstance(version, str) else None
+
+
+def verify_workshop_download(
+    workshop_dir: Path,
+    *,
+    expected_version: str,
+    expected_dll: Path,
+) -> list[str]:
+    """Verify a downloaded Workshop item folder.
+
+    Args:
+        workshop_dir: Downloaded Workshop item directory.
+        expected_version: Expected ``manifest.json`` Version value.
+        expected_dll: DLL path, or release ZIP path, that the downloaded
+            Workshop DLL must match.
+
+    Returns:
+        A list of validation findings. An empty list means the download matches.
+
+    Raises:
+        ValueError: If ``expected_version`` is not simple ``X.Y.Z`` semver.
+    """
+    if re.fullmatch(r"\d+\.\d+\.\d+", expected_version) is None:
+        msg = f"expected_version must be simple semver X.Y.Z: {expected_version!r}"
+        raise ValueError(msg)
+
+    findings: list[str] = []
+    manifest_path = workshop_dir / "manifest.json"
+    downloaded_dll = workshop_dir / "Assemblies" / "QudJP.dll"
+
+    if not manifest_path.is_file():
+        findings.append("Workshop manifest not found")
+        return findings
+
+    try:
+        actual_version = _read_manifest_version(manifest_path)
+    except json.JSONDecodeError as exc:
+        findings.append(f"Workshop manifest is not valid JSON: {exc.msg}")
+        actual_version = None
+
+    if actual_version != expected_version:
+        findings.append(f"manifest version mismatch: expected {expected_version}, got {actual_version or '<missing>'}")
+
+    if not expected_dll.is_file():
+        findings.append(f"expected DLL not found: {expected_dll}")
+        return findings
+
+    if not downloaded_dll.is_file():
+        findings.append("Workshop DLL not found: Assemblies/QudJP.dll")
+        return findings
+
+    expected_payload = _read_expected_dll(expected_dll)
+    if _sha256(downloaded_dll) != _sha256_bytes(expected_payload):
+        findings.append("DLL SHA256 mismatch: downloaded QudJP.dll does not match expected DLL")
+
+    return findings
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the command line parser."""
+    parser = argparse.ArgumentParser(description="Verify a downloaded QudJP Steam Workshop item.")
+    parser.add_argument("--workshop-dir", type=Path, required=True)
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--expected-dll", type=Path, required=True, help="Expected QudJP.dll or QudJP release ZIP.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the Workshop download verifier."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        findings = verify_workshop_download(
+            args.workshop_dir,
+            expected_version=args.expected_version,
+            expected_dll=args.expected_dll,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)  # noqa: T201
+        return 1
+
+    if findings:
+        for finding in findings:
+            print(f"Error: {finding}", file=sys.stderr)  # noqa: T201
+        return 1
+
+    downloaded_dll = args.workshop_dir / "Assemblies" / "QudJP.dll"
+    print(  # noqa: T201
+        "Workshop download verified: "
+        f"version={args.expected_version} "
+        f"dll_sha256={_sha256(downloaded_dll)}",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Fix the Workshop inventory item-name regression by avoiding direct `Vector2.x/y` access in `UnityRuntimeCompatibility.ToVector3`.
- Add a regression test for the Unity ABI hazard that compiled to missing `Vector2.get_x/get_y` calls.
- Prepare `0.2.46` manifest/changelog/release evidence after the emergency Workshop hotfix.
- Add `just workshop-download-check` to verify the public Workshop download version and DLL SHA against the release artifact.

## Release / Workshop Evidence
- Workshop item `3718988020` was already updated to `0.2.46` as an emergency hotfix.
- Steam Web API observed `time_updated=2026-05-07 20:12:39 JST`, `hcontent_file=2488077146811212590`.
- Public Workshop re-download reports `manifest.json` version `0.2.46`.
- Downloaded Workshop DLL SHA256 matches the release/staging DLL: `ca8ad3b9f2f94df472a6e04f6f169ce23afa28c6aca7a1500c82cca699391b0c`.
- Follow-up root-cause investigation is tracked separately in #574.

## Verification
- `just test-l1`
- `just python-check`
- `uv run pytest scripts/tests/test_verify_workshop_download.py scripts/tests/test_verify_release_dll.py scripts/tests/test_build_release.py scripts/tests/test_build_workshop_upload.py scripts/tests/test_sync_mod.py -q`
- `just build-workshop-upload dist/QudJP-v0.2.46.zip /tmp/qudjp-workshop-changenote.txt`
- `just release-zip-check dist/QudJP-v0.2.46.zip`
- `just workshop-download-check 0.2.46 dist/QudJP-v0.2.46.zip`

## Notes
This PR records and normalizes the emergency Workshop hotfix that was uploaded before the PR flow completed. The normal annotated `v0.2.46` tag was not created here; it should be created after this lands on `main` if you want the GitHub Release/tag surface to match the Workshop version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * Steam Workshop ビルドでインベントリアイテム名が消える問題を修正し、該当するランタイム例外を回避して名前修復が停止しないようにしました（v0.2.46）。  
  * パッケージのバージョンを v0.2.46 に更新しました。

* **ドキュメント**
  * リリース後の検証手順を強化し、Workshop ダウンロード検証の手順を明記しました。
  * リリース報告書に v0.2.46 の公開手順と既知の問題を追加しました。

* **テスト / ツール**
  * Workshop ダウンロード検証コマンド、検証スクリプト、および関連テストと互換性チェックを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->