### PR TITLE
Document Rosetta launcher usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ Caves of Qud は完全な英語ローカライゼーション API が整備さ�
 - 英語以外の他言語サポート
 - Caves of Qud 1.0.4 の挙動を破壊する実験的リファクタ
 
+## macOS Apple Silicon
+
+M1/M2/M3/M4 などの Apple Silicon Mac では、Caves of Qud をネイティブ起動すると Harmony patch が `mprotect returned EACCES` で失敗し、QudJP の UI 翻訳が効かない場合があります。その場合は Rosetta 2 経由で起動してください。
+
+Steam Workshop 版と GitHub Release ZIP には `QudJP/Launch CavesOfQud (Rosetta).command` を同梱しています。ダブルクリックで Caves of Qud を Rosetta 経由で起動できます。macOS の Steam 既定ライブラリでは、Workshop 版の wrapper は次の場所にあります。
+
+```text
+~/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020/Launch CavesOfQud (Rosetta).command
+```
+
+Steam ライブラリを別の場所に置いている場合は、そのライブラリ配下の `steamapps/workshop/content/333640/3718988020/` を探してください。GitHub Release ZIP を手動展開した場合は、展開した `QudJP/` フォルダ直下にあります。Rosetta 2 が未インストールの場合は、ターミナルで次を実行してください。
+
+```bash
+softwareupdate --install-rosetta --agree-to-license
+```
+
+直接起動する場合のコマンドは次の通りです。このコマンドはワンショットで、Steam から普通に起動した場合の設定を永続変更しません。
+
+```bash
+arch -x86_64 "$HOME/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/MacOS/CoQ"
+```
+
 ## Current Release Sources
 
 | 項目 | Source of truth |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -148,8 +148,23 @@ For inventory / equipment display checks, follow the runtime evidence rules in
 ### Apple Silicon / Rosetta
 
 - On Apple Silicon, in-game verification must run under Rosetta 2
-- Use `scripts/launch_rosetta.sh` or `Launch CavesOfQud (Rosetta).command`
+- For local repo verification, use `scripts/launch_rosetta.sh` or the root
+  `Launch CavesOfQud (Rosetta).command`
+- For player-facing builds, the release ZIP and Workshop content include
+  `QudJP/Launch CavesOfQud (Rosetta).command`; launch through that wrapper
+  from the installed `QudJP` folder
+- On macOS with the default Steam library, the subscribed Workshop item is
+  normally under:
+  `~/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020/`
+  If Steam uses another library, look under that library's
+  `steamapps/workshop/content/333640/3718988020/` directory instead.
+- `arch -x86_64 .../CoQ` is a one-shot launch path. It does not persist to
+  future Steam launches, so Apple Silicon users should use the wrapper each
+  time unless they have separately configured a reliable Rosetta launch path.
 - Do not use native ARM64 runtime logs as localization observability evidence
+- If `Player.log` contains `mprotect returned EACCES` or QudJP reports
+  `Harmony patching complete: 0 method(s) patched`, treat that run as native
+  ARM64 and ask for a Rosetta-backed retry before triaging localization routes.
 
 ### Troubleshooting
 
@@ -160,6 +175,7 @@ For inventory / equipment display checks, follow the runtime evidence rules in
 | Japanese text shows as tofu squares | CJK font not bundled | Verify Fonts directory is deployed |
 | DLL load error | `QudJP.dll` not built | Run `just deploy-mod` |
 | No QudJP traces in Player.log | Bootstrap.cs not deployed or failed to compile | Verify `Bootstrap.cs` exists in game `Mods/QudJP/` directory; check Player.log for compile errors |
+| Apple Silicon: title/UI text stays English and `mprotect returned EACCES` appears | Native ARM64 launch blocked Harmony patching | Launch through `Launch CavesOfQud (Rosetta).command` or `arch -x86_64 .../CoQ` |
 
 ---
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -97,6 +97,7 @@ Required files in the staged content folder:
 | `LICENSE` | License compliance |
 | `NOTICE.md` | Third-party and project notices |
 | `Bootstrap.cs` | Game-compiled loader shim |
+| `Launch CavesOfQud (Rosetta).command` | macOS Apple Silicon helper launcher |
 | `Assemblies/QudJP.dll` | Built Harmony patch DLL |
 | `Localization/` | XML overlays, JSON dictionaries, and text corpus assets |
 | `Fonts/` | CJK font assets and font license |
@@ -336,6 +337,9 @@ After Steam finishes processing the item:
 
 1. Open the Workshop page and confirm the title, description, tags, preview
    image, visibility, file size, and change note.
+   - For Apple Silicon support, confirm the description mentions
+     `Launch CavesOfQud (Rosetta).command`, Rosetta 2, and the one-shot
+     `arch -x86_64` launch command.
 2. Subscribe to the item from a clean Steam client state or unsubscribe and
    resubscribe if updating an existing item.
 3. Validate the downloaded Workshop item against the staged content:
@@ -348,7 +352,14 @@ After Steam finishes processing the item:
    version and that the downloaded `Assemblies/QudJP.dll` SHA256 matches the
    release ZIP DLL. Do not mark the release GO if the public Workshop download
    still contains an older DLL.
+   Also confirm the downloaded `Launch CavesOfQud (Rosetta).command` exists and
+   is executable in the downloaded `QudJP` folder.
+   On the default macOS Steam library, the downloaded Workshop folder is usually
+   `~/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020/`.
 4. Launch the game, enable only QudJP for the smoke pass, and restart.
+   - On Apple Silicon, launch through the downloaded Rosetta wrapper. A native
+     ARM64 run with `mprotect returned EACCES` or zero patched Harmony methods
+     does not count as a valid smoke pass.
 5. Confirm the Mod Manager lists QudJP with the expected version and preview.
 6. Confirm the Options screen and one short conversation render Japanese text
    and CJK glyphs correctly.

--- a/steam/workshop_description.ja.txt
+++ b/steam/workshop_description.ja.txt
@@ -32,6 +32,8 @@ macOS Apple Silicon での注意
   * M1/M2/M3/M4 などの Apple Silicon Mac では、Caves of Qud をネイティブ起動すると Harmony パッチが `mprotect returned EACCES` で失敗し、この Mod の UI 翻訳が効かない場合があります。
   * その場合は Rosetta 2 経由で Caves of Qud を起動してください。
   * この Mod には `Launch CavesOfQud (Rosetta).command` という起動用 wrapper を同梱しています。Steam Workshop のダウンロード先にある `QudJP` フォルダ内からダブルクリックで起動できます。
+  * macOS の Steam 既定ライブラリでは、通常 `~/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020/Launch CavesOfQud (Rosetta).command` にあります。別の Steam ライブラリを使っている場合は、そのライブラリ内の `steamapps/workshop/content/333640/3718988020/` を探してください。
+  * Steam から通常起動した場合、この wrapper の効果は引き継がれません。Apple Silicon で翻訳が効かない場合は、毎回 wrapper から起動してください。
   * Rosetta 2 が未インストールの場合は、ターミナルで `softwareupdate --install-rosetta --agree-to-license` を実行してください。
   * 起動例:
 


### PR DESCRIPTION
## Summary
- Add user-facing Apple Silicon/Rosetta launcher guidance to README and Workshop description
- Document the default macOS Steam Workshop path for item 3718988020
- Add deployment and release checklist notes for Rosetta-wrapper smoke checks

## Context
- Follow-up to #595 after the Rosetta wrapper packaging landed on main

## Verification
- `git diff --check origin/main..HEAD`
- `npx secretlint README.md docs/deployment.md docs/release.md steam/workshop_description.ja.txt`