### PR TITLE
Document QJ004 probe guard boundaries

### DIFF
--- a/Mods/QudJP/Assemblies/AGENTS.md
+++ b/Mods/QudJP/Assemblies/AGENTS.md
@@ -44,6 +44,15 @@ just test-l2g
   `[QudJP] Translator: missing key`, and `no pattern for` are dev-only by
   default and are rejected by the release DLL verifier when they remain in a
   release artifact.
+- Keep QJ004 as a narrow bypass guard, not a general C# logging or
+  format-string analyzer. It should detect known verbose probe markers that
+  are statically visible on direct logging calls. Do not expand it into
+  arbitrary format reconstruction, exception message inspection, or broad
+  Unity/System.Diagnostics logging API modeling unless the probe policy itself
+  changes.
+- When future probes need stronger guarantees, prefer tightening the
+  centralized `RuntimeDiagnostics` API, marker convention, release verifier, or
+  focused analyzer tests before adding broad static inference to QJ004.
 - For tooltip, TMP, or RTF display fixes:
   - identify the upstream producer route before patching sinks; prefer
     `Look.GenerateTooltipInformation(GameObject)` or another pre-render owner

--- a/docs/workflows/runtime-evidence.md
+++ b/docs/workflows/runtime-evidence.md
@@ -123,6 +123,12 @@ Runtime diagnostics must keep shipping logs small and actionable:
   `QUDJP_DEV_BUILD` when their marker strings are not needed in release builds
 - release artifacts must not contain obvious verbose probe markers such as
   `DynamicTextProbe/v1`, `FinalOutputProbe/v1`, or `SinkObserve/v1`
+- QJ004 is a bypass guard for statically visible verbose probe markers on
+  direct logging calls. It is intentionally not a general formatter,
+  exception-message, or Unity logging API analyzer. If new probes need stronger
+  guarantees, tighten `RuntimeDiagnostics`, the marker convention, release
+  verification, or focused analyzer coverage before adding broad static
+  inference.
 
 Use dev builds for route-proof collection. Release/shipping builds keep the
 important QudJP startup, warning, and error logs, but verbose probes are off by


### PR DESCRIPTION
## Summary

- document that QJ004 should stay a narrow direct verbose probe bypass guard
- capture the preferred escalation path for stronger probe guarantees: RuntimeDiagnostics, marker conventions, release verification, or focused analyzer coverage
- add the same runtime evidence guidance to the workflow docs

## Verification

- `git diff --check`
- `just markdown-report-check origin/main HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション

* 開発者向けドキュメントを更新し、分析ツールのルール適用範囲に関する明確なガイダンスを追加しました。特定ルールの役割と今後の改善方針が明記されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->