### PR TITLE
[codex] Prepare QudJP v0.2.50 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,7 +267,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.2.50...HEAD
 [0.2.50]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.50
+[0.2.46]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.46
+[0.2.45]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.45
 [0.2.44]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.44
 [0.2.43]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.43
 [0.2.42]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.42

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.2.50] - 2026-05-09
+
+### Changed
+
+- 内部リリースメタデータとドキュメントの対象ゲーム表記を Caves of Qud 1.0.4 に合わせました。
+- チュートリアルに対応しました。具体的には、ポップアップ、ガイド付きハイライト、look-mode コマンド、キャラクタープリセット案内を日本語化しました。
+- 固有タイトル `Caves of Qud` は許容しつつ、単独の `Qud` 表記を glossary check で検出する挙動を文書化しました。
+
+### Fixed
+
+- `L` キーの look 表示経路で使われる TMP ツールチップに対して、日本語説明文が途中で欠けたり非表示になったりする問題を修復する処理を追加しました。
+- 長い日本語説明文を TMP / Qud markup / 変数 placeholder を壊さずに意味的な区切りで折り返すようにし、look tooltip の長文表示を読みやすくしました。
+- インベントリ項目名の TMP replacement が折り畳み・更新・非アクティブ行の影響で不安定になる経路を固めました。
+- verbose probe と runtime diagnostics の gate を整理し、通常リリースビルドでの診断ログ生成や観測処理の負荷を抑えるようにしました。
+- 実行時 JSON アセットの読み込みを `Newtonsoft.Json` ベースに統一し、Linux Unity/Mono 環境での辞書・パターン読み込み互換性を改善しました。
+- Workshop staging で release DLL に必須の runtime marker が含まれることを検証し、dev-only probe marker を含む DLL を弾くようにしました。
+- 改行エスケープ表記だけが異なる重複 JSON 辞書キーを検出できるようにしました。
+
+---
+
 ## [0.2.46] - 2026-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+[0.2.50]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.50
 [0.2.44]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.44
 [0.2.43]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.43
 [0.2.42]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.42

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -143,7 +143,7 @@ public sealed class ColorTagAllowlistCoverageTests
             ["Mods/QudJP/Assemblies/src/Patches/ZoneWindChangeTranslationPatch.cs:114:TryTranslate"] = "Delegates capture and whole-boundary restoration to matched owner-route branches.",
             ["Mods/QudJP/Assemblies/src/Translation/ColorAwareTranslationComposer.cs:30:Strip"] = "Wrapper method exposes the Strip API; callers are checked where they consume the returned spans.",
             ["Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs:77:Translate"] = "Passes stripped text and spans to TranslateStripped, where template application restores colors.",
-            ["Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs:80:Translate"] = "Passes stripped text and spans to TranslateStripped, where template application restores colors.",
+            ["Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs:82:Translate"] = "Passes stripped text and spans to TranslateStripped, where template application restores colors.",
             ["Mods/QudJP/Assemblies/src/UI/FontManager.cs:250:TryWarmPrimaryFontCharactersForUi"] = "UI glyph warmup intentionally strips markup only to add visible characters to the font atlas.",
         };
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -106,6 +106,18 @@ public sealed class MessagePatternTranslatorTests
         Assert.That(translated, Is.EqualTo("{{c|腐食性ガス放出}}をオンにした。"));
     }
 
+    [TestCase("You are a snapjaw.", "あなたはスナップジョー。")]
+    [TestCase("You are a スナップジョー.", "あなたはスナップジョー。")]
+    public void Translate_TranslatedCaptureStripsLeadingArticleBeforeLogicResolution(string source, string expected)
+    {
+        WriteExactDictionary(("snapjaw", "スナップジョー"));
+        WritePatternDictionary(("^You are (.+?)[.!]?$", "あなたは{t0}。"));
+
+        var translated = MessagePatternTranslator.Translate(source);
+
+        Assert.That(translated, Is.EqualTo(expected));
+    }
+
 
     [Test]
     public void Translate_SupportsPlaceholderReordering()

--- a/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
@@ -17,6 +17,8 @@ internal static class MessagePatternTranslator
     private static readonly object SyncRoot = new object();
     private static readonly ConcurrentDictionary<string, Regex> RegexCache =
         new ConcurrentDictionary<string, Regex>(StringComparer.Ordinal);
+    private static readonly Regex JapaneseCharacterPattern =
+        new Regex("[\\p{IsHiragana}\\p{IsKatakana}\\p{IsCJKUnifiedIdeographs}]", RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly ConcurrentDictionary<string, int> MissingPatternCounts =
         new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
     private static readonly ConcurrentDictionary<string, int> MissingRouteCounts =
@@ -963,7 +965,40 @@ internal static class MessagePatternTranslator
             return historicGeneratedCapture;
         }
 
+        var articleStripped = TranslateArticleStrippedTemplateCapture(source);
+        if (articleStripped is not null)
+        {
+            return articleStripped;
+        }
+
         return source;
+    }
+
+    private static string? TranslateArticleStrippedTemplateCapture(string source)
+    {
+        var strippedArticle = StringHelpers.StripLeadingEnglishArticle(source);
+        if (string.Equals(strippedArticle, source, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var direct = Translator.Translate(strippedArticle);
+        if (!string.Equals(direct, strippedArticle, StringComparison.Ordinal))
+        {
+            return direct;
+        }
+
+        var lower = LowerAscii(strippedArticle);
+        if (!string.Equals(lower, strippedArticle, StringComparison.Ordinal))
+        {
+            var lowered = Translator.Translate(lower);
+            if (!string.Equals(lowered, lower, StringComparison.Ordinal))
+            {
+                return lowered;
+            }
+        }
+
+        return JapaneseCharacterPattern.IsMatch(strippedArticle) ? strippedArticle : null;
     }
 
     private static string LowerAscii(string source)

--- a/Mods/QudJP/Localization/ActivatedAbilities.jp.xml
+++ b/Mods/QudJP/Localization/ActivatedAbilities.jp.xml
@@ -1384,7 +1384,7 @@
   </ability>
   <ability Command="CommandSnapjawHowl">
     <description>
-      <p>遠吠えし、近くのスナップジョウを狂乱させる。</p>
+      <p>遠吠えし、近くのスナップジョーを狂乱させる。</p>
       <br />
       <statline Name="Radius" DisplayName="効果半径" />
       <statline Name="Duration" />      

--- a/Mods/QudJP/Localization/Dictionaries/achievements.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/achievements.ja.json
@@ -242,11 +242,11 @@
     },
     {
       "key": "Jawsnapper",
-      "text": "スナップジョウ・スナッパー"
+      "text": "スナップジョー・スナッパー"
     },
     {
       "key": "Kill 100 snapjaws.",
-      "text": "スナップジョウを100体倒す。"
+      "text": "スナップジョーを100体倒す。"
     },
     {
       "key": "Your Thirst Is Mine, My Water Is Yours",

--- a/Mods/QudJP/Localization/ObjectBlueprints/Creatures.jp.xml
+++ b/Mods/QudJP/Localization/ObjectBlueprints/Creatures.jp.xml
@@ -10644,7 +10644,7 @@
 
 <object Name="Snapjaw Golem" Inherits="Snapjaw" Replace="true">
     <mixin Name="BaseVehicleGolem" />
-    <part Name="Render" DisplayName="スナップジョウのゴーレム" RenderString="S" Tile="Creatures/sw_golem_snapjaw.png" />
+    <part Name="Render" DisplayName="スナップジョーのゴーレム" RenderString="S" Tile="Creatures/sw_golem_snapjaw.png" />
   </object>
 
 <object Name="Spider Golem" Inherits="BaseSpider" Replace="true">

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.2.46",
+  "Version": "0.2.50",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/release-notes/unreleased/issue-573-game-version-1.0.4.md
+++ b/docs/release-notes/unreleased/issue-573-game-version-1.0.4.md
@@ -1,3 +1,0 @@
-### Changed
-
-- Align internal release metadata and documentation with Caves of Qud 1.0.4.

--- a/docs/release-notes/unreleased/snapjaw-article-capture.md
+++ b/docs/release-notes/unreleased/snapjaw-article-capture.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Remove stray English articles from translated dynamic message captures such as `あなたは a ...`.
+- Standardize snapjaw-related Japanese text on `スナップジョー`.

--- a/docs/release-notes/unreleased/translation-duplicate-normalization.md
+++ b/docs/release-notes/unreleased/translation-duplicate-normalization.md
@@ -1,8 +1,0 @@
-### Changed
-
-- Standardize duplicated tutorial and quit-confirmation Japanese text across UI dictionary routes.
-- Document glossary-check behavior that allows the proper title "Caves of Qud" while still flagging standalone "Qud".
-
-### Fixed
-
-- Detect duplicate JSON dictionary keys that differ only by escaped newline spelling.

--- a/docs/release-notes/unreleased/tutorial-localization.md
+++ b/docs/release-notes/unreleased/tutorial-localization.md
@@ -1,6 +1,0 @@
-### Changed
-
-- Improve Japanese coverage for tutorial popups and guided highlight text.
-- Improve Japanese coverage for tutorial character presets and look-mode command text.
-- Add missing owner-route translations for tutorial object highlights.
-- Standardize Japanese names for tutorial preset builds across character creation and tutorial guidance.

--- a/justfile
+++ b/justfile
@@ -121,6 +121,7 @@ release-zip-check release_zip="":
       "QudJP/LICENSE",
       "QudJP/NOTICE.md",
       "QudJP/Bootstrap.cs",
+      "QudJP/Launch CavesOfQud (Rosetta).command",
       "QudJP/Assemblies/QudJP.dll",
   }
   required_prefixes = {

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -14,6 +14,12 @@ from typing import NoReturn, Self
 FRAGMENTS_DIR = Path("docs/release-notes/unreleased")
 LOCALIZATION_PREFIX = "Mods/QudJP/Localization/"
 SECTION_ORDER = ("Added", "Changed", "Fixed", "Removed", "Deprecated", "Security")
+_NAME_STATUS_STATUS_INDEX = 0
+_NAME_STATUS_PATH_INDEX = 1
+_NAME_STATUS_RENAMED_PATH_INDEX = 2
+_NAME_STATUS_MIN_PATH_FIELDS = 2
+_NAME_STATUS_MIN_RENAME_FIELDS = 3
+_RENAMED_OR_COPIED_STATUSES = ("R", "C")
 
 
 class ReleaseNoteError(ValueError):
@@ -191,7 +197,7 @@ def git_changed_files(base_ref: str, head_ref: str) -> list[str]:
         raise ReleaseNoteError(msg)
     try:
         result = subprocess.run(  # noqa: S603
-            [git, "diff", "--name-only", f"{base_ref}...{head_ref}"],
+            [git, "diff", "--name-status", f"{base_ref}...{head_ref}"],
             check=True,
             capture_output=True,
             text=True,
@@ -200,7 +206,21 @@ def git_changed_files(base_ref: str, head_ref: str) -> list[str]:
         detail = (exc.stderr or "").strip() or str(exc)
         msg = f"git diff failed for {base_ref}...{head_ref}: {detail}"
         raise ReleaseNoteError(msg) from exc
-    return [line for line in result.stdout.splitlines() if line]
+    changed_files: list[str] = []
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        fields = line.split("\t")
+        status = fields[_NAME_STATUS_STATUS_INDEX]
+        if status == "D":
+            continue
+        if status.startswith(_RENAMED_OR_COPIED_STATUSES):
+            if len(fields) >= _NAME_STATUS_MIN_RENAME_FIELDS:
+                changed_files.append(fields[_NAME_STATUS_RENAMED_PATH_INDEX])
+            continue
+        if len(fields) >= _NAME_STATUS_MIN_PATH_FIELDS:
+            changed_files.append(fields[_NAME_STATUS_PATH_INDEX])
+    return changed_files
 
 
 def _write_output(path: Path, text: str) -> None:

--- a/scripts/sync_mod.py
+++ b/scripts/sync_mod.py
@@ -20,6 +20,7 @@ _RSYNC_INCLUDES: tuple[str, ...] = (
     "manifest.json",
     "preview.png",
     "Bootstrap.cs",
+    "Launch CavesOfQud (Rosetta).command",
     "Assemblies/",
     "Assemblies/QudJP.dll",
     "Localization/",
@@ -188,6 +189,7 @@ def _iter_sync_files(source: Path, *, exclude_fonts: bool) -> list[Path]:
         Path("manifest.json"),
         Path("preview.png"),
         Path("Bootstrap.cs"),
+        Path("Launch CavesOfQud (Rosetta).command"),
         Path("Assemblies") / "QudJP.dll",
     ):
         candidate = source / relative

--- a/scripts/tests/test_localization_canonical_terms.py
+++ b/scripts/tests/test_localization_canonical_terms.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOCALIZATION_ROOT = REPO_ROOT / "Mods" / "QudJP" / "Localization"
+
+
+def test_snapjaw_visible_assets_use_canonical_long_vowel() -> None:
+    """Visible localization assets must use スナップジョー, not stale snapjaw variants."""
+    stale_occurrences: list[str] = []
+    for path in sorted(LOCALIZATION_ROOT.rglob("*")):
+        if not path.is_file() or path.suffix not in {".json", ".xml", ".txt"}:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "スナップジョウ" not in text:
+            continue
+        relative_path = path.relative_to(LOCALIZATION_ROOT).as_posix()
+        stale_occurrences.append(relative_path)
+
+    assert stale_occurrences == []

--- a/scripts/tests/test_release_notes.py
+++ b/scripts/tests/test_release_notes.py
@@ -314,6 +314,37 @@ def test_git_changed_files_wraps_git_diff_errors(monkeypatch: pytest.MonkeyPatch
         git_changed_files("bad", "HEAD")
 
 
+def test_git_changed_files_excludes_deleted_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deleted unreleased fragments are ignored after their content is rolled into CHANGELOG."""
+
+    def fake_run(
+        args: Sequence[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        assert "--name-status" in args
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=(
+                "M\tMods/QudJP/Localization/Dictionaries/ui-popup.ja.json\n"
+                "D\tdocs/release-notes/unreleased/old-fragment.md\n"
+                "A\tdocs/release-notes/unreleased/new-fragment.md\n"
+                "R100\tdocs/release-notes/unreleased/renamed-old.md\t"
+                "docs/release-notes/unreleased/renamed-new.md\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(release_notes.shutil, "which", lambda _name: "git")
+    monkeypatch.setattr(release_notes.subprocess, "run", fake_run)
+
+    assert git_changed_files("base", "HEAD") == [
+        "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+        "docs/release-notes/unreleased/new-fragment.md",
+        "docs/release-notes/unreleased/renamed-new.md",
+    ]
+
+
 def test_main_reports_parse_errors_without_traceback(capsys: pytest.CaptureFixture[str]) -> None:
     """CLI argument errors are normalized into the release-note error format."""
     assert main(["render"]) == 1

--- a/scripts/tests/test_sync_mod.py
+++ b/scripts/tests/test_sync_mod.py
@@ -245,7 +245,7 @@ class TestRunSync:
             (source / "Localization" / doc_name).write_text("# docs", encoding="utf-8")
         (source / "Fonts" / "Font.otf").write_bytes(b"font")
         (source / "Launch CavesOfQud (Rosetta).command").write_text(
-            "#!/usr/bin/env bash\nexec arch -x86_64 \"$HOME/game/CoQ\"\n",
+            '#!/usr/bin/env bash\nexec arch -x86_64 "$HOME/game/CoQ"\n',
             encoding="utf-8",
         )
         (source / "src.cs").write_text("// do not copy", encoding="utf-8")

--- a/scripts/tests/test_sync_mod.py
+++ b/scripts/tests/test_sync_mod.py
@@ -244,6 +244,10 @@ class TestRunSync:
         for doc_name in LOCALIZATION_DOC_NAMES:
             (source / "Localization" / doc_name).write_text("# docs", encoding="utf-8")
         (source / "Fonts" / "Font.otf").write_bytes(b"font")
+        (source / "Launch CavesOfQud (Rosetta).command").write_text(
+            "#!/usr/bin/env bash\nexec arch -x86_64 \"$HOME/game/CoQ\"\n",
+            encoding="utf-8",
+        )
         (source / "src.cs").write_text("// do not copy", encoding="utf-8")
         destination.mkdir()
         (destination / "stale.txt").write_text("stale", encoding="utf-8")
@@ -255,6 +259,7 @@ class TestRunSync:
         assert (destination / "manifest.json").exists()
         assert (destination / "preview.png").exists()
         assert (destination / "Bootstrap.cs").exists()
+        assert (destination / "Launch CavesOfQud (Rosetta).command").exists()
         assert (destination / "Assemblies" / "QudJP.dll").exists()
         assert (destination / "Localization" / "Creatures.jp.xml").exists()
         assert (destination / "Localization" / "ui.ja.json").exists()

--- a/scripts/tests/test_workshop_comments_inbox.py
+++ b/scripts/tests/test_workshop_comments_inbox.py
@@ -105,6 +105,20 @@ def test_build_steam_discussion_thread_url_uses_fixed_endpoint() -> None:
     )
 
 
+def test_build_steam_discussion_thread_url_preserves_numeric_page() -> None:
+    """Discussion page URLs keep Steam's ctp page while dropping unrelated query fields."""
+    url = build_steam_discussion_thread_url(
+        "https://steamcommunity.com/workshop/filedetails/discussion/"
+        "3718988020/837250028234869281/?ctp=2&tscn=1778250394",
+    )
+
+    assert (
+        url
+        == "https://steamcommunity.com/workshop/filedetails/discussion/"
+        "3718988020/837250028234869281/?ctp=2&l=japanese"
+    )
+
+
 def test_build_steam_discussion_thread_url_rejects_non_workshop_hosts_and_ids() -> None:
     """User-provided discussion URLs cannot become arbitrary HTTP endpoints."""
     with pytest.raises(ValueError, match="Steam discussion URL"):
@@ -113,6 +127,11 @@ def test_build_steam_discussion_thread_url_rejects_non_workshop_hosts_and_ids() 
     with pytest.raises(ValueError, match="discussion_topic"):
         build_steam_discussion_thread_url(
             "https://steamcommunity.com/workshop/filedetails/discussion/3718988020/not-numeric/",
+        )
+
+    with pytest.raises(ValueError, match="ctp"):
+        build_steam_discussion_thread_url(
+            "https://steamcommunity.com/workshop/filedetails/discussion/3718988020/837250028234869281/?ctp=two",
         )
 
 
@@ -277,6 +296,53 @@ def test_collect_workshop_comments_includes_configured_discussion_threads(tmp_pa
     assert summary.new_snapshots == 2
     assert comments == [("222", 0), ("444", 0)]
     assert snapshots == [("Bug",), ("Thread bug",)]
+
+
+def test_collect_workshop_comments_does_not_starve_discussion_threads(tmp_path: Path) -> None:
+    """Per-run caps keep configured discussion threads represented alongside Workshop comments."""
+    metadata_path = tmp_path / "workshop_metadata.json"
+    metadata_path.write_text(json.dumps({"publishedfileid": "3718988020"}), encoding="utf-8")
+    steam = _FakeTransport(
+        [
+            _metadata_response(),
+            _comments_response(
+                _comment_html(comment_id="222", account_id="123", author="Reporter", body="Bug A")
+                + _comment_html(comment_id="223", account_id="124", author="Reporter2", body="Bug B"),
+                total_count=2,
+            ),
+            HttpResponse(
+                status_code=200,
+                body=_comment_html(
+                    comment_id="444",
+                    account_id="456",
+                    author="ThreadReporter",
+                    body="Thread bug",
+                ).encode(),
+                headers={},
+            ),
+        ],
+    )
+
+    with open_workshop_inbox(tmp_path / "inbox.sqlite3") as store:
+        summary = collect_workshop_comments(
+            metadata_path=metadata_path,
+            discussion_thread_urls=[
+                "https://steamcommunity.com/workshop/filedetails/discussion/3718988020/837250028234869281/",
+            ],
+            steam_transport=steam,
+            store=store,
+            options=CollectionOptions(dry_run=False, max_comments_per_run=2),
+        )
+        comments = list(
+            store.connection.execute("SELECT steam_comment_id, is_creator FROM workshop_comments ORDER BY id"),
+        )
+        snapshots = list(store.connection.execute("SELECT body_text FROM workshop_comment_snapshots ORDER BY id"))
+
+    assert summary.fetched == 3
+    assert summary.new_comments == 2
+    assert summary.new_snapshots == 2
+    assert comments == [("222", 0), ("444", 0)]
+    assert snapshots == [("Bug A",), ("Thread bug",)]
 
 
 def test_collect_workshop_comments_adds_snapshot_when_body_changes(tmp_path: Path) -> None:

--- a/scripts/tests/test_workshop_comments_inbox.py
+++ b/scripts/tests/test_workshop_comments_inbox.py
@@ -14,6 +14,7 @@ from scripts.workshop_comments_inbox import (
     WorkshopComment,
     WorkshopInboxStore,
     build_steam_comments_url,
+    build_steam_discussion_thread_url,
     collect_workshop_comments,
     creator_account_id_from_steam_id,
     default_workshop_state_dir,
@@ -89,6 +90,30 @@ def test_build_steam_comments_url_uses_fixed_endpoint() -> None:
         == "https://steamcommunity.com/comment/PublishedFile_Public/render/"
         "76561198205102067/3718988020/?start=20&count=10&l=japanese"
     )
+
+
+def test_build_steam_discussion_thread_url_uses_fixed_endpoint() -> None:
+    """Discussion URLs are parsed into a fixed public page endpoint with numeric path slots only."""
+    url = build_steam_discussion_thread_url(
+        "https://steamcommunity.com/workshop/filedetails/discussion/3718988020/837250028234869281/?tscn=1778250394",
+    )
+
+    assert (
+        url
+        == "https://steamcommunity.com/workshop/filedetails/discussion/"
+        "3718988020/837250028234869281/?l=japanese"
+    )
+
+
+def test_build_steam_discussion_thread_url_rejects_non_workshop_hosts_and_ids() -> None:
+    """User-provided discussion URLs cannot become arbitrary HTTP endpoints."""
+    with pytest.raises(ValueError, match="Steam discussion URL"):
+        build_steam_discussion_thread_url("https://example.com/workshop/filedetails/discussion/3718988020/1/")
+
+    with pytest.raises(ValueError, match="discussion_topic"):
+        build_steam_discussion_thread_url(
+            "https://steamcommunity.com/workshop/filedetails/discussion/3718988020/not-numeric/",
+        )
 
 
 def test_creator_account_id_from_steam_id_converts_steamid64() -> None:
@@ -211,6 +236,47 @@ def test_collect_workshop_comments_stores_local_comments_and_snapshots(tmp_path:
     assert summary.new_snapshots == 1
     assert comments == [("222", 0)]
     assert snapshots == [("Bug report",)]
+
+
+def test_collect_workshop_comments_includes_configured_discussion_threads(tmp_path: Path) -> None:
+    """Configured Workshop discussion threads are collected into the same local inbox."""
+    metadata_path = tmp_path / "workshop_metadata.json"
+    metadata_path.write_text(json.dumps({"publishedfileid": "3718988020"}), encoding="utf-8")
+    steam = _FakeTransport(
+        [
+            _metadata_response(),
+            _comments_response(_comment_html(comment_id="222", account_id="123", author="Reporter", body="Bug")),
+            HttpResponse(
+                status_code=200,
+                body=(
+                    _comment_html(comment_id="333", account_id="244836339", author="Creator", body="Template")
+                    + _comment_html(comment_id="444", account_id="456", author="ThreadReporter", body="Thread bug")
+                ).encode(),
+                headers={},
+            ),
+        ],
+    )
+
+    with open_workshop_inbox(tmp_path / "inbox.sqlite3") as store:
+        summary = collect_workshop_comments(
+            metadata_path=metadata_path,
+            discussion_thread_urls=[
+                "https://steamcommunity.com/workshop/filedetails/discussion/3718988020/837250028234869281/",
+            ],
+            steam_transport=steam,
+            store=store,
+            options=CollectionOptions(dry_run=False),
+        )
+        comments = list(
+            store.connection.execute("SELECT steam_comment_id, is_creator FROM workshop_comments ORDER BY id"),
+        )
+        snapshots = list(store.connection.execute("SELECT body_text FROM workshop_comment_snapshots ORDER BY id"))
+
+    assert summary.fetched == 3
+    assert summary.new_comments == 2
+    assert summary.new_snapshots == 2
+    assert comments == [("222", 0), ("444", 0)]
+    assert snapshots == [("Bug",), ("Thread bug",)]
 
 
 def test_collect_workshop_comments_adds_snapshot_when_body_changes(tmp_path: Path) -> None:

--- a/scripts/workshop_comments_inbox.py
+++ b/scripts/workshop_comments_inbox.py
@@ -17,7 +17,7 @@ from html.parser import HTMLParser
 from pathlib import Path
 from typing import Self
 from urllib.error import HTTPError
-from urllib.parse import urlencode, urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse
 from urllib.request import Request, urlopen
 
 _NUMERIC_ID_PATTERN = re.compile(r"^[0-9]+$")
@@ -428,30 +428,33 @@ def collect_workshop_comments(
         steam_transport=steam_transport,
         max_response_bytes=options.max_response_bytes,
     )
-    comments = _fetch_all_comments(
-        creator_id=creator_id,
-        published_file_id=published_file_id,
-        steam_transport=steam_transport,
+    comment_sources = [
+        _fetch_all_comments(
+            creator_id=creator_id,
+            published_file_id=published_file_id,
+            steam_transport=steam_transport,
+            options=options,
+        ),
+    ]
+    comment_sources.extend(
+        _fetch_discussion_thread_comments(
+            discussion_thread_url=discussion_thread_url,
+            published_file_id=published_file_id,
+            steam_transport=steam_transport,
+            options=options,
+        )
+        for discussion_thread_url in discussion_thread_urls or []
+    )
+    creator_account_id = creator_account_id_from_steam_id(creator_id)
+    fetched_count = sum(len(source) for source in comment_sources)
+    importable_comments = _select_importable_comments(
+        comment_sources,
+        creator_account_id=creator_account_id,
         options=options,
     )
-    for discussion_thread_url in discussion_thread_urls or []:
-        comments.extend(
-            _fetch_discussion_thread_comments(
-                discussion_thread_url=discussion_thread_url,
-                published_file_id=published_file_id,
-                steam_transport=steam_transport,
-                options=options,
-            ),
-        )
-    creator_account_id = creator_account_id_from_steam_id(creator_id)
-    importable_comments = [
-        comment
-        for comment in comments
-        if not options.skip_creator_comments or comment.author_account_id != creator_account_id
-    ][: options.max_comments_per_run]
 
     if options.dry_run:
-        return CollectionSummary(fetched=len(comments), new_comments=len(importable_comments), new_snapshots=0)
+        return CollectionSummary(fetched=fetched_count, new_comments=len(importable_comments), new_snapshots=0)
 
     before_comments = store.count_comments()
     before_snapshots = store.count_snapshots()
@@ -469,7 +472,7 @@ def collect_workshop_comments(
         store.finish_collection_run(
             run_id=run_id,
             status="success",
-            fetched_count=len(comments),
+            fetched_count=fetched_count,
             new_comment_count=new_comments,
             new_snapshot_count=new_snapshots,
         )
@@ -477,13 +480,46 @@ def collect_workshop_comments(
         store.finish_collection_run(
             run_id=run_id,
             status="failed",
-            fetched_count=len(comments),
+            fetched_count=fetched_count,
             new_comment_count=store.count_comments() - before_comments,
             new_snapshot_count=store.count_snapshots() - before_snapshots,
             error_message=str(error),
         )
         raise
-    return CollectionSummary(fetched=len(comments), new_comments=new_comments, new_snapshots=new_snapshots)
+    return CollectionSummary(fetched=fetched_count, new_comments=new_comments, new_snapshots=new_snapshots)
+
+
+def _select_importable_comments(
+    comment_sources: list[list[WorkshopComment]],
+    *,
+    creator_account_id: str | None,
+    options: CollectionOptions,
+) -> list[WorkshopComment]:
+    """Select importable comments without starving configured sources."""
+    filtered_sources = [
+        [
+            comment
+            for comment in source
+            if not options.skip_creator_comments or comment.author_account_id != creator_account_id
+        ]
+        for source in comment_sources
+    ]
+    selected: list[WorkshopComment] = []
+    positions = [0 for _ in filtered_sources]
+    while len(selected) < options.max_comments_per_run:
+        added = False
+        for index, source in enumerate(filtered_sources):
+            if len(selected) >= options.max_comments_per_run:
+                break
+            position = positions[index]
+            if position >= len(source):
+                continue
+            selected.append(source[position])
+            positions[index] = position + 1
+            added = True
+        if not added:
+            break
+    return selected
 
 
 def validate_numeric_id(value: object, *, field_name: str) -> str:
@@ -533,7 +569,14 @@ def build_steam_discussion_thread_url(discussion_thread_url: str) -> str:
         raise ValueError(msg)
     published_file_id = validate_numeric_id(parts[3], field_name="publishedfileid")
     topic_id = validate_numeric_id(parts[4], field_name="discussion_topic")
-    return f"https://steamcommunity.com/workshop/filedetails/discussion/{published_file_id}/{topic_id}/?l=japanese"
+    query_params: list[tuple[str, str]] = []
+    for key, value in parse_qsl(parsed.query, keep_blank_values=True):
+        if key == "ctp":
+            query_params.append(("ctp", validate_numeric_id(value, field_name="ctp")))
+            break
+    query_params.append(("l", "japanese"))
+    query = urlencode(query_params)
+    return f"https://steamcommunity.com/workshop/filedetails/discussion/{published_file_id}/{topic_id}/?{query}"
 
 
 def extract_comments_from_render_response(payload: bytes) -> list[WorkshopComment]:

--- a/scripts/workshop_comments_inbox.py
+++ b/scripts/workshop_comments_inbox.py
@@ -17,7 +17,7 @@ from html.parser import HTMLParser
 from pathlib import Path
 from typing import Self
 from urllib.error import HTTPError
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 from urllib.request import Request, urlopen
 
 _NUMERIC_ID_PATTERN = re.compile(r"^[0-9]+$")
@@ -26,6 +26,7 @@ _STEAM_DETAILS_URL = "https://api.steampowered.com/ISteamRemoteStorage/GetPublis
 _TRUNCATION_NOTE = "[truncated]"
 _HTTP_OK = 200
 _STEAMID64_ACCOUNT_ID_BASE = 76_561_197_960_265_728
+_DISCUSSION_THREAD_PATH_PARTS = 5
 _DEFAULT_STATE_DIR = Path(".coq-japanese_workshop/state")
 _DEFAULT_DB_NAME = "workshop-inbox.sqlite3"
 _COLLECTOR_VERSION = "local-sqlite-v1"
@@ -396,6 +397,7 @@ def main(argv: list[str] | None = None) -> int:
     with open_workshop_inbox(args.db_path) as store:
         summary = collect_workshop_comments(
             metadata_path=args.metadata_path,
+            discussion_thread_urls=args.discussion_thread_url,
             steam_transport=_make_urllib_transport(
                 timeout_seconds=options.timeout_seconds,
                 max_response_bytes=options.max_response_bytes,
@@ -413,6 +415,7 @@ def main(argv: list[str] | None = None) -> int:
 def collect_workshop_comments(
     *,
     metadata_path: Path,
+    discussion_thread_urls: list[str] | None = None,
     steam_transport: Transport,
     store: WorkshopInboxStore,
     options: CollectionOptions,
@@ -431,6 +434,15 @@ def collect_workshop_comments(
         steam_transport=steam_transport,
         options=options,
     )
+    for discussion_thread_url in discussion_thread_urls or []:
+        comments.extend(
+            _fetch_discussion_thread_comments(
+                discussion_thread_url=discussion_thread_url,
+                published_file_id=published_file_id,
+                steam_transport=steam_transport,
+                options=options,
+            ),
+        )
     creator_account_id = creator_account_id_from_steam_id(creator_id)
     importable_comments = [
         comment
@@ -509,6 +521,21 @@ def build_steam_comments_url(*, creator_id: str, published_file_id: str, start: 
     return f"{_STEAM_COMMENTS_URL.format(creator=creator, published=published)}?start={start}&count={count}&l=japanese"
 
 
+def build_steam_discussion_thread_url(discussion_thread_url: str) -> str:
+    """Build the fixed public Workshop discussion page URL from a user-provided Steam URL."""
+    parsed = urlparse(discussion_thread_url)
+    if parsed.scheme != "https" or parsed.netloc != "steamcommunity.com":
+        msg = "Steam discussion URL must use https://steamcommunity.com"
+        raise ValueError(msg)
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) != _DISCUSSION_THREAD_PATH_PARTS or parts[:3] != ["workshop", "filedetails", "discussion"]:
+        msg = "Steam discussion URL must be a Workshop filedetails discussion URL"
+        raise ValueError(msg)
+    published_file_id = validate_numeric_id(parts[3], field_name="publishedfileid")
+    topic_id = validate_numeric_id(parts[4], field_name="discussion_topic")
+    return f"https://steamcommunity.com/workshop/filedetails/discussion/{published_file_id}/{topic_id}/?l=japanese"
+
+
 def extract_comments_from_render_response(payload: bytes) -> list[WorkshopComment]:
     """Extract normalized comments from a Steam render JSON response."""
     data = json.loads(payload.decode("utf-8"))
@@ -522,6 +549,14 @@ def extract_comments_from_render_response(payload: bytes) -> list[WorkshopCommen
 
     parser = _SteamCommentParser()
     parser.feed(comments_html)
+    parser.close()
+    return parser.comments
+
+
+def extract_comments_from_discussion_page(payload: bytes) -> list[WorkshopComment]:
+    """Extract normalized comments from a public Steam Workshop discussion page."""
+    parser = _SteamCommentParser()
+    parser.feed(payload.decode("utf-8"))
     parser.close()
     return parser.comments
 
@@ -922,6 +957,26 @@ def _fetch_all_comments(
     return comments
 
 
+def _fetch_discussion_thread_comments(
+    *,
+    discussion_thread_url: str,
+    published_file_id: str,
+    steam_transport: Transport,
+    options: CollectionOptions,
+) -> list[WorkshopComment]:
+    url = build_steam_discussion_thread_url(discussion_thread_url)
+    expected_prefix = f"https://steamcommunity.com/workshop/filedetails/discussion/{published_file_id}/"
+    if not url.startswith(expected_prefix):
+        msg = "Steam discussion URL publishedfileid did not match Workshop metadata"
+        raise ValueError(msg)
+    response = steam_transport("GET", url, None, {})
+    if response.status_code != _HTTP_OK:
+        msg = "Steam discussion thread request failed"
+        raise ValueError(msg)
+    _require_bounded_response(response, max_response_bytes=options.max_response_bytes)
+    return extract_comments_from_discussion_page(response.body)
+
+
 def _require_bounded_response(response: HttpResponse, *, max_response_bytes: int) -> None:
     if len(response.body) > max_response_bytes:
         msg = "HTTP response exceeded max response bytes"
@@ -961,6 +1016,12 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     collect.add_argument("--max-body-chars", type=int, default=4000)
     collect.add_argument("--timeout-seconds", type=int, default=20)
     collect.add_argument("--max-response-bytes", type=int, default=2_097_152)
+    collect.add_argument(
+        "--discussion-thread-url",
+        action="append",
+        default=[],
+        help="Also collect public comments from this Steam Workshop discussion thread URL.",
+    )
     collect.add_argument("--include-creator-comments", action="store_true")
     collect.add_argument("--dry-run", action="store_true")
     return parser.parse_args(argv)


### PR DESCRIPTION
## Summary
- prepare the QudJP `v0.2.50` release by updating `manifest.json`, `CHANGELOG.md`, and retiring consumed release-note fragments
- keep `release-zip-check` aligned with the shipped Rosetta launcher now included in release ZIPs
- extend the Workshop comments inbox collector to optionally import configured public Workshop discussion threads

## Context
`v0.2.50` keeps the public version monotonic after the untagged Workshop `0.2.46` emergency hotfix. The release notes now call out tutorial coverage, first-open inventory/TMP rendering work, performance/logging stabilization, Newtonsoft JSON loading, and release DLL marker gates.

The release ZIP contains `QudJP/Launch CavesOfQud (Rosetta).command`; the check recipe now treats that file as expected rather than an unexpected extra.

## Validation
- `uv run python scripts/release_identity.py --tag v0.2.50 --skip-git`
- `uv run pytest scripts/tests/test_workshop_comments_inbox.py -q`
- `uv run pytest scripts/tests/test_build_release.py::TestCreateZip::test_zip_contains_rosetta_launcher_when_present scripts/tests/test_build_workshop_upload.py::test_create_workshop_staging_extracts_qudjp_root -q`
- `just build-release`
- `just release-zip-check dist/QudJP-v0.2.50.zip`

## Release Notes
- This PR does not push the release tag or upload to Steam Workshop.
- After merge, create/push annotated `v0.2.50`, wait for the draft GitHub Release asset, then continue Workshop staging and upload gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Steam Workshop のディスカッションスレッドコメント収集に対応
  * Rosetta 用ランチャースクリプトを配布に含めるよう強化

* **バグ修正**
  * 日本語チュートリアル文言、ツールチップの切り詰め・折返しを改善
  * インベントリ表示での名前置換を安定化
  * 重複する JSON キー検出やリリース検証を強化

* **変更**
  * 日本語翻訳表記（スナップジョー等）とチュートリアル翻訳を更新
  * Linux/Mono 互換性向上のための資産読み込みを統一
* **テスト**
  * Workshop URL/収集と翻訳表記の検出に関するテストを追加

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/614)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->