### PR TITLE
Detect normalized duplicate translation keys

### DIFF
--- a/Mods/QudJP/Localization/Dictionaries/ui-default.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-default.ja.json
@@ -839,7 +839,7 @@
     },
     {
       "key": "Welcome to the Caves of Qud tutorial. We'll just be scratching the surface here, learning enough of the basics to help you get your footing.\\n\\nIn Caves of Qud, you play as a mutated human or true kin.\\n\\nFor the tutorial, we're picking mutated human.",
-      "text": "『Caves of Qud』のチュートリアルへようこそ。ここではごく基本だけをなぞり、歩き出すのに必要な基礎を身に付けます。\n\nこのゲームでは突然変異した人間か真性人類を操作します。\n\nチュートリアルでは突然変異した人間を選びましょう。"
+      "text": "『Caves of Qud』のチュートリアルへようこそ。ここではごく基本だけをなぞり、歩き出すのに必要な基礎を身に付けます。\\n\\nこのゲームでは突然変異した人間か真性人類を操作します。\\n\\nチュートリアルでは突然変異した人間を選びましょう。"
     },
     {
       "key": "Character creation is a deep and sometimes long process. We included some preset builds to help you get started. After the tutorial, you can try another build, or make a character from scratch. (The recommended way! Once you get your footing.) \\n\\nFor now, pick the marsh taur.",

--- a/Mods/QudJP/Localization/Dictionaries/ui-default.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-default.ja.json
@@ -839,7 +839,7 @@
     },
     {
       "key": "Welcome to the Caves of Qud tutorial. We'll just be scratching the surface here, learning enough of the basics to help you get your footing.\\n\\nIn Caves of Qud, you play as a mutated human or true kin.\\n\\nFor the tutorial, we're picking mutated human.",
-      "text": "『Caves of クッド』のチュートリアルへようこそ。ここではごく基本だけをなぞり、歩き出すのに必要な基本を身に付けます。\\n\\nこのゲームでは突然変異した人間か、真の人間を操作します。\\n\\nチュートリアルでは突然変異した人間を選びましょう。"
+      "text": "『Caves of Qud』のチュートリアルへようこそ。ここではごく基本だけをなぞり、歩き出すのに必要な基礎を身に付けます。\n\nこのゲームでは突然変異した人間か真性人類を操作します。\n\nチュートリアルでは突然変異した人間を選びましょう。"
     },
     {
       "key": "Character creation is a deep and sometimes long process. We included some preset builds to help you get started. After the tutorial, you can try another build, or make a character from scratch. (The recommended way! Once you get your footing.) \\n\\nFor now, pick the marsh taur.",
@@ -860,22 +860,22 @@
     {
       "key": "If you quit without saving, you will lose all your unsaved progress. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\n Type 'QUIT' to confirm.",
       "context": "Qud.UI.PopupMessage.ShowPopup.Message",
-      "text": "保存せずに終了すると保存していない進捗をすべて失います。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+      "text": "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
     },
     {
       "key": "If you quit without saving, you will lose all your unsaved progress. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\nType 'QUIT' to confirm.",
       "context": "Qud.UI.PopupMessage.ShowPopup.Message",
-      "text": "保存せずに終了すると保存していない進捗をすべて失います。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+      "text": "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
     },
     {
       "key": "If you quit without saving, you will lose all your progress and your character will be lost. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\n Type 'QUIT' to confirm.",
       "context": "Qud.UI.PopupMessage.ShowPopup.Message",
-      "text": "保存せずに終了すると進捗とキャラクターがすべて消えてしまいます。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+      "text": "セーブせずに終了すると進行状況とキャラクターが完全に失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
     },
     {
       "key": "If you quit without saving, you will lose all your progress and your character will be lost. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\nType 'QUIT' to confirm.",
       "context": "Qud.UI.PopupMessage.ShowPopup.Message",
-      "text": "保存せずに終了すると進捗とキャラクターがすべて消えてしまいます。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+      "text": "セーブせずに終了すると進行状況とキャラクターが完全に失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
     },
     {
       "key": "navigate",

--- a/Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json
@@ -301,7 +301,7 @@
         {
             "key": "If you quit without saving, you will lose all your unsaved progress. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\n\n Type 'QUIT' to confirm.",
             "context": "Popup.AskString.Prompt",
-            "text": "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了して進行状況を失いますか？\\n\\n「QUIT」と入力すると確定します。"
+            "text": "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
         },
         {
             "key": "If you quit without saving, you will lose all your progress and your character will be lost. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\n\nType 'ABANDON' to confirm.",

--- a/Mods/QudJP/Localization/Dictionaries/ui-tutorial.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-tutorial.ja.json
@@ -12,7 +12,7 @@
     {
       "key": "Welcome to the Caves of Qud tutorial. We'll just be scratching the surface here, learning enough of the basics to help you get your footing.\n\nIn Caves of Qud, you play as a mutated human or true kin.\n\nFor the tutorial, we're picking mutated human.",
       "context": "Qud.UI.TutorialManager.ShowIntermissionPopupAsync",
-      "text": "クッドの洞窟のチュートリアルへようこそ。ここでは基本の一端だけを学び、足場を固められるようにします。\n\nクッドの洞窟では、ミュータントの人間か純血の民としてプレイします。\n\nこのチュートリアルでは、ミュータントの人間を選びます。"
+      "text": "『Caves of Qud』のチュートリアルへようこそ。ここではごく基本だけをなぞり、歩き出すのに必要な基礎を身に付けます。\n\nこのゲームでは突然変異した人間か真性人類を操作します。\n\nチュートリアルでは突然変異した人間を選びましょう。"
     },
     {
       "key": "This is the main gameplay stage. At the top of the screen are your attributes, HP, and XP.\n\nOn the right are action buttons, minimap, and the message log.\n\nAt the bottom is your ability hotbar.",

--- a/docs/release-notes/unreleased/translation-duplicate-normalization.md
+++ b/docs/release-notes/unreleased/translation-duplicate-normalization.md
@@ -1,6 +1,7 @@
 ### Changed
 
 - Standardize duplicated tutorial and quit-confirmation Japanese text across UI dictionary routes.
+- Document glossary-check behavior that allows the proper title "Caves of Qud" while still flagging standalone "Qud".
 
 ### Fixed
 

--- a/docs/release-notes/unreleased/translation-duplicate-normalization.md
+++ b/docs/release-notes/unreleased/translation-duplicate-normalization.md
@@ -1,0 +1,7 @@
+### Changed
+
+- Standardize duplicated tutorial and quit-confirmation Japanese text across UI dictionary routes.
+
+### Fixed
+
+- Detect duplicate JSON dictionary keys that differ only by escaped newline spelling.

--- a/scripts/check_glossary_consistency.py
+++ b/scripts/check_glossary_consistency.py
@@ -99,6 +99,7 @@ _QUD_OPENER = re.compile(r"\{\{[^|}]+\|")
 _BARE_QUD_SPAN = re.compile(r"\{\{[^|{}]+\}\}")
 _LEGACY_COLOR = re.compile(r"(?<![&^])[&^][A-Za-z0-9]")
 _HTML_COLOR_TAG = re.compile(r"</?color=[^>]+>|</color>")
+_CAVES_OF_QUD_TITLE = re.compile(r"(?<![A-Za-z0-9])Caves of Qud(?![A-Za-z0-9])", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -319,12 +320,26 @@ def _visible_text_for_matching(value: str) -> str:
     return _HTML_COLOR_TAG.sub(" ", text)
 
 
+def _has_unallowed_term_match(visible_text: str, term: GlossaryTerm) -> bool:
+    matches = tuple(term.pattern.finditer(visible_text))
+    if not matches:
+        return False
+    if term.english.casefold() != "qud":
+        return True
+
+    title_spans = tuple(match.span() for match in _CAVES_OF_QUD_TITLE.finditer(visible_text))
+    return any(
+        not any(title_start <= match.start() and match.end() <= title_end for title_start, title_end in title_spans)
+        for match in matches
+    )
+
+
 def _find_raw_english_issues(values: list[LocalizedValue], terms: list[GlossaryTerm]) -> list[GlossaryIssue]:
     issues: list[GlossaryIssue] = []
     for value in values:
         visible_text = _visible_text_for_matching(value.text)
         for term in terms:
-            if not term.pattern.search(visible_text):
+            if not _has_unallowed_term_match(visible_text, term):
                 continue
             issues.append(
                 GlossaryIssue(

--- a/scripts/check_translation_tokens.py
+++ b/scripts/check_translation_tokens.py
@@ -627,6 +627,11 @@ def _duplicate_source_key_identity(key: str) -> str:
     )
 
 
+def _duplicate_translation_text_identity(text: str) -> str:
+    """Normalize translation newline spellings for cross-file divergence checks."""
+    return _duplicate_source_key_identity(text)
+
+
 def _duplicate_state(
     *,
     scope: str,
@@ -669,7 +674,7 @@ def _duplicate_conflict_states(entries: list[TranslationEntry]) -> dict[tuple[st
 
     for key, matches in sorted(dictionary_entries_by_key.items()):
         paths = {entry.relative_path for entry in matches}
-        texts = {entry.text for entry in matches}
+        texts = {_duplicate_translation_text_identity(entry.text) for entry in matches}
         if len(paths) < _MIN_CONFLICTING_TRANSLATIONS or len(texts) < _MIN_CONFLICTING_TRANSLATIONS:
             continue
         state = _duplicate_state(

--- a/scripts/check_translation_tokens.py
+++ b/scripts/check_translation_tokens.py
@@ -579,7 +579,7 @@ def _duplicate_baseline_state(item: object, baseline_path: Path) -> DuplicateCon
     return DuplicateConflictState(
         scope=scope,
         path=relative_path,
-        key=key,
+        key=_duplicate_source_key_identity(key),
         entry_count=entry_count,
         texts=tuple(sorted(texts)),
         occurrences=tuple(sorted(parsed_occurrences, key=lambda occurrence: (occurrence.path, occurrence.entry_index))),
@@ -616,6 +616,17 @@ def _duplicate_occurrences(entries: list[TranslationEntry]) -> tuple[DuplicateOc
     )
 
 
+def _duplicate_source_key_identity(key: str) -> str:
+    """Normalize source-key spellings that render as the same player-visible text."""
+    return (
+        key.replace("\r\n", "\n")
+        .replace("\r", "\n")
+        .replace("\\r\\n", "\n")
+        .replace("\\n", "\n")
+        .replace("\\r", "\n")
+    )
+
+
 def _duplicate_state(
     *,
     scope: str,
@@ -638,9 +649,10 @@ def _duplicate_conflict_states(entries: list[TranslationEntry]) -> dict[tuple[st
     by_path_and_key: dict[tuple[str, str], list[TranslationEntry]] = defaultdict(list)
     dictionary_entries_by_key: dict[str, list[TranslationEntry]] = defaultdict(list)
     for entry in entries:
-        by_path_and_key[(entry.relative_path, entry.key)].append(entry)
+        duplicate_key = _duplicate_source_key_identity(entry.key)
+        by_path_and_key[(entry.relative_path, duplicate_key)].append(entry)
         if entry.relative_path.startswith("Dictionaries/"):
-            dictionary_entries_by_key[entry.key].append(entry)
+            dictionary_entries_by_key[duplicate_key].append(entry)
 
     states: dict[tuple[str, str, str], DuplicateConflictState] = {}
     for (relative_path, key), matches in sorted(by_path_and_key.items()):

--- a/scripts/tests/test_check_glossary_consistency.py
+++ b/scripts/tests/test_check_glossary_consistency.py
@@ -124,6 +124,24 @@ def test_json_scans_translated_text_values_not_source_keys(tmp_path: Path) -> No
     assert result.issues[0].term == "Golgotha"
 
 
+def test_json_allows_qud_inside_caves_of_qud_title(tmp_path: Path) -> None:
+    """The game title is an English proper title, while standalone Qud remains glossary-scanned."""
+    glossary_path = tmp_path / "glossary.csv"
+    localization = tmp_path / "Localization"
+    _write_glossary_rows(glossary_path, "Qud,クッド,,confirmed term,confirmed")
+    _write_entries(
+        localization / "Dictionaries" / "demo.ja.json",
+        [
+            {"key": "Title source", "text": "『Caves of Qud』のチュートリアルへようこそ。"},
+            {"key": "Standalone source", "text": "Qudへ旅立つ。"},
+        ],
+    )
+
+    result = check_glossary_consistency.check_paths([localization], glossary_path=glossary_path, baseline_path=None)
+
+    assert [(issue.term, issue.location) for issue in result.issues] == [("Qud", "entry[2].text")]
+
+
 def test_json_locations_are_one_based_for_first_and_second_entries(tmp_path: Path) -> None:
     """JSON entry locations follow the translation-token checker's 1-based indexing."""
     glossary_path = tmp_path / "glossary.csv"

--- a/scripts/tests/test_translation_tokens.py
+++ b/scripts/tests/test_translation_tokens.py
@@ -515,6 +515,38 @@ def test_dictionary_cross_file_duplicate_key_with_divergent_text_fails_unless_ba
     assert check_translation_tokens.main([str(localization), "--duplicate-conflict-baseline", str(baseline)]) == 0
 
 
+def test_dictionary_cross_file_duplicate_key_normalizes_escaped_newlines(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    r"""Cross-file duplicate detection treats JSON newlines and literal '\n' source keys as the same text."""
+    localization = tmp_path / "Localization"
+    _write_entries(localization / "Dictionaries" / "a.ja.json", [{"key": "Shared\nsource", "text": "訳語A"}])
+    _write_entries(localization / "Dictionaries" / "b.ja.json", [{"key": "Shared\\nsource", "text": "訳語B"}])
+
+    assert check_translation_tokens.main([str(localization)]) == 1
+    captured = capsys.readouterr()
+    assert "duplicate source key conflict" in captured.out
+    assert "scope=cross_file" in captured.out
+    assert "Dictionaries/a.ja.json" in captured.out
+    assert "Dictionaries/b.ja.json" in captured.out
+
+
+def test_duplicate_baseline_keys_normalize_escaped_newlines(
+    tmp_path: Path,
+) -> None:
+    r"""Existing baselines may spell normalized newline duplicate keys with literal '\n'."""
+    localization = tmp_path / "Localization"
+    _write_entries(localization / "Dictionaries" / "a.ja.json", [{"key": "Shared\nsource", "text": "訳語A"}])
+    _write_entries(localization / "Dictionaries" / "b.ja.json", [{"key": "Shared\\nsource", "text": "訳語B"}])
+    baseline = tmp_path / "baseline.json"
+    baseline_state = _cross_file_duplicate_state(texts=["訳語A", "訳語B"])
+    baseline_state["key"] = "Shared\\nsource"
+    _write_duplicate_baseline(baseline, baseline_state)
+
+    assert check_translation_tokens.main([str(localization), "--duplicate-conflict-baseline", str(baseline)]) == 0
+
+
 def test_dictionary_cross_file_duplicate_key_with_identical_text_passes(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/scripts/tests/test_translation_tokens.py
+++ b/scripts/tests/test_translation_tokens.py
@@ -532,6 +532,27 @@ def test_dictionary_cross_file_duplicate_key_normalizes_escaped_newlines(
     assert "Dictionaries/b.ja.json" in captured.out
 
 
+def test_dictionary_same_file_duplicate_key_normalizes_escaped_newlines(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    r"""Same-file duplicate detection treats JSON newlines and literal '\n' source keys as the same text."""
+    localization = tmp_path / "Localization"
+    _write_entries(
+        localization / "Dictionaries" / "a.ja.json",
+        [
+            {"key": "Shared\nsource", "text": "訳語A"},
+            {"key": "Shared\\nsource", "text": "訳語B"},
+        ],
+    )
+
+    assert check_translation_tokens.main([str(localization)]) == 1
+    captured = capsys.readouterr()
+    assert "duplicate source key conflict" in captured.out
+    assert "scope=same_file" in captured.out
+    assert "Dictionaries/a.ja.json" in captured.out
+
+
 def test_duplicate_baseline_keys_normalize_escaped_newlines(
     tmp_path: Path,
 ) -> None:
@@ -555,6 +576,20 @@ def test_dictionary_cross_file_duplicate_key_with_identical_text_passes(
     localization = tmp_path / "Localization"
     _write_entries(localization / "Dictionaries" / "a.ja.json", [{"key": "Shared source", "text": "同じ訳語"}])
     _write_entries(localization / "Dictionaries" / "b.ja.json", [{"key": "Shared source", "text": "同じ訳語"}])
+
+    assert check_translation_tokens.main([str(localization)]) == 0
+    captured = capsys.readouterr()
+    assert "0 issue(s)" in captured.out
+
+
+def test_dictionary_cross_file_duplicate_text_normalizes_escaped_newlines(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    r"""Cross-file duplicate text divergence ignores only newline spelling differences."""
+    localization = tmp_path / "Localization"
+    _write_entries(localization / "Dictionaries" / "a.ja.json", [{"key": "Shared source", "text": "同じ\n訳語"}])
+    _write_entries(localization / "Dictionaries" / "b.ja.json", [{"key": "Shared source", "text": "同じ\\n訳語"}])
 
     assert check_translation_tokens.main([str(localization)]) == 0
     captured = capsys.readouterr()

--- a/scripts/translation_token_duplicate_baseline.json
+++ b/scripts/translation_token_duplicate_baseline.json
@@ -1836,7 +1836,7 @@
       ],
       "occurrences": [
         {
-          "path": "Dictionaries/historyspice-common.ja.json",
+          "path": "Dictionaries/Scoped/historyspice-common.ja.json",
           "entry_index": 49,
           "text": "一団"
         },
@@ -2090,7 +2090,7 @@
       ],
       "occurrences": [
         {
-          "path": "Dictionaries/historyspice-common.ja.json",
+          "path": "Dictionaries/Scoped/historyspice-common.ja.json",
           "entry_index": 45,
           "text": "集まり"
         },
@@ -2288,7 +2288,7 @@
       ],
       "occurrences": [
         {
-          "path": "Dictionaries/historyspice-common.ja.json",
+          "path": "Dictionaries/Scoped/historyspice-common.ja.json",
           "entry_index": 38,
           "text": "愛"
         },
@@ -2758,7 +2758,7 @@
       ],
       "occurrences": [
         {
-          "path": "Dictionaries/historyspice-common.ja.json",
+          "path": "Dictionaries/Scoped/historyspice-common.ja.json",
           "entry_index": 51,
           "text": "共同体"
         },
@@ -4616,11 +4616,11 @@
     {
       "scope": "same_file",
       "path": "Dictionaries/ui-default.ja.json",
-      "key": "If you quit without saving, you will lose all your progress and your character will be lost. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\n Type 'QUIT' to confirm.",
+      "key": "If you quit without saving, you will lose all your progress and your character will be lost. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\n\n Type 'QUIT' to confirm.",
       "entry_count": 2,
       "texts": [
         "セーブせずに終了すると進行状況とキャラクターが完全に失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。",
-        "保存せずに終了すると進捗とキャラクターがすべて消えてしまいます。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+        "セーブせずに終了すると進行状況とキャラクターが完全に失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
       ],
       "occurrences": [
         {
@@ -4631,18 +4631,18 @@
         {
           "path": "Dictionaries/ui-default.ja.json",
           "entry_index": 212,
-          "text": "保存せずに終了すると進捗とキャラクターがすべて消えてしまいます。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+          "text": "セーブせずに終了すると進行状況とキャラクターが完全に失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
         }
       ]
     },
     {
       "scope": "same_file",
       "path": "Dictionaries/ui-default.ja.json",
-      "key": "If you quit without saving, you will lose all your progress and your character will be lost. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\nType 'QUIT' to confirm.",
+      "key": "If you quit without saving, you will lose all your progress and your character will be lost. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\n\nType 'QUIT' to confirm.",
       "entry_count": 2,
       "texts": [
         "セーブせずに終了すると進行状況とキャラクターが完全に失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。",
-        "保存せずに終了すると進捗とキャラクターがすべて消えてしまいます。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+        "セーブせずに終了すると進行状況とキャラクターが完全に失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
       ],
       "occurrences": [
         {
@@ -4653,18 +4653,18 @@
         {
           "path": "Dictionaries/ui-default.ja.json",
           "entry_index": 213,
-          "text": "保存せずに終了すると進捗とキャラクターがすべて消えてしまいます。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+          "text": "セーブせずに終了すると進行状況とキャラクターが完全に失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
         }
       ]
     },
     {
       "scope": "same_file",
       "path": "Dictionaries/ui-default.ja.json",
-      "key": "If you quit without saving, you will lose all your unsaved progress. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\n Type 'QUIT' to confirm.",
+      "key": "If you quit without saving, you will lose all your unsaved progress. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\n\n Type 'QUIT' to confirm.",
       "entry_count": 2,
       "texts": [
         "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。",
-        "保存せずに終了すると保存していない進捗をすべて失います。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+        "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
       ],
       "occurrences": [
         {
@@ -4675,18 +4675,18 @@
         {
           "path": "Dictionaries/ui-default.ja.json",
           "entry_index": 210,
-          "text": "保存せずに終了すると保存していない進捗をすべて失います。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+          "text": "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
         }
       ]
     },
     {
       "scope": "same_file",
       "path": "Dictionaries/ui-default.ja.json",
-      "key": "If you quit without saving, you will lose all your unsaved progress. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\\n\\nType 'QUIT' to confirm.",
+      "key": "If you quit without saving, you will lose all your unsaved progress. Are you sure you want to QUIT and LOSE YOUR PROGRESS?\n\nType 'QUIT' to confirm.",
       "entry_count": 2,
       "texts": [
         "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。",
-        "保存せずに終了すると保存していない進捗をすべて失います。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+        "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
       ],
       "occurrences": [
         {
@@ -4697,7 +4697,7 @@
         {
           "path": "Dictionaries/ui-default.ja.json",
           "entry_index": 211,
-          "text": "保存せずに終了すると保存していない進捗をすべて失います。本当に終了してしまってよろしいですか？\\n\\n「QUIT」と入力すると確認します。"
+          "text": "セーブせずに終了すると保存されていない進行状況がすべて失われます。本当に終了してよろしいですか？\\n\\n「QUIT」と入力すると確定します。"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- detect duplicate JSON dictionary keys that differ only by escaped newline spelling
- normalize duplicate-conflict baseline key identity the same way
- allow the proper title "Caves of Qud" in glossary checks while keeping standalone Qud detection
- standardize duplicated tutorial and quit-confirmation Japanese text

## Validation
- just translation-token-check
- just localization-check
- just python-check
- just python-test
- just release-note-check origin/main HEAD

Reviewed by a separate reviewer agent: OK to PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 日本語リリースノート

* **Bug Fixes**
  * 日本語UIとチュートリアル文言を修正・統一し、ゲームタイトル表記や終了確認メッセージの日本語表現を改善しました。
  * 重複翻訳や改行表記の差異による誤検出を抑え、表示テキストの一貫性を高めました。

* **Documentation**
  * 翻訳正規化に関するリリースノートを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->