### PR TITLE
[codex] Clarify runtime evidence closeout decisions

### DIFF
--- a/docs/workflows/runtime-evidence.md
+++ b/docs/workflows/runtime-evidence.md
@@ -48,6 +48,19 @@ matches the build under review. If the latest log predates the sync or lacks a
 matching marker, summarize it as stale context and do not use it as proof that
 the current worktree regressed or succeeded.
 
+For issue closeout PRs that rely on runtime evidence, state the closeout
+decision explicitly in both the PR body and the runtime report:
+
+- identify whether the PR is a root-cause fix, a supported fallback path, or an
+  observability-only mitigation;
+- if the issue acceptance criteria allowed multiple outcomes, name the chosen
+  outcome before using `Closes #...`;
+- include the final smoke log time or matching build marker, the success
+  marker counts, and the relevant failure marker counts;
+- if a supported fallback path is adopted provisionally, document the runtime
+  signals that should reopen root-cause investigation, such as performance
+  regressions, visual regressions, or instability in the affected UI route.
+
 ## Phase F boundary
 
 Phase F means runtime route-proof evidence. It is distinct from static coverage,

--- a/docs/workflows/runtime-evidence.md
+++ b/docs/workflows/runtime-evidence.md
@@ -58,8 +58,14 @@ the current worktree regressed or succeeded.
 For issue closeout PRs that rely on runtime evidence, state the closeout
 decision explicitly in both the PR body and the runtime report:
 
-- identify whether the PR is a root-cause fix, a supported fallback path, or an
-  observability-only mitigation;
+- identify the decision type:
+  - root-cause fix: fixes the underlying failure so the original route works
+    normally, such as correcting a broken API call;
+  - supported fallback path: adopts a controlled alternate route when the
+    original route is unreliable, such as rendering through a replacement UI
+    child;
+  - observability-only mitigation: adds evidence or monitoring without claiming
+    user-visible behavior is fixed, such as bounded diagnostic log markers;
 - if the issue acceptance criteria allowed multiple outcomes, name the chosen
   outcome before using `Closes #...`;
 - include the final smoke log time or matching build marker, the success


### PR DESCRIPTION
## Summary

- Add runtime-evidence closeout guidance for PRs that use runtime logs to close issues.
- Require PR bodies and runtime reports to state whether a change is a root-cause fix, supported fallback path, or observability-only mitigation.
- Require final smoke log/build marker details, success/failure marker counts, and provisional fallback reopen conditions before using `Closes #...`.

## Verification

- `python3 scripts/check_markdown_reports.py --base-ref origin/main --head-ref HEAD`
- `git diff --check`

Note: `bash scripts/check-dotfiles.sh` is not present in this repository worktree, so it could not be run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント

* ランタイムエビデンスのクローズアウト記述ガイダンスを追加しました。決定タイプの明示的な記載、エビデンス詳細の具体化、再オープントリガーのドキュメント化に関する新しいセクションが追加されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->