### PR TITLE
[codex] Gate verbose probes to dev builds

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/RuntimeDiagnosticsTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/RuntimeDiagnosticsTests.cs
@@ -1,0 +1,59 @@
+namespace QudJP.Tests.L1;
+
+[TestFixture]
+[Category("L1")]
+[NonParallelizable]
+public sealed class RuntimeDiagnosticsTests
+{
+    [TearDown]
+    public void TearDown()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(null);
+    }
+
+    [Test]
+    public void VerboseProbesEnabled_DefaultsToDevBuildSetting()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(RuntimeDiagnostics.BuildFlavor, Is.EqualTo("dev"));
+            Assert.That(RuntimeDiagnostics.VerboseProbesEnabled, Is.True);
+        });
+    }
+
+    [Test]
+    public void VerboseProbeOverride_DisablesDynamicAndFinalOutputProbeLogs()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(false);
+        DynamicTextObservability.ResetForTests();
+        FinalOutputObservability.ResetForTests();
+        var finalOutputObservation = new FinalOutputObservation(
+            "Sink",
+            "Route",
+            "Detail",
+            FinalOutputObservability.PhaseBeforeSink,
+            FinalOutputObservability.TranslationStatusSinkUnclaimed,
+            FinalOutputObservability.NotEvaluatedStatus,
+            FinalOutputObservability.NotEvaluatedStatus,
+            "source",
+            "source",
+            string.Empty,
+            "source");
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+        {
+            DynamicTextObservability.RecordTransform("Route", "Family", "source", "translated");
+            FinalOutputObservability.Record(finalOutputObservation);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(output, Does.Not.Contain("DynamicTextProbe/v1"));
+            Assert.That(output, Does.Not.Contain("FinalOutputProbe/v1"));
+            Assert.That(DynamicTextObservability.GetRouteFamilyHitCountForTests("Route", "Family"), Is.Zero);
+            Assert.That(FinalOutputObservability.GetHitCountForTests(finalOutputObservation), Is.Zero);
+        });
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj
@@ -10,6 +10,7 @@
     <GameDir Condition="'$(GameDir)' == ''">$(HOME)/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/Resources/Data</GameDir>
     <AssemblyCSharpPath Condition="'$(AssemblyCSharpPath)' == ''">$(GameDir)/Managed/Assembly-CSharp.dll</AssemblyCSharpPath>
     <ManagedDir>$([System.IO.Path]::GetDirectoryName('$(AssemblyCSharpPath)'))</ManagedDir>
+    <DefineConstants>$(DefineConstants);QUDJP_DEV_BUILD</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="Exists('$(AssemblyCSharpPath)')">
@@ -42,6 +43,7 @@
     <Compile Include="../src/Observability/*.cs" Link="Production/Observability/%(Filename)%(Extension)" />
     <Compile Include="../src/Patches/*.cs" Link="Production/Patches/%(Filename)%(Extension)" />
     <Compile Include="../src/QudJPMod.cs" Link="Production/QudJPMod.cs" />
+    <Compile Include="../src/RuntimeDiagnostics.cs" Link="Production/RuntimeDiagnostics.cs" />
     <Compile Include="../src/Translation/*.cs" Link="Production/Translation/%(Filename)%(Extension)" />
     <Compile Include="../src/UI/*.cs" Link="Production/UI/%(Filename)%(Extension)" />
   </ItemGroup>

--- a/Mods/QudJP/Assemblies/QudJP.csproj
+++ b/Mods/QudJP/Assemblies/QudJP.csproj
@@ -19,6 +19,10 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(QudJPDevBuild)' == 'true' Or '$(QUDJP_DEV_BUILD)' == '1' Or '$(QUDJP_DEV_BUILD)' == 'true'">
+    <DefineConstants>$(DefineConstants);QUDJP_DEV_BUILD</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="src/**/*.cs" />
   </ItemGroup>

--- a/Mods/QudJP/Assemblies/src/Observability/CompareProbeRunner.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/CompareProbeRunner.cs
@@ -12,12 +12,10 @@ internal static class CompareProbeRunner
     internal static void Run(object screenInstance)
     {
 #if HAS_TMP
-        if (!RuntimeDiagnostics.VerboseProbesEnabled)
-        {
-            return;
-        }
+        var verboseProbesEnabled = RuntimeDiagnostics.VerboseProbesEnabled;
 
-        if (TmpTextRepairer.TryBuildTextShellLeafProbe(screenInstance, "HandleSelectItemLeafReachBefore/v1", out var beforeLeafLog)
+        if (verboseProbesEnabled
+            && TmpTextRepairer.TryBuildTextShellLeafProbe(screenInstance, "HandleSelectItemLeafReachBefore/v1", out var beforeLeafLog)
             && beforeLeafLog is not null
             && beforeLeafLog.Length > 0)
         {
@@ -25,46 +23,58 @@ internal static class CompareProbeRunner
         }
 
         var repaired = TmpTextRepairer.TryRepairInvisibleTexts(screenInstance);
-        if (repaired > 0)
+        if (verboseProbesEnabled && repaired > 0)
         {
             LogProbe(TmpTextRepairer.BuildRepairLog("HandleSelectItemRepair/v1", repaired));
         }
 
-        if (TmpTextRepairer.TryBuildTextShellLeafProbe(screenInstance, "HandleSelectItemLeafReachAfter/v1", out var afterLeafLog)
+        if (verboseProbesEnabled
+            && TmpTextRepairer.TryBuildTextShellLeafProbe(screenInstance, "HandleSelectItemLeafReachAfter/v1", out var afterLeafLog)
             && afterLeafLog is not null
             && afterLeafLog.Length > 0)
         {
             LogProbe(afterLeafLog);
         }
 
-        if (UiChildTextObservability.TryBuildSnapshot(screenInstance, "HandleSelectItemProbe/v1", out var logLine)
+        if (verboseProbesEnabled
+            && UiChildTextObservability.TryBuildSnapshot(screenInstance, "HandleSelectItemProbe/v1", out var logLine)
             && logLine is not null
             && logLine.Length > 0)
         {
             LogProbe(logLine);
         }
 
-        if (ComparePopupTextFixer.TryRepairActiveComparePopup(out var comparePopupRepairLog)
+        if (verboseProbesEnabled
+            && ComparePopupTextFixer.TryRepairActiveComparePopup(out var comparePopupRepairLog)
             && comparePopupRepairLog is not null
             && comparePopupRepairLog.Length > 0)
         {
             LogProbe(comparePopupRepairLog);
         }
+        else if (!verboseProbesEnabled)
+        {
+            _ = ComparePopupTextFixer.RepairActiveComparePopup();
+        }
 
-        if (ScreenHierarchyObservability.TryBuildNeighborhoodSnapshot(screenInstance, "CompareHierarchyProbe/v1", out var hierarchyLogLine)
+        if (verboseProbesEnabled
+            && ScreenHierarchyObservability.TryBuildNeighborhoodSnapshot(screenInstance, "CompareHierarchyProbe/v1", out var hierarchyLogLine)
             && hierarchyLogLine is not null
             && hierarchyLogLine.Length > 0)
         {
             LogProbe(hierarchyLogLine);
         }
 
-        var focusedBranchLogs = ScreenHierarchyObservability.BuildFocusedBranchSnapshots(screenInstance, "CompareBranchProbe/v1");
-        for (var index = 0; index < focusedBranchLogs.Length; index++)
+        if (verboseProbesEnabled)
         {
-            LogProbe(focusedBranchLogs[index]);
+            var focusedBranchLogs = ScreenHierarchyObservability.BuildFocusedBranchSnapshots(screenInstance, "CompareBranchProbe/v1");
+            for (var index = 0; index < focusedBranchLogs.Length; index++)
+            {
+                LogProbe(focusedBranchLogs[index]);
+            }
         }
 
-        if (SceneTextObservability.TryBuildCompareSceneSnapshot("CompareSceneProbe/v1", out var sceneLogLine)
+        if (verboseProbesEnabled
+            && SceneTextObservability.TryBuildCompareSceneSnapshot("CompareSceneProbe/v1", out var sceneLogLine)
             && sceneLogLine is not null
             && sceneLogLine.Length > 0)
         {

--- a/Mods/QudJP/Assemblies/src/Observability/CompareProbeRunner.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/CompareProbeRunner.cs
@@ -12,6 +12,11 @@ internal static class CompareProbeRunner
     internal static void Run(object screenInstance)
     {
 #if HAS_TMP
+        if (!RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            return;
+        }
+
         if (TmpTextRepairer.TryBuildTextShellLeafProbe(screenInstance, "HandleSelectItemLeafReachBefore/v1", out var beforeLeafLog)
             && beforeLeafLog is not null
             && beforeLeafLog.Length > 0)
@@ -67,6 +72,8 @@ internal static class CompareProbeRunner
         }
 
         DelayedSceneProbeScheduler.ScheduleCompareSceneProbe(screenInstance);
+#else
+        _ = screenInstance;
 #endif
     }
 
@@ -151,6 +158,11 @@ internal static class CompareProbeRunner
 
     internal static void LogProbe(string message)
     {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            return;
+        }
+
         try
         {
             var debugType = Type.GetType("UnityEngine.Debug, UnityEngine.CoreModule", throwOnError: false);

--- a/Mods/QudJP/Assemblies/src/Observability/DelayedSceneProbeScheduler.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/DelayedSceneProbeScheduler.cs
@@ -13,11 +13,6 @@ internal static class DelayedSceneProbeScheduler
 
     internal static void ScheduleCompareSceneProbe(object? screenInstance)
     {
-        if (!RuntimeDiagnostics.VerboseProbesEnabled)
-        {
-            return;
-        }
-
         if (compareSceneScheduled)
         {
             return;
@@ -31,7 +26,10 @@ internal static class DelayedSceneProbeScheduler
             return;
         }
 
-        SceneTextObservability.ResetBuckets();
+        if (RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            SceneTextObservability.ResetBuckets();
+        }
         compareSceneScheduled = true;
         runner.StartCoroutine(RunCompareSceneProbe());
     }

--- a/Mods/QudJP/Assemblies/src/Observability/DelayedSceneProbeScheduler.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/DelayedSceneProbeScheduler.cs
@@ -13,6 +13,11 @@ internal static class DelayedSceneProbeScheduler
 
     internal static void ScheduleCompareSceneProbe(object? screenInstance)
     {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            return;
+        }
+
         if (compareSceneScheduled)
         {
             return;

--- a/Mods/QudJP/Assemblies/src/Observability/DynamicTextObservability.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/DynamicTextObservability.cs
@@ -31,6 +31,11 @@ internal static class DynamicTextObservability
         string? translated,
         bool logWhenUnchanged = false)
     {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            return;
+        }
+
         var sourceValue = source ?? string.Empty;
         var translatedValue = translated ?? string.Empty;
         var changed = !string.Equals(sourceValue, translatedValue, StringComparison.Ordinal);

--- a/Mods/QudJP/Assemblies/src/Observability/FinalOutputObservability.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/FinalOutputObservability.cs
@@ -155,6 +155,11 @@ internal static class FinalOutputObservability
 
     internal static void Record(FinalOutputObservation observation)
     {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            return;
+        }
+
         var normalized = Normalize(observation);
         var hitCount = AddOrUpdateCapped(HitCounts, BuildCounterKey(normalized), MaxObservedEntries);
         if (!ObservabilityHelpers.ShouldLogMissingHit(hitCount))

--- a/Mods/QudJP/Assemblies/src/Observability/SinkObservation.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/SinkObservation.cs
@@ -59,6 +59,11 @@ internal static class SinkObservation
         string source,
         string stripped)
     {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            return;
+        }
+
         if (suppressionDepth > 0)
         {
             return;

--- a/Mods/QudJP/Assemblies/src/Patches/BaseLineWithTooltipStartTooltipPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/BaseLineWithTooltipStartTooltipPatch.cs
@@ -1,3 +1,4 @@
+#if QUDJP_DEV_BUILD
 using System;
 using System.Diagnostics;
 using System.Reflection;
@@ -70,3 +71,4 @@ public static class BaseLineWithTooltipStartTooltipPatch
         }
     }
 }
+#endif

--- a/Mods/QudJP/Assemblies/src/Patches/GameSummaryScreenMenuBarsTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GameSummaryScreenMenuBarsTranslationPatch.cs
@@ -60,7 +60,7 @@ public static class GameSummaryScreenMenuBarsTranslationPatch
         {
 #if HAS_TMP
             var repaired = TmpTextRepairer.TryRepairInvisibleTexts(__instance);
-            if (repaired > 0)
+            if (repaired > 0 && RuntimeDiagnostics.VerboseProbesEnabled)
             {
                 QudJPMod.LogToUnity(TmpTextRepairer.BuildRepairLog("GameSummaryTextRepair/v1", repaired));
             }

--- a/Mods/QudJP/Assemblies/src/Patches/LookTooltipContentPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/LookTooltipContentPatch.cs
@@ -53,10 +53,14 @@ public static class LookTooltipContentPatch
             }
 
             __result = TranslateTooltipContent(__result);
-            LogProbe(BuildTooltipContentProbe(__result));
+            if (RuntimeDiagnostics.VerboseProbesEnabled)
+            {
+                LogProbe(BuildTooltipContentProbe(__result));
 #if HAS_TMP
-            DelayedSceneProbeScheduler.ScheduleCompareSceneProbe(__instance);
-#else
+                DelayedSceneProbeScheduler.ScheduleCompareSceneProbe(__instance);
+#endif
+            }
+#if !HAS_TMP
             _ = __instance;
 #endif
         }
@@ -92,6 +96,11 @@ public static class LookTooltipContentPatch
 
     private static void LogProbe(string message)
     {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            return;
+        }
+
         try
         {
             var debugType = Type.GetType("UnityEngine.Debug, UnityEngine.CoreModule", throwOnError: false);

--- a/Mods/QudJP/Assemblies/src/Patches/LookTooltipContentPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/LookTooltipContentPatch.cs
@@ -56,11 +56,10 @@ public static class LookTooltipContentPatch
             if (RuntimeDiagnostics.VerboseProbesEnabled)
             {
                 LogProbe(BuildTooltipContentProbe(__result));
-#if HAS_TMP
-                DelayedSceneProbeScheduler.ScheduleCompareSceneProbe(__instance);
-#endif
             }
-#if !HAS_TMP
+#if HAS_TMP
+            DelayedSceneProbeScheduler.ScheduleCompareSceneProbe(__instance);
+#else
             _ = __instance;
 #endif
         }

--- a/Mods/QudJP/Assemblies/src/Patches/QudMenuBottomContextTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/QudMenuBottomContextTranslationPatch.cs
@@ -104,6 +104,11 @@ public static class QudMenuBottomContextTranslationPatch
 
     private static void LogProbe(object? contextInstance, string phase)
     {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            return;
+        }
+
         if (QudMenuBottomContextObservability.TryBuildState(contextInstance, phase, out var logLine)
             && !string.IsNullOrEmpty(logLine))
         {

--- a/Mods/QudJP/Assemblies/src/Patches/SelectableTextMenuItemProbePatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/SelectableTextMenuItemProbePatch.cs
@@ -1,3 +1,4 @@
+#if QUDJP_DEV_BUILD
 using System;
 using System.Diagnostics;
 using System.Reflection;
@@ -45,3 +46,4 @@ public static class SelectableTextMenuItemProbePatch
         }
     }
 }
+#endif

--- a/Mods/QudJP/Assemblies/src/QudJPMod.cs
+++ b/Mods/QudJP/Assemblies/src/QudJPMod.cs
@@ -54,7 +54,8 @@ public static class QudJPMod
         try
         {
             var assemblyVersion = typeof(QudJPMod).Assembly.GetName().Version;
-            LogToUnity($"[QudJP] Build marker: {BuildMarker}, Version: {assemblyVersion}");
+            LogToUnity(
+                $"[QudJP] Build marker: {BuildMarker}, Version: {assemblyVersion}, BuildFlavor: {RuntimeDiagnostics.BuildFlavor}");
             initializeFonts();
             applyPatches();
         }

--- a/Mods/QudJP/Assemblies/src/RuntimeDiagnostics.cs
+++ b/Mods/QudJP/Assemblies/src/RuntimeDiagnostics.cs
@@ -1,0 +1,45 @@
+using System.Threading;
+
+namespace QudJP;
+
+internal static class RuntimeDiagnostics
+{
+    private const int OverrideUnset = -1;
+    private const int OverrideDisabled = 0;
+    private const int OverrideEnabled = 1;
+
+#if QUDJP_DEV_BUILD
+    private const bool DefaultVerboseProbesEnabled = true;
+    internal const string BuildFlavor = "dev";
+#else
+    private const bool DefaultVerboseProbesEnabled = false;
+    internal const string BuildFlavor = "release";
+#endif
+
+    private static int verboseProbesOverride = OverrideUnset;
+
+    internal static bool VerboseProbesEnabled
+    {
+        get
+        {
+            var overrideValue = Volatile.Read(ref verboseProbesOverride);
+            return overrideValue switch
+            {
+                OverrideEnabled => true,
+                OverrideDisabled => false,
+                _ => DefaultVerboseProbesEnabled,
+            };
+        }
+    }
+
+    internal static void SetVerboseProbesEnabledForTests(bool? enabled)
+    {
+        var value = enabled switch
+        {
+            true => OverrideEnabled,
+            false => OverrideDisabled,
+            _ => OverrideUnset,
+        };
+        Volatile.Write(ref verboseProbesOverride, value);
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs
@@ -129,12 +129,15 @@ internal static class JournalPatternTranslator
             return translated;
         }
 
-        var hitCount = RecordMissingPattern(source);
-        if (ObservabilityHelpers.ShouldLogMissingHit(hitCount))
+        if (RuntimeDiagnostics.VerboseProbesEnabled)
         {
-            var sanitizedSource = SanitizeForLog(source);
-            LogObservability(
-                $"[QudJP] JournalPatternTranslator: no pattern for '{sanitizedSource}' (hit {hitCount}).{Translator.GetCurrentLogContextSuffix()}");
+            var hitCount = RecordMissingPattern(source);
+            if (ObservabilityHelpers.ShouldLogMissingHit(hitCount))
+            {
+                var sanitizedSource = SanitizeForLog(source);
+                LogObservability(
+                    $"[QudJP] JournalPatternTranslator: no pattern for '{sanitizedSource}' (hit {hitCount}).{Translator.GetCurrentLogContextSuffix()}");
+            }
         }
 
         return spans is null || spans.Count == 0

--- a/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
@@ -230,12 +230,15 @@ internal static class MessagePatternTranslator
             return translated;
         }
 
-        var hitCount = RecordMissingPattern(source);
-        if (ObservabilityHelpers.ShouldLogMissingHit(hitCount))
+        if (RuntimeDiagnostics.VerboseProbesEnabled)
         {
-            var sanitizedSource = SanitizeForLog(source);
-            LogObservability(
-                $"[QudJP] MessagePatternTranslator: no pattern for '{sanitizedSource}' (hit {hitCount}).{Translator.GetCurrentLogContextSuffix()}{Translator.BuildTranslatorStructuredSuffix(Translator.ExtractCurrentRoute(), "message_pattern", sanitizedSource)}");
+            var hitCount = RecordMissingPattern(source);
+            if (ObservabilityHelpers.ShouldLogMissingHit(hitCount))
+            {
+                var sanitizedSource = SanitizeForLog(source);
+                LogObservability(
+                    $"[QudJP] MessagePatternTranslator: no pattern for '{sanitizedSource}' (hit {hitCount}).{Translator.GetCurrentLogContextSuffix()}{Translator.BuildTranslatorStructuredSuffix(Translator.ExtractCurrentRoute(), "message_pattern", sanitizedSource)}");
+            }
         }
 
         return spans is null || spans.Count == 0

--- a/Mods/QudJP/Assemblies/src/Translation/Translator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/Translator.cs
@@ -180,6 +180,11 @@ public static class Translator
             return translated;
         }
 
+        if (!RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            return key;
+        }
+
         var hitCount = RecordMissingKey(key);
         if (!IsMissingKeyLoggingSuppressed() && ObservabilityHelpers.ShouldLogMissingHit(hitCount))
         {

--- a/Mods/QudJP/Assemblies/src/UI/DelayedInventoryLineRepairScheduler.cs
+++ b/Mods/QudJP/Assemblies/src/UI/DelayedInventoryLineRepairScheduler.cs
@@ -130,8 +130,10 @@ internal static class DelayedInventoryLineRepairScheduler
             if (replaced > 0)
             {
                 _ = TmpTextRepairer.TryRepairInvisibleTexts(component);
-                _ = TextShellReplacementRenderer.TryBuildReplacementState(component, "InventoryLineReplacementStateNextFrame/v1", out _);
-                _ = ScreenHierarchyObservability.TryBuildLineItemSnapshot(component, "InventoryLineItemProbe/v1", out _);
+                if (RuntimeDiagnostics.VerboseProbesEnabled)
+                {
+                    BuildVerboseRepairProbeSnapshots(component);
+                }
             }
 
         }
@@ -139,6 +141,15 @@ internal static class DelayedInventoryLineRepairScheduler
         {
             Scheduled.TryRemove(lineId, out _);
         }
+    }
+
+    private static void BuildVerboseRepairProbeSnapshots(Component component)
+    {
+        _ = TextShellReplacementRenderer.TryBuildReplacementState(
+            component,
+            "InventoryLineReplacementStateNextFrame/v1",
+            out _);
+        _ = ScreenHierarchyObservability.TryBuildLineItemSnapshot(component, "InventoryLineItemProbe/v1", out _);
     }
 
     private sealed class RepairHost : MonoBehaviour

--- a/Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs
@@ -248,6 +248,11 @@ internal static class InventoryLineFontFixer
 
     private static void LogDiagnostics(object? textSkin, TextMeshProUGUI? tmp, string? finalText, bool applied)
     {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            return;
+        }
+
         var count = Interlocked.Increment(ref diagnosticsCount);
         if (count > MaxDiagnostics)
         {

--- a/Mods/QudJP/Assemblies/src/UI/TextShellReplacementRenderer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/TextShellReplacementRenderer.cs
@@ -124,11 +124,10 @@ internal static class TextShellReplacementRenderer
 
             if (renderAction == ReplacementRenderAction.DisableReplacement)
             {
-                if (TryBuildDisableProbe(component, relativePath, original, out var disableLog)
-                    && disableLog is not null
-                    && disableLog.Length > 0)
+                if (RuntimeDiagnostics.VerboseProbesEnabled
+                    && TryBuildDisableProbe(component, relativePath, original, out var disableLog))
                 {
-                    UnityEngine.Debug.Log(disableLog);
+                    LogProbeIfPresent(disableLog);
                 }
 
                 TryDisableReplacement(original.transform.parent);
@@ -201,11 +200,10 @@ internal static class TextShellReplacementRenderer
 
             if (replacement.textInfo.characterCount == 0)
             {
-                if (TryBuildReplacementFailureProbe(component, relativePath, original, replacement, creationStageLog.ToString(), out var failureLog)
-                    && failureLog is not null
-                    && failureLog.Length > 0)
+                if (RuntimeDiagnostics.VerboseProbesEnabled
+                    && TryBuildReplacementFailureProbe(component, relativePath, original, replacement, creationStageLog.ToString(), out var failureLog))
                 {
-                    UnityEngine.Debug.Log(failureLog);
+                    LogProbeIfPresent(failureLog);
                 }
 
                 replacement.enabled = false;
@@ -429,6 +427,14 @@ internal static class TextShellReplacementRenderer
 
         logLine = builder.ToString();
         return true;
+    }
+
+    private static void LogProbeIfPresent(string? logLine)
+    {
+        if (logLine is { Length: > 0 })
+        {
+            UnityEngine.Debug.Log(logLine);
+        }
     }
 
     private static void TryDisableReplacement(Transform? shell)

--- a/justfile
+++ b/justfile
@@ -12,7 +12,8 @@ build:
   dotnet build Mods/QudJP/Assemblies/QudJP.csproj
 
 # Build the QudJP assembly for local development.
-build-dev: build
+build-dev:
+  dotnet build Mods/QudJP/Assemblies/QudJP.csproj -p:QudJPDevBuild=true
 
 # Clean and rebuild the shipped QudJP assembly without incremental artifacts.
 rebuild:
@@ -20,7 +21,9 @@ rebuild:
   dotnet build Mods/QudJP/Assemblies/QudJP.csproj --no-incremental
 
 # Clean and rebuild the QudJP assembly for local development.
-rebuild-dev: rebuild
+rebuild-dev:
+  dotnet clean Mods/QudJP/Assemblies/QudJP.csproj
+  dotnet build Mods/QudJP/Assemblies/QudJP.csproj --no-incremental -p:QudJPDevBuild=true
 
 # Run fast C# L1 tests.
 test-l1:

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -280,10 +280,10 @@ def build_release() -> None:
         localization_files,
         legal_files=legal_files,
     )
-    missing_markers = verify_release_dll(output_path)
-    if missing_markers:
+    marker_findings = verify_release_dll(output_path)
+    if marker_findings:
         output_path.unlink(missing_ok=True)
-        msg = "release DLL missing required marker(s): " + ", ".join(missing_markers)
+        msg = "release DLL marker validation failed: " + ", ".join(marker_findings)
         raise ValueError(msg)
 
     print(f"\nCreated: {output_path}")  # noqa: T201

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -550,7 +550,7 @@ class TestBuildReleaseImport:
             patch("scripts.build_release.collect_localization_files", return_value=[]),
             patch("scripts.build_release.create_zip", side_effect=_write_marker_reject_fixture_zip),
             patch("scripts.build_release.verify_release_dll", return_value=["InventoryLineFontFixer"]),
-            pytest.raises(ValueError, match="release DLL missing required marker\\(s\\): InventoryLineFontFixer"),
+            pytest.raises(ValueError, match="release DLL marker validation failed: InventoryLineFontFixer"),
         ):
             build_release()
         assert not (tmp_path / "dist" / "QudJP-v1.2.3.zip").exists()

--- a/scripts/tests/test_verify_release_dll.py
+++ b/scripts/tests/test_verify_release_dll.py
@@ -8,22 +8,22 @@ from scripts.verify_release_dll import verify_release_dll
 if TYPE_CHECKING:
     from pathlib import Path
 
+_REQUIRED_MARKER_PAYLOAD = b"\0".join(
+    [
+        b"Unity.TextMeshPro",
+        b"TextMeshProUguiFontPatch",
+        b"TmpInputFieldFontPatch",
+        b"InventoryLineFontFixer",
+        b"DelayedInventoryLineRepairScheduler",
+        b"ShouldPreserveActiveReplacementForTests",
+    ],
+)
+
 
 def test_verify_release_dll_accepts_required_markers(tmp_path: Path) -> None:
     """Accept a DLL that contains all required runtime markers."""
     dll = tmp_path / "QudJP.dll"
-    dll.write_bytes(
-        b"\0".join(
-            [
-                b"Unity.TextMeshPro",
-                b"TextMeshProUguiFontPatch",
-                b"TmpInputFieldFontPatch",
-                b"InventoryLineFontFixer",
-                b"DelayedInventoryLineRepairScheduler",
-                b"ShouldPreserveActiveReplacementForTests",
-            ],
-        ),
-    )
+    dll.write_bytes(_REQUIRED_MARKER_PAYLOAD)
 
     assert verify_release_dll(dll) == []
 
@@ -42,22 +42,33 @@ def test_verify_release_dll_reports_missing_markers(tmp_path: Path) -> None:
     ]
 
 
+def test_verify_release_dll_reports_dev_only_probe_markers(tmp_path: Path) -> None:
+    """Reject release DLLs that contain dev-only probe patch markers."""
+    dll = tmp_path / "QudJP.dll"
+    dll.write_bytes(
+        _REQUIRED_MARKER_PAYLOAD
+        + b"\0"
+        + b"\0".join(
+            [
+                b"BaseLineWithTooltipStartTooltipPatch",
+                b"SelectableTextMenuItemProbePatch",
+            ],
+        ),
+    )
+
+    assert verify_release_dll(dll) == [
+        "forbidden dev marker: BaseLineWithTooltipStartTooltipPatch",
+        "forbidden dev marker: SelectableTextMenuItemProbePatch",
+    ]
+
+
 def test_verify_release_dll_reads_release_zip(tmp_path: Path) -> None:
     """Read QudJP.dll from a release ZIP before checking markers."""
     release_zip = tmp_path / "QudJP-v0.0.0.zip"
     with zipfile.ZipFile(release_zip, "w") as archive:
         archive.writestr(
             "QudJP/Assemblies/QudJP.dll",
-            b"\0".join(
-                [
-                    b"Unity.TextMeshPro",
-                    b"TextMeshProUguiFontPatch",
-                    b"TmpInputFieldFontPatch",
-                    b"InventoryLineFontFixer",
-                    b"DelayedInventoryLineRepairScheduler",
-                    b"ShouldPreserveActiveReplacementForTests",
-                ],
-            ),
+            _REQUIRED_MARKER_PAYLOAD,
         )
 
     assert verify_release_dll(release_zip) == []

--- a/scripts/verify_release_dll.py
+++ b/scripts/verify_release_dll.py
@@ -1,4 +1,4 @@
-"""Verify that a QudJP release DLL contains required runtime feature markers."""
+"""Verify QudJP release DLL runtime markers and dev-only marker absence."""
 
 from __future__ import annotations
 
@@ -16,6 +16,11 @@ _REQUIRED_DLL_MARKERS = (
     b"ShouldPreserveActiveReplacementForTests",
 )
 
+_FORBIDDEN_RELEASE_DLL_MARKERS = (
+    b"BaseLineWithTooltipStartTooltipPatch",
+    b"SelectableTextMenuItemProbePatch",
+)
+
 
 def _read_dll(path: Path) -> bytes:
     if path.suffix.lower() == ".zip":
@@ -30,13 +35,19 @@ def _read_dll(path: Path) -> bytes:
 
 
 def verify_release_dll(path: Path) -> list[str]:
-    """Return release DLL marker names missing from a DLL or release ZIP."""
+    """Return release DLL marker validation findings for a DLL or release ZIP."""
     data = _read_dll(path)
-    return [
+    missing_markers = [
         marker.decode("ascii")
         for marker in _REQUIRED_DLL_MARKERS
         if marker not in data
     ]
+    forbidden_markers = [
+        "forbidden dev marker: " + marker.decode("ascii")
+        for marker in _FORBIDDEN_RELEASE_DLL_MARKERS
+        if marker in data
+    ]
+    return missing_markers + forbidden_markers
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -45,11 +56,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("path", type=Path, help="QudJP.dll or QudJP release ZIP")
     args = parser.parse_args(argv)
 
-    missing = verify_release_dll(args.path)
-    if missing:
+    findings = verify_release_dll(args.path)
+    if findings:
         print(  # noqa: T201
-            f"{args.path}: release DLL is missing required marker(s): "
-            + ", ".join(missing),
+            f"{args.path}: release DLL marker validation failed: "
+            + ", ".join(findings),
             file=sys.stderr,
         )
         return 1


### PR DESCRIPTION
## Summary
- Add a `RuntimeDiagnostics` build gate so verbose probes default on only for dev builds.
- Route `just build-dev`, `rebuild-dev`, `QudJPDevBuild=true`, and `QUDJP_DEV_BUILD=1` through the `QUDJP_DEV_BUILD` compile symbol.
- Suppress probe logging and probe-only patch classes from normal shipping builds while keeping runtime repair paths active.
- Extend release DLL verification to reject dev-only probe markers in release artifacts.

## Review
- Separate code-reviewer instance requested changes initially.
- Addressed the release probe patch and release verifier coverage findings.
- Follow-up code-reviewer instance returned `APPROVE`.
- Ran simplify pass after approval and kept changes behavior-preserving.

## Validation
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~RuntimeDiagnosticsTests" --no-restore`
- `uv run pytest scripts/tests/test_verify_release_dll.py scripts/tests/test_build_release.py::TestBuildReleaseImport::test_build_release_rejects_release_dll_missing_required_markers scripts/tests/test_release_justfile_contract.py -q`
- normal DLL strings check: `BaseLineWithTooltipStartTooltipPatch` and `SelectableTextMenuItemProbePatch` absent
- `QUDJP_DEV_BUILD=1 dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- dev DLL strings check: `BaseLineWithTooltipStartTooltipPatch` and `SelectableTextMenuItemProbePatch` present
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "TestCategory=L1" --no-restore`

Closes #563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 詳細診断（verboseプローブ）の有効/無効制御を追加。開発・本番で挙動を切り替え可能。

* **改善**
  * 開発ビルド向けコードを明確に分離し、ビルド時に条件付きで有効化。
  * リリース検証を強化し、開発専用の診断マーカーが含まれるビルドを拒否。

* **テスト**
  * 診断制御の振る舞いを検証する自動テストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->