### PR TITLE
[codex] Use setup action for just in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Install just
         if: steps.changes.outputs.justfile == 'true'
-        run: sudo apt-get update && sudo apt-get install -y just
+        uses: extractions/setup-just@v3
 
       - name: Check justfile
         if: steps.changes.outputs.justfile == 'true'


### PR DESCRIPTION
## Summary
- replace the CI `sudo apt-get update && sudo apt-get install -y just` step with `extractions/setup-just@v3`

## Why
PR #609 hit a cancelled CI run while the hosted runner was stuck in apt mirror/package retrieval during the `Install just` step. Using the setup action avoids depending on Ubuntu apt availability for this small tool install.

## Scope
This intentionally carries over only the independently useful CI hardening from #609. The `GameTypeResolver` preflight work remains out of this PR and is tracked for Roslyn-based follow-up in #613.

## Verification
- `just --summary`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CD ワークフローの最適化を実施しました。ビルドツールのセットアップ処理がより効率的になっています。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/615)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->