### PR TITLE
[codex] Gate Workshop staging on release DLL markers

### DIFF
--- a/scripts/build_workshop_upload.py
+++ b/scripts/build_workshop_upload.py
@@ -11,6 +11,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+try:
+    from scripts.verify_release_dll import verify_release_dll
+except ModuleNotFoundError:
+    from verify_release_dll import verify_release_dll
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -191,6 +196,14 @@ def _validate_release_zip_members(zip_path: Path, members: list[str]) -> None:
         raise ValueError(msg)
 
 
+def _validate_release_dll_markers(release_zip: Path) -> None:
+    """Reject Workshop staging inputs whose DLL is not a release DLL."""
+    marker_findings = verify_release_dll(release_zip)
+    if marker_findings:
+        msg = "release DLL marker validation failed: " + ", ".join(marker_findings)
+        raise ValueError(msg)
+
+
 def create_workshop_staging(release_zip: Path, staging_root: Path) -> tuple[Path, Path]:
     """Extract a release ZIP into the generated Workshop staging directory."""
     resolved_release_zip = release_zip.resolve()
@@ -207,6 +220,7 @@ def create_workshop_staging(release_zip: Path, staging_root: Path) -> tuple[Path
     with zipfile.ZipFile(resolved_release_zip) as zf:
         members = zf.namelist()
         _validate_release_zip_members(resolved_release_zip, members)
+        _validate_release_dll_markers(resolved_release_zip)
         for info in zf.infolist():
             target = (staging_root / info.filename).resolve()
             if not target.is_relative_to(staging_root):

--- a/scripts/build_workshop_upload.py
+++ b/scripts/build_workshop_upload.py
@@ -200,7 +200,7 @@ def _validate_release_dll_markers(release_zip: Path) -> None:
     """Reject Workshop staging inputs whose DLL is not a release DLL."""
     marker_findings = verify_release_dll(release_zip)
     if marker_findings:
-        msg = "release DLL marker validation failed: " + ", ".join(marker_findings)
+        msg = f"{release_zip}: release DLL marker validation failed: " + ", ".join(marker_findings)
         raise ValueError(msg)
 
 

--- a/scripts/tests/test_build_workshop_upload.py
+++ b/scripts/tests/test_build_workshop_upload.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import zipfile
 from pathlib import Path
 
@@ -239,7 +240,10 @@ def test_create_workshop_staging_rejects_release_zip_with_dev_probe_markers(tmp_
         dll_payload=_VALID_RELEASE_DLL_MARKER_PAYLOAD + b"\0[QudJP] SinkObserve/v1:",
     )
 
-    with pytest.raises(ValueError, match=r"forbidden dev marker: \[QudJP\] SinkObserve/v1:"):
+    with pytest.raises(
+        ValueError,
+        match=rf"{re.escape(str(release_zip))}.*forbidden dev marker: \[QudJP\] SinkObserve/v1:",
+    ):
         create_workshop_staging(release_zip, tmp_path / "workshop")
 
 
@@ -248,7 +252,7 @@ def test_create_workshop_staging_rejects_release_zip_missing_required_dll_marker
     release_zip = tmp_path / "dist" / "QudJP-v0.2.0.zip"
     _write_release_zip(release_zip, dll_payload=b"dll")
 
-    with pytest.raises(ValueError, match=r"Unity\.TextMeshPro"):
+    with pytest.raises(ValueError, match=rf"{re.escape(str(release_zip))}.*Unity\.TextMeshPro"):
         create_workshop_staging(release_zip, tmp_path / "workshop")
 
 

--- a/scripts/tests/test_build_workshop_upload.py
+++ b/scripts/tests/test_build_workshop_upload.py
@@ -19,8 +19,24 @@ from scripts.build_workshop_upload import (
     vdf_escape,
 )
 
+_VALID_RELEASE_DLL_MARKER_PAYLOAD = b"\0".join(
+    [
+        b"Unity.TextMeshPro",
+        b"TextMeshProUguiFontPatch",
+        b"TmpInputFieldFontPatch",
+        b"InventoryLineFontFixer",
+        b"DelayedInventoryLineRepairScheduler",
+        b"ShouldPreserveActiveReplacementForTests",
+    ],
+)
 
-def _write_release_zip(path: Path, *, version: str = "0.2.0") -> None:
+
+def _write_release_zip(
+    path: Path,
+    *,
+    version: str = "0.2.0",
+    dll_payload: bytes = _VALID_RELEASE_DLL_MARKER_PAYLOAD,
+) -> None:
     """Create a minimal QudJP release ZIP fixture."""
     path.parent.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
@@ -35,7 +51,7 @@ def _write_release_zip(path: Path, *, version: str = "0.2.0") -> None:
         launcher_info = zipfile.ZipInfo("QudJP/Launch CavesOfQud (Rosetta).command")
         launcher_info.external_attr = 0o100755 << 16
         zf.writestr(launcher_info, "#!/usr/bin/env bash\n")
-        zf.writestr("QudJP/Assemblies/QudJP.dll", b"dll")
+        zf.writestr("QudJP/Assemblies/QudJP.dll", dll_payload)
         zf.writestr("QudJP/Localization/ui.json", "{}")
         zf.writestr("QudJP/Fonts/OFL.txt", "SIL Open Font License")
 
@@ -147,6 +163,17 @@ def test_create_workshop_staging_extracts_qudjp_root(tmp_path: Path) -> None:
     assert preview_file == content_folder / "preview.png"
 
 
+def test_create_workshop_staging_accepts_zip_content_without_zip_suffix(tmp_path: Path) -> None:
+    """Workshop staging validates ZIP content without requiring a .zip file suffix."""
+    release_zip = tmp_path / "dist" / "QudJP-v0.2.0"
+    _write_release_zip(release_zip)
+    staging_root = tmp_path / "dist" / "workshop"
+
+    content_folder, _preview_file = create_workshop_staging(release_zip, staging_root)
+
+    assert (content_folder / "Assemblies" / "QudJP.dll").is_file()
+
+
 def test_create_workshop_staging_removes_previous_generated_contents(tmp_path: Path) -> None:
     """Regenerating staging removes stale files from previous releases."""
     release_zip = tmp_path / "dist" / "QudJP-v0.2.0.zip"
@@ -201,6 +228,27 @@ def test_create_workshop_staging_rejects_zip_without_localization_or_fonts(tmp_p
         zf.writestr("QudJP/Assemblies/QudJP.dll", b"dll")
 
     with pytest.raises(ValueError, match="QudJP/Fonts/"):
+        create_workshop_staging(release_zip, tmp_path / "workshop")
+
+
+def test_create_workshop_staging_rejects_release_zip_with_dev_probe_markers(tmp_path: Path) -> None:
+    """Workshop staging rejects release ZIPs whose DLL still contains dev-only probes."""
+    release_zip = tmp_path / "dist" / "QudJP-v0.2.0.zip"
+    _write_release_zip(
+        release_zip,
+        dll_payload=_VALID_RELEASE_DLL_MARKER_PAYLOAD + b"\0[QudJP] SinkObserve/v1:",
+    )
+
+    with pytest.raises(ValueError, match=r"forbidden dev marker: \[QudJP\] SinkObserve/v1:"):
+        create_workshop_staging(release_zip, tmp_path / "workshop")
+
+
+def test_create_workshop_staging_rejects_release_zip_missing_required_dll_markers(tmp_path: Path) -> None:
+    """Workshop staging rejects ZIPs whose DLL is missing required release markers."""
+    release_zip = tmp_path / "dist" / "QudJP-v0.2.0.zip"
+    _write_release_zip(release_zip, dll_payload=b"dll")
+
+    with pytest.raises(ValueError, match=r"Unity\.TextMeshPro"):
         create_workshop_staging(release_zip, tmp_path / "workshop")
 
 

--- a/scripts/tests/test_verify_release_dll.py
+++ b/scripts/tests/test_verify_release_dll.py
@@ -154,3 +154,15 @@ def test_verify_release_dll_reads_release_zip(tmp_path: Path) -> None:
         )
 
     assert verify_release_dll(release_zip) == []
+
+
+def test_verify_release_dll_reads_zip_content_without_zip_suffix(tmp_path: Path) -> None:
+    """Detect ZIP archives by content so callers are not tied to file suffixes."""
+    release_zip = tmp_path / "QudJP-v0.0.0"
+    with zipfile.ZipFile(release_zip, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(
+            "QudJP/Assemblies/QudJP.dll",
+            _REQUIRED_MARKER_PAYLOAD,
+        )
+
+    assert verify_release_dll(release_zip) == []

--- a/scripts/verify_release_dll.py
+++ b/scripts/verify_release_dll.py
@@ -37,7 +37,7 @@ _FORBIDDEN_VERBOSE_PROBE_FRAGMENTS = (
 
 
 def _read_dll(path: Path) -> bytes:
-    if path.suffix.lower() == ".zip":
+    if zipfile.is_zipfile(path):
         with zipfile.ZipFile(path) as archive:
             try:
                 return archive.read("QudJP/Assemblies/QudJP.dll")


### PR DESCRIPTION
## Summary

- Gate Workshop staging on the same release DLL marker validation used by release ZIP checks.
- Teach release DLL verification to detect ZIP archives by content, not only by `.zip` suffix.
- Add tests for dev-only marker rejection, missing required marker rejection, and suffixless ZIP archives.

## Validation

- `uv run pytest scripts/tests/test_build_release.py scripts/tests/test_build_workshop_upload.py scripts/tests/test_verify_release_dll.py scripts/tests/test_sync_mod.py -q`
- `ruff check scripts/build_workshop_upload.py scripts/tests/test_build_workshop_upload.py scripts/verify_release_dll.py scripts/tests/test_verify_release_dll.py`
- `git diff --check`
- Release smoke: `uv run python scripts/build_release.py`, then `uv run python scripts/build_workshop_upload.py --release-zip dist/QudJP-v0.2.46.zip --changenote-file /tmp/qudjp-workshop-release-dll-gate-changenote.txt`, then `uv run python scripts/verify_release_dll.py dist/workshop/QudJP/Assemblies/QudJP.dll`

## Review

- Two independent implementation reviews approved the initial change.
- Simplify review found a suffixless ZIP regression risk; fixed and re-reviewed.
- Final independent review approved the updated diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ワークショップのステージング中にDLLリリースマーカー検証が追加され、検証に失敗したアップロードはステージングが中止されます。

* **バグ修正**
  * ファイル拡張子に依らずZIPアーカイブを内容で判別するようになりました。

* **テスト**
  * マーカー有無や開発用マーカー検出、拡張子なしZIPの扱いを含む検証テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->