### PR TITLE
Refactor quality gates and fallback handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           roslyn_tools=false
           python=false
           localization=false
+          justfile=false
           markdown_reports=false
 
           if matches '^\.github/workflows/.*\.ya?ml$'; then
@@ -78,8 +79,11 @@ jobs:
           if [[ "$run_all" == true ]] || matches '^(pyproject\.toml|uv\.lock)$' || matches_python_scripts; then
             python=true
           fi
-          if [[ "$run_all" == true ]] || matches '^(Mods/QudJP/Localization/|scripts/(check_translation_tokens|check_glossary_consistency)\.py|scripts/(translation_token_duplicate_baseline|glossary_consistency_baseline)\.json)'; then
+          if [[ "$run_all" == true ]] || matches '^(Mods/QudJP/Localization/|scripts/(check_translation_tokens|check_glossary_consistency|validate_pattern_routes)\.py|scripts/(translation_token_duplicate_baseline|glossary_consistency_baseline)\.json|justfile$)'; then
             localization=true
+          fi
+          if [[ "$run_all" == true ]] || matches '^justfile$'; then
+            justfile=true
           fi
           if [[ "$run_all" == true ]] || matches '^docs/reports/.*\.md$' || matches '^scripts/check_markdown_reports\.py$'; then
             markdown_reports=true
@@ -93,6 +97,7 @@ jobs:
             echo "dotnet=$([[ "$qudjp_dotnet" == true || "$roslyn_tools" == true ]] && echo true || echo false)"
             echo "python=$python"
             echo "localization=$localization"
+            echo "justfile=$justfile"
             echo "markdown_reports=$markdown_reports"
           } >> "$GITHUB_OUTPUT"
 
@@ -151,6 +156,14 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
 
+      - name: Install just
+        if: steps.changes.outputs.justfile == 'true'
+        run: sudo apt-get update && sudo apt-get install -y just
+
+      - name: Check justfile
+        if: steps.changes.outputs.justfile == 'true'
+        run: just --summary
+
       - name: Check Markdown reports
         if: steps.changes.outputs.markdown_reports == 'true'
         run: >
@@ -184,6 +197,23 @@ jobs:
       - name: Check glossary consistency
         if: steps.changes.outputs.localization == 'true' && hashFiles('Mods/QudJP/Localization/**/*') != ''
         run: python scripts/check_glossary_consistency.py Mods/QudJP/Localization
+
+      - name: Check message pattern routes
+        if: steps.changes.outputs.localization == 'true' && hashFiles('Mods/QudJP/Localization/Dictionaries/messages.ja.json') != ''
+        run: >
+          python scripts/validate_pattern_routes.py
+          Mods/QudJP/Localization/Dictionaries/messages.ja.json
+          --expect-count message-frame=41
+          --expect-count popup=12
+          --expect-count journal=0
+          --expect-count leaf=0
+          --expect-count emit-message=302
+          --expect-count does-verb=0
+          --expect-count message-log=1
+          --expect-count description=4
+          --expect-count effect-cripple=1
+          --expect-count needs-harmony-patch=34
+          --expect-count unclassified=6
 
       - name: Install Python test dependencies
         if: steps.changes.outputs.python == 'true' && hashFiles('scripts/tests/**/*.py') != ''

--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyIssue201Batch1Targets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyIssue201Batch1Targets.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -135,8 +136,15 @@ namespace QudJP.Tests.DummyTargets
     {
         public List<object?> Items { get; private set; } = new List<object?>();
 
+        public bool ThrowOnBeforeShow { get; set; }
+
         public void BeforeShow(IEnumerable selections)
         {
+            if (ThrowOnBeforeShow)
+            {
+                throw new InvalidOperationException("simulated controller failure");
+            }
+
             Items = new List<object?>();
             foreach (var selection in selections)
             {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/AnnalsPatternsCollisionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/AnnalsPatternsCollisionTests.cs
@@ -58,8 +58,7 @@ public sealed class AnnalsPatternsCollisionTests
             foreach (var j in journal)
             {
                 if (j?.Pattern is null) continue;
-                Regex re;
-                try { re = new Regex(j.Pattern); } catch { continue; }
+                var re = RequireRegex(j.Pattern, $"journal pattern while checking annals pattern '{a.Pattern}'");
                 Assert.That(re.IsMatch(literalSample), Is.False,
                     $"annals pattern '{a.Pattern}' (sample={literalSample}) is swallowed by journal pattern '{j.Pattern}'");
             }
@@ -91,8 +90,7 @@ public sealed class AnnalsPatternsCollisionTests
         {
             var earlier = annals[i];
             if (earlier?.Pattern is null) continue;
-            Regex earlierRe;
-            try { earlierRe = new Regex(earlier.Pattern); } catch { continue; }
+            var earlierRe = RequireRegex(earlier.Pattern, $"annals pattern at index {i}");
             for (var j = i + 1; j < annals.Count; j++)
             {
                 var later = annals[j];
@@ -108,6 +106,19 @@ public sealed class AnnalsPatternsCollisionTests
                     $"earlier annals pattern '{earlier.Pattern}' (index {i}) swallows later pattern '{later.Pattern}' (index {j}, sample={laterSample}). "
                     + "Reorder so concrete patterns precede generic ones, fix the merge sort, or deduplicate.");
             }
+        }
+    }
+
+    private static Regex RequireRegex(string pattern, string context)
+    {
+        try
+        {
+            return new Regex(pattern);
+        }
+        catch (ArgumentException ex)
+        {
+            Assert.Fail($"Invalid regex in {context}: '{pattern}'. {ex.Message}");
+            throw;
         }
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudJPModTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudJPModTests.cs
@@ -8,6 +8,81 @@ namespace QudJP.Tests.L2;
 [NonParallelizable]
 public sealed class QudJPModTests
 {
+    [SetUp]
+    public void SetUp()
+    {
+        QudJPMod.ResetInitializationForTests();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        QudJPMod.ResetInitializationForTests();
+    }
+
+    [Test]
+    public void InitializeForTests_ResetsInitializationGuard_WhenInitializationFails()
+    {
+        var patchCalls = 0;
+
+        Assert.That(
+            () => QudJPMod.InitializeForTests(
+                () => throw new InvalidOperationException("font failure"),
+                () => patchCalls++),
+            Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("font failure"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(QudJPMod.IsInitializedForTests(), Is.False);
+            Assert.That(patchCalls, Is.EqualTo(0));
+        });
+
+        QudJPMod.InitializeForTests(
+            static () => { },
+            () => patchCalls++);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(QudJPMod.IsInitializedForTests(), Is.True);
+            Assert.That(patchCalls, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void InitializeForTests_ResetsInitializationGuard_WhenPatchApplicationFails()
+    {
+        var fontCalls = 0;
+        var patchCalls = 0;
+
+        Assert.That(
+            () => QudJPMod.InitializeForTests(
+                () => fontCalls++,
+                () =>
+                {
+                    patchCalls++;
+                    throw new InvalidOperationException("patch failure");
+                }),
+            Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("patch failure"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(QudJPMod.IsInitializedForTests(), Is.False);
+            Assert.That(fontCalls, Is.EqualTo(1));
+            Assert.That(patchCalls, Is.EqualTo(1));
+        });
+
+        QudJPMod.InitializeForTests(
+            () => fontCalls++,
+            () => patchCalls++);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(QudJPMod.IsInitializedForTests(), Is.True);
+            Assert.That(fontCalls, Is.EqualTo(2));
+            Assert.That(patchCalls, Is.EqualTo(2));
+        });
+    }
+
     [Test]
     public void InvokePatchAll_ScansCorrectAssembly_AndHandlesErrorsGracefully()
     {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/StatusScreenBindingOwnerPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/StatusScreenBindingOwnerPatchTests.cs
@@ -37,6 +37,10 @@ public sealed class StatusScreenBindingOwnerPatchTests
         };
         DummyCharacterStatusScreenBindingTarget.mutations = new List<DummyCharacterMutationRecord>();
         DummyCharacterStatusScreenBindingTarget.effects = new List<DummyStatusEffect>();
+        DummyCharacterStatusScreenBindingTarget.PrimaryAttributes = new[] { "Strength" };
+        DummyCharacterStatusScreenBindingTarget.SecondaryAttributes = Array.Empty<string>();
+        DummyCharacterStatusScreenBindingTarget.SecondaryAttributesWithCP = new[] { "CP" };
+        DummyCharacterStatusScreenBindingTarget.ResistanceAttributes = Array.Empty<string>();
     }
 
     [TearDown]
@@ -223,10 +227,18 @@ public sealed class StatusScreenBindingOwnerPatchTests
             ("Mutations", "突然変異"));
 
         var target = new DummyCharacterStatusScreenBindingTarget();
-        _ = CharacterStatusScreenBindingPatch.Prefix(target);
+        target.primaryAttributesController = null!;
+        target.secondaryAttributesController = null!;
+        target.resistanceAttributesController = null!;
+        target.mutationsController = null!;
+        target.effectsController = null!;
+
+        var shouldRunOriginal = true;
+        var trace = TestTraceHelper.CaptureTrace(() => shouldRunOriginal = CharacterStatusScreenBindingPatch.Prefix(target));
 
         Assert.Multiple(() =>
         {
+            Assert.That(shouldRunOriginal, Is.False, trace);
             Assert.That(target.mutationTermText.Text, Is.EqualTo("突然変異"));
             Assert.That(target.nameText.Text, Is.EqualTo("ソルトホッパー"));
             Assert.That(target.classText.Text, Is.EqualTo("変異人 巡礼者"));
@@ -250,6 +262,17 @@ public sealed class StatusScreenBindingOwnerPatchTests
                     "Level: 1 ¯ HP: 10/10 ¯ XP: 100/200 ¯ Weight: 123#"),
                 Is.EqualTo(0));
         });
+    }
+
+    [Test]
+    public void CharacterStatusScreenBindingPatch_AllowsOriginal_WhenControllerPopulationFails()
+    {
+        var target = new DummyCharacterStatusScreenBindingTarget();
+        target.primaryAttributesController.ThrowOnBeforeShow = true;
+
+        var shouldRunOriginal = CharacterStatusScreenBindingPatch.Prefix(target);
+
+        Assert.That(shouldRunOriginal, Is.True);
     }
 
     private static string CreateHarmonyId()

--- a/Mods/QudJP/Assemblies/src/Patches/CharacterStatusScreenBindingPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/CharacterStatusScreenBindingPatch.cs
@@ -52,7 +52,11 @@ public static class CharacterStatusScreenBindingPatch
             TryResolveMutationTerms(__instance, go);
             UpdateDirectTextFields(__instance, go);
             UpdatePointTexts(__instance, go);
-            TryPopulateControllers(__instance, instanceType, go);
+            if (!TryPopulateControllers(__instance, instanceType, go))
+            {
+                return true;
+            }
+
             TryUpdatePlayerIcon(__instance, go);
             return false;
         }
@@ -87,15 +91,17 @@ public static class CharacterStatusScreenBindingPatch
         }
     }
 
-    private static void TryPopulateControllers(object instance, Type instanceType, object go)
+    private static bool TryPopulateControllers(object instance, Type instanceType, object go)
     {
         try
         {
             PopulateControllers(instance, instanceType, go);
+            return true;
         }
         catch (Exception ex)
         {
             Trace.TraceWarning("QudJP: CharacterStatusScreenBindingPatch.PopulateControllers skipped: {0}", ex.Message);
+            return false;
         }
     }
 
@@ -551,7 +557,17 @@ public static class CharacterStatusScreenBindingPatch
         {
             mediaType = AccessTools.TypeByName("Media");
         }
-        var sizeClassValue = mediaType is null ? null : GetStaticMemberValue(mediaType, "sizeClass");
+        object? sizeClassValue;
+        try
+        {
+            sizeClassValue = mediaType is null ? null : GetStaticMemberValue(mediaType, "sizeClass");
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceWarning("QudJP: CharacterStatusScreenBindingPatch compact layout check skipped: {0}", ex.Message);
+            return false;
+        }
+
         if (sizeClassValue is null)
         {
             return false;

--- a/Mods/QudJP/Assemblies/src/QudJPMod.cs
+++ b/Mods/QudJP/Assemblies/src/QudJPMod.cs
@@ -26,15 +26,43 @@ public static class QudJPMod
 
     internal static void Initialize()
     {
-        if (Interlocked.Exchange(ref isInitialized, 1) == 1)
+        InitializeCore(FontManager.Initialize, ApplyHarmonyPatches);
+    }
+
+    internal static void InitializeForTests(Action initializeFonts, Action applyPatches)
+    {
+        InitializeCore(initializeFonts, applyPatches);
+    }
+
+    internal static void ResetInitializationForTests()
+    {
+        Interlocked.Exchange(ref isInitialized, 0);
+    }
+
+    internal static bool IsInitializedForTests()
+    {
+        return Volatile.Read(ref isInitialized) == 1;
+    }
+
+    private static void InitializeCore(Action initializeFonts, Action applyPatches)
+    {
+        if (Interlocked.CompareExchange(ref isInitialized, 1, 0) == 1)
         {
             return;
         }
 
-        var assemblyVersion = typeof(QudJPMod).Assembly.GetName().Version;
-        LogToUnity($"[QudJP] Build marker: {BuildMarker}, Version: {assemblyVersion}");
-        FontManager.Initialize();
-        ApplyHarmonyPatches();
+        try
+        {
+            var assemblyVersion = typeof(QudJPMod).Assembly.GetName().Version;
+            LogToUnity($"[QudJP] Build marker: {BuildMarker}, Version: {assemblyVersion}");
+            initializeFonts();
+            applyPatches();
+        }
+        catch
+        {
+            Interlocked.Exchange(ref isInitialized, 0);
+            throw;
+        }
     }
 
     internal static void ApplyHarmonyPatches()

--- a/docs/superpowers/plans/2026-05-08-quality-hardening-refactor.md
+++ b/docs/superpowers/plans/2026-05-08-quality-hardening-refactor.md
@@ -100,13 +100,13 @@ Expected: route tests pass.
 
 Update artifact gitignore assertions to match the intended policy: `.bak` and `merge_conflicts.json` ignored, `candidates_pending.json` tracked. Update annals collision tests to assert regex compile failures are test failures.
 
-- [x] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run focused tests to confirm current behavior**
 
 Run: `uv run pytest scripts/tests/test_artifact_gitignore.py -q`
 
 Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~AnnalsPatternsCollisionTests"`
 
-Expected: Python test passes after assertion text update if policy already matches; C# compile/collision test should still pass with valid current patterns.
+Expected: Python test may already pass if the tracked/ignored artifact policy is already encoded; C# compile/collision test should pass with valid current patterns. Any unexpected failure here identifies the implementation gap for Step 3.
 
 - [x] **Step 3: Write minimal implementation**
 

--- a/docs/superpowers/plans/2026-05-08-quality-hardening-refactor.md
+++ b/docs/superpowers/plans/2026-05-08-quality-hardening-refactor.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Character Status Fallback Safety
+## Task 1: Character Status Fallback Safety
 
 **Files:**
 - Modify: `Mods/QudJP/Assemblies/QudJP.Tests/L2/StatusScreenBindingOwnerPatchTests.cs`
@@ -36,7 +36,7 @@ Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 
 
 Expected: all focused status binding tests pass.
 
-### Task 2: QudJP Initialization Retry Safety
+## Task 2: QudJP Initialization Retry Safety
 
 **Files:**
 - Modify: `Mods/QudJP/Assemblies/QudJP.Tests/L2/QudJPModTests.cs`
@@ -44,7 +44,7 @@ Expected: all focused status binding tests pass.
 
 - [x] **Step 1: Write the failing test**
 
-Add test helpers to reset and inspect `isInitialized`, then add a test that calls a new internal `QudJPMod.MarkInitializationFailedForTests()` and asserts a later attempt is not locked out.
+Add test helpers to reset and inspect `isInitialized`, then add tests that call `QudJPMod.InitializeForTests(...)` and verify failures reset the guard so a later attempt is not locked out. Use `ResetInitializationForTests()` to isolate each test and `IsInitializedForTests()` to assert the guard state.
 
 - [x] **Step 2: Run test to verify it fails**
 
@@ -62,7 +62,7 @@ Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 
 
 Expected: all focused QudJPMod tests pass.
 
-### Task 3: Route Validation Gate
+## Task 3: Route Validation Gate
 
 **Files:**
 - Modify: `scripts/tests/test_validate_pattern_routes.py`
@@ -90,7 +90,7 @@ Run: `uv run pytest scripts/tests/test_validate_pattern_routes.py -q`
 
 Expected: route tests pass.
 
-### Task 4: Test Hygiene Fixes
+## Task 4: Test Hygiene Fixes
 
 **Files:**
 - Modify: `scripts/tests/test_artifact_gitignore.py`
@@ -118,7 +118,7 @@ Run both commands from Step 2 again.
 
 Expected: both focused tests pass.
 
-### Final Verification
+## Final Verification
 
 - [x] Run `just test-l1`
 - [x] Run `just python-test-filter 'validate_pattern_routes or artifact_gitignore or translate_corpus_batch'`

--- a/docs/superpowers/plans/2026-05-08-quality-hardening-refactor.md
+++ b/docs/superpowers/plans/2026-05-08-quality-hardening-refactor.md
@@ -1,0 +1,127 @@
+# Quality Hardening Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden known ad-hoc fallback and validation gaps without changing localization behavior.
+
+**Architecture:** Keep changes local to existing patch/bootstrap/validation surfaces. Prefer explicit failure signals over silent partial success, and add focused regression tests before implementation.
+
+**Tech Stack:** C# net10 NUnit tests for assembly behavior, Python pytest for script validation, GitHub Actions YAML for CI gate alignment.
+
+---
+
+### Task 1: Character Status Fallback Safety
+
+**Files:**
+- Modify: `Mods/QudJP/Assemblies/QudJP.Tests/L2/StatusScreenBindingOwnerPatchTests.cs`
+- Modify: `Mods/QudJP/Assemblies/src/Patches/CharacterStatusScreenBindingPatch.cs`
+
+- [x] **Step 1: Write the failing test**
+
+Add a test that sets `DummyCharacterStatusScreenBindingTarget.stats = null!`, calls `CharacterStatusScreenBindingPatch.Prefix(target)`, and asserts the prefix returns `true`.
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~StatusScreenBindingOwnerPatchTests"`
+
+Expected: the new test fails because `Prefix` currently returns `false` after `TryPopulateControllers` swallows the exception.
+
+- [x] **Step 3: Write minimal implementation**
+
+Change critical `TryPopulateControllers` to return `bool`; when it fails, log and return `true` from `Prefix` so upstream `UpdateViewFromData` can run.
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~StatusScreenBindingOwnerPatchTests"`
+
+Expected: all focused status binding tests pass.
+
+### Task 2: QudJP Initialization Retry Safety
+
+**Files:**
+- Modify: `Mods/QudJP/Assemblies/QudJP.Tests/L2/QudJPModTests.cs`
+- Modify: `Mods/QudJP/Assemblies/src/QudJPMod.cs`
+
+- [x] **Step 1: Write the failing test**
+
+Add test helpers to reset and inspect `isInitialized`, then add a test that calls a new internal `QudJPMod.MarkInitializationFailedForTests()` and asserts a later attempt is not locked out.
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~QudJPModTests"`
+
+Expected: compile fails until the test hook exists, or test fails because initialization failure does not reset the guard.
+
+- [x] **Step 3: Write minimal implementation**
+
+Wrap `FontManager.Initialize()` and `ApplyHarmonyPatches()` in `try/catch`; on exception, reset `isInitialized` to `0` and rethrow. Add internal test-only helpers under `#if DEBUG` if needed by tests.
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~QudJPModTests"`
+
+Expected: all focused QudJPMod tests pass.
+
+### Task 3: Route Validation Gate
+
+**Files:**
+- Modify: `scripts/tests/test_validate_pattern_routes.py`
+- Modify: `scripts/validate_pattern_routes.py`
+- Modify: `justfile`
+- Modify: `.github/workflows/ci.yml`
+
+- [x] **Step 1: Write the failing test**
+
+Change `test_main_reports_invalid_route_and_returns_nonzero` so `message-log` is accepted, and add an integration test that validates `Mods/QudJP/Localization/Dictionaries/messages.ja.json` successfully.
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest scripts/tests/test_validate_pattern_routes.py -q`
+
+Expected: tests fail because `message-log`, `description`, and `effect-cripple` are not allowed yet.
+
+- [x] **Step 3: Write minimal implementation**
+
+Add the current repository routes to `ALLOWED_ROUTES`, wire `scripts/validate_pattern_routes.py Mods/QudJP/Localization/Dictionaries/messages.ja.json` into `just localization-check`, and add the same validation to CI localization changes.
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest scripts/tests/test_validate_pattern_routes.py -q`
+
+Expected: route tests pass.
+
+### Task 4: Test Hygiene Fixes
+
+**Files:**
+- Modify: `scripts/tests/test_artifact_gitignore.py`
+- Modify: `Mods/QudJP/Assemblies/QudJP.Tests/L1/AnnalsPatternsCollisionTests.cs`
+
+- [x] **Step 1: Write the failing tests**
+
+Update artifact gitignore assertions to match the intended policy: `.bak` and `merge_conflicts.json` ignored, `candidates_pending.json` tracked. Update annals collision tests to assert regex compile failures are test failures.
+
+- [x] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest scripts/tests/test_artifact_gitignore.py -q`
+
+Run: `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~AnnalsPatternsCollisionTests"`
+
+Expected: Python test passes after assertion text update if policy already matches; C# compile/collision test should still pass with valid current patterns.
+
+- [x] **Step 3: Write minimal implementation**
+
+Replace broad `catch { continue; }` with `Assert.Fail` including pattern identifiers. Keep `.gitignore` unchanged unless the updated test exposes a real policy mismatch.
+
+- [x] **Step 4: Run focused tests**
+
+Run both commands from Step 2 again.
+
+Expected: both focused tests pass.
+
+### Final Verification
+
+- [x] Run `just test-l1`
+- [x] Run `just python-test-filter 'validate_pattern_routes or artifact_gitignore or translate_corpus_batch'`
+- [x] Run `just localization-check`
+- [x] Run `just translation-token-check`
+- [x] Run `git diff --check`

--- a/justfile
+++ b/justfile
@@ -48,6 +48,7 @@ python-test-filter pattern:
 localization-check:
   {{python}} scripts/check_encoding.py Mods/QudJP/Localization scripts
   {{python}} scripts/check_glossary_consistency.py Mods/QudJP/Localization
+  {{python}} scripts/validate_pattern_routes.py Mods/QudJP/Localization/Dictionaries/messages.ja.json --expect-count message-frame=41 --expect-count popup=12 --expect-count journal=0 --expect-count leaf=0 --expect-count emit-message=302 --expect-count does-verb=0 --expect-count message-log=1 --expect-count description=4 --expect-count effect-cripple=1 --expect-count needs-harmony-patch=34 --expect-count unclassified=6
   {{python}} scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
 
 # Check placeholder and markup-token parity in JSON localization assets.

--- a/scripts/tests/test_artifact_gitignore.py
+++ b/scripts/tests/test_artifact_gitignore.py
@@ -1,26 +1,41 @@
-"""Assert that scripts/_artifacts/annals/ is gitignored."""
+"""Assert that transient Annals artifacts are gitignored."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
+_GITIGNORE_PATH = Path(".gitignore")
 
-def test_gitignore_lists_annals_artifact_directory() -> None:
-    """scripts/_artifacts/annals/ must be present in .gitignore."""
-    text = Path(".gitignore").read_text(encoding="utf-8")
-    assert "scripts/_artifacts/annals/" in text, (
-        "scripts/_artifacts/annals/ must be gitignored to prevent accidental "
-        "commit of candidate JSON, conflict reports, and .bak backups."
-    )
+
+def _gitignore_lines() -> set[str]:
+    return {
+        line.strip()
+        for line in _GITIGNORE_PATH.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+def test_gitignore_lists_transient_annals_artifacts_without_hiding_review_source() -> None:
+    """Only transient Annals artifacts should be ignored."""
+    text = _GITIGNORE_PATH.read_text(encoding="utf-8")
+    lines = _gitignore_lines()
+    assert "scripts/_artifacts/annals/*.bak" in lines
+    assert "scripts/_artifacts/annals/*.bak-*" in lines
+    assert "scripts/_artifacts/annals/merge_conflicts.json" in lines
+    assert "scripts/_artifacts/annals/candidates_pending.json" not in lines
+    assert "scripts/_artifacts/annals/" not in lines
+    assert "scripts/_artifacts/annals/*" not in lines
+    assert "scripts/_artifacts/annals/**" not in lines
+    assert "candidates_pending.json IS committed" in text
 
 
 def test_gitignore_lists_local_workshop_state_directories() -> None:
     """Local Workshop inbox state contains raw comments and must not be committed."""
-    text = Path(".gitignore").read_text(encoding="utf-8")
-    assert ".coq-japanese_workshop/state/*" in text
-    assert ".coq-japanese_workshop/backups/*" in text
-    assert ".coq-japanese_workshop/exports/*" in text
-    assert "!.coq-japanese_workshop/README.md" in text
-    assert "!.coq-japanese_workshop/state/.gitkeep" in text
-    assert "!.coq-japanese_workshop/backups/.gitkeep" in text
-    assert "!.coq-japanese_workshop/exports/.gitkeep" in text
+    lines = _gitignore_lines()
+    assert ".coq-japanese_workshop/state/*" in lines
+    assert ".coq-japanese_workshop/backups/*" in lines
+    assert ".coq-japanese_workshop/exports/*" in lines
+    assert "!.coq-japanese_workshop/README.md" in lines
+    assert "!.coq-japanese_workshop/state/.gitkeep" in lines
+    assert "!.coq-japanese_workshop/backups/.gitkeep" in lines
+    assert "!.coq-japanese_workshop/exports/.gitkeep" in lines

--- a/scripts/tests/test_validate_pattern_routes.py
+++ b/scripts/tests/test_validate_pattern_routes.py
@@ -21,6 +21,11 @@ _EXPECTED_MESSAGE_ROUTE_COUNTS = {
     "unclassified": 6,
 }
 
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_REPOSITORY_MESSAGE_PATTERNS_PATH = (
+    _REPO_ROOT / "Mods" / "QudJP" / "Localization" / "Dictionaries" / "messages.ja.json"
+)
+
 
 def _write_patterns(path: Path, patterns: list[dict[str, str]]) -> None:
     path.write_text(json.dumps({"patterns": patterns}, ensure_ascii=False), encoding="utf-8")
@@ -91,11 +96,14 @@ def test_main_reports_invalid_route_and_returns_nonzero(
     assert "invalid route 'unknown-route'" in captured.out
 
 
-def test_repository_message_patterns_match_expected_route_inventory() -> None:
+def test_repository_message_patterns_match_expected_route_inventory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The shipped message pattern dictionary must match the reviewed route inventory."""
-    path = Path("Mods/QudJP/Localization/Dictionaries/messages.ja.json")
+    monkeypatch.chdir(tmp_path)
 
-    report = validate_pattern_routes(path, _EXPECTED_MESSAGE_ROUTE_COUNTS)
+    report = validate_pattern_routes(_REPOSITORY_MESSAGE_PATTERNS_PATH, _EXPECTED_MESSAGE_ROUTE_COUNTS)
 
     assert report.missing_routes == []
     assert report.invalid_routes == []
@@ -142,6 +150,19 @@ def test_main_reports_route_count_mismatch_and_returns_nonzero(
     assert result == 1
     assert "Route count mismatches: 1" in captured.out
     assert "route 'emit-message' expected 2 entries but found 1" in captured.out
+
+
+def test_main_rejects_duplicate_expected_route_counts(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI fails when --expect-count repeats a route."""
+    path = tmp_path / "duplicate-count.json"
+    _write_patterns(path, [{"pattern": "^You hit (.+)$", "template": "x", "route": "emit-message"}])
+
+    with pytest.raises(SystemExit) as exc_info:
+        main([str(path), "--expect-count", "emit-message=1", "--expect-count", "emit-message=2"])
+    captured = capsys.readouterr()
+
+    assert exc_info.value.code == 2
+    assert "--expect-count for route 'emit-message' is duplicated" in captured.err
 
 
 def test_main_reports_successful_validation(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/scripts/tests/test_validate_pattern_routes.py
+++ b/scripts/tests/test_validate_pattern_routes.py
@@ -7,6 +7,20 @@ import pytest
 
 from scripts.validate_pattern_routes import ALLOWED_ROUTES, main, validate_pattern_routes
 
+_EXPECTED_MESSAGE_ROUTE_COUNTS = {
+    "message-frame": 41,
+    "popup": 12,
+    "journal": 0,
+    "leaf": 0,
+    "emit-message": 302,
+    "does-verb": 0,
+    "message-log": 1,
+    "description": 4,
+    "effect-cripple": 1,
+    "needs-harmony-patch": 34,
+    "unclassified": 6,
+}
+
 
 def _write_patterns(path: Path, patterns: list[dict[str, str]]) -> None:
     path.write_text(json.dumps({"patterns": patterns}, ensure_ascii=False), encoding="utf-8")
@@ -66,7 +80,7 @@ def test_main_reports_invalid_route_and_returns_nonzero(
     path = tmp_path / "invalid-route.json"
     _write_patterns(
         path,
-        [{"pattern": "^You hit (.+)$", "template": "x", "route": "message-log"}],
+        [{"pattern": "^You hit (.+)$", "template": "x", "route": "unknown-route"}],
     )
 
     result = main([str(path)])
@@ -74,7 +88,19 @@ def test_main_reports_invalid_route_and_returns_nonzero(
 
     assert result == 1
     assert "Invalid route entries: 1" in captured.out
-    assert "invalid route 'message-log'" in captured.out
+    assert "invalid route 'unknown-route'" in captured.out
+
+
+def test_repository_message_patterns_match_expected_route_inventory() -> None:
+    """The shipped message pattern dictionary must match the reviewed route inventory."""
+    path = Path("Mods/QudJP/Localization/Dictionaries/messages.ja.json")
+
+    report = validate_pattern_routes(path, _EXPECTED_MESSAGE_ROUTE_COUNTS)
+
+    assert report.missing_routes == []
+    assert report.invalid_routes == []
+    assert report.route_count_mismatches == []
+    assert report.has_errors is False
 
 
 def test_main_reports_nonstr_route_and_returns_nonzero(
@@ -96,9 +122,12 @@ def test_main_reports_nonstr_route_and_returns_nonzero(
     assert "invalid route '['emit-message']'" in captured.out
 
 
-def test_main_reports_successful_validation(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    """CLI reports success and counts when all routes are present and valid."""
-    path = tmp_path / "ok.json"
+def test_main_reports_route_count_mismatch_and_returns_nonzero(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CLI fails when an expected route count does not match the inventory."""
+    path = tmp_path / "count-mismatch.json"
     _write_patterns(
         path,
         [
@@ -107,7 +136,29 @@ def test_main_reports_successful_validation(tmp_path: Path, capsys: pytest.Captu
         ],
     )
 
-    result = main([str(path)])
+    result = main([str(path), "--expect-count", "emit-message=2", "--expect-count", "leaf=1"])
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "Route count mismatches: 1" in captured.out
+    assert "route 'emit-message' expected 2 entries but found 1" in captured.out
+
+
+def test_main_reports_successful_validation(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI reports success and counts when all routes are present and valid."""
+    path = tmp_path / "ok.json"
+    _write_patterns(
+        path,
+        [
+            {"pattern": "^You hit (.+)$", "template": "x", "route": "emit-message"},
+            {"pattern": "^You are stunned$", "template": "x", "route": "leaf"},
+            {"pattern": "^(.+?) has nothing to trade$", "template": "x", "route": "message-log"},
+            {"pattern": "^This object is a monument to (.+)$", "template": "x", "route": "description"},
+            {"pattern": "^You are crippled for (.+?)!$", "template": "x", "route": "effect-cripple"},
+        ],
+    )
+
+    result = main([str(path), "--expect-count", "emit-message=1", "--expect-count", "leaf=1"])
     captured = capsys.readouterr()
 
     assert result == 0

--- a/scripts/tests/test_validate_xml.py
+++ b/scripts/tests/test_validate_xml.py
@@ -122,6 +122,32 @@ def test_strict_mode_fails_on_warning_not_in_baseline(tmp_path: Path, capsys: py
     assert "NEW WARNING" in captured.err
 
 
+def test_strict_mode_fails_when_same_file_adds_second_empty_text_warning(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A baseline for one empty text element must not hide another location."""
+    xml_path = tmp_path / "strict.xml"
+    baseline_path = tmp_path / "baseline.json"
+    _write_xml(
+        xml_path,
+        '<root><node ID="Allowed"><text /></node></root>',
+    )
+
+    assert main([str(xml_path), "--write-warning-baseline", str(baseline_path)]) == 0
+    _ = capsys.readouterr()
+    _write_xml(
+        xml_path,
+        '<root><node ID="Allowed"><text /></node><node ID="New"><text /></node></root>',
+    )
+
+    result = main(["--strict", "--warning-baseline", str(baseline_path), str(xml_path)])
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "NEW WARNING" in captured.err
+    assert "node[@ID='New']" in captured.err
+
+
 def test_directory_scanning_finds_nested_xml_files(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """Directory input recursively scans nested XML files."""
     root_dir = tmp_path / "Localization"

--- a/scripts/validate_pattern_routes.py
+++ b/scripts/validate_pattern_routes.py
@@ -17,6 +17,9 @@ ALLOWED_ROUTES = (
     "leaf",
     "emit-message",
     "does-verb",
+    "message-log",
+    "description",
+    "effect-cripple",
     "needs-harmony-patch",
     "unclassified",
 )
@@ -59,6 +62,12 @@ class RouteValidationReport:
     counts: dict[str, int]
     missing_routes: list[str]
     invalid_routes: list[str]
+    route_count_mismatches: list[str]
+
+    @property
+    def has_errors(self) -> bool:
+        """Return true when any validation check failed."""
+        return bool(self.missing_routes or self.invalid_routes or self.route_count_mismatches)
 
 
 def classify_route(pattern: str) -> str:
@@ -84,7 +93,7 @@ def classify_route(pattern: str) -> str:
     return route
 
 
-def validate_pattern_routes(path: Path) -> RouteValidationReport:
+def validate_pattern_routes(path: Path, expected_counts: dict[str, int] | None = None) -> RouteValidationReport:
     """Validate route fields and summarize counts by allowed route."""
     raw = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(raw, dict):
@@ -116,11 +125,20 @@ def validate_pattern_routes(path: Path) -> RouteValidationReport:
         counts[route] += 1
 
     ordered_counts = {route: counts.get(route, 0) for route in ALLOWED_ROUTES}
+    route_count_mismatches = []
+    for route, expected_count in (expected_counts or {}).items():
+        actual_count = ordered_counts.get(route)
+        if actual_count != expected_count:
+            route_count_mismatches.append(
+                f"route '{route}' expected {expected_count} entries but found {actual_count}"
+            )
+
     return RouteValidationReport(
         path=path,
         counts=ordered_counts,
         missing_routes=missing_routes,
         invalid_routes=invalid_routes,
+        route_count_mismatches=route_count_mismatches,
     )
 
 
@@ -130,18 +148,39 @@ def _print_report(report: RouteValidationReport) -> None:
     for route in ALLOWED_ROUTES:
         print(f"  {route}: {report.counts[route]}")  # noqa: T201
 
-    if report.missing_routes:
-        print(f"Missing route entries: {len(report.missing_routes)}")  # noqa: T201
-        for issue in report.missing_routes:
-            print(f"  ERROR: {issue}")  # noqa: T201
+    _print_issues("Missing route entries", report.missing_routes)
+    _print_issues("Invalid route entries", report.invalid_routes)
+    _print_issues("Route count mismatches", report.route_count_mismatches)
 
-    if report.invalid_routes:
-        print(f"Invalid route entries: {len(report.invalid_routes)}")  # noqa: T201
-        for issue in report.invalid_routes:
-            print(f"  ERROR: {issue}")  # noqa: T201
-
-    if not report.missing_routes and not report.invalid_routes:
+    if not report.has_errors:
         print("All pattern routes are present and valid.")  # noqa: T201
+
+
+def _print_issues(label: str, issues: list[str]) -> None:
+    if not issues:
+        return
+    print(f"{label}: {len(issues)}")  # noqa: T201
+    for issue in issues:
+        print(f"  ERROR: {issue}")  # noqa: T201
+
+
+def _parse_expected_count(value: str) -> tuple[str, int]:
+    route, separator, raw_count = value.partition("=")
+    if not separator:
+        msg = f"expected count must use ROUTE=COUNT syntax: {value}"
+        raise argparse.ArgumentTypeError(msg)
+    if route not in ALLOWED_ROUTE_SET:
+        msg = f"unknown route in expected count: {route}"
+        raise argparse.ArgumentTypeError(msg)
+    try:
+        count = int(raw_count)
+    except ValueError as exc:
+        msg = f"expected count for {route} must be an integer: {raw_count}"
+        raise argparse.ArgumentTypeError(msg) from exc
+    if count < 0:
+        msg = f"expected count for {route} must be non-negative: {count}"
+        raise argparse.ArgumentTypeError(msg)
+    return route, count
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -156,16 +195,24 @@ def main(argv: list[str] | None = None) -> int:
         default=DEFAULT_PATTERN_FILE,
         help="Pattern dictionary path. Defaults to the repository messages.ja.json file.",
     )
+    parser.add_argument(
+        "--expect-count",
+        action="append",
+        default=[],
+        metavar="ROUTE=COUNT",
+        type=_parse_expected_count,
+        help="Require an exact route count. May be specified more than once.",
+    )
     args = parser.parse_args(argv)
 
     try:
-        report = validate_pattern_routes(args.path)
+        report = validate_pattern_routes(args.path, dict(args.expect_count))
     except (FileNotFoundError, TypeError, json.JSONDecodeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)  # noqa: T201
         return 1
 
     _print_report(report)
-    if report.missing_routes or report.invalid_routes:
+    if report.has_errors:
         return 1
     return 0
 

--- a/scripts/validate_pattern_routes.py
+++ b/scripts/validate_pattern_routes.py
@@ -204,9 +204,14 @@ def main(argv: list[str] | None = None) -> int:
         help="Require an exact route count. May be specified more than once.",
     )
     args = parser.parse_args(argv)
+    expected_counts: dict[str, int] = {}
+    for route, count in args.expect_count:
+        if route in expected_counts:
+            parser.error(f"--expect-count for route '{route}' is duplicated")
+        expected_counts[route] = count
 
     try:
-        report = validate_pattern_routes(args.path, dict(args.expect_count))
+        report = validate_pattern_routes(args.path, expected_counts)
     except (FileNotFoundError, TypeError, json.JSONDecodeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)  # noqa: T201
         return 1

--- a/scripts/validate_xml.py
+++ b/scripts/validate_xml.py
@@ -257,13 +257,14 @@ def _find_duplicate_siblings(root: ET.Element) -> list[str]:
 def _find_empty_text_elements(root: ET.Element) -> list[str]:
     warnings: list[str] = []
 
-    for element in root.iter():
+    for record in _element_path_records(root):
+        element = record.element
         if element.tag != "text":
             continue
         if len(element) > 0:
             continue
         if element.text is None or element.text.strip() == "":
-            warnings.append(f"Empty text in element {_format_element_descriptor(element)}")
+            warnings.append(f"Empty text in element {_format_element_descriptor(element)} at {record.keyed_path}")
 
     return warnings
 

--- a/scripts/validate_xml_warning_baseline.json
+++ b/scripts/validate_xml_warning_baseline.json
@@ -3,7 +3,7 @@
   "warnings": [
     {
       "path": "Mods/QudJP/Localization/Conversations.jp.xml",
-      "warning": "Empty text in element 'text'",
+      "warning": "Empty text in element 'text' at /conversations[1]/conversation[@ID='Tzedech'][1]/node[@ID='Welcome'][1]/text[1]",
       "note": "Intentional upstream-preserved Tzedech/Welcome slot; base Conversations.xml 1.0.4 has the same empty <text></text> at line 12869."
     }
   ]


### PR DESCRIPTION
## Summary
- Harden CharacterStatusScreenBinding fallback behavior so controller population failures run the original method, while successful handled paths still suppress the original.
- Reset QudJP initialization guard when font initialization or Harmony patch application fails, allowing retries.
- Promote message pattern route validation into local and CI gates with exact reviewed route inventory counts.
- Tighten tests around regex compilation, transient artifact ignores, and route inventory drift.

## Review / Simplify
- Reviewed by separate subagent instances for code quality, CI/validation reliability, and ad-hoc workaround/low-quality code risks.
- Follow-up review findings were addressed and re-reviewed to APPROVE.
- Ran simplify with three read-only subagents; adopted only behavior-preserving cleanup and test hardening.

## Verification
- `just --summary`
- `just python-check`
- `just python-test-filter 'validate_pattern_routes or artifact_gitignore or translate_corpus_batch'`
- `just localization-check` (existing baseline warning: empty text in `Conversations.jp.xml`)
- `just translation-token-check`
- `just test-l1`
- `just test-l2`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * 初期化・ステータス画面・パターンルート・XML・.gitignore 周りの追加/強化テストを導入

* **バグ修正**
  * 初期化失敗時のロックアウト防止とリカバリ、コントローラ未取得時のフォールバック動作を強化

* **ドキュメント**
  * 品質強化の実装計画を追加

* **Chores**
  * ローカライゼーション検証を拡張し CI とビルドタスクに統合、検証ツールに期待カウントオプションを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->