### PR TITLE
[codex] Parallelize CI test lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  detect-changes:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
+
+    outputs:
+      base_ref: ${{ steps.changes.outputs.base_ref }}
+      head_ref: ${{ steps.changes.outputs.head_ref }}
+      qudjp_dotnet: ${{ steps.changes.outputs.qudjp_dotnet }}
+      roslyn_tools: ${{ steps.changes.outputs.roslyn_tools }}
+      python: ${{ steps.changes.outputs.python }}
+      localization: ${{ steps.changes.outputs.localization }}
+      justfile: ${{ steps.changes.outputs.justfile }}
+      markdown_reports: ${{ steps.changes.outputs.markdown_reports }}
 
     steps:
       - uses: actions/checkout@v5
@@ -94,15 +104,22 @@ jobs:
             echo "head_ref=$head"
             echo "qudjp_dotnet=$qudjp_dotnet"
             echo "roslyn_tools=$roslyn_tools"
-            echo "dotnet=$([[ "$qudjp_dotnet" == true || "$roslyn_tools" == true ]] && echo true || echo false)"
             echo "python=$python"
             echo "localization=$localization"
             echo "justfile=$justfile"
             echo "markdown_reports=$markdown_reports"
           } >> "$GITHUB_OUTPUT"
 
+  qudjp-dotnet-build:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.qudjp_dotnet == 'true'
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v5
+
       - name: Setup .NET
-        if: steps.changes.outputs.dotnet == 'true'
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
@@ -110,24 +127,85 @@ jobs:
             10.0.x
 
       - name: Cache NuGet packages
-        if: steps.changes.outputs.dotnet == 'true'
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('Mods/QudJP/Assemblies/**/*.csproj', 'scripts/tools/**/*.csproj') }}
+          key: ${{ runner.os }}-nuget-qudjp-${{ hashFiles('Mods/QudJP/Assemblies/**/*.csproj') }}
           restore-keys: |
+            ${{ runner.os }}-nuget-qudjp-
             ${{ runner.os }}-nuget-
 
       - name: Build QudJP
-        if: steps.changes.outputs.qudjp_dotnet == 'true'
         run: dotnet build Mods/QudJP/Assemblies/QudJP.csproj --configuration Release
 
       - name: Build QudJP.Tests
-        if: steps.changes.outputs.qudjp_dotnet == 'true' && hashFiles('Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj') != ''
+        if: hashFiles('Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj') != ''
         run: dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release
 
+      - name: Upload QudJP test artifact
+        if: hashFiles('Mods/QudJP/Assemblies/QudJP.Tests/bin/Release/net10.0/QudJP.Tests.dll') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: qudjp-tests-release
+          path: Mods/QudJP/Assemblies/QudJP.Tests/bin/Release/net10.0
+          if-no-files-found: error
+
+  qudjp-dotnet-test:
+    name: C# tests (${{ matrix.category }})
+    runs-on: ubuntu-latest
+    needs: [detect-changes, qudjp-dotnet-build]
+    if: always() && needs.detect-changes.outputs.qudjp_dotnet == 'true' && needs.qudjp-dotnet-build.result == 'success'
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        category: [L1, L2, L2G]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Download QudJP test artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: qudjp-tests-release
+          path: Mods/QudJP/Assemblies/QudJP.Tests/bin/Release/net10.0
+
+      - name: Test QudJP ${{ matrix.category }}
+        run: >
+          dotnet test Mods/QudJP/Assemblies/QudJP.Tests/bin/Release/net10.0/QudJP.Tests.dll
+          --filter "TestCategory=${{ matrix.category }}"
+
+  roslyn-tools:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.roslyn_tools == 'true'
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-roslyn-tools-${{ hashFiles('scripts/tools/**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-roslyn-tools-
+            ${{ runner.os }}-nuget-
+
       - name: Build script tools
-        if: steps.changes.outputs.roslyn_tools == 'true' && hashFiles('scripts/tools/**/*.csproj') != ''
+        if: hashFiles('scripts/tools/**/*.csproj') != ''
         shell: bash
         run: |
           set -euo pipefail
@@ -144,62 +222,77 @@ jobs:
             echo "::endgroup::"
           done
 
-      - name: Test QudJP
-        if: steps.changes.outputs.qudjp_dotnet == 'true' && hashFiles('Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj') != ''
-        run: dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-build
+  python:
+    runs-on: ubuntu-latest
+    needs: [detect-changes, roslyn-tools]
+    if: always() && needs.detect-changes.outputs.python == 'true' && (needs.roslyn-tools.result == 'success' || needs.roslyn-tools.result == 'skipped')
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET for Roslyn-backed Python tests
+        if: needs.detect-changes.outputs.roslyn_tools == 'true'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
 
       - name: Setup Python
-        if: steps.changes.outputs.python == 'true' || steps.changes.outputs.localization == 'true' || steps.changes.outputs.markdown_reports == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
 
-      - name: Install just
-        if: steps.changes.outputs.justfile == 'true'
-        run: sudo apt-get update && sudo apt-get install -y just
+      - name: Install ast-grep
+        run: npm install -g @ast-grep/cli
 
-      - name: Check justfile
-        if: steps.changes.outputs.justfile == 'true'
-        run: just --summary
+      - name: Install Python test tools
+        run: pip install hypothesis pytest ruff
 
-      - name: Check Markdown reports
-        if: steps.changes.outputs.markdown_reports == 'true'
-        run: >
-          python scripts/check_markdown_reports.py
-          --base-ref "${{ steps.changes.outputs.base_ref }}"
-          --head-ref "${{ steps.changes.outputs.head_ref }}"
+      - name: Lint Python
+        if: hashFiles('scripts/**/*.py') != ''
+        run: ruff check scripts/
+
+      - name: Test Python
+        if: hashFiles('scripts/tests/**/*.py') != ''
+        run: pytest scripts/tests/
+
+  localization:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.localization == 'true'
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Check release-note fragment
-        if: github.event_name == 'pull_request' && steps.changes.outputs.localization == 'true'
+        if: github.event_name == 'pull_request'
         run: >
           python scripts/release_notes.py check-fragment
           --base-ref "${{ github.event.pull_request.base.sha }}"
           --head-ref "${{ github.event.pull_request.head.sha }}"
 
-      - name: Install ast-grep
-        if: steps.changes.outputs.python == 'true'
-        run: npm install -g @ast-grep/cli
-
-      - name: Install Ruff
-        if: steps.changes.outputs.python == 'true'
-        run: pip install ruff
-
-      - name: Lint Python
-        if: steps.changes.outputs.python == 'true' && hashFiles('scripts/**/*.py') != ''
-        run: ruff check scripts/
-
       - name: Check translation tokens
-        if: steps.changes.outputs.localization == 'true' && hashFiles('Mods/QudJP/Localization/**/*.ja.json') != ''
+        if: hashFiles('Mods/QudJP/Localization/**/*.ja.json') != ''
         run: python scripts/check_translation_tokens.py Mods/QudJP/Localization
 
       - name: Check glossary consistency
-        if: steps.changes.outputs.localization == 'true' && hashFiles('Mods/QudJP/Localization/**/*') != ''
+        if: hashFiles('Mods/QudJP/Localization/**/*') != ''
         run: python scripts/check_glossary_consistency.py Mods/QudJP/Localization
 
       - name: Check message pattern routes
-        if: steps.changes.outputs.localization == 'true' && hashFiles('Mods/QudJP/Localization/Dictionaries/messages.ja.json') != ''
+        if: hashFiles('Mods/QudJP/Localization/Dictionaries/messages.ja.json') != ''
         run: >
           python scripts/validate_pattern_routes.py
           Mods/QudJP/Localization/Dictionaries/messages.ja.json
@@ -215,10 +308,87 @@ jobs:
           --expect-count needs-harmony-patch=34
           --expect-count unclassified=6
 
-      - name: Install Python test dependencies
-        if: steps.changes.outputs.python == 'true' && hashFiles('scripts/tests/**/*.py') != ''
-        run: pip install hypothesis pytest
+  justfile:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.justfile == 'true'
+    timeout-minutes: 10
 
-      - name: Test Python
-        if: steps.changes.outputs.python == 'true' && hashFiles('scripts/tests/**/*.py') != ''
-        run: pytest scripts/tests/
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Check justfile
+        run: just --summary
+
+  markdown-reports:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.markdown_reports == 'true'
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Check Markdown reports
+        run: >
+          python scripts/check_markdown_reports.py
+          --base-ref "${{ needs.detect-changes.outputs.base_ref }}"
+          --head-ref "${{ needs.detect-changes.outputs.head_ref }}"
+
+  build:
+    runs-on: ubuntu-latest
+    needs:
+      - detect-changes
+      - qudjp-dotnet-build
+      - qudjp-dotnet-test
+      - roslyn-tools
+      - python
+      - localization
+      - justfile
+      - markdown-reports
+    if: always()
+    timeout-minutes: 5
+
+    steps:
+      - name: Check required jobs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          failed=0
+          check_result() {
+            local job_name="$1"
+            local result="$2"
+
+            case "$result" in
+              success|skipped)
+                ;;
+              *)
+                printf '%s ended with result: %s\n' "$job_name" "$result" >&2
+                failed=1
+                ;;
+            esac
+          }
+
+          check_result detect-changes "${{ needs.detect-changes.result }}"
+          check_result qudjp-dotnet-build "${{ needs.qudjp-dotnet-build.result }}"
+          check_result qudjp-dotnet-test "${{ needs.qudjp-dotnet-test.result }}"
+          check_result roslyn-tools "${{ needs.roslyn-tools.result }}"
+          check_result python "${{ needs.python.result }}"
+          check_result localization "${{ needs.localization.result }}"
+          check_result justfile "${{ needs.justfile.result }}"
+          check_result markdown-reports "${{ needs.markdown-reports.result }}"
+
+          exit "$failed"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -412,12 +412,12 @@ L3 検証や "再現するか?" の判断は Caves of Qud のランタイムロ�
 
 PR を出すと GitHub Actions (`.github/workflows/ci.yml`) が変更ファイルを見て必要なゲートだけを実行します。`.github/workflows/ci.yml` 自体が変わった場合は全ゲートを実行します。
 
-- `Mods/QudJP/Assemblies/` 変更: `.NET SDK 8.0.x + 10.0.x` をインストールし、QudJP / QudJP.Tests の Release build と `dotnet test ... --no-build` を実行します。テストカテゴリのフィルタは付けません。L2G は `QudJP.Tests.csproj` の `<Exists('$(AssemblyCSharpPath)')>` 条件付き参照により、CI 環境に `Assembly-CSharp.dll` が存在しないため自動的にスキップされます。
+- `Mods/QudJP/Assemblies/` 変更: `.NET SDK 8.0.x + 10.0.x` をインストールし、QudJP / QudJP.Tests を Release build します。build artifact を作成した後、C# テストは `L1` / `L2` / `L2G` の matrix job で並列実行します。L2G は `QudJP.Tests.csproj` の `<Exists('$(AssemblyCSharpPath)')>` 条件付き参照により、CI 環境に `Assembly-CSharp.dll` が存在しないため自動的にスキップされます。
 - `scripts/tools/` または Annals extractor のテスト / fixture 変更: `scripts/tools/**/*.csproj` を列挙し、見つかった tool projects をすべて Release build します。
-- `scripts/` 変更: `ast-grep`、`ruff`、`pytest` をセットアップし、`ruff check scripts/` と `pytest scripts/tests/` を実行します。
+- `scripts/` 変更: `ast-grep`、`ruff`、`pytest` をセットアップし、`ruff check scripts/` と `pytest scripts/tests/` を実行します。この Python lane は QudJP C# test matrix を待たずに並列実行されます。
 - `Mods/QudJP/Localization/` 変更: release-note fragment requirement、translation-token check、glossary consistency check を実行します。
 - `pyproject.toml` / `uv.lock` 変更: Python tooling 変更として `ruff check scripts/` と `pytest scripts/tests/` を実行します。
-- CI は同一 ref の古い実行を自動キャンセルし、NuGet / pip キャッシュを使います。
+- CI は同一 ref の古い実行を自動キャンセルし、NuGet / pip キャッシュを使います。branch protection 用の `build` job は最後に各 lane の結果を集約する互換チェックです。
 
 **全ジョブがパスしないとマージできません。**
 

--- a/scripts/tests/test_ci_workflow_contract.py
+++ b/scripts/tests/test_ci_workflow_contract.py
@@ -1,0 +1,66 @@
+"""Static contract tests for the pull-request CI workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _workflow_text() -> str:
+    return (_REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+
+def _job_block(workflow: str, job_name: str, next_job_name: str | None) -> str:
+    start = workflow.index(f"\n  {job_name}:\n")
+    end = len(workflow) if next_job_name is None else workflow.index(f"\n  {next_job_name}:\n")
+    return workflow[start:end]
+
+
+def test_ci_keeps_required_build_check_as_aggregator() -> None:
+    """The branch-protection-facing build job stays stable while work runs in parallel jobs."""
+    workflow = _workflow_text()
+    build_job = _job_block(workflow, "build", None)
+
+    assert "Check required jobs" in build_job
+    for job_name in ("qudjp-dotnet-build", "qudjp-dotnet-test", "python"):
+        assert f"      - {job_name}" in build_job
+        assert f'check_result {job_name} "${{{{ needs.{job_name}.result }}}}"' in build_job
+
+
+def test_ci_splits_qudjp_test_categories_into_matrix() -> None:
+    """C# L1/L2/L2G categories should run as separate matrix legs after a shared build."""
+    workflow = _workflow_text()
+
+    assert "category: [L1, L2, L2G]" in workflow
+    assert "dotnet test Mods/QudJP/Assemblies/QudJP.Tests/bin/Release/net10.0/QudJP.Tests.dll" in workflow
+    assert '--filter "TestCategory=${{ matrix.category }}"' in workflow
+    assert "actions/upload-artifact" in workflow
+    assert "actions/download-artifact" in workflow
+
+
+def test_ci_checks_out_repo_for_qudjp_test_matrix() -> None:
+    """C# tests need repository assets and source files in addition to the built DLL."""
+    workflow = _workflow_text()
+    job = _job_block(workflow, "qudjp-dotnet-test", "roslyn-tools")
+
+    assert "uses: actions/checkout@v5" in job
+    assert job.index("uses: actions/checkout@v5") < job.index("uses: actions/download-artifact@v4")
+
+
+def test_ci_runs_python_and_dotnet_lanes_as_independent_jobs() -> None:
+    """Python tests should not wait for the QudJP C# test matrix."""
+    workflow = _workflow_text()
+    python_job = _job_block(workflow, "python", "localization")
+
+    assert "\n  detect-changes:\n" in workflow
+    assert "pytest scripts/tests/" in python_job
+    assert "qudjp-dotnet-test" not in python_job
+
+
+def test_ci_installs_just_without_apt_update() -> None:
+    """The justfile-only lane should avoid apt package-index overhead."""
+    workflow = _workflow_text()
+
+    assert "uses: extractions/setup-just@v3" in workflow
+    assert "sudo apt-get update" not in workflow


### PR DESCRIPTION
## Summary

- Split CI into path detection, QudJP .NET build, C# category matrix tests, Roslyn tools, Python, localization, justfile, and Markdown report lanes.
- Run QudJP C# L1/L2/L2G tests in parallel from a shared Release build artifact while keeping repository checkout available for asset-reading tests.
- Keep the branch-protection-facing `build` check as an aggregate job and document the new CI shape.
- Add static workflow contract tests for the parallel CI structure.

## Validation

- `actionlint .github/workflows/ci.yml`
- `uv run pytest scripts/tests/test_ci_workflow_contract.py -q`
- `just python-check`
- `just python-test`
- `dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/bin/Release/net10.0/QudJP.Tests.dll --filter "TestCategory=L1"`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/bin/Release/net10.0/QudJP.Tests.dll --filter "TestCategory=L2"`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/bin/Release/net10.0/QudJP.Tests.dll --filter "TestCategory=L2G"`

## Review / Simplify

- Independent code review requested changes for missing checkout in the C# test matrix; fixed and re-reviewed as APPROVED.
- Simplify pass kept workflow behavior unchanged and tightened the CI contract test scoping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * CI パイプラインの動作説明を更新しました。並列実行、マトリクステスト、キャッシュ機構について詳細な手順を記載しました。

* **Tests**
  * CI ワークフローの構成検証テストを追加しました。パイプラインの整合性を自動で確認します。

* **Chores**
  * CI/CD パイプラインを再構成し、ビルド・テスト・ツール実行を独立したジョブに分割しました。処理の効率化と並列実行を実現します。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/616)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->