### PR TITLE
Codify tooltip wrapping route rules

### DIFF
--- a/Mods/QudJP/Assemblies/AGENTS.md
+++ b/Mods/QudJP/Assemblies/AGENTS.md
@@ -36,6 +36,18 @@ just test-l2g
   - use `just sg-cs '<pattern>'` with the default decompiled-source target when tracing upstream game producers
 - Optional examples: try patterns such as `DynamicTextObservability.RecordTransform($$$ARGS)`, `Popup.Show($$$ARGS)`, or the method/class name you are changing.
 - If structural search is intentionally skipped for C# route work, state the reason in the work note or PR summary.
+- For tooltip, TMP, or RTF display fixes:
+  - identify the upstream producer route before patching sinks; prefer
+    `Look.GenerateTooltipInformation(GameObject)` or another pre-render owner
+    when the UI route permits it
+  - preserve root contract tokens and markup as indivisible text boundaries:
+    Qud wrappers, `&`/`^` color codes, TMP/rich-text tags, `\x01`,
+    `=variable.name=`, `{0}`, and `{12:format}`
+  - prove both no-op fallback behavior and at least one route boundary with
+    tests; use L2G target-resolution coverage when the upstream game signature
+    is the contract
+  - verify both normal game-DLL builds/tests and the no-game Release build path
+    when a patch needs `#if HAS_GAME_DLL` fallback code
 - Constraints:
   - one patch class per file in `src/Patches/`
   - do not instantiate real game types in L1/L2 tests; use dummy targets with matching signatures

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -156,6 +156,7 @@ Preserve all supported markup exactly while translating visible text:
 - escaped forms such as `&&` and `^^`
 - TMP tags such as `<color=#44ff88>text</color>`
 - runtime placeholders such as `=variable.name=`
+- numeric format placeholders such as `{0}` and `{12:format}`
 
 For color-aware restoration:
 
@@ -164,6 +165,31 @@ For color-aware restoration:
 - do not add ad hoc restore logic in unrelated files when a shared helper already defines the contract
 
 Mixed Qud markup and TMP markup must be fixed route-by-route, with tests that preserve the exact broken input shape.
+
+## Tooltip and pre-render wrapping rules
+
+Treat tooltip overflow and CJK wrapping as route-owned pre-render text shaping,
+not as a TMP sink or truncation problem by default. First identify whether the
+visible route flows through `Look.GenerateTooltipInformation(GameObject)`,
+`Look.GenerateTooltipContent(GameObject)`, or a direct
+`Description.GetLongDescription(...)` caller. Apply wrapping before
+`RTF.FormatToRTF(...)`, `Sidebar.FormatToRTF(...)`, `ToRTFCached()`, or TMP field
+assignment whenever an upstream owner exists.
+
+Wrapping must preserve every non-visible or structurally significant token as an
+indivisible boundary:
+
+- Qud wrappers and foreground/background color codes
+- TMP/rich-text tags such as `<sprite name=key>` and `<color=...>`
+- direct translation and runtime markers such as `\x01` and `=variable.name=`
+- numeric format placeholders such as `{0}` and `{12:format}`
+
+Do not split on punctuation merely because it is syntactically easy. Prefer
+Japanese punctuation and spaces for human-readable line breaks, but keep route
+semantics intact: stat delimiters such as `/`, `:`, and `;` often bind numeric
+terms and should not become preferred break points without route-specific
+evidence. Add regression tests for the exact long tooltip shape, token-boundary
+preservation, empty/no-op fallback, and at least one route-level patch boundary.
 
 Markup semantic diagnostics must distinguish raw token shape from user-visible
 semantic drift. Repeated same-color Qud wrappers and statically proven upstream


### PR DESCRIPTION
## Summary
- codify tooltip overflow fixes as pre-render route-owned wrapping guidance
- document root contract tokens and TMP/rich-text tags as indivisible wrapping boundaries
- add C# patch checklist coverage for tooltip/TMP/RTF route work and no-game build verification

## Validation
- `uv run python scripts/check_markdown_reports.py --base-ref origin/main --head-ref HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * ツールチップおよび前処理ラッピング関連の新しいガイダンスを追加しました
  * マークアップ保持ルールとテスト要件に関する詳細な制約を文書化しました
  * RTFおよびTMP関連の修正手順についての説明を拡充しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->