### PR TITLE
[codex] Clarify dev build and README guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,36 @@
 >
 > **対象ゲームバージョン**: Caves of Qud 1.0.4
 >
-> experimental branch (`lang-experimental`, build 212.x 系) は別リポジトリ [`ToaruPen/CoQ-Japanese_v2`](https://github.com/ToaruPen/CoQ-Japanese_v2) で observation mode 追跡中。
+> **Steam Workshop**: [`3718988020`](https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020)
 
 ## Why
 
 Caves of Qud は完全な英語ローカライゼーション API が整備される前から運用されてきたタイトルで、UI / quest / conversation / 自動生成テキストを日本語化するには Harmony patch を主軸としたアプローチが必要。本リポジトリは Caves of Qud 1.0.4 ユーザーが実際にプレイできる翻訳状態を維持することを最優先する。
 
-experimental ブランチ (`lang-experimental`) の新ローカライゼーションフレームワーク (`Strings/_T/_S` / `[LanguageProvider]` / `ExampleLanguage` 等) は 2026-04-07 時点で early alpha 段階であることが判明しており、詳細な一次調査結果と observation mode 復帰の意思決定は v2 リポジトリの [`docs/snapshots/2026-04-07-beta-l10n-status.md`](https://github.com/ToaruPen/CoQ-Japanese_v2/blob/main/docs/snapshots/2026-04-07-beta-l10n-status.md) / [`docs/decisions/0001-v1-v2-roles.md`](https://github.com/ToaruPen/CoQ-Japanese_v2/blob/main/docs/decisions/0001-v1-v2-roles.md) を参照。
-
 ## What This Repo Is For
 
 - Caves of Qud 1.0.4 ユーザー向け日本語化 Mod の開発と出荷
 - 会話 / UI / quest / 自動生成テキスト / 装備名 / 能力名 / 書籍 等の翻訳資産の保守
-- Harmony patch 群 + Markov コーパス + 翻訳パイプラインスクリプトの維持
-- CJK フォント同梱
+- Harmony patch 群、CJK フォント、翻訳辞書、検証・release tooling の維持
+- フォント資産とライセンス情報の同梱管理
 
 ## What It Is Not For
 
-- experimental branch (`lang-experimental`, 212.x 系) ターゲットの開発 (→ v2)
+- experimental branch (`lang-experimental` 系) ターゲットの開発 (→ v2)
 - 新ローカライゼーション API (`Strings/_T/_S` / `[LanguageProvider]`) への先行移植
 - 英語以外の他言語サポート
 - Caves of Qud 1.0.4 の挙動を破壊する実験的リファクタ
+
+## Current Release Sources
+
+| 項目 | Source of truth |
+|---|---|
+| Mod metadata / version | [`Mods/QudJP/manifest.json`](Mods/QudJP/manifest.json) |
+| Release history | [`CHANGELOG.md`](CHANGELOG.md) |
+| Steam Workshop release procedure | [`docs/release.md`](docs/release.md) |
+| Local deployment / smoke check | [`docs/deployment.md`](docs/deployment.md) |
+| Public Workshop metadata | [`steam/workshop_metadata.json`](steam/workshop_metadata.json) |
+| Public Workshop description | [`steam/workshop_description.ja.txt`](steam/workshop_description.ja.txt) |
 
 ## Docs
 
@@ -34,6 +43,9 @@ experimental ブランチ (`lang-experimental`) の新ローカライゼーシ�
 | [`docs/test-architecture.md`](docs/test-architecture.md) | 3 層 + L3 テストアーキテクチャ定義 |
 | [`docs/contributing.md`](docs/contributing.md) | 貢献ガイド |
 | [`docs/deployment.md`](docs/deployment.md) | デプロイ手順 |
+| [`docs/release.md`](docs/release.md) | GitHub Release / Steam Workshop 出荷手順 |
+| [`docs/workflows/pr-review.md`](docs/workflows/pr-review.md) | PR レビュー手順 |
+| [`docs/workflows/runtime-evidence.md`](docs/workflows/runtime-evidence.md) | runtime evidence 収集手順 |
 | [`docs/glossary.csv`](docs/glossary.csv) | 翻訳用語集 |
 | [`docs/static-producer-inventory.json`](docs/static-producer-inventory.json) | issue #493 static producer inventory |
 | [`docs/reports/2026-05-05-issue-493-static-producer-inventory.md`](docs/reports/2026-05-05-issue-493-static-producer-inventory.md) | static producer inventory report |
@@ -41,15 +53,18 @@ experimental ブランチ (`lang-experimental`) の新ローカライゼーシ�
 
 ## Development / Verification
 
+- 開発コマンドは `justfile` に集約しています。初回は `just --list` で利用可能な recipe を確認してください。
+- 通常の `just build` / `just deploy-mod` は shipping 相当の DLL を作成し、冗長な probe ログを出しません。probe が必要なローカル調査では `just build-dev` / `just deploy-dev` を使います。
 - C# テストは NUnit、L1 / L2 / L2G の 3 層構成 + 手動 L3 ([`docs/test-architecture.md`](docs/test-architecture.md))
 - Python ツールは pytest + Ruff + ast-grep
 - 静的解析: Roslyn analyzer suite (`QudJP.Analyzers`) に独自規約 QJ001 / QJ002 / QJ003 を加えて強制
-- CI: GitHub Actions (Ubuntu 24.04 / .NET 8 + 10 / Python 3.12) で push / PR ごとに build + test
+- CI: GitHub Actions で変更パスに応じて .NET build/test、Roslyn tool build、Python lint/test、localization checks、justfile parse check を実行
+- Release: tag-triggered GitHub Actions が release ZIP と draft GitHub Release を作成し、Steam Workshop upload は `docs/release.md` の手動 gate に従う
 - コードレビュー: CodeRabbit
 
 ## Related Repo
 
-- [`ToaruPen/CoQ-Japanese_v2`](https://github.com/ToaruPen/CoQ-Japanese_v2) — **v2, observation mode (frozen 2026-04-07)**, Caves of Qud experimental branch (`lang-experimental`, build 212.x) 追跡用
+- [`ToaruPen/CoQ-Japanese_v2`](https://github.com/ToaruPen/CoQ-Japanese_v2) — Caves of Qud experimental branch (`lang-experimental` 系) と新ローカライゼーション API の追跡用
 
 ## License
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,7 +16,15 @@ QudJP へのコントリビューションを歓迎します。このドキュ�
 - 対応 OS: macOS / Linux / Windows / WSL2
 - .NET SDK `10.0.x` (`QudJP.Tests.csproj` が `net10.0` をターゲットするため。これを入れておけば `QudJP.csproj` の `net48` ビルドも同じ SDK で可能)
 - Python `3.12` 以上
+- `just` — 開発・検証コマンドの標準入口
+- `uv` — Python ツールと release helper の実行環境
 - (任意) `ast-grep` — Python スキャナーツールと CI で使用
+
+macOS の Homebrew 環境では、開発コマンドの入口は次で揃えられます。
+
+```bash
+brew install just uv
+```
 
 > `Assembly-CSharp.dll` はリポジトリに含まれていません。ゲームを所有していない場合でも、リポジトリを clone してローカライゼーションファイル (JSON / XML) を編集することは可能です。ただし C# のビルドと L2G テスト実行にはゲームの所有が必要です。
 >
@@ -33,7 +41,26 @@ git clone git@github.com:ToaruPen/coq-japanese_stable.git
 cd coq-japanese_stable
 ```
 
-### 2. ゲーム DLL 参照パスを設定する
+### 2. 開発コマンドを確認する
+
+QudJP の日常的な build / test / deploy / release helper は `justfile` に集約しています。コマンド名が不明な場合は、まず recipe 一覧を確認してください。
+
+```bash
+just --list
+```
+
+通常の `just build` / `just rebuild` / `just deploy-mod` は、Steam Workshop へ出す shipping 相当の DLL を作ります。このビルドでは冗長な runtime probe ログは出ません。
+
+ローカル調査で probe ログが必要な場合だけ、開発者用 build を使います。
+
+```bash
+just build-dev
+just deploy-dev
+```
+
+`build-dev` / `deploy-dev` は `QudJPDevBuild=true` を付けて DLL を作成し、dev-only probe を有効にします。Workshop / release 用の成果物には使わないでください。
+
+### 3. ゲーム DLL 参照パスを設定する
 
 `Mods/QudJP/Assemblies/QudJP.csproj` はゲーム同梱 DLL (`0Harmony.dll` / Unity ランタイム) を参照します。OS ごとの Steam 既定パスを `-p:GameDir=...` で MSBuild に渡してください。csproj 内の `<HintPath>` を直接書き換える必要はありません。
 
@@ -68,28 +95,28 @@ dotnet build Mods/QudJP/Assemblies/QudJP.csproj \
 
 > `Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj` も `QudJP.csproj` と同様に `-p:GameDir=...` を受け付けます。`Managed/Assembly-CSharp.dll` を直接指したい場合は `-p:AssemblyCSharpPath=...` でも上書きできます。
 
-### 3. ビルドを確認する
+### 4. ビルドを確認する
 
 ```bash
-dotnet build Mods/QudJP/Assemblies/QudJP.csproj
+just build
 ```
 
 `Mods/QudJP/Assemblies/QudJP.dll` が生成されれば成功です。
+非標準の `GameDir` を渡してゲーム DLL 参照を明示したい場合は、前節の `dotnet build ... -p:GameDir=...` 例を使ってください。
 
-### 4. テストを実行する
+### 5. テストを実行する
 
 ```bash
-# L1 + L2 (ゲーム DLL 不要、常に実行可能)
-dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj \
-  --filter "TestCategory=L1|TestCategory=L2"
+# L1 + L2 (L2G 以外はゲーム DLL 不要、常に実行可能)
+just test-l1
+just test-l2
 
 # L2G (ゲーム DLL 必須)
-dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj \
-  --filter TestCategory=L2G
+just test-l2g
 
 # Python スクリプトの lint とテスト
-ruff check scripts/
-pytest scripts/tests/
+just python-check
+just python-test
 ```
 
 全テストがパスすれば環境構築完了です。

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,8 +10,27 @@ For Steam Workshop publishing, use `docs/release.md` after local deployment and 
 
 - Caves of Qud installed (Steam, macOS / Windows / WSL2 / Linux)
 - `QudJP.dll` built via `just build` or `just rebuild`
+- `just` and `uv` installed for the recommended deployment recipes
 
 ---
+
+## Build Flavors
+
+`just deploy-mod` is the normal local deployment path. It rebuilds the same
+shipping-style DLL used for Workshop packaging and keeps verbose runtime probe
+logs disabled.
+
+Use `just deploy-dev` only when you are actively investigating runtime behavior
+and need dev-only probe logs. Development builds are for local diagnosis; do not
+use them for Steam Workshop staging, release ZIPs, or player-facing uploads.
+
+```bash
+# Shipping-style local deployment
+just deploy-mod
+
+# Local diagnostic deployment with dev-only probes enabled
+just deploy-dev
+```
 
 ## Deployment Methods
 

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ default:
 build:
   dotnet build Mods/QudJP/Assemblies/QudJP.csproj
 
-# Build the QudJP assembly for local development.
+# Build the QudJP assembly for local development with dev-only probes enabled.
 build-dev:
   dotnet build Mods/QudJP/Assemblies/QudJP.csproj -p:QudJPDevBuild=true
 
@@ -20,7 +20,7 @@ rebuild:
   dotnet clean Mods/QudJP/Assemblies/QudJP.csproj
   dotnet build Mods/QudJP/Assemblies/QudJP.csproj --no-incremental
 
-# Clean and rebuild the QudJP assembly for local development.
+# Clean and rebuild the QudJP assembly for local development with dev-only probes enabled.
 rebuild-dev:
   dotnet clean Mods/QudJP/Assemblies/QudJP.csproj
   dotnet build Mods/QudJP/Assemblies/QudJP.csproj --no-incremental -p:QudJPDevBuild=true
@@ -242,7 +242,7 @@ download-release-zip version:
 sync-mod:
   {{python}} scripts/sync_mod.py
 
-# Sync the built mod into the local game install as a local dev build.
+# Sync the built mod into the local game install as a dev build with dev-only probes enabled.
 sync-mod-dev:
   {{python}} scripts/sync_mod.py --dev
 
@@ -250,7 +250,7 @@ sync-mod-dev:
 sync-mod-dry-run:
   {{python}} scripts/sync_mod.py --dry-run
 
-# Preview the local dev sync without copying files.
+# Preview the local dev sync with dev-only probes enabled without copying files.
 sync-mod-dev-dry-run:
   {{python}} scripts/sync_mod.py --dev --dry-run
 
@@ -262,14 +262,14 @@ sync-mod-exclude-fonts:
 sync-mod-to destination:
   {{python}} scripts/sync_mod.py --destination {{quote(destination)}}
 
-# Sync the built mod to an explicit Mods/QudJP destination as a local dev build.
+# Sync the built mod to an explicit Mods/QudJP destination as a dev build with dev-only probes enabled.
 sync-mod-dev-to destination:
   {{python}} scripts/sync_mod.py --dev --destination {{quote(destination)}}
 
 # Rebuild and sync the local mod into the game install.
 deploy-mod: rebuild sync-mod
 
-# Rebuild and sync the local dev mod into the game install.
+# Rebuild and sync the local dev mod with dev-only probes enabled.
 deploy-dev: rebuild-dev sync-mod-dev
 
 # Rebuild and sync the local mod to an explicit Mods/QudJP destination.
@@ -277,7 +277,7 @@ deploy-mod-to destination:
   just rebuild
   just sync-mod-to {{quote(destination)}}
 
-# Rebuild and sync the local dev mod to an explicit Mods/QudJP destination.
+# Rebuild and sync the local dev mod with dev-only probes enabled to an explicit destination.
 deploy-dev-to destination:
   just rebuild-dev
   just sync-mod-dev-to {{quote(destination)}}


### PR DESCRIPTION
## Summary

- Refresh README repo guidance around current release sources, Workshop metadata, CI, and release flow.
- Document `just` / `uv` as the standard developer command entrypoint.
- Clarify that normal `just build` / `just deploy-mod` produce shipping-style builds with verbose probes disabled, while `just build-dev` / `just deploy-dev` are for local diagnostic probe logging.
- Update `just --list` descriptions for dev recipes so the build flavor is visible at command discovery time.

## Validation

- `git diff --check HEAD~1..HEAD`
- `just markdown-report-check origin/main HEAD`
- `just --summary`
