### PR TITLE
[codex] Measure and reduce QudJP startup overhead

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -144,7 +144,7 @@ public sealed class ColorTagAllowlistCoverageTests
             ["Mods/QudJP/Assemblies/src/Translation/ColorAwareTranslationComposer.cs:30:Strip"] = "Wrapper method exposes the Strip API; callers are checked where they consume the returned spans.",
             ["Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs:77:Translate"] = "Passes stripped text and spans to TranslateStripped, where template application restores colors.",
             ["Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs:80:Translate"] = "Passes stripped text and spans to TranslateStripped, where template application restores colors.",
-            ["Mods/QudJP/Assemblies/src/UI/FontManager.cs:231:TryWarmPrimaryFontCharactersForUi"] = "UI glyph warmup intentionally strips markup only to add visible characters to the font atlas.",
+            ["Mods/QudJP/Assemblies/src/UI/FontManager.cs:250:TryWarmPrimaryFontCharactersForUi"] = "UI glyph warmup intentionally strips markup only to add visible characters to the font atlas.",
         };
 
     private static readonly SortedDictionary<string, string> NameLikeRestoreCaptureWithoutGuardAllowlist =

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/GameTypeResolverTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/GameTypeResolverTests.cs
@@ -87,7 +87,7 @@ public sealed class GameTypeResolverTests
         {
             Assert.That(GameTypeResolver.FallbackScanCountForDiagnostics, Is.EqualTo(2));
             Assert.That(
-                System.Text.RegularExpressions.Regex.Matches(output, "GameTypeResolver failed to resolve type").Count,
+                System.Text.RegularExpressions.Regex.Count(output, "GameTypeResolver failed to resolve type"),
                 Is.EqualTo(2));
         });
     }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/GameTypeResolverTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/GameTypeResolverTests.cs
@@ -4,6 +4,18 @@ namespace QudJP.Tests.L1;
 [Category("L1")]
 public sealed class GameTypeResolverTests
 {
+    [SetUp]
+    public void SetUp()
+    {
+        GameTypeResolver.ResetCacheForTests();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        GameTypeResolver.ResetCacheForTests();
+    }
+
     [Test]
     public void FindType_ReturnsFullNameMatch_WhenAvailable()
     {
@@ -42,6 +54,41 @@ public sealed class GameTypeResolverTests
             Assert.That(output, Does.Contain("GameTypeResolver failed to resolve type"));
             Assert.That(output, Does.Contain(fullTypeName));
             Assert.That(output, Does.Contain(simpleTypeName));
+        });
+    }
+
+    [Test]
+    public void FindType_CachesFallbackSimpleNameResolution()
+    {
+        var first = GameTypeResolver.FindType("QudJP.Tests.L1.Does.Not.Exist", nameof(GameTypeResolverTests));
+        var second = GameTypeResolver.FindType("QudJP.Tests.L1.Does.Not.Exist", nameof(GameTypeResolverTests));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.EqualTo(typeof(GameTypeResolverTests)));
+            Assert.That(second, Is.EqualTo(typeof(GameTypeResolverTests)));
+            Assert.That(GameTypeResolver.FallbackScanCountForDiagnostics, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void FindType_DoesNotCacheMisses_BecauseLaterAssemblyLoadsCanResolveThem()
+    {
+        const string fullTypeName = "QudJP.Tests.L1.Does.Not.Exist";
+        const string simpleTypeName = "NoSuchSimpleTypeName";
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+        {
+            Assert.That(GameTypeResolver.FindType(fullTypeName, simpleTypeName), Is.Null);
+            Assert.That(GameTypeResolver.FindType(fullTypeName, simpleTypeName), Is.Null);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(GameTypeResolver.FallbackScanCountForDiagnostics, Is.EqualTo(2));
+            Assert.That(
+                System.Text.RegularExpressions.Regex.Matches(output, "GameTypeResolver failed to resolve type").Count,
+                Is.EqualTo(2));
         });
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/RuntimeDiagnosticsTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/RuntimeDiagnosticsTests.cs
@@ -71,6 +71,24 @@ public sealed class RuntimeDiagnosticsTests
     }
 
     [Test]
+    public void StartupTiming_WritesStructuredElapsedMarker()
+    {
+        var output = TestTraceHelper.CaptureTrace(() =>
+            RuntimeStartupTiming.LogElapsed(
+                "harmony.prepare_patch_types",
+                TimeSpan.FromMilliseconds(12.3456),
+                "patch_types=140;prepared=139"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(output, Does.Contain("[QudJP] StartupTiming/v1:"));
+            Assert.That(output, Does.Contain("phase=harmony.prepare_patch_types"));
+            Assert.That(output, Does.Contain("elapsed_ms=12.346"));
+            Assert.That(output, Does.Contain("detail=patch_types\\=140\\;prepared\\=139"));
+        });
+    }
+
+    [Test]
     public void LogVerboseProbe_DoesNotInvokeMessageFactory_WhenVerboseProbesAreDisabled()
     {
         RuntimeDiagnostics.SetVerboseProbesEnabledForTests(false);

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/RuntimeDiagnosticsTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/RuntimeDiagnosticsTests.cs
@@ -109,12 +109,12 @@ public sealed class RuntimeDiagnosticsTests
     {
         var summary = QudJPMod.FormatPatchLoopSummary(
             new QudJPMod.PatchLoopSummary(
-                PatchTypes: 10,
-                Prepared: 9,
-                PrepareSkipped: 1,
-                Applied: 0,
-                ApplySkipped: 9,
-                Preflight: true));
+                10,
+                9,
+                1,
+                0,
+                9,
+                true));
 
         Assert.Multiple(() =>
         {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/RuntimeDiagnosticsTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/RuntimeDiagnosticsTests.cs
@@ -1,6 +1,9 @@
 namespace QudJP.Tests.L1;
 
 using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using System.Text.RegularExpressions;
 
 [TestFixture]
 [Category("L1")]
@@ -85,6 +88,33 @@ public sealed class RuntimeDiagnosticsTests
             Assert.That(output, Does.Contain("phase=harmony.prepare_patch_types"));
             Assert.That(output, Does.Contain("elapsed_ms=12.346"));
             Assert.That(output, Does.Contain("detail=patch_types\\=140\\;prepared\\=139"));
+        });
+    }
+
+    [Test]
+    public void PatchLoopSummaries_KeepPrepareAndApplySkippedCountsSeparate()
+    {
+        var patchByClassProcessor = typeof(QudJPMod).GetMethod(
+            "PatchByClassProcessor",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        var createClassProcessor = typeof(NullClassProcessorFactory).GetMethod(
+            nameof(NullClassProcessorFactory.CreateClassProcessor));
+        Assert.That(patchByClassProcessor, Is.Not.Null);
+        Assert.That(createClassProcessor, Is.Not.Null);
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+            patchByClassProcessor!.Invoke(
+                null,
+                new object[] { new object(), createClassProcessor! }));
+
+        var prepare = ParseTimingCounts(output, "harmony.prepare_patch_types");
+        var apply = ParseTimingCounts(output, "harmony.apply_patch_types");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(apply["skipped"], Is.GreaterThan(0));
+            Assert.That(prepare["prepared"] + prepare["skipped"], Is.LessThanOrEqualTo(prepare["patch_types"]));
+            Assert.That(prepare["skipped"], Is.EqualTo(prepare["patch_types"] - prepare["prepared"]));
         });
     }
 
@@ -205,5 +235,25 @@ public sealed class RuntimeDiagnosticsTests
             EventTypes.Add(eventType);
             base.TraceEvent(eventCache, source, eventType, id, format, args);
         }
+    }
+
+    private static class NullClassProcessorFactory
+    {
+        public static object? CreateClassProcessor(Type patchType)
+        {
+            _ = patchType;
+            return null;
+        }
+    }
+
+    private static Dictionary<string, int> ParseTimingCounts(string output, string phase)
+    {
+        var line = output
+            .Split('\n')
+            .Single(value => value.Contains($"phase={phase}", StringComparison.Ordinal));
+        return Regex.Matches(line, @"(?:detail=|\\;)(patch_types|prepared|skipped|applied)\\=(\d+)")
+            .ToDictionary(
+                match => match.Groups[1].Value,
+                match => int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture));
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/RuntimeDiagnosticsTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/RuntimeDiagnosticsTests.cs
@@ -2,8 +2,7 @@ namespace QudJP.Tests.L1;
 
 using System.Diagnostics;
 using System.Globalization;
-using System.Reflection;
-using System.Text.RegularExpressions;
+using System.Threading;
 
 [TestFixture]
 [Category("L1")]
@@ -76,11 +75,25 @@ public sealed class RuntimeDiagnosticsTests
     [Test]
     public void StartupTiming_WritesStructuredElapsedMarker()
     {
-        var output = TestTraceHelper.CaptureTrace(() =>
-            RuntimeStartupTiming.LogElapsed(
-                "harmony.prepare_patch_types",
-                TimeSpan.FromMilliseconds(12.3456),
-                "patch_types=140;prepared=139"));
+        var originalCulture = Thread.CurrentThread.CurrentCulture;
+        var originalUiCulture = Thread.CurrentThread.CurrentUICulture;
+        string output;
+        try
+        {
+            var commaDecimalCulture = CultureInfo.GetCultureInfo("fr-FR");
+            Thread.CurrentThread.CurrentCulture = commaDecimalCulture;
+            Thread.CurrentThread.CurrentUICulture = commaDecimalCulture;
+            output = TestTraceHelper.CaptureTrace(() =>
+                RuntimeStartupTiming.LogElapsed(
+                    "harmony.prepare_patch_types",
+                    TimeSpan.FromMilliseconds(12.3456),
+                    "patch_types=140;prepared=139"));
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+            Thread.CurrentThread.CurrentUICulture = originalUiCulture;
+        }
 
         Assert.Multiple(() =>
         {
@@ -94,27 +107,19 @@ public sealed class RuntimeDiagnosticsTests
     [Test]
     public void PatchLoopSummaries_KeepPrepareAndApplySkippedCountsSeparate()
     {
-        var patchByClassProcessor = typeof(QudJPMod).GetMethod(
-            "PatchByClassProcessor",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        var createClassProcessor = typeof(NullClassProcessorFactory).GetMethod(
-            nameof(NullClassProcessorFactory.CreateClassProcessor));
-        Assert.That(patchByClassProcessor, Is.Not.Null);
-        Assert.That(createClassProcessor, Is.Not.Null);
-
-        var output = TestTraceHelper.CaptureTrace(() =>
-            patchByClassProcessor!.Invoke(
-                null,
-                new object[] { new object(), createClassProcessor! }));
-
-        var prepare = ParseTimingCounts(output, "harmony.prepare_patch_types");
-        var apply = ParseTimingCounts(output, "harmony.apply_patch_types");
+        var summary = QudJPMod.FormatPatchLoopSummary(
+            new QudJPMod.PatchLoopSummary(
+                PatchTypes: 10,
+                Prepared: 9,
+                PrepareSkipped: 1,
+                Applied: 0,
+                ApplySkipped: 9,
+                Preflight: true));
 
         Assert.Multiple(() =>
         {
-            Assert.That(apply["skipped"], Is.GreaterThan(0));
-            Assert.That(prepare["prepared"] + prepare["skipped"], Is.LessThanOrEqualTo(prepare["patch_types"]));
-            Assert.That(prepare["skipped"], Is.EqualTo(prepare["patch_types"] - prepare["prepared"]));
+            Assert.That(summary.PrepareDetail, Is.EqualTo("patch_types=10;prepared=9;skipped=1;preflight=True"));
+            Assert.That(summary.ApplyDetail, Is.EqualTo("patch_types=10;applied=0;skipped=9"));
         });
     }
 
@@ -237,23 +242,4 @@ public sealed class RuntimeDiagnosticsTests
         }
     }
 
-    private static class NullClassProcessorFactory
-    {
-        public static object? CreateClassProcessor(Type patchType)
-        {
-            _ = patchType;
-            return null;
-        }
-    }
-
-    private static Dictionary<string, int> ParseTimingCounts(string output, string phase)
-    {
-        var line = output
-            .Split('\n')
-            .Single(value => value.Contains($"phase={phase}", StringComparison.Ordinal));
-        return Regex.Matches(line, @"(?:detail=|\\;)(patch_types|prepared|skipped|applied)\\=(\d+)")
-            .ToDictionary(
-                match => match.Groups[1].Value,
-                match => int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture));
-    }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/XDidYTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/XDidYTranslationPatchTests.cs
@@ -54,6 +54,21 @@ public sealed class XDidYTranslationPatchTests
     }
 
     [Test]
+    public void TheTypeName_UsesCanonicalGameNamespace()
+    {
+        Assert.That(XDidYTranslationPatch.TheTypeName, Is.EqualTo("XRL.The"));
+#if HAS_GAME_DLL
+        var gameAssemblyName = AssemblyName.GetAssemblyName(Path.Combine(AppContext.BaseDirectory, "Assembly-CSharp.dll"));
+        _ = Assembly.Load(gameAssemblyName);
+        Assert.Multiple(() =>
+        {
+            Assert.That(GameTypeResolver.FindType(XDidYTranslationPatch.TheTypeName, "The")?.FullName, Is.EqualTo("XRL.The"));
+            Assert.That(AccessTools.TypeByName("XRL.World.The"), Is.Null);
+        });
+#endif
+    }
+
+    [Test]
     public void Prefix_TranslatesXDidYAndSkipsOriginalEnglishAssembly()
     {
         WriteDictionary(tier1: new[] { ("block", "防いだ") });

--- a/Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj
@@ -45,6 +45,7 @@
     <Compile Include="../src/Patches/*.cs" Link="Production/Patches/%(Filename)%(Extension)" />
     <Compile Include="../src/QudJPMod.cs" Link="Production/QudJPMod.cs" />
     <Compile Include="../src/RuntimeDiagnostics.cs" Link="Production/RuntimeDiagnostics.cs" />
+    <Compile Include="../src/RuntimeStartupTiming.cs" Link="Production/RuntimeStartupTiming.cs" />
     <Compile Include="../src/Translation/*.cs" Link="Production/Translation/%(Filename)%(Extension)" />
     <Compile Include="../src/UI/*.cs" Link="Production/UI/%(Filename)%(Extension)" />
   </ItemGroup>

--- a/Mods/QudJP/Assemblies/src/GameTypeResolver.cs
+++ b/Mods/QudJP/Assemblies/src/GameTypeResolver.cs
@@ -1,12 +1,19 @@
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
+using System.Threading;
 using HarmonyLib;
 
 namespace QudJP;
 
 internal static class GameTypeResolver
 {
+    private static readonly ConcurrentDictionary<string, Type> FallbackResolutionCache =
+        new ConcurrentDictionary<string, Type>(StringComparer.Ordinal);
+
+    private static int fallbackScanCount;
+
     internal static Type? FindType(string fullTypeName, string simpleTypeName)
     {
         var byFullName = AccessTools.TypeByName(fullTypeName);
@@ -15,11 +22,37 @@ internal static class GameTypeResolver
             return byFullName;
         }
 
+        var cacheKey = BuildCacheKey(fullTypeName, simpleTypeName);
+        if (FallbackResolutionCache.TryGetValue(cacheKey, out var cached))
+        {
+            return cached;
+        }
+
+        var resolved = FindTypeBySimpleName(fullTypeName, simpleTypeName, AppDomain.CurrentDomain.GetAssemblies());
+        if (resolved is not null)
+        {
+            _ = FallbackResolutionCache.TryAdd(cacheKey, resolved);
+        }
+
+        return resolved;
+    }
+
+    internal static void ResetCacheForTests()
+    {
+        FallbackResolutionCache.Clear();
+        Interlocked.Exchange(ref fallbackScanCount, 0);
+    }
+
+    internal static int FallbackScanCountForDiagnostics => Volatile.Read(ref fallbackScanCount);
+
+    private static Type? FindTypeBySimpleName(string fullTypeName, string simpleTypeName, Assembly[] assemblies)
+    {
+        Interlocked.Increment(ref fallbackScanCount);
+
         Type? firstMatch = null;
         string? firstMatchAssembly = null;
         System.Collections.Generic.List<string>? allCandidates = null;
 
-        var assemblies = AppDomain.CurrentDomain.GetAssemblies();
         for (var assemblyIndex = 0; assemblyIndex < assemblies.Length; assemblyIndex++)
         {
             Type[] types;
@@ -75,5 +108,10 @@ internal static class GameTypeResolver
         }
 
         return firstMatch;
+    }
+
+    private static string BuildCacheKey(string fullTypeName, string simpleTypeName)
+    {
+        return fullTypeName + "\n" + simpleTypeName;
     }
 }

--- a/Mods/QudJP/Assemblies/src/Patches/XDidYTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/XDidYTranslationPatch.cs
@@ -14,13 +14,14 @@ public static class XDidYTranslationPatch
     private const string XDidYMethodName = "XDidY";
     private const string XDidYToZMethodName = "XDidYToZ";
     private const string WDidXToYWithZMethodName = "WDidXToYWithZ";
+    internal const string TheTypeName = "XRL.The";
 
     private static readonly Type? MessagingType =
         GameTypeResolver.FindType("XRL.World.Capabilities.Messaging", "Messaging");
     private static readonly Type? GameObjectType =
         GameTypeResolver.FindType("XRL.World.GameObject", "GameObject");
     private static readonly Type? TheType =
-        GameTypeResolver.FindType("XRL.World.The", "The");
+        GameTypeResolver.FindType(TheTypeName, "The");
 
     private static readonly MethodInfo? HandleMessageMethod = FindHandleMessageMethod();
     private static readonly MethodInfo? ValidateMethod = ResolveValidateMethod();

--- a/Mods/QudJP/Assemblies/src/QudJPMod.cs
+++ b/Mods/QudJP/Assemblies/src/QudJPMod.cs
@@ -307,19 +307,42 @@ public static class QudJPMod
             }
         }
 
+        var patchLoopSummary = FormatPatchLoopSummary(
+            new PatchLoopSummary(
+                patchTypes.Length,
+                preparedCount,
+                prepareSkippedCount,
+                appliedCount,
+                applySkippedCount,
+                preflightPatchTargets));
         RuntimeStartupTiming.LogElapsed(
             "harmony.prepare_patch_types",
             preparationStopwatch.Elapsed,
-            $"patch_types={patchTypes.Length};prepared={preparedCount};skipped={prepareSkippedCount};"
-            + $"preflight={preflightPatchTargets}");
+            patchLoopSummary.PrepareDetail);
         RuntimeStartupTiming.LogElapsed(
             "harmony.apply_patch_types",
             patchStopwatch.Elapsed,
-            $"patch_types={patchTypes.Length};applied={appliedCount};skipped={applySkippedCount}");
+            patchLoopSummary.ApplyDetail);
         RuntimeStartupTiming.LogElapsed(
             "harmony.type_fallback_scans_total",
             TimeSpan.Zero,
             $"count={GameTypeResolver.FallbackScanCountForDiagnostics - fallbackScansBeforePatchLoop}");
+    }
+
+    internal readonly record struct PatchLoopSummary(
+        int PatchTypes,
+        int Prepared,
+        int PrepareSkipped,
+        int Applied,
+        int ApplySkipped,
+        bool Preflight);
+
+    internal static (string PrepareDetail, string ApplyDetail) FormatPatchLoopSummary(PatchLoopSummary summary)
+    {
+        return (
+            $"patch_types={summary.PatchTypes};prepared={summary.Prepared};skipped={summary.PrepareSkipped};"
+            + $"preflight={summary.Preflight}",
+            $"patch_types={summary.PatchTypes};applied={summary.Applied};skipped={summary.ApplySkipped}");
     }
 
     internal static bool TryPreparePatchType(Type patchType, out string failureReason)

--- a/Mods/QudJP/Assemblies/src/QudJPMod.cs
+++ b/Mods/QudJP/Assemblies/src/QudJPMod.cs
@@ -51,13 +51,21 @@ public static class QudJPMod
             return;
         }
 
+        using var totalTiming = RuntimeStartupTiming.Measure("qudjp.initialize_core");
         try
         {
             var assemblyVersion = typeof(QudJPMod).Assembly.GetName().Version;
             RuntimeDiagnostics.LogStatus(
                 $"[QudJP] Build marker: {BuildMarker}, Version: {assemblyVersion}, BuildFlavor: {RuntimeDiagnostics.BuildFlavor}");
-            initializeFonts();
-            applyPatches();
+            using (RuntimeStartupTiming.Measure("font.initialize"))
+            {
+                initializeFonts();
+            }
+
+            using (RuntimeStartupTiming.Measure("harmony.setup_and_apply"))
+            {
+                applyPatches();
+            }
         }
         catch
         {
@@ -68,15 +76,27 @@ public static class QudJPMod
 
     internal static void ApplyHarmonyPatches()
     {
-        var harmony = CreateHarmony("com.qudjp.localization");
+        object? harmony;
+        using (RuntimeStartupTiming.Measure("harmony.create"))
+        {
+            harmony = CreateHarmony("com.qudjp.localization");
+        }
+
         if (harmony is null)
         {
             throw new InvalidOperationException(
                 "QudJP: Harmony runtime not available. The mod cannot function without Harmony.");
         }
 
-        InvokePatchAll(harmony);
-        LogPatchResults(harmony);
+        using (RuntimeStartupTiming.Measure("harmony.invoke_patch_all"))
+        {
+            InvokePatchAll(harmony);
+        }
+
+        using (RuntimeStartupTiming.Measure("harmony.log_patch_results"))
+        {
+            LogPatchResults(harmony);
+        }
     }
 
     internal static object? CreateHarmony(string harmonyId)
@@ -144,21 +164,87 @@ public static class QudJPMod
     private static void PatchByClassProcessor(object harmony, MethodInfo createClassProcessor)
     {
         var patchAssembly = Assembly.GetExecutingAssembly();
-        var patchTypes = GetHarmonyPatchTypes(patchAssembly);
+        Type[] patchTypes;
+        using (RuntimeStartupTiming.Measure("harmony.scan_patch_types"))
+        {
+            patchTypes = GetHarmonyPatchTypes(patchAssembly);
+        }
+
+        var preparedCount = 0;
+        var skippedCount = 0;
+        var appliedCount = 0;
+        var fallbackScansBeforePreparation = GameTypeResolver.FallbackScanCountForDiagnostics;
+        var preparationStopwatch = new Stopwatch();
+        var patchStopwatch = new Stopwatch();
+        var detailedPatchTiming = IsDetailedPatchTimingEnabled();
+        var preflightPatchTargets = IsPatchTargetPreflightEnabled();
         for (var index = 0; index < patchTypes.Length; index++)
         {
             var patchType = patchTypes[index];
+            var patchTypeName = patchType.FullName ?? patchType.Name;
+            var resolvedTargetCount = 0;
+            var currentPhase = "prepare";
+            var detailedStopwatch = detailedPatchTiming ? Stopwatch.StartNew() : null;
             try
             {
-                if (!TryPreparePatchType(patchType, out var preparationFailure))
+                if (ShouldPreflightPatchType(patchType, preflightPatchTargets))
                 {
-                    RuntimeDiagnostics.LogWarning($"[QudJP] Warning: Skipping patch {patchType.FullName}: {preparationFailure}");
-                    continue;
+                    preparationStopwatch.Start();
+                    if (!TryPreparePatchType(patchType, out var preparationFailure, out resolvedTargetCount))
+                    {
+                        preparationStopwatch.Stop();
+                        detailedStopwatch?.Stop();
+                        skippedCount++;
+                        LogPatchTypeTiming(
+                            detailedPatchTiming,
+                            "harmony.patch_prepare",
+                            patchTypeName,
+                            detailedStopwatch?.Elapsed ?? TimeSpan.Zero,
+                            "skipped",
+                            resolvedTargetCount);
+                        RuntimeDiagnostics.LogWarning($"[QudJP] Warning: Skipping patch {patchType.FullName}: {preparationFailure}");
+                        continue;
+                    }
+                    preparationStopwatch.Stop();
+                    detailedStopwatch?.Stop();
+                    preparedCount++;
+                    LogPatchTypeTiming(
+                        detailedPatchTiming,
+                        "harmony.patch_prepare",
+                        patchTypeName,
+                        detailedStopwatch?.Elapsed ?? TimeSpan.Zero,
+                        "prepared",
+                        resolvedTargetCount);
+                }
+                else
+                {
+                    detailedStopwatch?.Stop();
+                    preparedCount++;
+                    LogPatchTypeTiming(
+                        detailedPatchTiming,
+                        "harmony.patch_prepare",
+                        patchTypeName,
+                        detailedStopwatch?.Elapsed ?? TimeSpan.Zero,
+                        "preflight_disabled",
+                        resolvedTargetCount);
                 }
 
+                currentPhase = "apply";
+                detailedStopwatch = detailedPatchTiming ? Stopwatch.StartNew() : null;
+                patchStopwatch.Start();
                 var processor = createClassProcessor.Invoke(harmony, new object[] { patchType });
                 if (processor is null)
                 {
+                    patchStopwatch.Stop();
+                    detailedStopwatch?.Stop();
+                    skippedCount++;
+                    LogPatchTypeTiming(
+                        detailedPatchTiming,
+                        "harmony.patch_apply",
+                        patchTypeName,
+                        detailedStopwatch?.Elapsed ?? TimeSpan.Zero,
+                        "skipped_null_processor",
+                        resolvedTargetCount);
                     RuntimeDiagnostics.LogWarning($"[QudJP] Warning: Harmony returned null class processor for patch {patchType.FullName}.");
                     continue;
                 }
@@ -166,39 +252,95 @@ public static class QudJPMod
                 var patchMethod = processor.GetType().GetMethod("Patch", Type.EmptyTypes);
                 if (patchMethod is null)
                 {
+                    patchStopwatch.Stop();
+                    detailedStopwatch?.Stop();
+                    skippedCount++;
+                    LogPatchTypeTiming(
+                        detailedPatchTiming,
+                        "harmony.patch_apply",
+                        patchTypeName,
+                        detailedStopwatch?.Elapsed ?? TimeSpan.Zero,
+                        "skipped_missing_patch_method",
+                        resolvedTargetCount);
                     RuntimeDiagnostics.LogWarning($"[QudJP] Warning: Patch() missing on class processor for {patchType.FullName}.");
                     continue;
                 }
 
                 patchMethod.Invoke(processor, null);
+                patchStopwatch.Stop();
+                detailedStopwatch?.Stop();
+                appliedCount++;
+                LogPatchTypeTiming(
+                    detailedPatchTiming,
+                    "harmony.patch_apply",
+                    patchTypeName,
+                    detailedStopwatch?.Elapsed ?? TimeSpan.Zero,
+                    "applied",
+                    resolvedTargetCount);
             }
             catch (Exception ex)
             {
+                preparationStopwatch.Stop();
+                patchStopwatch.Stop();
+                detailedStopwatch?.Stop();
+                skippedCount++;
+                LogPatchTypeTiming(
+                    detailedPatchTiming,
+                    currentPhase == "prepare" ? "harmony.patch_prepare" : "harmony.patch_apply",
+                    patchTypeName,
+                    detailedStopwatch?.Elapsed ?? TimeSpan.Zero,
+                    "failed",
+                    resolvedTargetCount);
                 var details = ex is TargetInvocationException tie
                     ? tie.InnerException?.ToString() ?? tie.ToString()
                     : ex.ToString();
                 RuntimeDiagnostics.LogWarning($"[QudJP] Warning: Failed to apply patch {patchType.FullName}: {details}");
             }
         }
+
+        RuntimeStartupTiming.LogElapsed(
+            "harmony.prepare_patch_types",
+            preparationStopwatch.Elapsed,
+            $"patch_types={patchTypes.Length};prepared={preparedCount};skipped={skippedCount};"
+            + $"preflight={preflightPatchTargets};"
+            + $"type_fallback_scans={GameTypeResolver.FallbackScanCountForDiagnostics - fallbackScansBeforePreparation}");
+        RuntimeStartupTiming.LogElapsed(
+            "harmony.apply_patch_types",
+            patchStopwatch.Elapsed,
+            $"patch_types={patchTypes.Length};applied={appliedCount};skipped={skippedCount}");
     }
 
     internal static bool TryPreparePatchType(Type patchType, out string failureReason)
     {
+        return TryPreparePatchType(patchType, out failureReason, out _);
+    }
+
+    internal static bool TryPreparePatchType(Type patchType, out string failureReason, out int resolvedTargetCount)
+    {
+        resolvedTargetCount = 0;
         var methods = AccessTools.GetDeclaredMethods(patchType);
         for (var index = 0; index < methods.Count; index++)
         {
             var method = methods[index];
 
-            if (HasHarmonyTargetMethodAttribute(method)
-                && !TryResolveSingleTarget(method, out failureReason))
+            if (HasHarmonyTargetMethodAttribute(method))
             {
-                return false;
+                if (!TryResolveSingleTarget(method, out failureReason, out var singleTargetCount))
+                {
+                    return false;
+                }
+
+                resolvedTargetCount += singleTargetCount;
             }
 
-            if (HasHarmonyTargetMethodsAttribute(method)
-                && !TryResolveMultipleTargets(method, out failureReason))
+            if (HasHarmonyTargetMethodsAttribute(method))
             {
-                return false;
+                if (!TryResolveMultipleTargets(method, out failureReason, out var multipleTargetCount))
+                {
+                    return false;
+                }
+
+                resolvedTargetCount += multipleTargetCount;
             }
         }
 
@@ -286,12 +428,14 @@ public static class QudJPMod
         return false;
     }
 
-    private static bool TryResolveSingleTarget(MethodInfo resolver, out string failureReason)
+    private static bool TryResolveSingleTarget(MethodInfo resolver, out string failureReason, out int resolvedTargetCount)
     {
+        resolvedTargetCount = 0;
         try
         {
             if (resolver.Invoke(null, null) is MethodBase)
             {
+                resolvedTargetCount = 1;
                 failureReason = string.Empty;
                 return true;
             }
@@ -309,8 +453,9 @@ public static class QudJPMod
         }
     }
 
-    private static bool TryResolveMultipleTargets(MethodInfo resolver, out string failureReason)
+    private static bool TryResolveMultipleTargets(MethodInfo resolver, out string failureReason, out int resolvedTargetCount)
     {
+        resolvedTargetCount = 0;
         try
         {
             if (resolver.Invoke(null, null) is not IEnumerable enumerable)
@@ -319,7 +464,8 @@ public static class QudJPMod
                 return false;
             }
 
-            if (enumerable.Cast<object?>().OfType<MethodBase>().Any())
+            resolvedTargetCount = enumerable.Cast<object?>().OfType<MethodBase>().Count();
+            if (resolvedTargetCount > 0)
             {
                 failureReason = string.Empty;
                 return true;
@@ -336,6 +482,51 @@ public static class QudJPMod
             failureReason = $"{resolver.DeclaringType?.FullName}.{resolver.Name} threw: {details}";
             return false;
         }
+    }
+
+    private static bool IsDetailedPatchTimingEnabled()
+    {
+        return IsEnvironmentFlagEnabled("QUDJP_STARTUP_PATCH_TIMING");
+    }
+
+    private static bool IsPatchTargetPreflightEnabled()
+    {
+        return IsEnvironmentFlagEnabled("QUDJP_PATCH_TARGET_PREFLIGHT");
+    }
+
+    private static bool IsEnvironmentFlagEnabled(string name)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        return string.Equals(value, "1", StringComparison.Ordinal)
+            || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool ShouldPreflightPatchType(Type patchType, bool preflightAllPatchTargets)
+    {
+        return preflightAllPatchTargets
+            || string.Equals(
+                patchType.FullName,
+                "QudJP.Patches.HistoricStringExpanderPatch",
+                StringComparison.Ordinal);
+    }
+
+    private static void LogPatchTypeTiming(
+        bool enabled,
+        string phasePrefix,
+        string patchTypeName,
+        TimeSpan elapsed,
+        string status,
+        int resolvedTargetCount)
+    {
+        if (!enabled)
+        {
+            return;
+        }
+
+        RuntimeStartupTiming.LogElapsed(
+            phasePrefix + "." + patchTypeName,
+            elapsed,
+            $"status={status};targets={resolvedTargetCount}");
     }
 
     internal static void LogToUnity(string message)

--- a/Mods/QudJP/Assemblies/src/QudJPMod.cs
+++ b/Mods/QudJP/Assemblies/src/QudJPMod.cs
@@ -329,13 +329,36 @@ public static class QudJPMod
             $"count={GameTypeResolver.FallbackScanCountForDiagnostics - fallbackScansBeforePatchLoop}");
     }
 
-    internal readonly record struct PatchLoopSummary(
-        int PatchTypes,
-        int Prepared,
-        int PrepareSkipped,
-        int Applied,
-        int ApplySkipped,
-        bool Preflight);
+    internal readonly struct PatchLoopSummary
+    {
+        internal PatchLoopSummary(
+            int patchTypes,
+            int prepared,
+            int prepareSkipped,
+            int applied,
+            int applySkipped,
+            bool preflight)
+        {
+            PatchTypes = patchTypes;
+            Prepared = prepared;
+            PrepareSkipped = prepareSkipped;
+            Applied = applied;
+            ApplySkipped = applySkipped;
+            Preflight = preflight;
+        }
+
+        internal int PatchTypes { get; }
+
+        internal int Prepared { get; }
+
+        internal int PrepareSkipped { get; }
+
+        internal int Applied { get; }
+
+        internal int ApplySkipped { get; }
+
+        internal bool Preflight { get; }
+    }
 
     internal static (string PrepareDetail, string ApplyDetail) FormatPatchLoopSummary(PatchLoopSummary summary)
     {

--- a/Mods/QudJP/Assemblies/src/QudJPMod.cs
+++ b/Mods/QudJP/Assemblies/src/QudJPMod.cs
@@ -173,7 +173,7 @@ public static class QudJPMod
         var preparedCount = 0;
         var skippedCount = 0;
         var appliedCount = 0;
-        var fallbackScansBeforePreparation = GameTypeResolver.FallbackScanCountForDiagnostics;
+        var fallbackScansBeforePatchLoop = GameTypeResolver.FallbackScanCountForDiagnostics;
         var preparationStopwatch = new Stopwatch();
         var patchStopwatch = new Stopwatch();
         var detailedPatchTiming = IsDetailedPatchTimingEnabled();
@@ -302,12 +302,15 @@ public static class QudJPMod
             "harmony.prepare_patch_types",
             preparationStopwatch.Elapsed,
             $"patch_types={patchTypes.Length};prepared={preparedCount};skipped={skippedCount};"
-            + $"preflight={preflightPatchTargets};"
-            + $"type_fallback_scans={GameTypeResolver.FallbackScanCountForDiagnostics - fallbackScansBeforePreparation}");
+            + $"preflight={preflightPatchTargets}");
         RuntimeStartupTiming.LogElapsed(
             "harmony.apply_patch_types",
             patchStopwatch.Elapsed,
             $"patch_types={patchTypes.Length};applied={appliedCount};skipped={skippedCount}");
+        RuntimeStartupTiming.LogElapsed(
+            "harmony.type_fallback_scans_total",
+            TimeSpan.Zero,
+            $"count={GameTypeResolver.FallbackScanCountForDiagnostics - fallbackScansBeforePatchLoop}");
     }
 
     internal static bool TryPreparePatchType(Type patchType, out string failureReason)

--- a/Mods/QudJP/Assemblies/src/QudJPMod.cs
+++ b/Mods/QudJP/Assemblies/src/QudJPMod.cs
@@ -171,7 +171,8 @@ public static class QudJPMod
         }
 
         var preparedCount = 0;
-        var skippedCount = 0;
+        var prepareSkippedCount = 0;
+        var applySkippedCount = 0;
         var appliedCount = 0;
         var fallbackScansBeforePatchLoop = GameTypeResolver.FallbackScanCountForDiagnostics;
         var preparationStopwatch = new Stopwatch();
@@ -194,7 +195,7 @@ public static class QudJPMod
                     {
                         preparationStopwatch.Stop();
                         detailedStopwatch?.Stop();
-                        skippedCount++;
+                        prepareSkippedCount++;
                         LogPatchTypeTiming(
                             detailedPatchTiming,
                             "harmony.patch_prepare",
@@ -237,7 +238,7 @@ public static class QudJPMod
                 {
                     patchStopwatch.Stop();
                     detailedStopwatch?.Stop();
-                    skippedCount++;
+                    applySkippedCount++;
                     LogPatchTypeTiming(
                         detailedPatchTiming,
                         "harmony.patch_apply",
@@ -254,7 +255,7 @@ public static class QudJPMod
                 {
                     patchStopwatch.Stop();
                     detailedStopwatch?.Stop();
-                    skippedCount++;
+                    applySkippedCount++;
                     LogPatchTypeTiming(
                         detailedPatchTiming,
                         "harmony.patch_apply",
@@ -283,7 +284,15 @@ public static class QudJPMod
                 preparationStopwatch.Stop();
                 patchStopwatch.Stop();
                 detailedStopwatch?.Stop();
-                skippedCount++;
+                if (currentPhase == "prepare")
+                {
+                    prepareSkippedCount++;
+                }
+                else
+                {
+                    applySkippedCount++;
+                }
+
                 LogPatchTypeTiming(
                     detailedPatchTiming,
                     currentPhase == "prepare" ? "harmony.patch_prepare" : "harmony.patch_apply",
@@ -301,12 +310,12 @@ public static class QudJPMod
         RuntimeStartupTiming.LogElapsed(
             "harmony.prepare_patch_types",
             preparationStopwatch.Elapsed,
-            $"patch_types={patchTypes.Length};prepared={preparedCount};skipped={skippedCount};"
+            $"patch_types={patchTypes.Length};prepared={preparedCount};skipped={prepareSkippedCount};"
             + $"preflight={preflightPatchTargets}");
         RuntimeStartupTiming.LogElapsed(
             "harmony.apply_patch_types",
             patchStopwatch.Elapsed,
-            $"patch_types={patchTypes.Length};applied={appliedCount};skipped={skippedCount}");
+            $"patch_types={patchTypes.Length};applied={appliedCount};skipped={applySkippedCount}");
         RuntimeStartupTiming.LogElapsed(
             "harmony.type_fallback_scans_total",
             TimeSpan.Zero,

--- a/Mods/QudJP/Assemblies/src/RuntimeStartupTiming.cs
+++ b/Mods/QudJP/Assemblies/src/RuntimeStartupTiming.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace QudJP;
+
+internal static class RuntimeStartupTiming
+{
+    internal const string Marker = "[QudJP] StartupTiming/v1:";
+
+    internal static IDisposable Measure(string phase, string? detail = null)
+    {
+        return new TimingScope(phase, detail);
+    }
+
+    internal static void LogElapsed(string phase, TimeSpan elapsed, string? detail = null)
+    {
+        var message = Marker
+            + " phase="
+            + EscapeFieldValue(phase)
+            + " elapsed_ms="
+            + elapsed.TotalMilliseconds.ToString("0.###", CultureInfo.InvariantCulture);
+        if (!string.IsNullOrWhiteSpace(detail))
+        {
+            message += " detail=" + EscapeFieldValue(detail!);
+        }
+
+        RuntimeDiagnostics.LogStatus(message);
+    }
+
+    private static string EscapeFieldValue(string value)
+    {
+        return value
+            .Replace("\\", "\\\\")
+            .Replace(" ", "\\ ")
+            .Replace(";", "\\;")
+            .Replace("=", "\\=");
+    }
+
+    private sealed class TimingScope : IDisposable
+    {
+        private readonly string phase;
+        private readonly string? detail;
+        private readonly Stopwatch stopwatch;
+        private bool disposed;
+
+        internal TimingScope(string phase, string? detail)
+        {
+            this.phase = phase;
+            this.detail = detail;
+            stopwatch = Stopwatch.StartNew();
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            stopwatch.Stop();
+            LogElapsed(phase, stopwatch.Elapsed, detail);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs
@@ -169,6 +169,7 @@ internal static class JournalPatternTranslator
 
     private static List<JournalPatternDefinition> LoadPatterns()
     {
+        using var timing = RuntimeStartupTiming.Measure("journal_pattern.load_patterns");
         Interlocked.Increment(ref loadInvocationCount);
 
         var paths = ResolvePatternFilePaths();

--- a/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
@@ -146,6 +146,7 @@ internal static class MessagePatternTranslator
             var leafPath = leafFileOverride ?? ResolveLeafFilePath();
             if (leafPath != null && File.Exists(leafPath))
             {
+                using var timing = RuntimeStartupTiming.Measure("message_pattern.load_leaf_dictionary");
                 try
                 {
                     var file = JsonAssetLoader.LoadFromFile<LeafDictionaryFile>(leafPath);
@@ -271,6 +272,7 @@ internal static class MessagePatternTranslator
 
     private static List<MessagePatternDefinition> LoadPatterns()
     {
+        using var timing = RuntimeStartupTiming.Measure("message_pattern.load_patterns");
         Interlocked.Increment(ref loadInvocationCount);
 
         var patternFilePath = ResolvePatternFilePath();

--- a/Mods/QudJP/Assemblies/src/Translation/Translator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/Translator.cs
@@ -219,6 +219,7 @@ public static class Translator
 
     private static Dictionary<string, string> LoadTranslations()
     {
+        using var timing = RuntimeStartupTiming.Measure("translator.load_global_dictionaries");
         Interlocked.Increment(ref loadInvocationCount);
 
         var translations = new Dictionary<string, string>(StringComparer.Ordinal);

--- a/Mods/QudJP/Assemblies/src/UI/FontManager.cs
+++ b/Mods/QudJP/Assemblies/src/UI/FontManager.cs
@@ -48,7 +48,12 @@ public static class FontManager
 #if HAS_TMP
         try
         {
-            var fontPath = ResolveFontPath();
+            string fontPath;
+            using (RuntimeStartupTiming.Measure("font.resolve_path"))
+            {
+                fontPath = ResolveFontPath();
+            }
+
             if (!File.Exists(fontPath))
             {
                 throw new FileNotFoundException($"CJK font not found: {fontPath}", fontPath);
@@ -56,7 +61,11 @@ public static class FontManager
 
             RuntimeDiagnostics.LogStatus($"[QudJP] FontManager: Loading CJK font from {fontPath}");
 
-            var fontAsset = TMP_FontAsset.CreateFontAsset(fontPath, 0, 96, 6, GlyphRenderMode.SDFAA, 4096, 4096);
+            TMP_FontAsset fontAsset;
+            using (RuntimeStartupTiming.Measure("font.create_tmp_asset"))
+            {
+                fontAsset = TMP_FontAsset.CreateFontAsset(fontPath, 0, 96, 6, GlyphRenderMode.SDFAA, 4096, 4096);
+            }
 #pragma warning disable CA1508 // Unity objects may be null despite non-nullable annotations
             if (fontAsset is null)
             {
@@ -91,9 +100,19 @@ public static class FontManager
                 EnsureFontListed(TMP_Settings.fallbackFontAssets, previousDefaultFont, prepend: false);
             }
 
-            var patchedFontAssetCount = EnsureFallbackOnAllFontAssets(fontAsset);
+            int patchedFontAssetCount;
+            using (RuntimeStartupTiming.Measure("font.patch_existing_fallbacks"))
+            {
+                patchedFontAssetCount = EnsureFallbackOnAllFontAssets(fontAsset);
+            }
 
-            if (!TryWarmFontCharacters(fontAsset, "日本語テスト"))
+            bool warmed;
+            using (RuntimeStartupTiming.Measure("font.warm_startup_glyphs"))
+            {
+                warmed = TryWarmFontCharacters(fontAsset, "日本語テスト");
+            }
+
+            if (!warmed)
             {
                 RuntimeDiagnostics.LogStatus(
                     "[QudJP] FontManager: CJK font startup warmup did not confirm glyphs for '日本語テスト'; runtime dynamic fallback remains enabled.");

--- a/Mods/QudJP/Bootstrap.cs
+++ b/Mods/QudJP/Bootstrap.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using XRL;
@@ -11,6 +13,7 @@ namespace QudJP
         [ModSensitiveCacheInit]
         public static void Bootstrap()
         {
+            var total = Stopwatch.StartNew();
             try
             {
                 UnityEngine.Debug.Log("[QudJP] Bootstrap: resolving QudJP.dll path...");
@@ -40,7 +43,16 @@ namespace QudJP
                 }
 
                 UnityEngine.Debug.Log("[QudJP] Bootstrap: loading assembly from " + dllPath);
-                Assembly assembly = Assembly.LoadFrom(dllPath);
+                Assembly assembly;
+                var loadAssembly = Stopwatch.StartNew();
+                try
+                {
+                    assembly = Assembly.LoadFrom(dllPath);
+                }
+                finally
+                {
+                    LogStartupTiming("bootstrap.load_assembly", loadAssembly.Elapsed);
+                }
 
                 Type modType = assembly.GetType("QudJP.QudJPMod");
                 if (modType == null)
@@ -56,7 +68,15 @@ namespace QudJP
                     throw new InvalidOperationException("[QudJP] Bootstrap: method 'Init' not found on QudJP.QudJPMod");
                 }
 
-                initMethod.Invoke(null, null);
+                var invokeInit = Stopwatch.StartNew();
+                try
+                {
+                    initMethod.Invoke(null, null);
+                }
+                finally
+                {
+                    LogStartupTiming("bootstrap.invoke_init", invokeInit.Elapsed);
+                }
 
                 UnityEngine.Debug.Log("[QudJP] Bootstrap: initialization complete.");
             }
@@ -65,6 +85,20 @@ namespace QudJP
                 UnityEngine.Debug.LogError("[QudJP] Bootstrap failed: " + ex);
                 throw;
             }
+            finally
+            {
+                total.Stop();
+                LogStartupTiming("bootstrap.total", total.Elapsed);
+            }
+        }
+
+        private static void LogStartupTiming(string phase, TimeSpan elapsed)
+        {
+            UnityEngine.Debug.Log(
+                "[QudJP] StartupTiming/v1: phase="
+                + phase
+                + " elapsed_ms="
+                + elapsed.TotalMilliseconds.ToString("0.###", CultureInfo.InvariantCulture));
         }
     }
 }

--- a/scripts/startup_measure.py
+++ b/scripts/startup_measure.py
@@ -401,7 +401,7 @@ def _wait_for_ready_marker(log_path: Path, timeout_seconds: float, ready_marker:
             text = log_path.read_text(encoding="utf-8", errors="replace")
             if ready_marker in text:
                 return "ready", time.monotonic() - started
-            if "QudJP: Harmony patched zero methods" in text or "mprotect returned EACCES" in text:
+            if "Harmony patched zero methods" in text or "mprotect returned EACCES" in text:
                 return "harmony_failed", time.monotonic() - started
         time.sleep(0.25)
     return "timeout", None
@@ -475,18 +475,18 @@ def _collect(args: argparse.Namespace) -> int:
                 shutil.copy2(args.log, previous_log)
                 args.log.unlink()
             started_at = datetime.now(UTC).isoformat()
-            process = subprocess.Popen(  # noqa: S603 -- command is explicit CLI input for local measurement.
-                command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            status, elapsed = _wait_for_ready_marker(args.log, args.timeout, ready_marker)
-            if status == "ready" and args.settle_seconds > 0:
-                time.sleep(args.settle_seconds)
-            _stop_process(process)
-            stdout, stderr = process.communicate(timeout=5)
-            (iteration_dir / "stdout.txt").write_bytes(stdout)
-            (iteration_dir / "stderr.txt").write_bytes(stderr)
+            with (iteration_dir / "stdout.txt").open("wb") as stdout_file, (iteration_dir / "stderr.txt").open(
+                "wb",
+            ) as stderr_file:
+                process = subprocess.Popen(  # noqa: S603 -- command is explicit CLI input for local measurement.
+                    command,
+                    stdout=stdout_file,
+                    stderr=stderr_file,
+                )
+                status, elapsed = _wait_for_ready_marker(args.log, args.timeout, ready_marker)
+                if status == "ready" and args.settle_seconds > 0:
+                    time.sleep(args.settle_seconds)
+                _stop_process(process)
             if args.log.exists():
                 shutil.copy2(args.log, iteration_dir / "Player.log")
             else:

--- a/scripts/startup_measure.py
+++ b/scripts/startup_measure.py
@@ -1,0 +1,639 @@
+"""Collect and summarize Caves of Qud startup timing logs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from statistics import mean, median
+from typing import TYPE_CHECKING
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.sync_mod import resolve_default_destination  # noqa: E402
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+_DEFAULT_LOG = Path.home() / "Library" / "Logs" / "Freehold Games" / "CavesOfQud" / "Player.log"
+_DEFAULT_ARTIFACT_DIR = Path(".sisyphus") / "evidence" / f"issue-604-{datetime.now(UTC):%Y%m%dT%H%M%SZ}"
+_STARTUP_TIMING_MARKER = "[QudJP] StartupTiming/v1:"
+_GAME_LOADING_TASK_PATTERN = re.compile(r"INFO - Finished 'Loading (?P<task>[^']+)' task in (?P<elapsed>\d+)ms")
+_BUILD_MARKER = "[QudJP] Build marker:"
+_HARMONY_COMPLETE_MARKER = "[QudJP] Harmony patching complete:"
+_ERROR_MARKERS = (
+    "MissingMethodException",
+    "MODWARN",
+    "[QudJP] Bootstrap failed",
+    "[QudJP] FontManager failed",
+)
+
+
+@dataclass(frozen=True)
+class StartupTimingEntry:
+    """A single `StartupTiming/v1` timing entry from Player.log."""
+
+    phase: str
+    elapsed_ms: float
+    detail: str | None
+    line_number: int
+
+
+@dataclass(frozen=True)
+class ParsedStartupLog:
+    """Structured timing and marker data extracted from one Player.log."""
+
+    timings: tuple[StartupTimingEntry, ...]
+    build_marker_seen: bool
+    harmony_complete_seen: bool
+    error_lines: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class IterationMetadata:
+    """Runner-side metadata for one startup iteration."""
+
+    profile: str
+    iteration: int
+    command: tuple[str, ...]
+    started_at: str
+    status: str
+    elapsed_until_ready_ms: float | None
+    exit_code: int | None
+
+
+@dataclass(frozen=True)
+class IterationResult:
+    """Combined runner metadata and parsed log data for one iteration."""
+
+    metadata: IterationMetadata
+    parsed: ParsedStartupLog
+
+
+@dataclass(frozen=True)
+class PhaseSummary:
+    """Aggregate timing statistics for one phase in one profile."""
+
+    phase: str
+    count: int
+    mean_ms: float
+    median_ms: float
+    min_ms: float
+    max_ms: float
+
+
+@dataclass(frozen=True)
+class ProfileSummary:
+    """Aggregate timing statistics for one measurement profile."""
+
+    profile: str
+    iterations: int
+    ready_iterations: int
+    phases: tuple[PhaseSummary, ...]
+
+
+@dataclass(frozen=True)
+class PhaseComparison:
+    """Comparison for a phase shared by two profiles."""
+
+    phase: str
+    baseline_median_ms: float
+    candidate_median_ms: float
+    delta_median_ms: float
+
+
+def parse_startup_log_text(text: str) -> ParsedStartupLog:
+    """Parse QudJP startup timing markers from Player.log text."""
+    timings: list[StartupTimingEntry] = []
+    error_lines: list[str] = []
+    build_marker_seen = False
+    harmony_complete_seen = False
+
+    for index, line in enumerate(text.splitlines(), start=1):
+        if _BUILD_MARKER in line:
+            build_marker_seen = True
+        if _HARMONY_COMPLETE_MARKER in line:
+            harmony_complete_seen = True
+        if any(marker in line for marker in _ERROR_MARKERS):
+            error_lines.append(line)
+        marker_index = line.find(_STARTUP_TIMING_MARKER)
+        if marker_index != -1:
+            fields = _parse_timing_fields(line[marker_index + len(_STARTUP_TIMING_MARKER) :].strip())
+            phase = fields.get("phase")
+            elapsed_ms = fields.get("elapsed_ms")
+            if phase is None or elapsed_ms is None:
+                continue
+            try:
+                elapsed = float(elapsed_ms)
+            except ValueError:
+                continue
+            timings.append(
+                StartupTimingEntry(
+                    phase=phase,
+                    elapsed_ms=elapsed,
+                    detail=fields.get("detail"),
+                    line_number=index,
+                ),
+            )
+            continue
+
+        game_loading_match = _GAME_LOADING_TASK_PATTERN.search(line)
+        if game_loading_match is not None:
+            timings.append(
+                StartupTimingEntry(
+                    phase="game.loading." + _normalize_phase_fragment(game_loading_match.group("task")),
+                    elapsed_ms=float(game_loading_match.group("elapsed")),
+                    detail=game_loading_match.group("task"),
+                    line_number=index,
+                ),
+            )
+
+    return ParsedStartupLog(
+        timings=tuple(timings),
+        build_marker_seen=build_marker_seen,
+        harmony_complete_seen=harmony_complete_seen,
+        error_lines=tuple(error_lines),
+    )
+
+
+def summarize_iterations(results: Iterable[IterationResult]) -> tuple[ProfileSummary, ...]:
+    """Build per-profile phase summaries from iteration results."""
+    grouped: dict[str, list[IterationResult]] = {}
+    for result in results:
+        grouped.setdefault(result.metadata.profile, []).append(result)
+
+    summaries: list[ProfileSummary] = []
+    for profile, profile_results in sorted(grouped.items()):
+        phase_values: dict[str, list[float]] = {}
+        for result in profile_results:
+            if result.metadata.elapsed_until_ready_ms is not None:
+                phase_values.setdefault("runner.elapsed_until_ready", []).append(result.metadata.elapsed_until_ready_ms)
+            for timing in result.parsed.timings:
+                phase_values.setdefault(timing.phase, []).append(timing.elapsed_ms)
+        phases = tuple(
+            PhaseSummary(
+                phase=phase,
+                count=len(values),
+                mean_ms=round(mean(values), 3),
+                median_ms=round(median(values), 3),
+                min_ms=round(min(values), 3),
+                max_ms=round(max(values), 3),
+            )
+            for phase, values in sorted(phase_values.items())
+        )
+        summaries.append(
+            ProfileSummary(
+                profile=profile,
+                iterations=len(profile_results),
+                ready_iterations=sum(1 for result in profile_results if result.metadata.status == "ready"),
+                phases=phases,
+            ),
+        )
+    return tuple(summaries)
+
+
+def compare_profiles(
+    summaries: Sequence[ProfileSummary],
+    *,
+    baseline_profile: str,
+    candidate_profile: str,
+) -> tuple[PhaseComparison, ...]:
+    """Compare median phase timings between two profiles."""
+    by_profile = {summary.profile: summary for summary in summaries}
+    baseline = by_profile[baseline_profile]
+    candidate = by_profile[candidate_profile]
+    baseline_phases = {phase.phase: phase for phase in baseline.phases}
+    candidate_phases = {phase.phase: phase for phase in candidate.phases}
+
+    comparisons: list[PhaseComparison] = []
+    for phase in sorted(set(baseline_phases) & set(candidate_phases)):
+        baseline_median = baseline_phases[phase].median_ms
+        candidate_median = candidate_phases[phase].median_ms
+        comparisons.append(
+            PhaseComparison(
+                phase=phase,
+                baseline_median_ms=baseline_median,
+                candidate_median_ms=candidate_median,
+                delta_median_ms=round(candidate_median - baseline_median, 3),
+            ),
+        )
+    return tuple(comparisons)
+
+
+def write_summary_markdown(summaries: Sequence[ProfileSummary], path: Path) -> None:
+    """Write a compact Markdown summary table."""
+    lines = ["# Startup Measurement Summary", ""]
+    for summary in summaries:
+        lines.extend(
+            [
+                f"## {summary.profile}",
+                "",
+                f"- iterations: {summary.iterations}",
+                f"- ready iterations: {summary.ready_iterations}",
+                "",
+                "| phase | count | median ms | mean ms | min ms | max ms |",
+                "| --- | ---: | ---: | ---: | ---: | ---: |",
+            ],
+        )
+        lines.extend(
+            f"| {phase.phase} | {phase.count} | {phase.median_ms:.3f} | {phase.mean_ms:.3f} | "
+            f"{phase.min_ms:.3f} | {phase.max_ms:.3f} |"
+            for phase in summary.phases
+        )
+        lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_comparison_markdown(comparisons: Sequence[PhaseComparison], path: Path) -> None:
+    """Write a compact Markdown comparison table."""
+    lines = [
+        "# Startup Measurement Comparison",
+        "",
+        "| phase | baseline median ms | candidate median ms | delta median ms |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    lines.extend(
+        f"| {item.phase} | {item.baseline_median_ms:.3f} | {item.candidate_median_ms:.3f} | "
+        f"{item.delta_median_ms:.3f} |"
+        for item in comparisons
+    )
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_top_phases_markdown(
+    summaries: Sequence[ProfileSummary],
+    path: Path,
+    *,
+    prefix: str,
+    limit: int,
+) -> None:
+    """Write the highest-median phases matching a prefix for each profile."""
+    lines = ["# Startup Measurement Top Phases", "", f"- prefix: `{prefix}`", f"- limit: {limit}", ""]
+    for summary in summaries:
+        matching = [phase for phase in summary.phases if phase.phase.startswith(prefix)]
+        matching.sort(key=lambda phase: phase.median_ms, reverse=True)
+        lines.extend(
+            [
+                f"## {summary.profile}",
+                "",
+                "| rank | phase | count | median ms | mean ms | min ms | max ms |",
+                "| ---: | --- | ---: | ---: | ---: | ---: | ---: |",
+            ],
+        )
+        if not matching:
+            lines.append("|  | _no matching phases_ |  |  |  |  |  |")
+        else:
+            lines.extend(
+                f"| {rank} | {phase.phase} | {phase.count} | {phase.median_ms:.3f} | "
+                f"{phase.mean_ms:.3f} | {phase.min_ms:.3f} | {phase.max_ms:.3f} |"
+                for rank, phase in enumerate(matching[:limit], start=1)
+            )
+        lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _parse_timing_fields(text: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for token in _split_escaped_tokens(text):
+        if "=" not in token:
+            continue
+        key, value = token.split("=", maxsplit=1)
+        fields[key] = value
+    return fields
+
+
+def _split_escaped_tokens(text: str) -> list[str]:
+    tokens: list[str] = []
+    current: list[str] = []
+    escaped = False
+    for char in text:
+        if escaped:
+            current.append(char)
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == " ":
+            if current:
+                tokens.append("".join(current))
+                current = []
+            continue
+        current.append(char)
+    if escaped:
+        current.append("\\")
+    if current:
+        tokens.append("".join(current))
+    return tokens
+
+
+def _normalize_phase_fragment(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+    return normalized or "unknown"
+
+
+def _as_jsonable(value: object) -> object:
+    if isinstance(value, tuple):
+        return [_as_jsonable(item) for item in value]
+    if isinstance(value, list):
+        return [_as_jsonable(item) for item in value]
+    if hasattr(value, "__dataclass_fields__"):
+        return {key: _as_jsonable(item) for key, item in asdict(value).items()}
+    if isinstance(value, dict):
+        return {key: _as_jsonable(item) for key, item in value.items()}
+    return value
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(_as_jsonable(value), ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _read_iteration_result(iteration_dir: Path) -> IterationResult:
+    metadata = json.loads((iteration_dir / "metadata.json").read_text(encoding="utf-8"))
+    parsed = parse_startup_log_text((iteration_dir / "Player.log").read_text(encoding="utf-8"))
+    return IterationResult(
+        metadata=IterationMetadata(
+            profile=metadata["profile"],
+            iteration=int(metadata["iteration"]),
+            command=tuple(metadata["command"]),
+            started_at=metadata["started_at"],
+            status=metadata["status"],
+            elapsed_until_ready_ms=metadata["elapsed_until_ready_ms"],
+            exit_code=metadata["exit_code"],
+        ),
+        parsed=parsed,
+    )
+
+
+def _find_iteration_dirs(input_dir: Path) -> list[Path]:
+    return sorted(path for path in input_dir.glob("profiles/*/iteration-*") if (path / "metadata.json").exists())
+
+
+def _read_profile_summaries(summary_path: Path) -> tuple[ProfileSummary, ...]:
+    summaries = json.loads(summary_path.read_text(encoding="utf-8"))
+    return tuple(
+        ProfileSummary(
+            profile=summary["profile"],
+            iterations=summary["iterations"],
+            ready_iterations=summary["ready_iterations"],
+            phases=tuple(PhaseSummary(**phase) for phase in summary["phases"]),
+        )
+        for summary in summaries
+    )
+
+
+def _wait_for_ready_marker(log_path: Path, timeout_seconds: float, ready_marker: str) -> tuple[str, float | None]:
+    started = time.monotonic()
+    deadline = started + timeout_seconds
+    while time.monotonic() < deadline:
+        if log_path.exists():
+            text = log_path.read_text(encoding="utf-8", errors="replace")
+            if ready_marker in text:
+                return "ready", time.monotonic() - started
+            if "QudJP: Harmony patched zero methods" in text or "mprotect returned EACCES" in text:
+                return "harmony_failed", time.monotonic() - started
+        time.sleep(0.25)
+    return "timeout", None
+
+
+def _stop_process(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+def _disable_mod(mod_dir: Path) -> Path | None:
+    if not mod_dir.exists():
+        return None
+    disabled_root = mod_dir.parent.parent / ".qudjp-startup-measure-disabled"
+    disabled_dir = disabled_root / mod_dir.name
+    if disabled_dir.exists():
+        msg = f"Refusing to overwrite existing disabled mod directory: {disabled_dir}"
+        raise FileExistsError(msg)
+    disabled_root.mkdir(parents=True, exist_ok=True)
+    mod_dir.rename(disabled_dir)
+    return disabled_dir
+
+
+def _restore_mod(mod_dir: Path, disabled_dir: Path | None) -> None:
+    if disabled_dir is None:
+        return
+    if mod_dir.exists():
+        msg = (
+            f"Refusing to restore disabled mod over existing directory: {mod_dir}. "
+            f"The disabled copy remains at: {disabled_dir}"
+        )
+        raise FileExistsError(msg)
+    mod_dir.parent.mkdir(parents=True, exist_ok=True)
+    disabled_dir.rename(mod_dir)
+
+
+def _resolve_ready_marker(*, disable_mod: bool, ready_marker: str | None) -> str:
+    if ready_marker is not None:
+        return ready_marker
+    if disable_mod:
+        msg = (
+            "--disable-mod requires --ready-marker because the default QudJP Harmony "
+            "completion marker will not appear while QudJP is disabled."
+        )
+        raise ValueError(msg)
+    return _HARMONY_COMPLETE_MARKER
+
+
+def _collect(args: argparse.Namespace) -> int:
+    command = tuple(shlex.split(args.launch_cmd))
+    artifact_dir = args.artifact_dir
+    mod_dir = args.mod_dir or resolve_default_destination()
+    ready_marker = _resolve_ready_marker(disable_mod=args.disable_mod, ready_marker=args.ready_marker)
+    disabled_dirs: list[tuple[Path, Path | None]] = []
+    try:
+        if args.disable_mod:
+            disabled_dirs.append((mod_dir, _disable_mod(mod_dir)))
+        disabled_dirs.extend((extra_mod_dir, _disable_mod(extra_mod_dir)) for extra_mod_dir in args.disable_mod_dir)
+        results: list[IterationResult] = []
+        for iteration in range(1, args.iterations + 1):
+            iteration_dir = artifact_dir / "profiles" / args.profile / f"iteration-{iteration:02d}"
+            iteration_dir.mkdir(parents=True, exist_ok=True)
+            previous_log = iteration_dir / "Player.before.log"
+            if args.log.exists():
+                shutil.copy2(args.log, previous_log)
+                args.log.unlink()
+            started_at = datetime.now(UTC).isoformat()
+            process = subprocess.Popen(  # noqa: S603 -- command is explicit CLI input for local measurement.
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            status, elapsed = _wait_for_ready_marker(args.log, args.timeout, ready_marker)
+            if status == "ready" and args.settle_seconds > 0:
+                time.sleep(args.settle_seconds)
+            _stop_process(process)
+            stdout, stderr = process.communicate(timeout=5)
+            (iteration_dir / "stdout.txt").write_bytes(stdout)
+            (iteration_dir / "stderr.txt").write_bytes(stderr)
+            if args.log.exists():
+                shutil.copy2(args.log, iteration_dir / "Player.log")
+            else:
+                (iteration_dir / "Player.log").write_text("", encoding="utf-8")
+
+            metadata = IterationMetadata(
+                profile=args.profile,
+                iteration=iteration,
+                command=command,
+                started_at=started_at,
+                status=status,
+                elapsed_until_ready_ms=None if elapsed is None else round(elapsed * 1000, 3),
+                exit_code=process.returncode,
+            )
+            parsed = parse_startup_log_text((iteration_dir / "Player.log").read_text(encoding="utf-8"))
+            result = IterationResult(metadata=metadata, parsed=parsed)
+            results.append(result)
+            _write_json(iteration_dir / "metadata.json", metadata)
+            _write_json(iteration_dir / "parsed.json", parsed)
+
+        summaries = summarize_iterations(results)
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        _write_json(artifact_dir / f"{args.profile}-summary.json", summaries)
+        write_summary_markdown(summaries, artifact_dir / f"{args.profile}-summary.md")
+        return 0
+    finally:
+        for enabled_dir, disabled_dir in reversed(disabled_dirs):
+            _restore_mod(enabled_dir, disabled_dir)
+
+
+def _parse(args: argparse.Namespace) -> int:
+    results = [_read_iteration_result(path) for path in _find_iteration_dirs(args.input_dir)]
+    summaries = summarize_iterations(results)
+    _write_json(args.output, summaries)
+    if args.markdown is not None:
+        write_summary_markdown(summaries, args.markdown)
+    return 0
+
+
+def _compare(args: argparse.Namespace) -> int:
+    profile_summaries = _read_profile_summaries(args.summary)
+    comparisons = compare_profiles(
+        profile_summaries,
+        baseline_profile=args.baseline,
+        candidate_profile=args.candidate,
+    )
+    _write_json(args.output, comparisons)
+    if args.markdown is not None:
+        write_comparison_markdown(comparisons, args.markdown)
+    return 0
+
+
+def _top(args: argparse.Namespace) -> int:
+    profile_summaries = _read_profile_summaries(args.summary)
+    selected_profiles = set(args.profile)
+    if selected_profiles:
+        profile_summaries = tuple(summary for summary in profile_summaries if summary.profile in selected_profiles)
+
+    top_by_profile: dict[str, list[PhaseSummary]] = {}
+    for summary in profile_summaries:
+        matching = [phase for phase in summary.phases if phase.phase.startswith(args.prefix)]
+        matching.sort(key=lambda phase: phase.median_ms, reverse=True)
+        top_by_profile[summary.profile] = matching[: args.limit]
+
+    _write_json(args.output, top_by_profile)
+    if args.markdown is not None:
+        write_top_phases_markdown(profile_summaries, args.markdown, prefix=args.prefix, limit=args.limit)
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    collect = subparsers.add_parser("collect", help="Launch the game repeatedly and preserve Player.log artifacts.")
+    collect.add_argument("--profile", required=True, help="Profile name, for example qudjp-enabled or qudjp-disabled.")
+    collect.add_argument("--iterations", type=int, default=3, help="Number of launch iterations.")
+    collect.add_argument("--artifact-dir", type=Path, default=_DEFAULT_ARTIFACT_DIR, help="Artifact output directory.")
+    collect.add_argument(
+        "--launch-cmd",
+        default="scripts/launch_rosetta.sh",
+        help="Command used to launch Caves of Qud.",
+    )
+    collect.add_argument("--log", type=Path, default=_DEFAULT_LOG, help="Path to Player.log.")
+    collect.add_argument("--timeout", type=float, default=90.0, help="Seconds to wait for the ready marker.")
+    collect.add_argument(
+        "--settle-seconds",
+        type=float,
+        default=0.0,
+        help="Seconds to keep the game running after the ready marker before preserving Player.log.",
+    )
+    collect.add_argument(
+        "--ready-marker",
+        default=None,
+        help=(
+            "Player.log marker that ends an iteration. Defaults to the QudJP Harmony "
+            "completion marker unless --disable-mod is used."
+        ),
+    )
+    collect.add_argument("--mod-dir", type=Path, default=None, help="Mods/QudJP directory to rename for --disable-mod.")
+    collect.add_argument(
+        "--disable-mod-dir",
+        type=Path,
+        action="append",
+        default=[],
+        help="Additional mod directory to temporarily rename during collection.",
+    )
+    collect.add_argument("--disable-mod", action="store_true", help="Temporarily disable QudJP for this profile.")
+    collect.set_defaults(func=_collect)
+
+    parse = subparsers.add_parser("parse", help="Parse preserved iteration artifacts into a summary.")
+    parse.add_argument(
+        "--input-dir",
+        type=Path,
+        required=True,
+        help="Artifact directory containing profiles/*/iteration-*.",
+    )
+    parse.add_argument("--output", type=Path, required=True, help="JSON summary output path.")
+    parse.add_argument("--markdown", type=Path, default=None, help="Optional Markdown summary output path.")
+    parse.set_defaults(func=_parse)
+
+    compare = subparsers.add_parser("compare", help="Compare two profiles from a summary JSON file.")
+    compare.add_argument("--summary", type=Path, required=True, help="JSON summary from the parse command.")
+    compare.add_argument("--baseline", required=True, help="Baseline profile name.")
+    compare.add_argument("--candidate", required=True, help="Candidate profile name.")
+    compare.add_argument("--output", type=Path, required=True, help="JSON comparison output path.")
+    compare.add_argument("--markdown", type=Path, default=None, help="Optional Markdown comparison output path.")
+    compare.set_defaults(func=_compare)
+
+    top = subparsers.add_parser("top", help="Report highest-median phases matching a prefix.")
+    top.add_argument("--summary", type=Path, required=True, help="JSON summary from the parse command.")
+    top.add_argument("--prefix", required=True, help="Phase prefix to include, for example harmony.patch_apply.")
+    top.add_argument("--limit", type=int, default=20, help="Maximum rows per profile.")
+    top.add_argument("--profile", action="append", default=[], help="Optional profile to include; may be repeated.")
+    top.add_argument("--output", type=Path, required=True, help="JSON top phases output path.")
+    top.add_argument("--markdown", type=Path, default=None, help="Optional Markdown top phases output path.")
+    top.set_defaults(func=_top)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the startup measurement CLI."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/startup_measure.py
+++ b/scripts/startup_measure.py
@@ -466,11 +466,11 @@ def _resolve_ready_marker(*, disable_mod: bool, ready_marker: str | None) -> str
 def _collect(args: argparse.Namespace) -> int:
     command = tuple(shlex.split(args.launch_cmd))
     artifact_dir = args.artifact_dir
-    mod_dir = args.mod_dir or resolve_default_destination()
     ready_marker = _resolve_ready_marker(disable_mod=args.disable_mod, ready_marker=args.ready_marker)
     disabled_dirs: list[tuple[Path, Path | None]] = []
     try:
         if args.disable_mod:
+            mod_dir = args.mod_dir or resolve_default_destination()
             disabled_dirs.append((mod_dir, _disable_mod(mod_dir)))
         disabled_dirs.extend((extra_mod_dir, _disable_mod(extra_mod_dir)) for extra_mod_dir in args.disable_mod_dir)
         results: list[IterationResult] = []

--- a/scripts/startup_measure.py
+++ b/scripts/startup_measure.py
@@ -399,10 +399,10 @@ def _wait_for_ready_marker(log_path: Path, timeout_seconds: float, ready_marker:
     while time.monotonic() < deadline:
         if log_path.exists():
             text = log_path.read_text(encoding="utf-8", errors="replace")
-            if ready_marker in text:
-                return "ready", time.monotonic() - started
             if "Harmony patched zero methods" in text or "mprotect returned EACCES" in text:
                 return "harmony_failed", time.monotonic() - started
+            if ready_marker in text:
+                return "ready", time.monotonic() - started
         time.sleep(0.25)
     return "timeout", None
 

--- a/scripts/startup_measure.py
+++ b/scripts/startup_measure.py
@@ -393,7 +393,12 @@ def _read_profile_summaries(summary_path: Path) -> tuple[ProfileSummary, ...]:
     )
 
 
-def _wait_for_ready_marker(log_path: Path, timeout_seconds: float, ready_marker: str) -> tuple[str, float | None]:
+def _wait_for_ready_marker(
+    log_path: Path,
+    timeout_seconds: float,
+    ready_marker: str,
+    process: subprocess.Popen[bytes] | None = None,
+) -> tuple[str, float | None]:
     started = time.monotonic()
     deadline = started + timeout_seconds
     while time.monotonic() < deadline:
@@ -403,6 +408,8 @@ def _wait_for_ready_marker(log_path: Path, timeout_seconds: float, ready_marker:
                 return "harmony_failed", time.monotonic() - started
             if ready_marker in text:
                 return "ready", time.monotonic() - started
+        if process is not None and process.poll() is not None:
+            return "process_exited", time.monotonic() - started
         time.sleep(0.25)
     return "timeout", None
 
@@ -483,7 +490,7 @@ def _collect(args: argparse.Namespace) -> int:
                     stdout=stdout_file,
                     stderr=stderr_file,
                 )
-                status, elapsed = _wait_for_ready_marker(args.log, args.timeout, ready_marker)
+                status, elapsed = _wait_for_ready_marker(args.log, args.timeout, ready_marker, process)
                 if status == "ready" and args.settle_seconds > 0:
                     time.sleep(args.settle_seconds)
                 _stop_process(process)

--- a/scripts/tests/test_startup_measure.py
+++ b/scripts/tests/test_startup_measure.py
@@ -1,0 +1,232 @@
+"""Tests for startup measurement tooling."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.startup_measure import (
+    IterationMetadata,
+    IterationResult,
+    PhaseSummary,
+    ProfileSummary,
+    _resolve_ready_marker,
+    _restore_mod,
+    compare_profiles,
+    main,
+    parse_startup_log_text,
+    summarize_iterations,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_parse_startup_log_text_extracts_timing_markers() -> None:
+    """StartupTiming lines are parsed with escaped detail fields."""
+    log = (
+        "[QudJP] Build marker: marker\n"
+        "[QudJP] StartupTiming/v1: phase=harmony.prepare_patch_types elapsed_ms=12.346 "
+        r"detail=patch_types\=140\;prepared\=139"
+        "\nINFO - Finished 'Loading Naming.xml' task in 42ms"
+        "\n[QudJP] Harmony patching complete: 590 method(s) patched."
+    )
+
+    parsed = parse_startup_log_text(log)
+
+    assert parsed.build_marker_seen is True
+    assert parsed.harmony_complete_seen is True
+    assert len(parsed.timings) == 2
+    assert parsed.timings[0].phase == "harmony.prepare_patch_types"
+    assert parsed.timings[0].elapsed_ms == 12.346
+    assert parsed.timings[0].detail == "patch_types=140;prepared=139"
+    assert parsed.timings[1].phase == "game.loading.naming_xml"
+    assert parsed.timings[1].elapsed_ms == 42.0
+    assert parsed.timings[1].detail == "Naming.xml"
+
+
+def test_summarize_iterations_groups_by_profile_and_phase() -> None:
+    """Iteration summaries report per-profile median and ready counts."""
+    results = [
+        _result("enabled", 1, "ready", {"font.initialize": 100.0, "harmony.setup_and_apply": 20.0}),
+        _result("enabled", 2, "ready", {"font.initialize": 120.0, "harmony.setup_and_apply": 30.0}),
+        _result("disabled", 1, "ready", {"bootstrap.total": 50.0}),
+    ]
+
+    summaries = summarize_iterations(results)
+    enabled = next(summary for summary in summaries if summary.profile == "enabled")
+    font = next(phase for phase in enabled.phases if phase.phase == "font.initialize")
+    runner = next(phase for phase in enabled.phases if phase.phase == "runner.elapsed_until_ready")
+
+    assert enabled.iterations == 2
+    assert enabled.ready_iterations == 2
+    assert font.count == 2
+    assert font.median_ms == 110.0
+    assert font.mean_ms == 110.0
+    assert runner.count == 2
+    assert runner.median_ms == 1000.0
+
+
+def test_compare_profiles_reports_median_delta() -> None:
+    """Profile comparisons use shared phase medians."""
+    summaries = (
+        ProfileSummary(
+            profile="disabled",
+            iterations=1,
+            ready_iterations=1,
+            phases=(PhaseSummary("bootstrap.total", 1, 50.0, 50.0, 50.0, 50.0),),
+        ),
+        ProfileSummary(
+            profile="enabled",
+            iterations=1,
+            ready_iterations=1,
+            phases=(PhaseSummary("bootstrap.total", 1, 80.0, 80.0, 80.0, 80.0),),
+        ),
+    )
+
+    comparisons = compare_profiles(summaries, baseline_profile="disabled", candidate_profile="enabled")
+
+    assert len(comparisons) == 1
+    assert comparisons[0].phase == "bootstrap.total"
+    assert comparisons[0].delta_median_ms == 30.0
+
+
+def test_parse_cli_reads_preserved_iteration_artifacts(tmp_path: Path) -> None:
+    """The parse command summarizes saved Player.log and metadata files."""
+    iteration_dir = tmp_path / "profiles" / "enabled" / "iteration-01"
+    iteration_dir.mkdir(parents=True)
+    (iteration_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "profile": "enabled",
+                "iteration": 1,
+                "command": ["scripts/launch_rosetta.sh"],
+                "started_at": "2026-05-09T00:00:00+00:00",
+                "status": "ready",
+                "elapsed_until_ready_ms": 1000.0,
+                "exit_code": 0,
+            },
+        ),
+        encoding="utf-8",
+    )
+    (iteration_dir / "Player.log").write_text(
+        "[QudJP] StartupTiming/v1: phase=font.initialize elapsed_ms=25\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "summary.json"
+    markdown = tmp_path / "summary.md"
+
+    exit_code = main(["parse", "--input-dir", str(tmp_path), "--output", str(output), "--markdown", str(markdown)])
+
+    summary = json.loads(output.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert summary[0]["profile"] == "enabled"
+    assert summary[0]["phases"][0]["phase"] == "font.initialize"
+    assert markdown.read_text(encoding="utf-8").startswith("# Startup Measurement Summary")
+
+
+def test_top_cli_reports_highest_matching_phases(tmp_path: Path) -> None:
+    """The top command ranks matching phase medians per profile."""
+    summary = [
+        {
+            "profile": "enabled",
+            "iterations": 1,
+            "ready_iterations": 1,
+            "phases": [
+                {
+                    "phase": "harmony.patch_apply.FastPatch",
+                    "count": 1,
+                    "mean_ms": 5.0,
+                    "median_ms": 5.0,
+                    "min_ms": 5.0,
+                    "max_ms": 5.0,
+                },
+                {
+                    "phase": "harmony.patch_apply.SlowPatch",
+                    "count": 1,
+                    "mean_ms": 50.0,
+                    "median_ms": 50.0,
+                    "min_ms": 50.0,
+                    "max_ms": 50.0,
+                },
+                {
+                    "phase": "font.initialize",
+                    "count": 1,
+                    "mean_ms": 100.0,
+                    "median_ms": 100.0,
+                    "min_ms": 100.0,
+                    "max_ms": 100.0,
+                },
+            ],
+        },
+    ]
+    summary_path = tmp_path / "summary.json"
+    output = tmp_path / "top.json"
+    markdown = tmp_path / "top.md"
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+    exit_code = main(
+        [
+            "top",
+            "--summary",
+            str(summary_path),
+            "--prefix",
+            "harmony.patch_apply.",
+            "--limit",
+            "1",
+            "--output",
+            str(output),
+            "--markdown",
+            str(markdown),
+        ],
+    )
+
+    top = json.loads(output.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert top["enabled"][0]["phase"] == "harmony.patch_apply.SlowPatch"
+    assert "SlowPatch" in markdown.read_text(encoding="utf-8")
+
+
+def test_restore_mod_refuses_to_delete_recreated_destination(tmp_path: Path) -> None:
+    """Restoring a disabled mod never removes a concurrently recreated destination."""
+    mod_dir = tmp_path / "Mods" / "QudJP"
+    disabled_dir = tmp_path / ".qudjp-startup-measure-disabled" / "QudJP"
+    mod_dir.mkdir(parents=True)
+    disabled_dir.mkdir(parents=True)
+    (mod_dir / "new-file.txt").write_text("new", encoding="utf-8")
+    (disabled_dir / "original-file.txt").write_text("original", encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="Refusing to restore disabled mod"):
+        _restore_mod(mod_dir, disabled_dir)
+
+    assert (mod_dir / "new-file.txt").read_text(encoding="utf-8") == "new"
+    assert (disabled_dir / "original-file.txt").read_text(encoding="utf-8") == "original"
+
+
+def test_disable_mod_requires_explicit_ready_marker() -> None:
+    """A disabled QudJP profile cannot wait on QudJP's own completion marker."""
+    with pytest.raises(ValueError, match="--disable-mod requires --ready-marker"):
+        _resolve_ready_marker(disable_mod=True, ready_marker=None)
+
+
+def _result(profile: str, iteration: int, status: str, timings: dict[str, float]) -> IterationResult:
+    parsed = parse_startup_log_text(
+        "\n".join(
+            f"[QudJP] StartupTiming/v1: phase={phase} elapsed_ms={elapsed}"
+            for phase, elapsed in timings.items()
+        ),
+    )
+    return IterationResult(
+        metadata=IterationMetadata(
+            profile=profile,
+            iteration=iteration,
+            command=("scripts/launch_rosetta.sh",),
+            started_at="2026-05-09T00:00:00+00:00",
+            status=status,
+            elapsed_until_ready_ms=1000.0,
+            exit_code=0,
+        ),
+        parsed=parsed,
+    )

--- a/scripts/tests/test_startup_measure.py
+++ b/scripts/tests/test_startup_measure.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from typing import TYPE_CHECKING
 
 import pytest
@@ -278,6 +279,40 @@ def test_collect_cli_writes_process_output_without_pipes(tmp_path: Path) -> None
     assert exit_code == 0
     assert (iteration_dir / "stdout.txt").read_text(encoding="utf-8").strip() == "stdout marker"
     assert (iteration_dir / "stderr.txt").read_text(encoding="utf-8").strip() == "stderr marker"
+
+
+def test_collect_cli_stops_waiting_after_launcher_exits(tmp_path: Path) -> None:
+    """The collect command records fast launcher exits without waiting for timeout."""
+    log_path = tmp_path / "Player.log"
+    launcher = tmp_path / "fast_exit.py"
+    launcher.write_text("import sys\nsys.exit(3)\n", encoding="utf-8")
+
+    started = time.monotonic()
+    exit_code = main(
+        [
+            "collect",
+            "--profile",
+            "enabled",
+            "--iterations",
+            "1",
+            "--artifact-dir",
+            str(tmp_path / "artifacts"),
+            "--launch-cmd",
+            f"{sys.executable} {launcher}",
+            "--log",
+            str(log_path),
+            "--timeout",
+            "1.25",
+        ],
+    )
+    elapsed = time.monotonic() - started
+
+    metadata_path = tmp_path / "artifacts" / "profiles" / "enabled" / "iteration-01" / "metadata.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert elapsed < 0.75
+    assert metadata["status"] == "process_exited"
+    assert metadata["exit_code"] == 3
 
 
 def _result(profile: str, iteration: int, status: str, timings: dict[str, float]) -> IterationResult:

--- a/scripts/tests/test_startup_measure.py
+++ b/scripts/tests/test_startup_measure.py
@@ -224,6 +224,25 @@ def test_wait_for_ready_marker_detects_zero_patch_warning(tmp_path: Path) -> Non
     assert elapsed is not None
 
 
+def test_wait_for_ready_marker_prefers_zero_patch_warning_over_ready_marker(tmp_path: Path) -> None:
+    """Harmony failure markers take precedence over completion markers."""
+    log_path = tmp_path / "Player.log"
+    log_path.write_text(
+        "[QudJP] Harmony patching complete: 0 method(s) patched.\n"
+        "[QudJP] Warning: Harmony patched zero methods.\n",
+        encoding="utf-8",
+    )
+
+    status, elapsed = _wait_for_ready_marker(
+        log_path,
+        timeout_seconds=1,
+        ready_marker="[QudJP] Harmony patching complete:",
+    )
+
+    assert status == "harmony_failed"
+    assert elapsed is not None
+
+
 def test_collect_cli_writes_process_output_without_pipes(tmp_path: Path) -> None:
     """The collect command preserves child stdout/stderr via files."""
     log_path = tmp_path / "Player.log"

--- a/scripts/tests/test_startup_measure.py
+++ b/scripts/tests/test_startup_measure.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -14,6 +15,7 @@ from scripts.startup_measure import (
     ProfileSummary,
     _resolve_ready_marker,
     _restore_mod,
+    _wait_for_ready_marker,
     compare_profiles,
     main,
     parse_startup_log_text,
@@ -209,6 +211,54 @@ def test_disable_mod_requires_explicit_ready_marker() -> None:
     """A disabled QudJP profile cannot wait on QudJP's own completion marker."""
     with pytest.raises(ValueError, match="--disable-mod requires --ready-marker"):
         _resolve_ready_marker(disable_mod=True, ready_marker=None)
+
+
+def test_wait_for_ready_marker_detects_zero_patch_warning(tmp_path: Path) -> None:
+    """Harmony zero-patch logs are treated as failed startup evidence."""
+    log_path = tmp_path / "Player.log"
+    log_path.write_text("[QudJP] Warning: Harmony patched zero methods.\n", encoding="utf-8")
+
+    status, elapsed = _wait_for_ready_marker(log_path, timeout_seconds=1, ready_marker="never appears")
+
+    assert status == "harmony_failed"
+    assert elapsed is not None
+
+
+def test_collect_cli_writes_process_output_without_pipes(tmp_path: Path) -> None:
+    """The collect command preserves child stdout/stderr via files."""
+    log_path = tmp_path / "Player.log"
+    launcher = tmp_path / "fake_launch.py"
+    launcher.write_text(
+        "from pathlib import Path\n"
+        "import sys\n"
+        f"Path({str(log_path)!r}).write_text('[QudJP] Harmony patching complete:\\n', encoding='utf-8')\n"
+        "print('stdout marker')\n"
+        "print('stderr marker', file=sys.stderr)\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "collect",
+            "--profile",
+            "enabled",
+            "--iterations",
+            "1",
+            "--artifact-dir",
+            str(tmp_path / "artifacts"),
+            "--launch-cmd",
+            f"{sys.executable} {launcher}",
+            "--log",
+            str(log_path),
+            "--timeout",
+            "5",
+        ],
+    )
+
+    iteration_dir = tmp_path / "artifacts" / "profiles" / "enabled" / "iteration-01"
+    assert exit_code == 0
+    assert (iteration_dir / "stdout.txt").read_text(encoding="utf-8").strip() == "stdout marker"
+    assert (iteration_dir / "stderr.txt").read_text(encoding="utf-8").strip() == "stderr marker"
 
 
 def _result(profile: str, iteration: int, status: str, timings: dict[str, float]) -> IterationResult:

--- a/scripts/tests/test_startup_measure.py
+++ b/scripts/tests/test_startup_measure.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from scripts import startup_measure
 from scripts.startup_measure import (
     IterationMetadata,
     IterationResult,
@@ -279,6 +280,45 @@ def test_collect_cli_writes_process_output_without_pipes(tmp_path: Path) -> None
     assert exit_code == 0
     assert (iteration_dir / "stdout.txt").read_text(encoding="utf-8").strip() == "stdout marker"
     assert (iteration_dir / "stderr.txt").read_text(encoding="utf-8").strip() == "stderr marker"
+
+
+def test_collect_cli_without_disable_mod_does_not_resolve_default_destination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The collect command only resolves the default mod directory when disabling QudJP."""
+    log_path = tmp_path / "Player.log"
+    launcher = tmp_path / "fake_launch.py"
+    launcher.write_text(
+        "from pathlib import Path\n"
+        f"Path({str(log_path)!r}).write_text('[QudJP] Harmony patching complete:\\n', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+
+    def fail_resolve_default_destination() -> Path:
+        raise AssertionError
+
+    monkeypatch.setattr(startup_measure, "resolve_default_destination", fail_resolve_default_destination)
+
+    exit_code = main(
+        [
+            "collect",
+            "--profile",
+            "enabled",
+            "--iterations",
+            "1",
+            "--artifact-dir",
+            str(tmp_path / "artifacts"),
+            "--launch-cmd",
+            f"{sys.executable} {launcher}",
+            "--log",
+            str(log_path),
+            "--timeout",
+            "5",
+        ],
+    )
+
+    assert exit_code == 0
 
 
 def test_collect_cli_stops_waiting_after_launcher_exits(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add startup timing instrumentation around bootstrap, font initialization, Harmony setup, and lazy dictionary/pattern loaders
- avoid duplicate Harmony target preflight by default while preserving the HistoricStringExpander skip guard and an opt-in preflight env flag
- cache successful GameTypeResolver fallback scans and add startup measurement collect/parse/compare/top tooling

## Performance Evidence
Measured with three repeated runs in `.sisyphus/evidence/issue-604-preflight-optimization-20260509T010145Z`:

| Profile | median ready time |
| --- | ---: |
| main-before | 54363.067 ms |
| branch-optimized | 42181.092 ms |

Delta: -12181.975 ms, about 22.4% faster to ready.

## Follow-ups
Deferred route-specific redesign and lazy patching work to #606, including Cooking Effect, HistoricStringExpander, CharGen, AbilityBar, SinkPrereq, EffectDescription/Details, and other non-startup-critical patch groups.

## Review and Simplify
- separate code-review agent initially found two measurement-script safety issues; both were fixed
- second review returned APPROVE
- simplify pass applied only behavior-preserving cleanup: thin type-resolution wrapper removal, env flag helper, JSON summary helpers, and clearer ready-marker elapsed timing

## Verification
- just deploy-mod: passed after rerun; first attempt failed due parallel dotnet file lock while test-l2g was building
- just test-l1: 2058 passed
- just test-l2: 1141 passed
- just test-l2g: 238 passed
- just python-check: passed
- just python-test: 987 passed, 1 skipped
- targeted dotnet test for GameTypeResolver/QudJPMod/RuntimeDiagnostics: 28 passed
- just python-test-filter startup_measure: 7 passed
- uv run ruff check scripts/startup_measure.py scripts/tests/test_startup_measure.py: passed
- git diff --check: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 起動時の詳細なタイミング計測と構造化ログ出力を導入し、各初期化フェーズ（フォント、翻訳、パッチ適用、ブート等）の可視化を強化
  * 起動測定の収集・解析・比較を行うCLIツールを追加
  * フォールバック型の型解決に結果キャッシュを導入してパフォーマンス改善と診断計測を追加

* **Tests**
  * 起動タイミング解析・CLIワークフローの自動テストを追加
  * パッチループ集計やキャッシュ振る舞いを検証する単体テストを追加/強化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->