### PR TITLE
Fix Polat looker tooltip rendering

### DIFF
--- a/CODERABBIT.md
+++ b/CODERABBIT.md
@@ -25,6 +25,8 @@ When reviewing a change, apply evidence in this order:
    `docs/coderabbit/owner-route-coverage.md`,
    `docs/coderabbit/color-token-review.md`, and
    `docs/coderabbit/glossary-variance-review.md`.
+   For TMP, Unity UI, and ModelShark tooltip rendering behavior, also use
+   `docs/coderabbit/tmp-runtime-rendering.md`.
 6. Derived findings from local decompiled inspection.
 7. Older notes in `docs/archive/` and historical reports.
 
@@ -207,6 +209,26 @@ Review changes involving observability for these expectations:
 On Apple Silicon, only Rosetta-launched L3 runtime logs count as localization
 observability evidence. Native ARM64 logs should not be accepted for that
 purpose.
+
+## TMP And Tooltip Rendering Contracts
+
+Use `docs/coderabbit/tmp-runtime-rendering.md` for the detailed maintainer notes.
+Critical review rules:
+
+- TMP `characterCount`, `pageCount`, and rect size prove mesh generation, not
+  final visibility.
+- Visibility investigation for Unity UI text should separately check active
+  state, `CanvasRenderer.GetAlpha()`, `cull`, TMP visibility limits, and tooltip
+  lifecycle callers.
+- Do not use `Graphic.color.a` as the primary proof of runtime draw visibility
+  when `CanvasRenderer.GetAlpha()` is the relevant evidence.
+- ModelShark tooltip warmup/display can leave generated text invisible if active
+  child `CanvasRenderer` alpha remains `0`.
+- `ForceHideTooltip()` in PolatLooker logs is not automatically a bug; distinguish
+  `TooltipManager.Update` automatic hide from `Look.ShowLooker` target-change
+  and `Look.HideTooltips` exit paths.
+- Permanent high-volume tooltip diagnostics, especially `StackTrace` collection
+  in hot UI paths, should be removed or guarded before merge.
 
 ## Localization Asset Contracts
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/TooltipTextRepairerTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/TooltipTextRepairerTests.cs
@@ -1,0 +1,74 @@
+using System.Reflection;
+
+namespace QudJP.Tests.L1;
+
+[TestFixture]
+[Category("L1")]
+public sealed class TooltipTextRepairerTests
+{
+    [Test]
+    public void NormalizeVisibilityLimits_ReopensHiddenTmpPages()
+    {
+        var method = RequireTooltipTextRepairerMethod("NormalizeVisibilityLimits");
+
+        var result = method.Invoke(null, new object[] { 0, 0, 0 });
+
+        Assert.That(result, Is.EqualTo((int.MaxValue, int.MaxValue, 1)));
+    }
+
+    [Test]
+    public void CanRepairTextForTests_SkipsInactiveAndEmptyText()
+    {
+        var method = RequireTooltipTextRepairerMethod("CanRepairText");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(method.Invoke(null, new object?[] { true, true, "日本語", "LongDescription" }), Is.EqualTo(true));
+            Assert.That(method.Invoke(null, new object?[] { true, false, "日本語", "LongDescription" }), Is.EqualTo(false));
+            Assert.That(method.Invoke(null, new object?[] { true, true, string.Empty, "LongDescription" }), Is.EqualTo(false));
+            Assert.That(method.Invoke(null, new object?[] { true, true, "日本語", "QudJPReplacementText" }), Is.EqualTo(false));
+        });
+    }
+
+    [Test]
+    public void IsLookerTooltipNameForTests_MatchesOnlyPolatLooker()
+    {
+        var method = RequireTooltipTextRepairerMethod("IsLookerTooltipName");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(method.Invoke(null, new object?[] { "PolatLooker" }), Is.EqualTo(true));
+            Assert.That(method.Invoke(null, new object?[] { "UI Manager/Tooltip Container/PolatLooker" }), Is.EqualTo(false));
+            Assert.That(method.Invoke(null, new object?[] { "DualPolatLooker" }), Is.EqualTo(false));
+            Assert.That(method.Invoke(null, new object?[] { "PolatLooker:Debug" }), Is.EqualTo(false));
+            Assert.That(method.Invoke(null, new object?[] { "TileTooltip" }), Is.EqualTo(false));
+            Assert.That(method.Invoke(null, new object?[] { null }), Is.EqualTo(false));
+        });
+    }
+
+    [Test]
+    public void ShouldRepairTooltipNameForTests_LimitsRepairToPolatLooker()
+    {
+        var method = RequireTooltipTextRepairerMethod("ShouldRepairTooltipName");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(method.Invoke(null, new object?[] { "PolatLooker" }), Is.EqualTo(true));
+            Assert.That(method.Invoke(null, new object?[] { "TileTooltip" }), Is.EqualTo(false));
+            Assert.That(method.Invoke(null, new object?[] { "GenericModelSharkTooltip" }), Is.EqualTo(false));
+            Assert.That(method.Invoke(null, new object?[] { "DualPolatLooker" }), Is.EqualTo(false));
+            Assert.That(method.Invoke(null, new object?[] { "PolatLooker:Debug" }), Is.EqualTo(false));
+            Assert.That(method.Invoke(null, new object?[] { null }), Is.EqualTo(false));
+        });
+    }
+
+    private static MethodInfo RequireTooltipTextRepairerMethod(string methodName)
+    {
+        var type = typeof(Translator).Assembly.GetType("QudJP.TooltipTextRepairer");
+        Assert.That(type, Is.Not.Null, "QudJP.TooltipTextRepairer is missing.");
+
+        var method = type!.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.That(method, Is.Not.Null, methodName + " is missing.");
+        return method!;
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TooltipDisplayVisibilityPatchResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TooltipDisplayVisibilityPatchResolutionTests.cs
@@ -1,0 +1,57 @@
+#if HAS_GAME_DLL
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace QudJP.Tests.L2G;
+
+[TestFixture]
+[Category("L2G")]
+public sealed class TooltipDisplayVisibilityPatchResolutionTests
+{
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _ = EnsureManagedAssemblyLoaded("Assembly-CSharp");
+    }
+
+    [Test]
+    public void TargetMethod_ResolvesModelSharkTooltipDisplay()
+    {
+        var patchType = typeof(Translator).Assembly.GetType("QudJP.Patches.TooltipDisplayVisibilityPatch");
+        Assert.That(patchType, Is.Not.Null, "TooltipDisplayVisibilityPatch is missing.");
+
+        var targetMethodAccessor = patchType!.GetMethod("TargetMethod", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.That(targetMethodAccessor, Is.Not.Null, "TargetMethod accessor is missing.");
+
+        var targetMethod = targetMethodAccessor!.Invoke(null, null) as MethodBase;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(targetMethod, Is.Not.Null);
+            Assert.That(targetMethod!.DeclaringType?.FullName, Is.EqualTo("ModelShark.Tooltip"));
+            Assert.That(targetMethod.Name, Is.EqualTo("Display"));
+            Assert.That(targetMethod.GetParameters(), Has.Length.EqualTo(1));
+            Assert.That(targetMethod.GetParameters()[0].ParameterType, Is.EqualTo(typeof(float)));
+        });
+    }
+
+    private static Assembly? EnsureManagedAssemblyLoaded(string assemblyName)
+    {
+        var alreadyLoaded = AssemblyLoadContext.Default.Assemblies
+            .FirstOrDefault(assembly => string.Equals(assembly.GetName().Name, assemblyName, StringComparison.Ordinal));
+        if (alreadyLoaded is not null)
+        {
+            return alreadyLoaded;
+        }
+
+        try
+        {
+            return AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(assemblyName));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}
+#endif

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TooltipManagerSetTextAndSizePatchResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TooltipManagerSetTextAndSizePatchResolutionTests.cs
@@ -1,0 +1,61 @@
+#if HAS_GAME_DLL
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace QudJP.Tests.L2G;
+
+[TestFixture]
+[Category("L2G")]
+public sealed class TooltipManagerSetTextAndSizePatchResolutionTests
+{
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _ = EnsureManagedAssemblyLoaded("Assembly-CSharp");
+#if HAS_TMP
+        _ = EnsureManagedAssemblyLoaded("UnityEngine.CoreModule");
+        _ = EnsureManagedAssemblyLoaded("Unity.TextMeshPro");
+#endif
+    }
+
+    [Test]
+    public void TargetMethod_ResolvesModelSharkSetTextAndSize()
+    {
+        var patchType = typeof(Translator).Assembly.GetType("QudJP.Patches.TooltipManagerSetTextAndSizePatch");
+        Assert.That(patchType, Is.Not.Null, "TooltipManagerSetTextAndSizePatch is missing.");
+
+        var targetMethodAccessor = patchType!.GetMethod("TargetMethod", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.That(targetMethodAccessor, Is.Not.Null, "TargetMethod accessor is missing.");
+
+        var targetMethod = targetMethodAccessor!.Invoke(null, null) as MethodBase;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(targetMethod, Is.Not.Null);
+            Assert.That(targetMethod!.DeclaringType?.FullName, Is.EqualTo("ModelShark.TooltipManager"));
+            Assert.That(targetMethod.Name, Is.EqualTo("SetTextAndSize"));
+            Assert.That(targetMethod.GetParameters(), Has.Length.EqualTo(1));
+            Assert.That(targetMethod.GetParameters()[0].ParameterType.FullName, Is.EqualTo("ModelShark.TooltipTrigger"));
+        });
+    }
+
+    private static Assembly? EnsureManagedAssemblyLoaded(string assemblyName)
+    {
+        var alreadyLoaded = AssemblyLoadContext.Default.Assemblies
+            .FirstOrDefault(assembly => string.Equals(assembly.GetName().Name, assemblyName, StringComparison.Ordinal));
+        if (alreadyLoaded is not null)
+        {
+            return alreadyLoaded;
+        }
+
+        try
+        {
+            return AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(assemblyName));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}
+#endif

--- a/Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj
@@ -72,6 +72,10 @@
       <HintPath>$(ManagedDir)/UnityEngine.UI.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <Reference Include="UnityEngine.UIModule">
+      <HintPath>$(ManagedDir)/UnityEngine.UIModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(ManagedDir)/UnityEngine.CoreModule.dll</HintPath>
       <Private>false</Private>
@@ -103,6 +107,11 @@
     <None Include="$(ManagedDir)/UnityEngine.UI.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>UnityEngine.UI.dll</TargetPath>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(ManagedDir)/UnityEngine.UIModule.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>UnityEngine.UIModule.dll</TargetPath>
       <Visible>false</Visible>
     </None>
     <None Include="$(ManagedDir)/UnityEngine.CoreModule.dll">

--- a/Mods/QudJP/Assemblies/QudJP.csproj
+++ b/Mods/QudJP/Assemblies/QudJP.csproj
@@ -82,6 +82,10 @@
       <HintPath>$(ManagedDir)/UnityEngine.UI.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <Reference Include="UnityEngine.UIModule">
+      <HintPath>$(ManagedDir)/UnityEngine.UIModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(ManagedDir)/UnityEngine.CoreModule.dll</HintPath>
       <Private>false</Private>

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.CoreModule/UnityEngineStubs.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.CoreModule/UnityEngineStubs.cs
@@ -203,11 +203,16 @@ public class Material : Object
 
 public class CanvasRenderer : Component
 {
+    private float alpha = 1f;
+
     public bool cull { get; set; }
+
     public void SetAlpha(float alpha)
     {
-        _ = alpha;
+        this.alpha = alpha;
     }
+
+    public float GetAlpha() => alpha;
 }
 
 public class CanvasGroup : Component

--- a/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.CoreModule/UnityEngineStubs.cs
+++ b/Mods/QudJP/Assemblies/ReferenceStubs/UnityEngine.CoreModule/UnityEngineStubs.cs
@@ -204,6 +204,10 @@ public class Material : Object
 public class CanvasRenderer : Component
 {
     public bool cull { get; set; }
+    public void SetAlpha(float alpha)
+    {
+        _ = alpha;
+    }
 }
 
 public class CanvasGroup : Component

--- a/Mods/QudJP/Assemblies/src/Patches/TooltipDisplayVisibilityPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/TooltipDisplayVisibilityPatch.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class TooltipDisplayVisibilityPatch
+{
+    private const string TargetTypeName = "ModelShark.Tooltip";
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = AccessTools.TypeByName(TargetTypeName);
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: Failed to resolve ModelShark.Tooltip. Display visibility patch will not apply.");
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "Display", new[] { typeof(float) });
+        if (method is not null)
+        {
+            return method;
+        }
+
+        Trace.TraceError("QudJP: Failed to resolve Tooltip.Display(float). Display visibility patch will not apply.");
+        return null;
+    }
+
+    public static void Postfix(object __instance)
+    {
+        try
+        {
+#if HAS_TMP
+            _ = QudJP.TooltipTextRepairer.TryRestoreLookerTooltipVisibility(__instance);
+#else
+            _ = __instance;
+#endif
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: TooltipDisplayVisibilityPatch.Postfix failed: {0}", ex);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/TooltipManagerSetTextAndSizePatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/TooltipManagerSetTextAndSizePatch.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class TooltipManagerSetTextAndSizePatch
+{
+    private const string TargetTypeName = "ModelShark.TooltipManager";
+    private const string TriggerTypeName = "ModelShark.TooltipTrigger";
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = AccessTools.TypeByName(TargetTypeName);
+        var triggerType = AccessTools.TypeByName(TriggerTypeName);
+        if (targetType is null || triggerType is null)
+        {
+            Trace.TraceError("QudJP: Failed to resolve ModelShark TooltipManager types. Patch will not apply.");
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "SetTextAndSize", new[] { triggerType });
+        if (method is not null)
+        {
+            return method;
+        }
+
+        Trace.TraceError("QudJP: Failed to resolve TooltipManager.SetTextAndSize(TooltipTrigger). Patch will not apply.");
+        return null;
+    }
+
+    public static void Postfix(object trigger)
+    {
+        try
+        {
+#if HAS_TMP
+            _ = QudJP.TooltipTextRepairer.TryRepairTooltip(trigger);
+            QudJP.DelayedTooltipRepairScheduler.ScheduleRepair(trigger);
+#else
+            _ = trigger;
+#endif
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: TooltipManagerSetTextAndSizePatch.Postfix failed: {0}", ex);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/src/UI/DelayedTooltipRepairScheduler.cs
+++ b/Mods/QudJP/Assemblies/src/UI/DelayedTooltipRepairScheduler.cs
@@ -1,0 +1,79 @@
+#if HAS_TMP
+using System.Collections;
+using System.Collections.Concurrent;
+using UnityEngine;
+#endif
+
+namespace QudJP;
+
+internal static class DelayedTooltipRepairScheduler
+{
+#if HAS_TMP
+    private static readonly ConcurrentDictionary<int, byte> Scheduled = new();
+    private static RepairHost? host;
+
+    internal static void ScheduleRepair(object? triggerInstance)
+    {
+        if (triggerInstance is not Component component
+            || !TooltipTextRepairer.ShouldScheduleRepair(triggerInstance))
+        {
+            return;
+        }
+
+        var triggerId = component.GetInstanceID();
+        if (!Scheduled.TryAdd(triggerId, 0))
+        {
+            return;
+        }
+
+        var runner = EnsureHost();
+        if (runner is null)
+        {
+            Scheduled.TryRemove(triggerId, out _);
+            return;
+        }
+
+        runner.StartCoroutine(RunRepair(component, triggerId));
+    }
+
+    private static RepairHost? EnsureHost()
+    {
+        if (host is not null)
+        {
+            return host;
+        }
+
+        var gameObject = new GameObject("QudJP.DelayedTooltipRepairHost");
+        UnityEngine.Object.DontDestroyOnLoad(gameObject);
+        gameObject.hideFlags = HideFlags.HideAndDontSave;
+        host = gameObject.AddComponent<RepairHost>();
+        _ = host.Touch();
+        return host;
+    }
+
+    private static IEnumerator RunRepair(Component trigger, int triggerId)
+    {
+        try
+        {
+            yield return null;
+            yield return new WaitForEndOfFrame();
+            _ = TooltipTextRepairer.TryRepairTooltip(trigger, restoreCanvasRendererVisibility: true);
+
+            yield return null;
+            _ = TooltipTextRepairer.TryRepairTooltip(trigger, restoreCanvasRendererVisibility: true);
+        }
+        finally
+        {
+            Scheduled.TryRemove(triggerId, out _);
+        }
+    }
+
+    private sealed class RepairHost : MonoBehaviour
+    {
+        internal int Touch()
+        {
+            return GetInstanceID();
+        }
+    }
+#endif
+}

--- a/Mods/QudJP/Assemblies/src/UI/DelayedTooltipRepairScheduler.cs
+++ b/Mods/QudJP/Assemblies/src/UI/DelayedTooltipRepairScheduler.cs
@@ -27,18 +27,26 @@ internal static class DelayedTooltipRepairScheduler
         }
 
         var runner = EnsureHost();
-        if (runner is null)
+        if (runner == null)
         {
             Scheduled.TryRemove(triggerId, out _);
             return;
         }
 
-        runner.StartCoroutine(RunRepair(component, triggerId));
+        try
+        {
+            runner.StartCoroutine(RunRepair(component, triggerId));
+        }
+        catch
+        {
+            Scheduled.TryRemove(triggerId, out _);
+            throw;
+        }
     }
 
     private static RepairHost? EnsureHost()
     {
-        if (host is not null)
+        if (host != null)
         {
             return host;
         }

--- a/Mods/QudJP/Assemblies/src/UI/TextShellReplacementRenderer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/TextShellReplacementRenderer.cs
@@ -79,7 +79,7 @@ internal static class TextShellReplacementRenderer
     private static readonly ConcurrentDictionary<string, byte> FailureProbeLogged = new();
     private static readonly ConcurrentDictionary<string, byte> DisableProbeLogged = new();
 
-    internal static int TryRenderReplacementTexts(object? componentInstance, out string? logLine)
+    internal static int TryRenderReplacementTexts(object? componentInstance, out string? logLine, bool emitDiagnostics = true)
     {
         logLine = null;
         if (componentInstance is not Component component)
@@ -88,10 +88,14 @@ internal static class TextShellReplacementRenderer
         }
 
         var texts = component.GetComponentsInChildren<TextMeshProUGUI>(includeInactive: true);
-        var builder = new StringBuilder();
-        builder.Append("[QudJP] InventoryLineReplacement/v1: root='");
-        builder.Append(component.gameObject.name);
-        builder.Append('\'');
+        var collectDiagnostics = emitDiagnostics && RuntimeDiagnostics.VerboseProbesEnabled;
+        var builder = collectDiagnostics ? new StringBuilder() : null;
+        if (builder is not null)
+        {
+            builder.Append("[QudJP] InventoryLineReplacement/v1: root='");
+            builder.Append(component.gameObject.name);
+            builder.Append('\'');
+        }
 
         var replaced = 0;
         for (var index = 0; index < texts.Length; index++)
@@ -124,8 +128,10 @@ internal static class TextShellReplacementRenderer
 
             if (renderAction == ReplacementRenderAction.DisableReplacement)
             {
-                if (RuntimeDiagnostics.VerboseProbesEnabled
-                    && TryBuildDisableProbe(component, relativePath, original, out var disableLog))
+                if (collectDiagnostics
+                    && TryBuildDisableProbe(component, relativePath, original, out var disableLog)
+                    && disableLog is not null
+                    && disableLog.Length > 0)
                 {
                     LogProbeIfPresent(disableLog);
                 }
@@ -146,7 +152,7 @@ internal static class TextShellReplacementRenderer
                 continue;
             }
 
-            var creationStageLog = new StringBuilder();
+            var creationStageLog = collectDiagnostics ? new StringBuilder() : null;
             AppendCreationStageSnapshot(creationStageLog, "afterGetOrCreate", replacement);
 
             SyncReplacement(replacement, original);
@@ -165,17 +171,21 @@ internal static class TextShellReplacementRenderer
                 StabilizeSuccessfulReplacement(replacement);
                 replaced++;
                 replacement.transform.SetAsLastSibling();
-                builder.Append("; leaf[");
-                builder.Append(replaced.ToString(CultureInfo.InvariantCulture));
-                builder.Append("] path='");
-                builder.Append(relativePath);
-                builder.Append("' replacementKind='tmp' replacementChars=");
-                builder.Append(replacement.textInfo.characterCount.ToString(CultureInfo.InvariantCulture));
-                builder.Append(" replacementPageCount=");
-                builder.Append(replacement.textInfo.pageCount.ToString(CultureInfo.InvariantCulture));
-                builder.Append(" parent='");
-                builder.Append(shell.name);
-                builder.Append("' phase='afterEnable'");
+                if (builder is not null)
+                {
+                    builder.Append("; leaf[");
+                    builder.Append(replaced.ToString(CultureInfo.InvariantCulture));
+                    builder.Append("] path='");
+                    builder.Append(relativePath);
+                    builder.Append("' replacementKind='tmp' replacementChars=");
+                    builder.Append(replacement.textInfo.characterCount.ToString(CultureInfo.InvariantCulture));
+                    builder.Append(" replacementPageCount=");
+                    builder.Append(replacement.textInfo.pageCount.ToString(CultureInfo.InvariantCulture));
+                    builder.Append(" parent='");
+                    builder.Append(shell.name);
+                    builder.Append("' phase='afterEnable'");
+                }
+
                 continue;
             }
 
@@ -200,8 +210,16 @@ internal static class TextShellReplacementRenderer
 
             if (replacement.textInfo.characterCount == 0)
             {
-                if (RuntimeDiagnostics.VerboseProbesEnabled
-                    && TryBuildReplacementFailureProbe(component, relativePath, original, replacement, creationStageLog.ToString(), out var failureLog))
+                if (collectDiagnostics
+                    && TryBuildReplacementFailureProbe(
+                        component,
+                        relativePath,
+                        original,
+                        replacement,
+                        creationStageLog?.ToString() ?? string.Empty,
+                        out var failureLog)
+                    && failureLog is not null
+                    && failureLog.Length > 0)
                 {
                     LogProbeIfPresent(failureLog);
                 }
@@ -214,25 +232,28 @@ internal static class TextShellReplacementRenderer
             replaced++;
             original.enabled = false;
             replacement.transform.SetAsLastSibling();
-            builder.Append("; leaf[");
-            builder.Append(replaced.ToString(CultureInfo.InvariantCulture));
-            builder.Append("] path='");
-            builder.Append(relativePath);
-            builder.Append("' replacementKind='tmp' replacementChars=");
-            builder.Append(replacement.textInfo.characterCount.ToString(CultureInfo.InvariantCulture));
-            builder.Append(" replacementPageCount=");
-            builder.Append(replacement.textInfo.pageCount.ToString(CultureInfo.InvariantCulture));
-            builder.Append(" parent='");
-            builder.Append(shell.name);
-            builder.Append('\'');
+            if (builder is not null)
+            {
+                builder.Append("; leaf[");
+                builder.Append(replaced.ToString(CultureInfo.InvariantCulture));
+                builder.Append("] path='");
+                builder.Append(relativePath);
+                builder.Append("' replacementKind='tmp' replacementChars=");
+                builder.Append(replacement.textInfo.characterCount.ToString(CultureInfo.InvariantCulture));
+                builder.Append(" replacementPageCount=");
+                builder.Append(replacement.textInfo.pageCount.ToString(CultureInfo.InvariantCulture));
+                builder.Append(" parent='");
+                builder.Append(shell.name);
+                builder.Append('\'');
+            }
         }
 
-        if (replaced == 0)
+        if (builder is not null && replaced == 0)
         {
             builder.Append("; replaced=0");
         }
 
-        logLine = builder.ToString();
+        logLine = builder?.ToString();
         return replaced;
     }
 
@@ -464,7 +485,7 @@ internal static class TextShellReplacementRenderer
     private static bool TryReuseActiveReplacement(
         Transform? shell,
         string relativePath,
-        StringBuilder builder,
+        StringBuilder? builder,
         ref int replaced)
     {
         if (shell is null)
@@ -501,19 +522,23 @@ internal static class TextShellReplacementRenderer
 
         replaced++;
         replacement.transform.SetAsLastSibling();
-        builder.Append("; leaf[");
-        builder.Append(replaced.ToString(CultureInfo.InvariantCulture));
-        builder.Append("] path='");
-        builder.Append(relativePath);
-        builder.Append("' replacementKind='tmp' replacementChars=");
-        builder.Append(replacement.textInfo.characterCount.ToString(CultureInfo.InvariantCulture));
-        builder.Append(" replacementPageCount=");
-        builder.Append(replacement.textInfo.pageCount.ToString(CultureInfo.InvariantCulture));
-        builder.Append(" parent='");
-        builder.Append(shell.name);
-        builder.Append("' phase='");
-        builder.Append(recovered ? "reuseActiveRecovered" : "reuseActive");
-        builder.Append('\'');
+        if (builder is not null)
+        {
+            builder.Append("; leaf[");
+            builder.Append(replaced.ToString(CultureInfo.InvariantCulture));
+            builder.Append("] path='");
+            builder.Append(relativePath);
+            builder.Append("' replacementKind='tmp' replacementChars=");
+            builder.Append(replacement.textInfo.characterCount.ToString(CultureInfo.InvariantCulture));
+            builder.Append(" replacementPageCount=");
+            builder.Append(replacement.textInfo.pageCount.ToString(CultureInfo.InvariantCulture));
+            builder.Append(" parent='");
+            builder.Append(shell.name);
+            builder.Append("' phase='");
+            builder.Append(recovered ? "reuseActiveRecovered" : "reuseActive");
+            builder.Append('\'');
+        }
+
         return true;
     }
 
@@ -856,8 +881,13 @@ internal static class TextShellReplacementRenderer
         return true;
     }
 
-    private static void AppendCreationStageSnapshot(StringBuilder builder, string stageName, TextMeshProUGUI text)
+    private static void AppendCreationStageSnapshot(StringBuilder? builder, string stageName, TextMeshProUGUI text)
     {
+        if (builder is null)
+        {
+            return;
+        }
+
         var subMeshes = text.GetComponentsInChildren<TMP_SubMeshUI>(includeInactive: true);
         if (builder.Length > 0)
         {
@@ -1402,9 +1432,10 @@ internal static class TextShellReplacementRenderer
         return false;
     }
 
-    internal static int TryRenderReplacementTexts(object? componentInstance, out string? logLine)
+    internal static int TryRenderReplacementTexts(object? componentInstance, out string? logLine, bool emitDiagnostics = true)
     {
         _ = componentInstance;
+        _ = emitDiagnostics;
         logLine = null;
         return 0;
     }

--- a/Mods/QudJP/Assemblies/src/UI/TooltipTextRepairer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/TooltipTextRepairer.cs
@@ -1,0 +1,343 @@
+using System;
+using System.Reflection;
+
+#if HAS_TMP
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using UguiText = UnityEngine.UI.Text;
+#endif
+
+namespace QudJP;
+
+internal static class TooltipTextRepairer
+{
+    private const string ReplacementObjectName = "QudJPReplacementText";
+
+    internal static (int MaxVisibleCharacters, int MaxVisibleLines, int PageToDisplay) NormalizeVisibilityLimits(
+        int maxVisibleCharacters,
+        int maxVisibleLines,
+        int pageToDisplay)
+    {
+        return (
+            maxVisibleCharacters <= 0 ? int.MaxValue : maxVisibleCharacters,
+            maxVisibleLines <= 0 ? int.MaxValue : maxVisibleLines,
+            pageToDisplay <= 0 ? 1 : pageToDisplay);
+    }
+
+    internal static bool CanRepairText(bool enabled, bool activeInHierarchy, string? text, string objectName)
+    {
+        return enabled
+            && activeInHierarchy
+            && !string.IsNullOrEmpty(text)
+            && !string.Equals(objectName, ReplacementObjectName, System.StringComparison.Ordinal);
+    }
+
+    internal static bool IsLookerTooltipName(string? objectName)
+    {
+        return string.Equals(objectName, "PolatLooker", StringComparison.Ordinal);
+    }
+
+    internal static bool ShouldRepairTooltipName(string? objectName)
+    {
+        return IsLookerTooltipName(objectName);
+    }
+
+#if HAS_TMP
+#pragma warning disable S3011
+    private const BindingFlags InstanceMemberFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+#pragma warning restore S3011
+
+    internal static bool TryRepairTooltip(object? triggerInstance, bool restoreCanvasRendererVisibility = false)
+    {
+        var tooltipObject = TryGetTooltipObjectFromTrigger(triggerInstance, out var tooltip);
+        if (tooltipObject is null || !ShouldRepairTooltipName(tooltipObject.name))
+        {
+            return false;
+        }
+
+        _ = TryPinLookerTooltip(triggerInstance, tooltip, tooltipObject);
+        var repaired = 0;
+        repaired += ApplyLegacyFonts(tooltipObject);
+        repaired += ApplyTmpFonts(tooltipObject);
+        repaired += TmpTextRepairer.TryRepairInvisibleTexts(tooltipObject.transform);
+        repaired += TextShellReplacementRenderer.TryRenderReplacementTexts(
+            tooltipObject.transform,
+            out _,
+            emitDiagnostics: false);
+        if (restoreCanvasRendererVisibility)
+        {
+            repaired += RestoreCanvasRendererVisibility(tooltipObject);
+        }
+
+        ForceRebuildLayout(tooltipObject);
+        return repaired > 0;
+    }
+
+    internal static bool TryPinLookerTooltip(object? triggerInstance)
+    {
+        var tooltipObject = TryGetTooltipObjectFromTrigger(triggerInstance, out var tooltip);
+        if (tooltipObject is null)
+        {
+            return false;
+        }
+
+        return TryPinLookerTooltip(triggerInstance, tooltip, tooltipObject);
+    }
+
+    internal static bool ShouldScheduleRepair(object? triggerInstance)
+    {
+        var tooltipObject = TryGetTooltipObjectFromTrigger(triggerInstance, out _);
+        return ShouldRepairTooltip(tooltipObject);
+    }
+
+    internal static bool TryRestoreLookerTooltipVisibility(object? tooltipInstance)
+    {
+        var tooltipObject = GetTooltipObject(tooltipInstance);
+        if (tooltipObject is null || !ShouldRepairTooltipName(tooltipObject.name))
+        {
+            return false;
+        }
+
+        return RestoreCanvasRendererVisibility(tooltipObject) > 0;
+    }
+
+    private static bool TryPinLookerTooltip(object? triggerInstance, object? tooltip, GameObject tooltipObject)
+    {
+        if (!IsLookerTooltipName(tooltipObject.name))
+        {
+            return false;
+        }
+
+        var updated = false;
+        updated |= TrySetBooleanMember(triggerInstance, "isManuallyTriggered", true);
+        updated |= TrySetBooleanMember(triggerInstance, "staysOpen", true);
+        updated |= TrySetBooleanMember(tooltip, "StaysOpen", true);
+        return updated;
+    }
+
+    private static bool ShouldRepairTooltip(GameObject? tooltipObject)
+    {
+        return tooltipObject is not null && ShouldRepairTooltipName(tooltipObject.name);
+    }
+
+    private static int RestoreCanvasRendererVisibility(GameObject root)
+    {
+        var restored = 0;
+        var renderers = root.GetComponentsInChildren<CanvasRenderer>(includeInactive: true);
+        for (var index = 0; index < renderers.Length; index++)
+        {
+            if (!renderers[index].gameObject.activeInHierarchy)
+            {
+                continue;
+            }
+
+            renderers[index].SetAlpha(1f);
+            restored++;
+        }
+
+        return restored;
+    }
+
+    private static int ApplyLegacyFonts(GameObject root)
+    {
+        var applied = 0;
+        var texts = root.GetComponentsInChildren<UguiText>(includeInactive: true);
+        for (var index = 0; index < texts.Length; index++)
+        {
+            var text = texts[index];
+            if (!CanRepairText(text.enabled, text.gameObject.activeInHierarchy, text.text, text.gameObject.name))
+            {
+                continue;
+            }
+
+            FontManager.ApplyToLegacyText(text);
+            applied++;
+        }
+
+        return applied;
+    }
+
+    private static int ApplyTmpFonts(GameObject root)
+    {
+        var applied = 0;
+        var texts = root.GetComponentsInChildren<TextMeshProUGUI>(includeInactive: true);
+        for (var index = 0; index < texts.Length; index++)
+        {
+            if (RepairTmpText(texts[index]))
+            {
+                applied++;
+            }
+        }
+
+        return applied;
+    }
+
+    private static bool RepairTmpText(TextMeshProUGUI text)
+    {
+        var currentText = text.text;
+        if (!CanRepairText(text.enabled, text.gameObject.activeInHierarchy, currentText, text.gameObject.name))
+        {
+            return false;
+        }
+
+        _ = FontManager.TryWarmPrimaryFontCharactersForUi(currentText);
+        FontManager.ApplyToText(text);
+        ApplySharedFontMaterial(text);
+
+        var limits = NormalizeVisibilityLimits(
+            text.maxVisibleCharacters,
+            text.maxVisibleLines,
+            text.pageToDisplay);
+        text.maxVisibleCharacters = limits.MaxVisibleCharacters;
+        text.maxVisibleLines = limits.MaxVisibleLines;
+        text.pageToDisplay = limits.PageToDisplay;
+
+        RefreshTextMesh(text, currentText);
+        if (text.textInfo.characterCount > 0)
+        {
+            return true;
+        }
+
+        FontManager.ForcePrimaryFont(text);
+        ApplySharedFontMaterial(text);
+
+        RefreshTextMesh(text, currentText);
+        return true;
+    }
+
+    private static void ApplySharedFontMaterial(TextMeshProUGUI text)
+    {
+        if (text.font is not null)
+        {
+            text.fontSharedMaterial = text.font.material;
+        }
+    }
+
+    private static void RefreshTextMesh(TextMeshProUGUI text, string currentText)
+    {
+        text.havePropertiesChanged = true;
+        text.UpdateMeshPadding();
+        text.SetAllDirty();
+        text.RecalculateClipping();
+        text.RecalculateMasking();
+        text.text = currentText;
+        ForceUpdateCanvases();
+        text.ForceMeshUpdate(ignoreActiveState: true, forceTextReparsing: true);
+    }
+
+    private static void ForceRebuildLayout(GameObject root)
+    {
+        if (root.transform is RectTransform rectTransform)
+        {
+            LayoutRebuilder.ForceRebuildLayoutImmediate(rectTransform);
+        }
+
+        ForceUpdateCanvases();
+    }
+
+
+    private static object? GetPropertyOrFieldValue(object? instance, string memberName)
+    {
+        if (instance is null)
+        {
+            return null;
+        }
+
+        var type = instance.GetType();
+        var property = type.GetProperty(memberName);
+        if (property is not null && property.GetIndexParameters().Length == 0)
+        {
+            return property.GetValue(instance);
+        }
+
+        return AccessField(type, instance, memberName);
+    }
+
+    private static GameObject? TryGetTooltipObjectFromTrigger(object? triggerInstance, out object? tooltip)
+    {
+        tooltip = GetPropertyOrFieldValue(triggerInstance, "Tooltip");
+        return GetTooltipObject(tooltip);
+    }
+
+    private static GameObject? GetTooltipObject(object? tooltip)
+    {
+        return GetPropertyOrFieldValue(tooltip, "GameObject") as GameObject;
+    }
+
+    private static void ForceUpdateCanvases()
+    {
+        try
+        {
+            var canvasType = Type.GetType("UnityEngine.Canvas, UnityEngine.UIModule", throwOnError: false);
+            if (canvasType is null)
+            {
+                canvasType = Type.GetType("UnityEngine.Canvas, UnityEngine.CoreModule", throwOnError: false);
+            }
+
+            if (canvasType is null)
+            {
+                canvasType = Type.GetType("UnityEngine.Canvas, UnityEngine", throwOnError: false);
+            }
+
+            var method = canvasType?.GetMethod(
+                "ForceUpdateCanvases",
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: Type.EmptyTypes,
+                modifiers: null);
+            method?.Invoke(null, null);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogWarning($"[QudJP] TooltipTextRepairer: ForceUpdateCanvases failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static object? AccessField(Type type, object instance, string memberName)
+    {
+        var field = type.GetField(memberName);
+        if (field is not null)
+        {
+            return field.GetValue(instance);
+        }
+
+#pragma warning disable S3011
+        var nonPublicField = type.GetField(memberName, InstanceMemberFlags);
+#pragma warning restore S3011
+        return nonPublicField?.GetValue(instance);
+    }
+
+    private static bool TrySetBooleanMember(object? instance, string memberName, bool value)
+    {
+        if (instance is null)
+        {
+            return false;
+        }
+
+        var type = instance.GetType();
+#pragma warning disable S3011
+        var property = type.GetProperty(memberName, InstanceMemberFlags);
+#pragma warning restore S3011
+        if (property is not null
+            && property.PropertyType == typeof(bool)
+            && property.CanWrite
+            && property.GetIndexParameters().Length == 0)
+        {
+            property.SetValue(instance, value);
+            return true;
+        }
+
+#pragma warning disable S3011
+        var field = type.GetField(memberName, InstanceMemberFlags);
+#pragma warning restore S3011
+        if (field is not null && field.FieldType == typeof(bool))
+        {
+            field.SetValue(instance, value);
+            return true;
+        }
+
+        return false;
+    }
+#endif
+}

--- a/Mods/QudJP/Assemblies/src/UI/TooltipTextRepairer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/TooltipTextRepairer.cs
@@ -203,7 +203,7 @@ internal static class TooltipTextRepairer
         ApplySharedFontMaterial(text);
 
         RefreshTextMesh(text, currentText);
-        return true;
+        return text.textInfo.characterCount > 0;
     }
 
     private static void ApplySharedFontMaterial(TextMeshProUGUI text)

--- a/Mods/QudJP/Assemblies/src/UI/TooltipTextRepairer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/TooltipTextRepairer.cs
@@ -50,28 +50,43 @@ internal static class TooltipTextRepairer
 
     internal static bool TryRepairTooltip(object? triggerInstance, bool restoreCanvasRendererVisibility = false)
     {
-        var tooltipObject = TryGetTooltipObjectFromTrigger(triggerInstance, out var tooltip);
-        if (tooltipObject is null || !ShouldRepairTooltipName(tooltipObject.name))
+        GameObject? tooltipObject = null;
+        try
         {
+            tooltipObject = TryGetTooltipObjectFromTrigger(triggerInstance, out var tooltip);
+            if (tooltipObject is null || !ShouldRepairTooltipName(tooltipObject.name))
+            {
+                return false;
+            }
+
+            _ = TryPinLookerTooltip(triggerInstance, tooltip, tooltipObject);
+            var repaired = 0;
+            repaired += ApplyLegacyFonts(tooltipObject);
+            repaired += ApplyTmpFonts(tooltipObject);
+            repaired += TmpTextRepairer.TryRepairInvisibleTexts(tooltipObject.transform);
+            repaired += TextShellReplacementRenderer.TryRenderReplacementTexts(
+                tooltipObject.transform,
+                out _,
+                emitDiagnostics: false);
+            if (restoreCanvasRendererVisibility)
+            {
+                repaired += RestoreCanvasRendererVisibility(tooltipObject);
+            }
+
+            ForceRebuildLayout(tooltipObject);
+            return repaired > 0;
+        }
+        catch (Exception ex)
+        {
+            var triggerType = triggerInstance?.GetType().FullName ?? "<null>";
+            var tooltipName = tooltipObject == null ? "<null>" : tooltipObject.name;
+            System.Diagnostics.Trace.TraceError(
+                "QudJP: TooltipTextRepairer.TryRepairTooltip failed for trigger '{0}', tooltip '{1}': {2}",
+                triggerType,
+                tooltipName,
+                ex);
             return false;
         }
-
-        _ = TryPinLookerTooltip(triggerInstance, tooltip, tooltipObject);
-        var repaired = 0;
-        repaired += ApplyLegacyFonts(tooltipObject);
-        repaired += ApplyTmpFonts(tooltipObject);
-        repaired += TmpTextRepairer.TryRepairInvisibleTexts(tooltipObject.transform);
-        repaired += TextShellReplacementRenderer.TryRenderReplacementTexts(
-            tooltipObject.transform,
-            out _,
-            emitDiagnostics: false);
-        if (restoreCanvasRendererVisibility)
-        {
-            repaired += RestoreCanvasRendererVisibility(tooltipObject);
-        }
-
-        ForceRebuildLayout(tooltipObject);
-        return repaired > 0;
     }
 
     internal static bool TryPinLookerTooltip(object? triggerInstance)

--- a/Mods/QudJP/Assemblies/src/UI/TooltipTextRepairer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/TooltipTextRepairer.cs
@@ -118,7 +118,7 @@ internal static class TooltipTextRepairer
 
     private static bool ShouldRepairTooltip(GameObject? tooltipObject)
     {
-        return tooltipObject is not null && ShouldRepairTooltipName(tooltipObject.name);
+        return tooltipObject != null && ShouldRepairTooltipName(tooltipObject.name);
     }
 
     private static int RestoreCanvasRendererVisibility(GameObject root)

--- a/docs/coderabbit/tmp-runtime-rendering.md
+++ b/docs/coderabbit/tmp-runtime-rendering.md
@@ -1,0 +1,98 @@
+# TMP And Unity UI Runtime Rendering Notes
+
+This document records derived QudJP review knowledge from runtime investigation
+of Caves of Qud 1.0.4 UI rendering. It is intended for maintainers and
+CodeRabbit-facing review context.
+
+Do not add copied game source, decompiled method bodies, or large symbol
+inventories here. Keep this file limited to behavioral contracts, review rules,
+and evidence patterns.
+
+## Scope
+
+These notes apply to QudJP patches that touch TextMeshPro, Unity UI
+`CanvasRenderer`, ModelShark tooltips, or runtime UI text repair. They are not a
+general license to mutate final UI sinks. Route ownership rules in
+`CODERABBIT.md` and `docs/RULES.md` still apply.
+
+## Runtime Rendering Contracts
+
+TMP mesh state is necessary but not sufficient evidence that text is visible.
+When investigating invisible UI text, check these layers separately:
+
+| Layer | Useful evidence | What it proves |
+| --- | --- | --- |
+| Text content | non-empty TMP text or legacy UI text | The route populated the field. |
+| TMP mesh | `characterCount`, `pageCount`, `rect` | TMP generated glyph geometry. |
+| Visibility limits | `maxVisibleCharacters`, `maxVisibleLines`, `pageToDisplay` | TMP is not hiding text via paging or line limits. |
+| Canvas renderer | `CanvasRenderer.GetAlpha()`, `cull`, active state | Unity UI will actually draw the generated geometry. |
+| Lifecycle | tooltip display/hide callers | The object is not being hidden after repair. |
+
+Reviewers should not accept "TMP has characters" as complete visibility proof.
+If a bug says text flashes and disappears, distinguish generated-but-hidden
+state from missing glyph or wrapping failures.
+
+## Tooltip-Specific Findings
+
+ModelShark tooltip display has a relevant warmup/display sequence:
+
+- tooltip warmup activates the tooltip object and can set child
+  `CanvasRenderer` alpha to `0`;
+- tooltip display later restores renderer alpha;
+- QudJP font/material/TMP repair may run between these lifecycle steps;
+- a tooltip can contain valid TMP text and mesh while still not being visible if
+  active child `CanvasRenderer` instances remain at alpha `0`.
+
+For PolatLooker-style L-key looker tooltips, `ForceHideTooltip()` in logs is not
+automatically a bug. The looker flow explicitly hides the current tooltip during
+target changes and on exit. Review runtime evidence by caller:
+
+| Caller family | Default interpretation |
+| --- | --- |
+| `TooltipManager.Update` | Suspicious for keyboard looker if it hides while the looker remains active. |
+| `Look.ShowLooker` target-change path | Usually expected when the selected target changes. |
+| `Look.HideTooltips` exit path | Expected when leaving the looker or closing UI. |
+
+The L-key looker route also needs the tooltip trigger and tooltip instance to
+agree on stay-open state. Setting only an `alwaysStayOpen`-style tooltip flag is
+not enough when the manager checks trigger fields for automatic hide behavior.
+
+## Review Guidance
+
+Flag TMP or tooltip fixes that:
+
+- rely only on `characterCount` or non-empty text as proof of visible output;
+- read `Graphic.color.a` as the primary runtime visibility signal when
+  `CanvasRenderer.GetAlpha()` is the actual draw-state evidence needed;
+- add permanent high-volume runtime logs in hot UI paths;
+- collect `StackTrace` during normal tooltip rendering without a debug gate;
+- repair broad tooltip or final UI sink behavior when the bug is scoped to a
+  known route such as PolatLooker;
+- keep diagnostic patches after the root cause is understood.
+
+Accept focused repairs when they:
+
+- target a known tooltip route or owner surface;
+- preserve fallback behavior and wrap Harmony patch bodies in crash-safe
+  `try`/`catch`;
+- include L2G target-resolution coverage for real game methods;
+- keep runtime diagnostics temporary, bounded, and free of raw body text;
+- use `CanvasRenderer.GetAlpha()` / `SetAlpha()` when fixing Unity UI draw
+  state, with the required Unity assembly references declared explicitly.
+
+## Runtime Evidence Pattern
+
+A healthy PolatLooker display after repair should have evidence equivalent to:
+
+- QudJP assembly loaded from local `StreamingAssets/Mods/QudJP`;
+- the relevant Harmony patches applied;
+- PolatLooker repair occurred for active TMP fields;
+- tooltip display state has `CanvasRenderer` alpha restored to `1`;
+- `cull` count is zero for visible tooltip renderers;
+- no automatic hide from `TooltipManager.Update` while the looker should remain
+  visible.
+
+Do not print raw tooltip bodies in diagnostic logs. Prefer bounded structural
+evidence: route name, object path, text length, character count, page count,
+active/enabled flags, rect size, renderer alpha range, cull count, and caller
+family.


### PR DESCRIPTION
## Summary
- Add focused ModelShark tooltip repair hooks for PolatLooker display/set-text lifecycle.
- Restore TMP/legacy font/material state and delayed CanvasRenderer visibility without old high-volume tooltip diagnostics.
- Document TMP/tooltip rendering contracts for CodeRabbit and add stub/test coverage for the new route.

## Verification
- `dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj -p:GameDir=/tmp/qudjp-no-game --no-incremental`
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj -p:GameDir=/tmp/qudjp-no-game --no-incremental`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~TooltipTextRepairerTests|FullyQualifiedName~TooltipManagerSetTextAndSizePatchResolutionTests|FullyQualifiedName~TooltipDisplayVisibilityPatchResolutionTests|FullyQualifiedName~UnityApiCompatibilityTests"`
- `just build && just test-l1 && just test-l2g`
- `just sync-mod`

## Review
- Separate-agent final review: APPROVE. Evidence included no-game builds, no-game L1, tooltip L2G, suppressed tooltip replacement diagnostics, no old `TooltipTextRepair/v1` or runtime `StackTrace` diagnostics, and clean `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - ツールチップの表示・可視性の安定性と復元性を向上しました
  - PolatLooker（Lキー検査）のツールチップ表示とテキストレンダリングの信頼性を強化しました

- **新機能**
  - 表示修復の遅延スケジューリング（重複抑止）を追加しました
  - 診断ログの高頻度出力を抑制するオプションを追加しました
  - Canvas 描画アルファ値の取得/復元が可能になりました

- **テスト**
  - ツールチップ表示・解決ロジックを検証する自動テストを追加しました

- **ドキュメント**
  - TextMeshPro/UI ランタイムレンダリングの確認チェックリストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->