### PR TITLE
Guard direct verbose probe logging

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/ProbeLoggingAnalyzerTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/ProbeLoggingAnalyzerTests.cs
@@ -39,6 +39,20 @@ namespace UnityEngine
     public static class Debug
     {
         public static void Log(string message) { }
+
+        public static void LogWarning(string message) { }
+
+        public static void LogError(string message) { }
+
+        public static void LogAssertion(string message) { }
+
+        public static void LogFormat(string format, params object[] args) { }
+
+        public static void LogWarningFormat(string format, params object[] args) { }
+
+        public static void LogErrorFormat(string format, params object[] args) { }
+
+        public static void LogAssertionFormat(string format, params object[] args) { }
     }
 }
 """;
@@ -83,6 +97,75 @@ public static class Sample
         await VerifyCS.VerifyAnalyzerAsync(source, expected).ConfigureAwait(false);
     }
 
+    [TestCase("LogWarning", "Debug.LogWarning")]
+    [TestCase("LogError", "Debug.LogError")]
+    [TestCase("LogAssertion", "Debug.LogAssertion")]
+    public async Task Diagnostic_WhenUnityDebugTextEmitterEmitsVersionedProbeMarkerAsync(
+        string methodName,
+        string targetName)
+    {
+        var source = QudJPStubs + $$"""
+public static class Sample
+{
+    public static void Log()
+    {
+        UnityEngine.Debug.{{methodName}}({|#0:"[QudJP] FutureProbe/v1: leaked"|});
+    }
+}
+""";
+
+        var expected = VerifyCS.Diagnostic(ProbeLoggingAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments(targetName);
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected).ConfigureAwait(false);
+    }
+
+    [TestCase("LogFormat", "Debug.LogFormat")]
+    [TestCase("LogWarningFormat", "Debug.LogWarningFormat")]
+    [TestCase("LogErrorFormat", "Debug.LogErrorFormat")]
+    [TestCase("LogAssertionFormat", "Debug.LogAssertionFormat")]
+    public async Task Diagnostic_WhenUnityDebugFormatEmitterContainsFullVersionedProbeMarkerAsync(
+        string methodName,
+        string targetName)
+    {
+        var source = QudJPStubs + $$"""
+public static class Sample
+{
+    public static void Log()
+    {
+        UnityEngine.Debug.{{methodName}}({|#0:"[QudJP] FutureProbe/v1: {0}"|}, "leaked");
+    }
+}
+""";
+
+        var expected = VerifyCS.Diagnostic(ProbeLoggingAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments(targetName);
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task Diagnostic_WhenUnityDebugFormatEmitterContainsVersionedProbeMarkerArgumentAsync()
+    {
+        var source = QudJPStubs + """
+public static class Sample
+{
+    public static void Log()
+    {
+        UnityEngine.Debug.LogFormat("{0}", {|#0:"[QudJP] FutureProbe/v1: leaked"|});
+    }
+}
+""";
+
+        var expected = VerifyCS.Diagnostic(ProbeLoggingAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Debug.LogFormat");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected).ConfigureAwait(false);
+    }
+
     [Test]
     public async Task Diagnostic_WhenTraceInformationEmitsTranslatorVerboseMarkerAsync()
     {
@@ -92,6 +175,26 @@ public static class Sample
     public static void Log()
     {
         Trace.TraceInformation({|#0:"[QudJP] Translator: missing key 'abc'"|});
+    }
+}
+""";
+
+        var expected = VerifyCS.Diagnostic(ProbeLoggingAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Trace.TraceInformation");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task Diagnostic_WhenTraceInformationEmitsVersionedRepairEvidenceMarkerAsync()
+    {
+        var source = "using System.Diagnostics;\n" + QudJPStubs + """
+public static class Sample
+{
+    public static void Log()
+    {
+        Trace.TraceInformation({|#0:"[QudJP] GameSummaryTextRepair/v1: repaired=1"|});
     }
 }
 """;
@@ -237,6 +340,22 @@ public static class Sample
         QudJP.RuntimeDiagnostics.LogVerboseProbe(() => "[QudJP] NewProbe/v1: gated");
         QudJP.RuntimeDiagnostics.LogImportant("[QudJP] Build marker: marker");
         Trace.TraceError("QudJP: failure");
+    }
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task NoDiagnostic_ForNonVersionedUnityWarningThatMentionsProbeAsync()
+    {
+        var source = QudJPStubs + """
+public static class Sample
+{
+    public static void Log()
+    {
+        UnityEngine.Debug.LogWarning("[QudJP] FontManager: CJK font probe warmup failed.");
     }
 }
 """;

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers/ProbeLoggingAnalyzer.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers/ProbeLoggingAnalyzer.cs
@@ -14,6 +14,12 @@ public sealed class ProbeLoggingAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "QJ004";
 
+    private static readonly string[] QudJPVerboseMarkerFragments =
+    {
+        "/v1:",
+        "Translator: missing key",
+    };
+
     private static readonly DiagnosticDescriptor Rule = new(
         id: DiagnosticId,
         title: "Verbose probe logs must use RuntimeDiagnostics",
@@ -56,8 +62,7 @@ public sealed class ProbeLoggingAnalyzer : DiagnosticAnalyzer
         }
 
         var argumentCount = invocation.ArgumentList.Arguments.Count;
-        var argumentsToInspect = targetName.StartsWith("Trace.", StringComparison.Ordinal) ? argumentCount : Math.Min(argumentCount, 1);
-        for (var index = 0; index < argumentsToInspect; index++)
+        for (var index = 0; index < argumentCount; index++)
         {
             var argumentExpression = invocation.ArgumentList.Arguments[index].Expression;
             if (!ContainsVerboseProbeMarker(argumentExpression, context.SemanticModel, context.CancellationToken))
@@ -97,6 +102,13 @@ public sealed class ProbeLoggingAnalyzer : DiagnosticAnalyzer
             ("QudJP.RuntimeDiagnostics", "LogWarning") => "RuntimeDiagnostics.LogWarning",
             ("QudJP.RuntimeDiagnostics", "LogError") => "RuntimeDiagnostics.LogError",
             ("UnityEngine.Debug", "Log") => "Debug.Log",
+            ("UnityEngine.Debug", "LogWarning") => "Debug.LogWarning",
+            ("UnityEngine.Debug", "LogError") => "Debug.LogError",
+            ("UnityEngine.Debug", "LogAssertion") => "Debug.LogAssertion",
+            ("UnityEngine.Debug", "LogFormat") => "Debug.LogFormat",
+            ("UnityEngine.Debug", "LogWarningFormat") => "Debug.LogWarningFormat",
+            ("UnityEngine.Debug", "LogErrorFormat") => "Debug.LogErrorFormat",
+            ("UnityEngine.Debug", "LogAssertionFormat") => "Debug.LogAssertionFormat",
             _ => null,
         };
     }
@@ -149,9 +161,15 @@ public sealed class ProbeLoggingAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        return text.Contains("Probe", StringComparison.Ordinal)
-            || text.Contains("SinkObserve", StringComparison.Ordinal)
-            || text.Contains("Translator: missing key", StringComparison.Ordinal);
+        for (var index = 0; index < QudJPVerboseMarkerFragments.Length; index++)
+        {
+            if (text.Contains(QudJPVerboseMarkerFragments[index], StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string? GetStaticStringText(ExpressionSyntax expression)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineRenderProbePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineRenderProbePatchTests.cs
@@ -148,6 +148,8 @@ public sealed class InventoryLineRenderProbePatchTests
         NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("ScreenHierarchyObservability.TryBuildLineItemSnapshot("));
         NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("\"InventoryLineItemProbe/v1\""));
         NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("LogInventoryReplacementEvidence(itemLogLine)"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("RuntimeDiagnostics.LogVerboseProbe(() => logLine!)"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Not.Contain("QudJPMod.LogToUnity("));
 
         var repairIndex = source.IndexOf(
             "TextShellReplacementRenderer.TryRenderReplacementTexts(component, out var replacementLogLine)",


### PR DESCRIPTION
## Summary

- shrink QJ004 back to a small list/convention-based guard for direct verbose probe logging
- catch versioned QudJP evidence markers on direct Unity Debug and Trace/QudJPMod log calls without reconstructing format strings
- add regression coverage that delayed inventory repair evidence stays behind `RuntimeDiagnostics.LogVerboseProbe`

## Verification

- `dotnet test Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/QudJP.Analyzers.Tests.csproj --no-restore`
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj --no-restore`
- `git diff --check`
- `just test-l1`

## Review

- Separate design consultation recommended shrinking QJ004 to known marker/direct-emitter detection instead of keeping the broader static formatter analyzer.
- Separate code review approved the reduced diff.
- Simplify pass removed the redundant `SinkObserve/v1:` marker fragment and kept the rest unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * Unity の各種ログ呼び出しを対象にテストを拡充し、バージョン付きマーカー検出やフォーマット引数内のマーカーも検証。非バージョン警告が誤検出されないケースも追加。

* **改善**
  * 診断の検出範囲を拡大（追加の Unity ログ種別と全引数の検査）し、マーカー判定を厳格化して誤検出を低減。ログ出力経路の検証を強化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->