### PR TITLE
Fix Japanese tooltip wrapping

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/JapaneseBlockWrapTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/JapaneseBlockWrapTests.cs
@@ -22,6 +22,23 @@ public sealed class JapaneseBlockWrapTests
         });
     }
 
+    [TestCase(null)]
+    [TestCase("")]
+    public void TryWrapForCjkBlock_ReturnsFalseForNullOrEmptyInput(string? source)
+    {
+        var changed = JapaneseBlockWrap.TryWrapForCjkBlock(
+            source!,
+            width: 10,
+            maxLines: 5000,
+            out var wrapped);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.False);
+            Assert.That(wrapped, Is.EqualTo(source));
+        });
+    }
+
     [Test]
     public void TryWrapForCjkBlock_ReopensActiveQudColorAfterInsertedBreak()
     {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/JapaneseBlockWrapTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/JapaneseBlockWrapTests.cs
@@ -72,6 +72,67 @@ public sealed class JapaneseBlockWrapTests
     }
 
     [Test]
+    public void TryWrapForCjkBlock_PreservesRootContractTokens()
+    {
+        const string source = "あいうえお\u0001=variable.name={0}{12:format}<sprite name=key>{{TMP|かきくけこ}}";
+
+        var changed = JapaneseBlockWrap.TryWrapForCjkBlock(
+            source,
+            width: 8,
+            maxLines: 5000,
+            out var wrapped);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(wrapped, Does.Contain("\u0001"));
+            Assert.That(wrapped, Does.Contain("=variable.name="));
+            Assert.That(wrapped, Does.Contain("{0}"));
+            Assert.That(wrapped, Does.Contain("{12:format}"));
+            Assert.That(wrapped, Does.Contain("<sprite name=key>"));
+            Assert.That(wrapped, Does.Contain("{{TMP|"));
+            Assert.That(wrapped, Does.Contain("}}"));
+        });
+    }
+
+    [TestCase("ああ{0}いう", "{0}")]
+    [TestCase("ああ{12:format}いう", "{12:format}")]
+    [TestCase("ああ=variable.name=いう", "=variable.name=")]
+    public void TryWrapForCjkBlock_PreservesRootContractTokenBoundariesAcrossForcedBreaks(
+        string source,
+        string token)
+    {
+        var changed = JapaneseBlockWrap.TryWrapForCjkBlock(
+            source,
+            width: 3,
+            maxLines: 5000,
+            out var wrapped);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(wrapped, Does.Contain(token));
+            Assert.That(wrapped, Does.Not.Contain(token[..^1] + "\n" + token[^1]));
+        });
+    }
+
+    [Test]
+    public void TryWrapForCjkBlock_RejectsPreferredBreakPastWidth()
+    {
+        var changed = JapaneseBlockWrap.TryWrapForCjkBlock(
+            "あいうえおかきくけこさし。すせそ",
+            width: 12,
+            maxLines: 5000,
+            out var wrapped);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(wrapped.Split('\n'), Has.All.Length.LessThanOrEqualTo(12));
+        });
+    }
+
+    [Test]
     public void TryWrapForCjkBlock_LeavesNonCjkTextForVanillaWrapper()
     {
         var changed = JapaneseBlockWrap.TryWrapForCjkBlock(

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/JapaneseBlockWrapTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/JapaneseBlockWrapTests.cs
@@ -1,0 +1,136 @@
+namespace QudJP.Tests.L1;
+
+using QudJP.UI;
+
+[TestFixture]
+[Category("L1")]
+public sealed class JapaneseBlockWrapTests
+{
+    [Test]
+    public void TryWrapForCjkBlock_BreaksJapaneseRunsAtVisibleWidth()
+    {
+        var changed = JapaneseBlockWrap.TryWrapForCjkBlock(
+            "あいうえおかきくけこ",
+            width: 5,
+            maxLines: 5000,
+            out var wrapped);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(wrapped, Is.EqualTo("あいうえお\nかきくけこ"));
+        });
+    }
+
+    [Test]
+    public void TryWrapForCjkBlock_ReopensActiveQudColorAfterInsertedBreak()
+    {
+        var changed = JapaneseBlockWrap.TryWrapForCjkBlock(
+            "&Yあいうえおかき",
+            width: 4,
+            maxLines: 5000,
+            out var wrapped);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(wrapped, Is.EqualTo("&Yあいうえ\n&Yおかき"));
+        });
+    }
+
+    [Test]
+    public void TryWrapForCjkBlock_PreservesQudMarkupBoundaries()
+    {
+        var changed = JapaneseBlockWrap.TryWrapForCjkBlock(
+            "{{y|あいうえおかき}}",
+            width: 4,
+            maxLines: 5000,
+            out var wrapped);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(wrapped, Is.EqualTo("{{y|あいうえ\nおかき}}"));
+        });
+    }
+
+    [Test]
+    public void TryWrapForCjkBlock_LeavesNonCjkTextForVanillaWrapper()
+    {
+        var changed = JapaneseBlockWrap.TryWrapForCjkBlock(
+            "The quick brown fox",
+            width: 5,
+            maxLines: 5000,
+            out var wrapped);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.False);
+            Assert.That(wrapped, Is.EqualTo("The quick brown fox"));
+        });
+    }
+
+    [Test]
+    public void TryWrapTooltipLongDescription_UsesNarrowWidthForJapaneseInjectorRules()
+    {
+        const string source = "持続：41-50ラウンド　熱耐性 +100／冷気耐性 -50／クイックネス +10（真系：+20）。凍結しない。あなたが与える熱ダメージ +25%。外部の熱源で体温は上昇しない。発火して効果を失わないよう、移動し続けなければならない。";
+
+        var changed = JapaneseBlockWrap.TryWrapTooltipLongDescription(source, out var wrapped);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(wrapped.Split('\n'), Has.All.Length.LessThanOrEqualTo(34));
+        });
+    }
+
+    [Test]
+    public void TryWrapForCjkBlock_PrefersRecentJapanesePunctuation()
+    {
+        var changed = JapaneseBlockWrap.TryWrapForCjkBlock(
+            "あいうえおかきくけこ。さしすせそたちつてと",
+            width: 12,
+            maxLines: 5000,
+            out var wrapped);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(wrapped, Is.EqualTo("あいうえおかきくけこ。\nさしすせそたちつてと"));
+        });
+    }
+
+    [Test]
+    public void TryWrapForCjkBlock_DoesNotPreferStatDelimitersAsLineBreaks()
+    {
+        var changed = JapaneseBlockWrap.TryWrapForCjkBlock(
+            "熱耐性 +100／冷気耐性 -50／クイックネス +10。",
+            width: 12,
+            maxLines: 5000,
+            out var wrapped);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(wrapped, Does.Not.Contain("／\n"));
+            Assert.That(wrapped, Does.Not.Contain("：\n"));
+            Assert.That(wrapped, Does.Not.Contain(";\n"));
+        });
+    }
+
+    [Test]
+    public void TryWrapForCjkBlock_PrefersRecentHalfWidthSpace()
+    {
+        var changed = JapaneseBlockWrap.TryWrapForCjkBlock(
+            "古い遺物 調査記録が残っている",
+            width: 8,
+            maxLines: 5000,
+            out var wrapped);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(wrapped, Is.EqualTo("古い遺物 \n調査記録が残って\nいる"));
+        });
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/LookTooltipInformationWrapPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/LookTooltipInformationWrapPatchTests.cs
@@ -24,5 +24,19 @@ public sealed class LookTooltipInformationWrapPatchTests
             information.LongDescription,
             Is.EqualTo(new string('あ', JapaneseBlockWrap.DefaultTooltipVisibleColumns) + "\nあ"));
     }
+
+    [TestCase("")]
+    [TestCase("The quick brown fox")]
+    public void Postfix_PreservesNoOpLongDescriptions(string source)
+    {
+        var information = new Look.TooltipInformation
+        {
+            LongDescription = source,
+        };
+
+        LookTooltipInformationWrapPatch.Postfix(ref information);
+
+        Assert.That(information.LongDescription, Is.EqualTo(source));
+    }
 }
 #endif

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/LookTooltipInformationWrapPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/LookTooltipInformationWrapPatchTests.cs
@@ -1,0 +1,28 @@
+#if HAS_GAME_DLL
+using QudJP.Patches;
+using QudJP.UI;
+using XRL.UI;
+
+namespace QudJP.Tests.L2G;
+
+[TestFixture]
+[Category("L2G")]
+public sealed class LookTooltipInformationWrapPatchTests
+{
+    [Test]
+    public void Postfix_WrapsLongDescriptionBeforeTooltipRtfFormatting()
+    {
+        var source = new string('あ', JapaneseBlockWrap.DefaultTooltipVisibleColumns + 1);
+        var information = new Look.TooltipInformation
+        {
+            LongDescription = source,
+        };
+
+        LookTooltipInformationWrapPatch.Postfix(ref information);
+
+        Assert.That(
+            information.LongDescription,
+            Is.EqualTo(new string('あ', JapaneseBlockWrap.DefaultTooltipVisibleColumns) + "\nあ"));
+    }
+}
+#endif

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -49,6 +49,7 @@ public sealed class TargetMethodResolutionTests
     })]
     [TestCase(typeof(GetDisplayNameProcessPatch), "ProcessFor", "XRL.World.GetDisplayNameEvent", "System.String", new[] { "XRL.World.GameObject", "System.Boolean" })]
     [TestCase(typeof(LookTooltipContentPatch), "GenerateTooltipContent", "XRL.UI.Look", "System.String", new[] { "XRL.World.GameObject" })]
+    [TestCase(typeof(LookTooltipInformationWrapPatch), "GenerateTooltipInformation", "XRL.UI.Look", "XRL.UI.Look+TooltipInformation", new[] { "XRL.World.GameObject" })]
     [TestCase(typeof(DescriptionLongDescriptionPatch), "GetLongDescription", "XRL.World.Parts.Description", "System.Void", new[] { "System.Text.StringBuilder" })]
     [TestCase(typeof(UITextSkinTranslationPatch), "SetText", "XRL.UI.UITextSkin", "System.Boolean", new[] { "System.String" })]
     [TestCase(typeof(CharacterStatusScreenTranslationPatch), "UpdateViewFromData", "Qud.UI.CharacterStatusScreen", "System.Void", new string[0])]

--- a/Mods/QudJP/Assemblies/src/Patches/LookTooltipInformationWrapPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/LookTooltipInformationWrapPatch.cs
@@ -3,7 +3,9 @@ using System.Diagnostics;
 using System.Reflection;
 using HarmonyLib;
 using QudJP.UI;
+#if HAS_GAME_DLL
 using XRL.UI;
+#endif
 
 namespace QudJP.Patches;
 
@@ -58,6 +60,7 @@ public static class LookTooltipInformationWrapPatch
         }
     }
 
+#if HAS_GAME_DLL
     public static void Postfix(ref Look.TooltipInformation __result)
     {
         try
@@ -72,4 +75,29 @@ public static class LookTooltipInformationWrapPatch
             Trace.TraceError("QudJP: LookTooltipInformationWrapPatch.Postfix failed: {0}", ex);
         }
     }
+#else
+    public static void Postfix(ref object? __result)
+    {
+        try
+        {
+            if (__result is null)
+            {
+                return;
+            }
+
+            var longDescriptionField = __result.GetType().GetField(
+                "LongDescription",
+                BindingFlags.Instance | BindingFlags.Public);
+            if (longDescriptionField?.GetValue(__result) is string source
+                && JapaneseBlockWrap.TryWrapTooltipLongDescription(source, out var wrapped))
+            {
+                longDescriptionField.SetValue(__result, wrapped);
+            }
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: LookTooltipInformationWrapPatch.Postfix failed: {0}", ex);
+        }
+    }
+#endif
 }

--- a/Mods/QudJP/Assemblies/src/Patches/LookTooltipInformationWrapPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/LookTooltipInformationWrapPatch.cs
@@ -15,39 +15,47 @@ public static class LookTooltipInformationWrapPatch
     [HarmonyTargetMethod]
     private static MethodBase? TargetMethod()
     {
-        var targetType = AccessTools.TypeByName(TargetTypeName);
-        if (targetType is null)
+        try
         {
-            Trace.TraceError("QudJP: Failed to resolve XRL.UI.Look. Tooltip information wrap patch will not apply.");
-            return null;
-        }
-
-        var gameObjectType = AccessTools.TypeByName("XRL.World.GameObject");
-        if (gameObjectType is null)
-        {
-            Trace.TraceError("QudJP: Failed to resolve XRL.World.GameObject. Tooltip information wrap patch will not apply.");
-            return null;
-        }
-
-        var method = AccessTools.Method(targetType, "GenerateTooltipInformation", new[] { gameObjectType });
-        if (method is not null)
-        {
-            return method;
-        }
-
-        var methods = AccessTools.GetDeclaredMethods(targetType);
-        for (var index = 0; index < methods.Count; index++)
-        {
-            var candidate = methods[index];
-            if (string.Equals(candidate.Name, "GenerateTooltipInformation", StringComparison.Ordinal)
-                && candidate.GetParameters().Length == 1)
+            var targetType = AccessTools.TypeByName(TargetTypeName);
+            if (targetType is null)
             {
-                return candidate;
+                Trace.TraceError("QudJP: Failed to resolve XRL.UI.Look. Tooltip information wrap patch will not apply.");
+                return null;
             }
-        }
 
-        Trace.TraceError("QudJP: Failed to resolve Look.GenerateTooltipInformation(GameObject). Tooltip information wrap patch will not apply.");
-        return null;
+            var gameObjectType = AccessTools.TypeByName("XRL.World.GameObject");
+            if (gameObjectType is null)
+            {
+                Trace.TraceError("QudJP: Failed to resolve XRL.World.GameObject. Tooltip information wrap patch will not apply.");
+                return null;
+            }
+
+            var method = AccessTools.Method(targetType, "GenerateTooltipInformation", new[] { gameObjectType });
+            if (method is not null)
+            {
+                return method;
+            }
+
+            var methods = AccessTools.GetDeclaredMethods(targetType);
+            for (var index = 0; index < methods.Count; index++)
+            {
+                var candidate = methods[index];
+                if (string.Equals(candidate.Name, "GenerateTooltipInformation", StringComparison.Ordinal)
+                    && candidate.GetParameters().Length == 1)
+                {
+                    return candidate;
+                }
+            }
+
+            Trace.TraceError("QudJP: Failed to resolve Look.GenerateTooltipInformation(GameObject). Tooltip information wrap patch will not apply.");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: LookTooltipInformationWrapPatch.TargetMethod failed: {0}", ex);
+            return null;
+        }
     }
 
     public static void Postfix(ref Look.TooltipInformation __result)

--- a/Mods/QudJP/Assemblies/src/Patches/LookTooltipInformationWrapPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/LookTooltipInformationWrapPatch.cs
@@ -43,8 +43,10 @@ public static class LookTooltipInformationWrapPatch
             for (var index = 0; index < methods.Count; index++)
             {
                 var candidate = methods[index];
+                var parameters = candidate.GetParameters();
                 if (string.Equals(candidate.Name, "GenerateTooltipInformation", StringComparison.Ordinal)
-                    && candidate.GetParameters().Length == 1)
+                    && parameters.Length == 1
+                    && parameters[0].ParameterType == gameObjectType)
                 {
                     return candidate;
                 }

--- a/Mods/QudJP/Assemblies/src/Patches/LookTooltipInformationWrapPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/LookTooltipInformationWrapPatch.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+using QudJP.UI;
+using XRL.UI;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class LookTooltipInformationWrapPatch
+{
+    private const string TargetTypeName = "XRL.UI.Look";
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = AccessTools.TypeByName(TargetTypeName);
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: Failed to resolve XRL.UI.Look. Tooltip information wrap patch will not apply.");
+            return null;
+        }
+
+        var gameObjectType = AccessTools.TypeByName("XRL.World.GameObject");
+        if (gameObjectType is null)
+        {
+            Trace.TraceError("QudJP: Failed to resolve XRL.World.GameObject. Tooltip information wrap patch will not apply.");
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "GenerateTooltipInformation", new[] { gameObjectType });
+        if (method is not null)
+        {
+            return method;
+        }
+
+        var methods = AccessTools.GetDeclaredMethods(targetType);
+        for (var index = 0; index < methods.Count; index++)
+        {
+            var candidate = methods[index];
+            if (string.Equals(candidate.Name, "GenerateTooltipInformation", StringComparison.Ordinal)
+                && candidate.GetParameters().Length == 1)
+            {
+                return candidate;
+            }
+        }
+
+        Trace.TraceError("QudJP: Failed to resolve Look.GenerateTooltipInformation(GameObject). Tooltip information wrap patch will not apply.");
+        return null;
+    }
+
+    public static void Postfix(ref Look.TooltipInformation __result)
+    {
+        try
+        {
+            if (JapaneseBlockWrap.TryWrapTooltipLongDescription(__result.LongDescription, out var wrapped))
+            {
+                __result.LongDescription = wrapped;
+            }
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: LookTooltipInformationWrapPatch.Postfix failed: {0}", ex);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/src/UI/JapaneseBlockWrap.cs
+++ b/Mods/QudJP/Assemblies/src/UI/JapaneseBlockWrap.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Text;
+
+namespace QudJP.UI;
+
+internal static class JapaneseBlockWrap
+{
+    internal const int DefaultTooltipVisibleColumns = 34;
+    private const int DefaultMaxLines = 5000;
+    private const int PreferredBreakSearchColumns = 12;
+
+    internal static bool TryWrapTooltipLongDescription(string source, out string wrapped)
+    {
+        return TryWrapForCjkBlock(source, DefaultTooltipVisibleColumns, DefaultMaxLines, out wrapped);
+    }
+
+    internal static bool TryWrapForCjkBlock(string source, int width, int maxLines, out string wrapped)
+    {
+        wrapped = source;
+        if (string.IsNullOrEmpty(source) || width <= 0 || maxLines <= 0 || !ContainsCjk(source))
+        {
+            return false;
+        }
+
+        var builder = new StringBuilder(source.Length + (source.Length / width) + 8);
+        char? activeForeground = null;
+        char? activeBackground = null;
+        var visibleColumn = 0;
+        var lineCount = 1;
+        var insertedBreak = false;
+        var preferredBreak = BreakCandidate.None;
+
+        for (var index = 0; index < source.Length; index++)
+        {
+            var current = source[index];
+            if (TryAppendQudMarkupToken(source, ref index, builder))
+            {
+                continue;
+            }
+
+            if (TryAppendFormattingCode(source, ref index, builder, ref activeForeground, ref activeBackground))
+            {
+                continue;
+            }
+
+            builder.Append(current);
+            if (current == '\n')
+            {
+                visibleColumn = 0;
+                lineCount++;
+                preferredBreak = BreakCandidate.None;
+                if (lineCount > maxLines)
+                {
+                    break;
+                }
+
+                AppendActiveFormatting(builder, activeForeground, activeBackground);
+                continue;
+            }
+
+            visibleColumn++;
+            if (IsPreferredBreakAfter(source, index))
+            {
+                preferredBreak = new BreakCandidate(
+                    builder.Length,
+                    visibleColumn,
+                    activeForeground,
+                    activeBackground);
+            }
+
+            if (visibleColumn < width || index >= source.Length - 1 || lineCount >= maxLines || !CanBreakAfter(source, index))
+            {
+                continue;
+            }
+
+            var breakAt = SelectBreakCandidate(preferredBreak, width);
+            if (breakAt.HasValue)
+            {
+                InsertBreakAtCandidate(builder, breakAt.Value);
+                visibleColumn -= breakAt.Value.VisibleColumn;
+            }
+            else
+            {
+                builder.Append('\n');
+                visibleColumn = 0;
+                AppendActiveFormatting(builder, activeForeground, activeBackground);
+            }
+
+            lineCount++;
+            insertedBreak = true;
+            preferredBreak = BreakCandidate.None;
+        }
+
+        if (!insertedBreak)
+        {
+            return false;
+        }
+
+        wrapped = builder.ToString();
+        return true;
+    }
+
+    private static bool TryAppendQudMarkupToken(string source, ref int index, StringBuilder builder)
+    {
+        if (index + 1 >= source.Length || source[index] != '{' || source[index + 1] != '{')
+        {
+            return TryAppendQudMarkupClose(source, ref index, builder);
+        }
+
+        var pipeIndex = source.IndexOf('|', index + 2);
+        var closeIndex = source.IndexOf("}}", index + 2, StringComparison.Ordinal);
+        if (pipeIndex < 0 || (closeIndex >= 0 && closeIndex < pipeIndex))
+        {
+            return false;
+        }
+
+        builder.Append(source, index, pipeIndex - index + 1);
+        index = pipeIndex;
+        return true;
+    }
+
+    private static bool TryAppendQudMarkupClose(string source, ref int index, StringBuilder builder)
+    {
+        if (index + 1 >= source.Length || source[index] != '}' || source[index + 1] != '}')
+        {
+            return false;
+        }
+
+        builder.Append("}}");
+        index++;
+        return true;
+    }
+
+    private static bool TryAppendFormattingCode(
+        string source,
+        ref int index,
+        StringBuilder builder,
+        ref char? activeForeground,
+        ref char? activeBackground)
+    {
+        var current = source[index];
+        if (current != '&' && current != '^')
+        {
+            return false;
+        }
+
+        if (index + 1 >= source.Length)
+        {
+            return false;
+        }
+
+        var next = source[index + 1];
+        builder.Append(current);
+        builder.Append(next);
+        index++;
+
+        if (current == '&' && next != '&')
+        {
+            activeForeground = next;
+        }
+        else if (current == '^' && next != '^')
+        {
+            activeBackground = next;
+        }
+
+        return true;
+    }
+
+    private static void AppendActiveFormatting(StringBuilder builder, char? activeForeground, char? activeBackground)
+    {
+        if (activeForeground.HasValue)
+        {
+            builder.Append('&');
+            builder.Append(activeForeground.Value);
+        }
+
+        if (activeBackground.HasValue)
+        {
+            builder.Append('^');
+            builder.Append(activeBackground.Value);
+        }
+    }
+
+    private static BreakCandidate? SelectBreakCandidate(BreakCandidate preferredBreak, int width)
+    {
+        if (!preferredBreak.HasValue)
+        {
+            return null;
+        }
+
+        var columnsBeforeLimit = width - preferredBreak.VisibleColumn;
+        if (columnsBeforeLimit > PreferredBreakSearchColumns)
+        {
+            return null;
+        }
+
+        return preferredBreak;
+    }
+
+    private static void InsertBreakAtCandidate(StringBuilder builder, BreakCandidate candidate)
+    {
+        var insertion = new StringBuilder(5);
+        insertion.Append('\n');
+        AppendActiveFormatting(insertion, candidate.ActiveForeground, candidate.ActiveBackground);
+        builder.Insert(candidate.BuilderIndex, insertion.ToString());
+    }
+
+    private static bool IsPreferredBreakAfter(string source, int index)
+    {
+        var current = source[index];
+        if (index >= source.Length - 1 || IsForbiddenLineStart(source[index + 1]))
+        {
+            return false;
+        }
+
+        return current is '。' or '、' or '，' or ','
+            || (current is '　' or ' ' && !StartsNumericTerm(source[index + 1]));
+    }
+
+    private static bool StartsNumericTerm(char value)
+    {
+        return value is '+' or '-' or >= '0' and <= '9' or >= '０' and <= '９';
+    }
+
+    private static bool CanBreakAfter(string source, int index)
+    {
+        if (index + 1 < source.Length && IsForbiddenLineStart(source[index + 1]))
+        {
+            return false;
+        }
+
+        return IsCjk(source[index]) || (index + 1 < source.Length && IsCjk(source[index + 1]));
+    }
+
+    private static bool IsForbiddenLineStart(char value)
+    {
+        return value is '。' or '、' or '，' or ',' or '；' or ';' or '：' or ':' or '／' or '/' or '）' or ')' or '］' or ']' or '}' or '」' or '』';
+    }
+
+    private static bool ContainsCjk(string value)
+    {
+        for (var index = 0; index < value.Length; index++)
+        {
+            if (IsCjk(value[index]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsCjk(char value)
+    {
+        return value is >= '\u3040' and <= '\u30ff'
+            or >= '\u3400' and <= '\u4dbf'
+            or >= '\u4e00' and <= '\u9fff'
+            or >= '\uf900' and <= '\ufaff'
+            or >= '\uff00' and <= '\uffef';
+    }
+
+    private readonly struct BreakCandidate
+    {
+        internal static BreakCandidate None => default;
+
+        internal BreakCandidate(int builderIndex, int visibleColumn, char? activeForeground, char? activeBackground)
+        {
+            BuilderIndex = builderIndex;
+            VisibleColumn = visibleColumn;
+            ActiveForeground = activeForeground;
+            ActiveBackground = activeBackground;
+            HasValue = true;
+        }
+
+        internal int BuilderIndex { get; }
+
+        internal int VisibleColumn { get; }
+
+        internal char? ActiveForeground { get; }
+
+        internal char? ActiveBackground { get; }
+
+        internal bool HasValue { get; }
+    }
+}

--- a/Mods/QudJP/Assemblies/src/UI/JapaneseBlockWrap.cs
+++ b/Mods/QudJP/Assemblies/src/UI/JapaneseBlockWrap.cs
@@ -33,7 +33,9 @@ internal static class JapaneseBlockWrap
         for (var index = 0; index < source.Length; index++)
         {
             var current = source[index];
-            if (TryAppendQudMarkupToken(source, ref index, builder))
+            if (TryAppendQudMarkupToken(source, ref index, builder)
+                || TryAppendRootContractToken(source, ref index, builder)
+                || TryAppendTmpRichTextTag(source, ref index, builder))
             {
                 continue;
             }
@@ -79,6 +81,11 @@ internal static class JapaneseBlockWrap
                 InsertBreakAtCandidate(builder, breakAt.Value);
                 visibleColumn -= breakAt.Value.VisibleColumn;
             }
+            else if (visibleColumn > width)
+            {
+                InsertBreakBeforeCurrent(builder, activeForeground, activeBackground);
+                visibleColumn = 1;
+            }
             else
             {
                 builder.Append('\n');
@@ -97,6 +104,121 @@ internal static class JapaneseBlockWrap
         }
 
         wrapped = builder.ToString();
+        return true;
+    }
+
+    private static bool TryAppendRootContractToken(string source, ref int index, StringBuilder builder)
+    {
+        if (source[index] == '\u0001')
+        {
+            builder.Append(source[index]);
+            return true;
+        }
+
+        return TryAppendNumericPlaceholder(source, ref index, builder)
+            || TryAppendVariablePlaceholder(source, ref index, builder);
+    }
+
+    private static bool TryAppendNumericPlaceholder(string source, ref int index, StringBuilder builder)
+    {
+        if (source[index] != '{' || index + 1 >= source.Length || source[index + 1] == '{')
+        {
+            return false;
+        }
+
+        var closeIndex = source.IndexOf('}', index + 1);
+        if (closeIndex < 0 || closeIndex == index + 1 || !IsAsciiDigit(source[index + 1]))
+        {
+            return false;
+        }
+
+        var scanIndex = index + 1;
+        while (scanIndex < closeIndex && IsAsciiDigit(source[scanIndex]))
+        {
+            scanIndex++;
+        }
+
+        if (scanIndex < closeIndex)
+        {
+            if (source[scanIndex] != ':' || scanIndex == closeIndex - 1)
+            {
+                return false;
+            }
+
+            scanIndex++;
+            while (scanIndex < closeIndex)
+            {
+                if (source[scanIndex] is '\n' or '{' or '}')
+                {
+                    return false;
+                }
+
+                scanIndex++;
+            }
+        }
+
+        builder.Append(source, index, closeIndex - index + 1);
+        index = closeIndex;
+        return true;
+    }
+
+    private static bool TryAppendVariablePlaceholder(string source, ref int index, StringBuilder builder)
+    {
+        if (source[index] != '=')
+        {
+            return false;
+        }
+
+        var closeIndex = source.IndexOf('=', index + 1);
+        if (closeIndex < 0 || closeIndex == index + 1)
+        {
+            return false;
+        }
+
+        var hasDot = false;
+        for (var scanIndex = index + 1; scanIndex < closeIndex; scanIndex++)
+        {
+            var current = source[scanIndex];
+            hasDot |= current == '.';
+            if (!IsVariablePlaceholderChar(current))
+            {
+                return false;
+            }
+        }
+
+        if (!hasDot)
+        {
+            return false;
+        }
+
+        builder.Append(source, index, closeIndex - index + 1);
+        index = closeIndex;
+        return true;
+    }
+
+    private static bool TryAppendTmpRichTextTag(string source, ref int index, StringBuilder builder)
+    {
+        if (source[index] != '<')
+        {
+            return false;
+        }
+
+        var closeIndex = source.IndexOf('>', index + 1);
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        for (var scanIndex = index + 1; scanIndex < closeIndex; scanIndex++)
+        {
+            if (source[scanIndex] == '\n')
+            {
+                return false;
+            }
+        }
+
+        builder.Append(source, index, closeIndex - index + 1);
+        index = closeIndex;
         return true;
     }
 
@@ -188,6 +310,11 @@ internal static class JapaneseBlockWrap
             return null;
         }
 
+        if (preferredBreak.VisibleColumn > width)
+        {
+            return null;
+        }
+
         var columnsBeforeLimit = width - preferredBreak.VisibleColumn;
         if (columnsBeforeLimit > PreferredBreakSearchColumns)
         {
@@ -205,6 +332,14 @@ internal static class JapaneseBlockWrap
         builder.Insert(candidate.BuilderIndex, insertion.ToString());
     }
 
+    private static void InsertBreakBeforeCurrent(StringBuilder builder, char? activeForeground, char? activeBackground)
+    {
+        var insertion = new StringBuilder(5);
+        insertion.Append('\n');
+        AppendActiveFormatting(insertion, activeForeground, activeBackground);
+        builder.Insert(builder.Length - 1, insertion.ToString());
+    }
+
     private static bool IsPreferredBreakAfter(string source, int index)
     {
         var current = source[index];
@@ -220,6 +355,20 @@ internal static class JapaneseBlockWrap
     private static bool StartsNumericTerm(char value)
     {
         return value is '+' or '-' or >= '0' and <= '9' or >= '０' and <= '９';
+    }
+
+    private static bool IsAsciiDigit(char value)
+    {
+        return value is >= '0' and <= '9';
+    }
+
+    private static bool IsVariablePlaceholderChar(char value)
+    {
+        return value is >= 'a' and <= 'z'
+            or >= 'A' and <= 'Z'
+            or >= '0' and <= '9'
+            or '_'
+            or '.';
     }
 
     private static bool CanBreakAfter(string source, int index)


### PR DESCRIPTION
## Summary
- wrap Japanese/CJK tooltip long descriptions before stable RTF/TextBlock formatting
- prefer Japanese punctuation and spaces as break points while avoiding slash/colon/stat-token splits
- add L1 and L2G coverage for the tooltip wrapping route and target resolution

## Root Cause
Stable TextBlock wrapping treats Japanese long descriptions as unbroken runs because it mainly breaks on spaces/newlines. Long injector and food tooltip descriptions can therefore overflow the TMP tooltip area.

## Validation
- just check
- no `scripts/smoke_test.py` is present in this repository

Closes #571


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ツールチップの長い説明文に対する日本語/CJK向け折り返しを追加。句読点・半角スペースを優先し、特定区切り文字は折り返しを避け、折り返し時に色指定やマークアップの適用状態を維持します。
  * 実行時にツールチップ生成結果へ折り返しを適用する処理を導入（安全に動作しない場合は影響を回避）。

* **テスト**
  * 折り返し動作（境界、空入力、非CJK、強制改行、マークアップ／トークン保持、表示幅制約、句読点優先など）を網羅する単体テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->