### PR TITLE
[codex] Formalize inventory replacement rendering path

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineRenderProbePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineRenderProbePatchTests.cs
@@ -122,4 +122,49 @@ public sealed class InventoryLineRenderProbePatchTests
         NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("AttemptCounts.TryRemove(lineId, out _)"));
         NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Not.Contain("ScheduleRepair(__instance, resetAttempts: true)"));
     }
+
+    [NUnit.Framework.Test]
+    public void DelayedInventoryLineRepairScheduler_LogsReplacementEvidenceAfterSuccessfulRepair()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "UI",
+            "DelayedInventoryLineRepairScheduler.cs");
+        var source = File.ReadAllText(sourcePath);
+
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Contain("TextShellReplacementRenderer.TryRenderReplacementTexts(component, out var replacementLogLine)"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("RuntimeDiagnostics.VerboseProbesEnabled"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("LogInventoryReplacementEvidence(replacementLogLine)"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("LogVerboseRepairProbeSnapshots(component)"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("TextShellReplacementRenderer.TryBuildReplacementState("));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("\"InventoryLineReplacementStateNextFrame/v1\""));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("LogInventoryReplacementEvidence(stateLogLine)"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("ScreenHierarchyObservability.TryBuildLineItemSnapshot("));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("\"InventoryLineItemProbe/v1\""));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("LogInventoryReplacementEvidence(itemLogLine)"));
+
+        var repairIndex = source.IndexOf(
+            "TextShellReplacementRenderer.TryRenderReplacementTexts(component, out var replacementLogLine)",
+            System.StringComparison.Ordinal);
+        var invisibleRepairIndex = source.IndexOf(
+            "TmpTextRepairer.TryRepairInvisibleTexts(component)",
+            System.StringComparison.Ordinal);
+        var verboseGateIndex = source.IndexOf(
+            "RuntimeDiagnostics.VerboseProbesEnabled",
+            System.StringComparison.Ordinal);
+        var logIndex = source.IndexOf(
+            "LogInventoryReplacementEvidence(replacementLogLine)",
+            System.StringComparison.Ordinal);
+
+        NUnit.Framework.Assert.That(repairIndex, NUnit.Framework.Is.GreaterThanOrEqualTo(0));
+        NUnit.Framework.Assert.That(invisibleRepairIndex, NUnit.Framework.Is.GreaterThan(repairIndex));
+        NUnit.Framework.Assert.That(verboseGateIndex, NUnit.Framework.Is.GreaterThan(invisibleRepairIndex));
+        NUnit.Framework.Assert.That(logIndex, NUnit.Framework.Is.GreaterThan(verboseGateIndex));
+    }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryReplacementHardeningTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryReplacementHardeningTests.cs
@@ -1,6 +1,7 @@
 #if HAS_TMP
 using TMPro;
 #endif
+using System.IO;
 
 namespace QudJP.Tests.L1;
 
@@ -56,6 +57,32 @@ public sealed class InventoryReplacementHardeningTests
     public bool IsReplacementTextNameForTests_DetectsOnlyReplacementName(string objectName)
     {
         return TextShellReplacementRenderer.IsReplacementTextNameForTests(objectName);
+    }
+
+    [NUnit.Framework.Test]
+    public void HasActiveReplacementForCurrentItemText_DoesNotForceMeshUpdateFromLateUpdateGuard()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "UI",
+            "TextShellReplacementRenderer.cs");
+        var source = File.ReadAllText(sourcePath);
+        var methodStart = source.IndexOf(
+            "internal static bool HasActiveReplacementForCurrentItemText",
+            System.StringComparison.Ordinal);
+        var methodEnd = source.IndexOf(
+            "internal static TextOverflowModes GetReplacementOverflowModeForTests",
+            System.StringComparison.Ordinal);
+
+        NUnit.Framework.Assert.That(methodStart, NUnit.Framework.Is.GreaterThanOrEqualTo(0));
+        NUnit.Framework.Assert.That(methodEnd, NUnit.Framework.Is.GreaterThan(methodStart));
+        var methodSource = source[methodStart..methodEnd];
+
+        NUnit.Framework.Assert.That(methodSource, NUnit.Framework.Does.Not.Contain("ForceMeshUpdate"));
     }
 
     [NUnit.Framework.TestCase("current", "original", ExpectedResult = "original")]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -76,6 +76,8 @@ public sealed class TargetMethodResolutionTests
     })]
     [TestCase(typeof(InventoryAndEquipmentStatusScreenTranslationPatch), "UpdateViewFromData", "Qud.UI.InventoryAndEquipmentStatusScreen", "System.Void", new string[0])]
     [TestCase(typeof(InventoryLineTranslationPatch), "setData", "Qud.UI.InventoryLine", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]
+    [TestCase(typeof(InventoryLineRenderProbePatch), "setData", "Qud.UI.InventoryLine", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]
+    [TestCase(typeof(InventoryLineActiveTextRefreshPatch), "LateUpdate", "Qud.UI.InventoryLine", "System.Void", new string[0])]
     [TestCase(typeof(EquipmentLineTranslationPatch), "setData", "Qud.UI.EquipmentLine", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]
     [TestCase(typeof(JournalLineTranslationPatch), "setData", "Qud.UI.JournalLine", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]
     [TestCase(typeof(TinkeringLineTranslationPatch), "setData", "Qud.UI.TinkeringLine", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]

--- a/Mods/QudJP/Assemblies/src/UI/DelayedInventoryLineRepairScheduler.cs
+++ b/Mods/QudJP/Assemblies/src/UI/DelayedInventoryLineRepairScheduler.cs
@@ -1,6 +1,7 @@
 #if HAS_TMP
 using System.Collections;
 using System.Collections.Concurrent;
+using System.Threading;
 using TMPro;
 using UnityEngine;
 #endif
@@ -11,10 +12,12 @@ internal static class DelayedInventoryLineRepairScheduler
 {
 #if HAS_TMP
     private const int MaxAttemptsPerLine = 2;
+    private const int MaxEvidenceLogs = 48;
 
     private static readonly ConcurrentDictionary<int, int> AttemptCounts = new();
     private static readonly ConcurrentDictionary<int, string> LastScheduledTextByLine = new();
     private static readonly ConcurrentDictionary<int, byte> Scheduled = new();
+    private static int evidenceLogCount;
 
     private static RepairHost? host;
 
@@ -123,7 +126,7 @@ internal static class DelayedInventoryLineRepairScheduler
                 yield break;
             }
 
-            var replaced = TextShellReplacementRenderer.TryRenderReplacementTexts(component, out _);
+            var replaced = TextShellReplacementRenderer.TryRenderReplacementTexts(component, out var replacementLogLine);
 
             yield return null;
 
@@ -132,7 +135,8 @@ internal static class DelayedInventoryLineRepairScheduler
                 _ = TmpTextRepairer.TryRepairInvisibleTexts(component);
                 if (RuntimeDiagnostics.VerboseProbesEnabled)
                 {
-                    BuildVerboseRepairProbeSnapshots(component);
+                    LogInventoryReplacementEvidence(replacementLogLine);
+                    LogVerboseRepairProbeSnapshots(component);
                 }
             }
 
@@ -143,13 +147,38 @@ internal static class DelayedInventoryLineRepairScheduler
         }
     }
 
-    private static void BuildVerboseRepairProbeSnapshots(Component component)
+    private static void LogVerboseRepairProbeSnapshots(Component component)
     {
-        _ = TextShellReplacementRenderer.TryBuildReplacementState(
+        if (TextShellReplacementRenderer.TryBuildReplacementState(
             component,
             "InventoryLineReplacementStateNextFrame/v1",
-            out _);
-        _ = ScreenHierarchyObservability.TryBuildLineItemSnapshot(component, "InventoryLineItemProbe/v1", out _);
+            out var stateLogLine))
+        {
+            LogInventoryReplacementEvidence(stateLogLine);
+        }
+
+        if (ScreenHierarchyObservability.TryBuildLineItemSnapshot(
+            component,
+            "InventoryLineItemProbe/v1",
+            out var itemLogLine))
+        {
+            LogInventoryReplacementEvidence(itemLogLine);
+        }
+    }
+
+    private static void LogInventoryReplacementEvidence(string? logLine)
+    {
+        if (string.IsNullOrEmpty(logLine))
+        {
+            return;
+        }
+
+        if (Interlocked.Increment(ref evidenceLogCount) > MaxEvidenceLogs)
+        {
+            return;
+        }
+
+        QudJPMod.LogToUnity(logLine!);
     }
 
     private sealed class RepairHost : MonoBehaviour

--- a/Mods/QudJP/Assemblies/src/UI/TextShellReplacementRenderer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/TextShellReplacementRenderer.cs
@@ -284,7 +284,6 @@ internal static class TextShellReplacementRenderer
                 continue;
             }
 
-            replacement.ForceMeshUpdate(ignoreActiveState: true, forceTextReparsing: false);
             if (replacement.textInfo.characterCount > 0)
             {
                 return true;

--- a/docs/reports/2026-05-08-issue-574-inventory-tmp.md
+++ b/docs/reports/2026-05-08-issue-574-inventory-tmp.md
@@ -38,6 +38,13 @@ Do not treat the original inventory TMP `charCount=0/pageCount=0` state as solve
 - once a matching active replacement exists, active-line refresh avoids rescheduling the original TMP path;
 - fresh runtime evidence must include the replacement success markers before #574 is closed.
 
+This is a provisional adoption of the replacement-rendering path rather than a
+root-cause fix for the original TMP geometry failure. If future runtime evidence
+shows replacement-rendering performance regressions, visual regressions, or
+inventory-line instability, reopen the root-cause investigation for the
+original `TextShell/Text` route instead of adding more replacement-layer
+workarounds.
+
 ## Branch Change
 
 `DelayedInventoryLineRepairScheduler` now logs bounded replacement evidence after successful replacement repair:

--- a/docs/reports/2026-05-08-issue-574-inventory-tmp.md
+++ b/docs/reports/2026-05-08-issue-574-inventory-tmp.md
@@ -1,0 +1,77 @@
+# Issue 574 Inventory TMP Zero-Character Investigation
+
+## Identity
+
+- Issue: https://github.com/ToaruPen/coq-japanese_stable/issues/574
+- Branch: `codex/issue-574-inventory-tmp`
+- Base: `origin/main` at `7bde26c`
+- Runtime log inspected: `~/Library/Logs/Freehold Games/CavesOfQud/Player.log`
+- Runtime log mtime: `2026-05-08 08:04:12 JST`
+
+## Finding
+
+The upstream inventory route is:
+
+1. `Qud.UI.InventoryLine.setData(FrameworkDataElement)` assigns item names through `text.SetText(inventoryLineData.displayName)`.
+2. `XRL.UI.UITextSkin.SetText(string)` stores the visible text and applies it to the underlying `TextMeshProUGUI`.
+3. `InventoryLineTranslationPatch` translates the item display name and writes it back through the owner text route.
+4. `InventoryLineFontFixer` treats `TextMeshProUGUI.textInfo.characterCount == 0` as a failed original TMP render.
+5. `InventoryLineActiveTextRefreshPatch` schedules delayed repair only when the active item line has no active replacement and the original TMP refresh still fails.
+6. `DelayedInventoryLineRepairScheduler` calls `TextShellReplacementRenderer`, which creates `QudJPReplacementText` under the original `TextShell` and preserves it as the intended fallback display path when it renders non-empty text.
+
+The fresh runtime log contains inventory-open evidence and original TMP zero-character evidence:
+
+- QudJP loaded from the local game install mod path.
+- Build marker: `ui-child-snapshot-v3`, assembly version `0.1.0.0`.
+- `InventoryLineTranslationPatch` and inventory status-screen rows appear in the log.
+- `InventoryLineReplacementDisable/v1` rows report `path='Modes/Item/TextShell/Text'`, `originalChars=0`, and `originalPages=0`.
+- No `MissingMethodException`, `Vector2.get_x`, `Vector2.get_y`, `MODWARN`, or QudJP exception was found.
+
+The same log did not contain `InventoryLineReplacement/v1`, `InventoryLineReplacementStateNextFrame/v1`, or `InventoryLineItemProbe/v1`. That made the log insufficient for closing #574, because it proved the original TMP row stayed empty but did not prove the chosen replacement display path in the same fresh run.
+
+## Decision
+
+Do not treat the original inventory TMP `charCount=0/pageCount=0` state as solved without Unity runtime evidence. Current source and prior runtime notes show that the original TMP can contain non-empty text while producing zero geometry in this inventory subtree. The supported behavior for this branch is therefore:
+
+- original item-row TMP with `enabled == true`, `activeInHierarchy == true`, and `characterCount == 0` is a repair candidate;
+- a successful `QudJPReplacementText` render is the intended display path for that row;
+- once a matching active replacement exists, active-line refresh avoids rescheduling the original TMP path;
+- fresh runtime evidence must include the replacement success markers before #574 is closed.
+
+## Branch Change
+
+`DelayedInventoryLineRepairScheduler` now logs bounded replacement evidence after successful replacement repair:
+
+- `InventoryLineReplacement/v1`
+- `InventoryLineReplacementStateNextFrame/v1`
+- `InventoryLineItemProbe/v1`
+
+This keeps the evidence path tied to actual `replaced > 0` success instead of logging every attempted repair. The output is capped to prevent first-open inventory spam from becoming unbounded.
+
+After rebasing onto `origin/main`, those evidence logs are emitted only when `RuntimeDiagnostics.VerboseProbesEnabled` is true, preserving the dev-build probe gating introduced for runtime diagnostics.
+
+## Final Runtime Evidence
+
+A follow-up smoke after deploying this branch confirmed the intended replacement path:
+
+- Runtime log mtime: `2026-05-09 00:46:09 JST`
+- `InventoryLineReplacement/v1`: 17 rows
+- `InventoryLineReplacementStateNextFrame/v1`: 16 rows
+- `InventoryLineItemProbe/v1`: 15 rows
+- `InventoryLineReplacementFailure/v1`: 0 rows
+- `MissingMethodException`: 0 rows
+- `Vector2.get_x` / `Vector2.get_y`: 0 rows
+- `MODWARN`: 0 rows
+- `QudJP: .*failed`: 0 rows
+
+Representative evidence shows the original inventory `TextShell/Text` disabled with `chars=0 pageCount=0` while the sibling `QudJPReplacementText` is active, enabled, and rendering `chars>0 pageCount=1`.
+
+## Verification Gate
+
+Static/test verification can prove the contract and target methods. Before release, repeat a fresh runtime smoke after any further change that touches inventory replacement rendering:
+
+1. Build and deploy the branch DLL.
+2. Launch Caves of Qud and open inventory.
+3. Confirm item names are visible.
+4. Confirm the fresh `Player.log` has no QudJP exceptions, `MissingMethodException`, `Vector2.get_x`, or `Vector2.get_y`.
+5. Confirm the fresh `Player.log` includes at least one successful `InventoryLineReplacement/v1` row and the corresponding `InventoryLineReplacementStateNextFrame/v1` or `InventoryLineItemProbe/v1` evidence.


### PR DESCRIPTION
## Summary

- Adopt the inventory replacement-rendering path as the supported display path for #574, while explicitly documenting that this is not an original TMP root-cause fix.
- Treat inventory original TMP `charCount=0/pageCount=0` as a replacement-render candidate and log bounded, dev-gated evidence after successful repair.
- Keep the active replacement `LateUpdate` guard passive by removing the mesh rebuild from `HasActiveReplacementForCurrentItemText`.
- Add target-resolution/source-shape regression tests and a runtime evidence report for #574.

Closes #574

## Decision

For now, QudJP will treat a successful `QudJPReplacementText` render as the intended inventory item-name display path when the original `TextShell/Text` route keeps non-empty text but produces zero TMP geometry.

This is a provisional adoption of the replacement-rendering path, not a claim that the original TMP route has been root-caused. If future runtime evidence shows replacement-rendering performance regressions, visual regressions, or inventory-line instability, we should reopen the original TMP root-cause investigation instead of layering on more replacement-path workarounds.

## Runtime Evidence

- Fresh `Player.log` after deploy showed `InventoryLineReplacement/v1`, `InventoryLineReplacementStateNextFrame/v1`, and `InventoryLineItemProbe/v1`.
- Original `TextShell/Text` remained `chars=0/pageCount=0`, while `QudJPReplacementText` rendered `chars>0/pageCount=1`.
- No `MissingMethodException`, `Vector2.get_x/get_y`, `MODWARN`, QudJP failure rows, or replacement failures.

## Review

- Reviewed by a separate Codex instance and approved.
- Follow-up simplify pass kept only the bounded cleanup: passive replacement guard assertion, clearer repair-probe logging name, line wrapping, and stronger source-shape tests.

## Verification

- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L1`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2G`
- `python3 scripts/check_markdown_reports.py --base-ref origin/main --head-ref HEAD`
- `git diff --check`
