### PR TITLE
[codex] Harden Workshop upload preflight

### DIFF
--- a/Mods/QudJP/Launch CavesOfQud (Rosetta).command
+++ b/Mods/QudJP/Launch CavesOfQud (Rosetta).command
@@ -2,42 +2,134 @@
 # Launch Caves of Qud through Rosetta 2 on Apple Silicon Macs.
 #
 # This helper is intentionally self-contained so it can be shipped inside the
-# Workshop/GitHub release ZIP. It does not install Rosetta automatically.
+# Workshop/GitHub release ZIP. Player-facing failures use macOS dialogs so the
+# launcher can be used by double-clicking it from Finder.
 
 set -euo pipefail
 
-GAME_BINARY="${HOME}/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/MacOS/CoQ"
+DEFAULT_GAME_BINARY="${HOME}/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/MacOS/CoQ"
+
+show_message() {
+  local title="$1"
+  local message="$2"
+
+  if command -v osascript >/dev/null 2>&1; then
+    osascript - "${title}" "${message}" <<'APPLESCRIPT' >/dev/null 2>&1 || true
+on run argv
+  display dialog (item 2 of argv) buttons {"OK"} default button "OK" with title (item 1 of argv)
+end run
+APPLESCRIPT
+  fi
+  printf '%s\n%s\n' "${title}" "${message}" >&2
+}
+
+confirm_dialog() {
+  local title="$1"
+  local message="$2"
+  local action="$3"
+
+  if ! command -v osascript >/dev/null 2>&1; then
+    return 1
+  fi
+
+  osascript - "${title}" "${message}" "${action}" <<'APPLESCRIPT' >/dev/null
+on run argv
+  set actionName to item 3 of argv
+  set dialogResult to display dialog (item 2 of argv) buttons {"Cancel", actionName} default button actionName cancel button "Cancel" with title (item 1 of argv)
+  return button returned of dialogResult
+end run
+APPLESCRIPT
+}
+
+install_rosetta() {
+  if ! confirm_dialog \
+    "QudJP Rosetta Launcher" \
+    "Rosetta 2 is required to launch Caves of Qud this way on Apple Silicon. Install Rosetta 2 now?" \
+    "Install Rosetta 2"; then
+    show_message \
+      "QudJP Rosetta Launcher" \
+      "Rosetta 2 is not installed. The game was not launched."
+    exit 1
+  fi
+
+  show_message \
+    "QudJP Rosetta Launcher" \
+    "macOS will install Rosetta 2 now. This may take a moment."
+
+  if ! /usr/sbin/softwareupdate --install-rosetta --agree-to-license; then
+    show_message \
+      "QudJP Rosetta Launcher" \
+      "Rosetta 2 installation did not complete. Please try this launcher again after installing Rosetta 2."
+    exit 1
+  fi
+}
+
+choose_game_binary() {
+  if ! command -v osascript >/dev/null 2>&1; then
+    return 1
+  fi
+
+  local selected_app
+  selected_app="$(
+    osascript <<'APPLESCRIPT'
+set promptText to "Caves of Qud was not found in the default Steam library. Please select CoQ.app from your Steam library."
+set selectedFile to choose file with prompt promptText
+return POSIX path of selectedFile
+APPLESCRIPT
+  )" || return 1
+
+  if [[ "${selected_app}" == *.app/ ]]; then
+    printf '%sContents/MacOS/CoQ\n' "${selected_app}"
+    return 0
+  fi
+
+  if [[ "${selected_app}" == *"/CoQ.app" ]]; then
+    printf '%s/Contents/MacOS/CoQ\n' "${selected_app}"
+    return 0
+  fi
+
+  printf '%s\n' "${selected_app}"
+}
+
+resolve_game_binary() {
+  if [[ -x "${DEFAULT_GAME_BINARY}" ]]; then
+    printf '%s\n' "${DEFAULT_GAME_BINARY}"
+    return 0
+  fi
+
+  show_message \
+    "QudJP Rosetta Launcher" \
+    "Caves of Qud was not found in the default Steam library. In the next window, select CoQ.app from your Steam library."
+
+  local chosen_binary
+  if ! chosen_binary="$(choose_game_binary)" || [[ ! -x "${chosen_binary}" ]]; then
+    show_message \
+      "QudJP Rosetta Launcher" \
+      "Caves of Qud could not be launched. Please select CoQ.app from your Steam library and try again."
+    exit 1
+  fi
+
+  printf '%s\n' "${chosen_binary}"
+}
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
-  echo "This launcher is only needed on macOS." >&2
-  echo "On Windows or Linux, start Caves of Qud normally from Steam." >&2
+  show_message \
+    "QudJP Rosetta Launcher" \
+    "This launcher is only needed on macOS. On Windows or Linux, start Caves of Qud normally from Steam."
   exit 1
 fi
 
 if [[ "$(uname -m)" == "arm64" ]]; then
   if ! /usr/bin/pgrep -q oahd 2>/dev/null &&
     ! arch -x86_64 /usr/bin/true 2>/dev/null; then
-    echo "Rosetta 2 does not appear to be installed." >&2
-    echo "Install it with:" >&2
-    echo "  softwareupdate --install-rosetta --agree-to-license" >&2
-    exit 1
+    install_rosetta
   fi
 fi
 
-if [[ ! -f "${GAME_BINARY}" ]]; then
-  echo "Caves of Qud was not found at the default Steam path:" >&2
-  echo "  ${GAME_BINARY}" >&2
-  echo "If your Steam library is in another location, edit this launcher and update GAME_BINARY." >&2
-  exit 1
-fi
+GAME_BINARY="$(resolve_game_binary)"
 
-if [[ ! -x "${GAME_BINARY}" ]]; then
-  echo "Caves of Qud is not executable:" >&2
-  echo "  ${GAME_BINARY}" >&2
-  exit 1
-fi
-
-echo "Launching Caves of Qud through Rosetta 2..."
-echo "Binary: ${GAME_BINARY}"
+printf '%s\n%s\n' \
+  "QudJP Rosetta Launcher" \
+  "Launching Caves of Qud through Rosetta 2." >&2
 
 exec arch -x86_64 "${GAME_BINARY}"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -153,6 +153,10 @@ For inventory / equipment display checks, follow the runtime evidence rules in
 - For player-facing builds, the release ZIP and Workshop content include
   `QudJP/Launch CavesOfQud (Rosetta).command`; launch through that wrapper
   from the installed `QudJP` folder
+- The Workshop launcher is intended for Finder double-click use. If Rosetta 2
+  is missing, it offers to install Rosetta 2 through a macOS dialog. If Caves of
+  Qud is not in the default Steam library, it opens a file picker so the user can
+  select `CoQ.app`.
 - On macOS with the default Steam library, the subscribed Workshop item is
   normally under:
   `~/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020/`

--- a/docs/release.md
+++ b/docs/release.md
@@ -297,6 +297,10 @@ publishing, verify the rendered Workshop page and changelog in the target
 locale, for example `?l=japanese`, because Steam stores localized Change Notes
 separately.
 
+Steam's KeyValues parser can reject escaped double quotes inside long
+description or changenote fields. Keep Workshop text free of literal `"`
+characters; prefer backticks, Japanese corner quotes, or plain text instead.
+
 ## Upload Or Update
 
 Run steamcmd with the generated VDF:
@@ -335,6 +339,19 @@ The release tag must point at the commit that produced the staged content. If
 the repo changes after generating `dist/workshop/`, regenerate the release ZIP
 and Workshop VDF before uploading.
 
+Immediately before `steamcmd +workshop_build_item`, verify that the generated
+content folder and VDF still match the intended release ZIP:
+
+```bash
+just workshop-upload-preflight \
+  dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip \
+  X.Y.Z
+```
+
+This catches stale `dist/workshop/QudJP/` contents, mismatched Workshop item
+IDs, mismatched `contentfolder`, escaped newline sequences, and escaped double
+quotes before Steam can reject or publish the wrong upload.
+
 ## Post-Publish Smoke
 
 After Steam finishes processing the item:
@@ -342,13 +359,14 @@ After Steam finishes processing the item:
 1. Open the Workshop page and confirm the title, description, tags, preview
    image, visibility, file size, and change note.
    - For Apple Silicon support, confirm the description mentions
-     `Launch CavesOfQud (Rosetta).command`, Rosetta 2, and the one-shot
-     `arch -x86_64` launch command.
+     `Launch CavesOfQud (Rosetta).command`, Rosetta 2, and a quote-free
+     `arch -x86_64` launch example.
 2. Subscribe to the item from a clean Steam client state or unsubscribe and
    resubscribe if updating an existing item.
 3. Validate the downloaded Workshop item against the staged content:
 
    ```bash
+   steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit
    just workshop-download-check X.Y.Z dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip
    ```
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -359,8 +359,9 @@ After Steam finishes processing the item:
 1. Open the Workshop page and confirm the title, description, tags, preview
    image, visibility, file size, and change note.
    - For Apple Silicon support, confirm the description mentions
-     `Launch CavesOfQud (Rosetta).command`, Rosetta 2, and a quote-free
-     `arch -x86_64` launch example.
+     `Launch CavesOfQud (Rosetta).command`, Rosetta 2, Finder double-click use,
+     the `CoQ.app` picker fallback, and a quote-free `arch -x86_64` launch
+     example for advanced users.
 2. Subscribe to the item from a clean Steam client state or unsubscribe and
    resubscribe if updating an existing item.
 3. Validate the downloaded Workshop item against the staged content:
@@ -375,7 +376,9 @@ After Steam finishes processing the item:
    release ZIP DLL. Do not mark the release GO if the public Workshop download
    still contains an older DLL.
    Also confirm the downloaded `Launch CavesOfQud (Rosetta).command` exists and
-   is executable in the downloaded `QudJP` folder.
+   is executable in the downloaded `QudJP` folder. The launcher should guide
+   player-facing failures with macOS dialogs rather than requiring manual script
+   edits.
    On the default macOS Steam library, the downloaded Workshop folder is usually
    `~/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020/`.
 4. Launch the game, enable only QudJP for the smoke pass, and restart.

--- a/docs/reports/templates/workshop-release.md
+++ b/docs/reports/templates/workshop-release.md
@@ -52,6 +52,7 @@ vX.Y.Z / <short-git-hash>
 - [ ] `just workshop-preflight X.Y.Z`
 - [ ] `just release-zip-check dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip`
 - [ ] `just build-workshop-upload dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip /tmp/qudjp-workshop-changenote.txt`
+- [ ] `just workshop-upload-preflight dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip X.Y.Z`
 
 ## Upload
 
@@ -64,6 +65,7 @@ vX.Y.Z / <short-git-hash>
 
 - [ ] Workshop page title, description, preview image, visibility, file size, and changenote checked
 - [ ] Subscribe/resubscribe checked
+- [ ] `steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit`
 - [ ] `just workshop-download-check X.Y.Z dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip`
 - [ ] Mod Manager lists QudJP with expected version and preview
 - [ ] Options screen renders Japanese text and CJK glyphs

--- a/justfile
+++ b/justfile
@@ -178,6 +178,10 @@ build-workshop-upload release_zip="" changenote_file="/tmp/qudjp-workshop-change
     {{python}} scripts/build_workshop_upload.py --changenote-file "{{changenote_file}}"; \
   fi
 
+# Verify generated Workshop staging and VDF before running steamcmd.
+workshop-upload-preflight release_zip version content_folder="dist/workshop/QudJP" vdf="dist/workshop/workshop_item.vdf":
+  {{python}} scripts/verify_workshop_upload.py --release-zip {{quote(release_zip)}} --content-folder {{quote(content_folder)}} --vdf {{quote(vdf)}} --expected-version {{quote(version)}}
+
 # Verify a downloaded Steam Workshop item against the expected release DLL or ZIP.
 workshop-download-check version expected_dll="" workshop_dir="":
   #!/usr/bin/env bash

--- a/scripts/build_workshop_upload.py
+++ b/scripts/build_workshop_upload.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import shutil
 import sys
@@ -124,6 +125,13 @@ def vdf_escape(value: str) -> str:
     return normalized.replace("\\", "\\\\").replace('"', '\\"')
 
 
+def _reject_double_quotes(field: str, value: str) -> None:
+    """Reject text that steamcmd's KeyValues parser can misparse after escaping."""
+    if '"' in value:
+        msg = f"Workshop {field} must not contain double quote characters"
+        raise ValueError(msg)
+
+
 def render_vdf(
     metadata: WorkshopMetadata,
     *,
@@ -136,6 +144,9 @@ def render_vdf(
     if not changenote.strip():
         msg = "Workshop changenote must be non-empty"
         raise ValueError(msg)
+    _reject_double_quotes("changenote", changenote)
+    if description is not None:
+        _reject_double_quotes("description", description)
 
     fields = [
         ("appid", metadata.appid),
@@ -241,6 +252,102 @@ def create_workshop_staging(release_zip: Path, staging_root: Path) -> tuple[Path
         msg = f"Workshop preview file not found after staging: {preview_file}"
         raise FileNotFoundError(msg)
     return content_folder, preview_file
+
+
+def _read_zip_text(zip_path: Path, member: str) -> str:
+    """Read a UTF-8 text member from a release ZIP."""
+    with zipfile.ZipFile(zip_path) as zf:
+        return zf.read(member).decode("utf-8")
+
+
+def _read_zip_bytes(zip_path: Path, member: str) -> bytes:
+    """Read a binary member from a release ZIP."""
+    with zipfile.ZipFile(zip_path) as zf:
+        return zf.read(member)
+
+
+def _sha256_bytes(data: bytes) -> str:
+    """Return the SHA256 digest for in-memory bytes."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _release_zip_file_hashes(release_zip: Path) -> dict[str, str]:
+    """Return SHA256 by release-relative path for files under QudJP/."""
+    hashes: dict[str, str] = {}
+    with zipfile.ZipFile(release_zip) as zf:
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+            if not info.filename.startswith("QudJP/"):
+                msg = f"release ZIP member is outside QudJP/: {info.filename}"
+                raise ValueError(msg)
+            relative_path = info.filename.removeprefix("QudJP/")
+            hashes[relative_path] = _sha256_bytes(zf.read(info))
+    return hashes
+
+
+def _staged_file_hashes(content_folder: Path) -> dict[str, str]:
+    """Return SHA256 by staged content-relative path."""
+    if not content_folder.is_dir():
+        return {}
+    return {
+        path.relative_to(content_folder).as_posix(): _sha256_bytes(path.read_bytes())
+        for path in sorted(content_folder.rglob("*"))
+        if path.is_file()
+    }
+
+
+def verify_workshop_upload_staging(
+    release_zip: Path,
+    content_folder: Path,
+    *,
+    expected_version: str | None = None,
+) -> list[str]:
+    """Verify staged Workshop content still matches the release ZIP to upload."""
+    findings: list[str] = []
+    release_zip = release_zip.resolve()
+    content_folder = content_folder.resolve()
+
+    release_manifest = json.loads(_read_zip_text(release_zip, "QudJP/manifest.json"))
+    if not isinstance(release_manifest, dict):
+        msg = f"release manifest must be a JSON object: {release_zip}"
+        raise TypeError(msg)
+    release_version = str(release_manifest.get("Version", "<missing>"))
+    version = expected_version or release_version
+
+    manifest_path = content_folder / "manifest.json"
+    if not manifest_path.is_file():
+        findings.append("staged manifest not found")
+    else:
+        staged_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if not isinstance(staged_manifest, dict):
+            findings.append("staged manifest is not a JSON object")
+        else:
+            staged_version = str(staged_manifest.get("Version", "<missing>"))
+            if staged_version != version:
+                findings.append(f"staged manifest version mismatch: expected {version}, got {staged_version}")
+
+    release_dll_sha = _sha256_bytes(_read_zip_bytes(release_zip, "QudJP/Assemblies/QudJP.dll"))
+    staged_dll = content_folder / "Assemblies" / "QudJP.dll"
+    if not staged_dll.is_file():
+        findings.append("staged QudJP.dll not found")
+    elif _sha256_bytes(staged_dll.read_bytes()) != release_dll_sha:
+        findings.append("staged QudJP.dll SHA256 does not match release ZIP")
+
+    release_hashes = _release_zip_file_hashes(release_zip)
+    staged_hashes = _staged_file_hashes(content_folder)
+    release_files = set(release_hashes)
+    staged_files = set(staged_hashes)
+    findings.extend(f"staged content missing file: {path}" for path in sorted(release_files - staged_files))
+    findings.extend(f"staged content has extra file: {path}" for path in sorted(staged_files - release_files))
+    hash_mismatch_suppressed = {"Assemblies/QudJP.dll"}
+    findings.extend(
+        f"staged file hash mismatch: {path}"
+        for path in sorted((release_files & staged_files) - hash_mismatch_suppressed)
+        if release_hashes[path] != staged_hashes[path]
+    )
+
+    return findings
 
 
 def _read_description(metadata: WorkshopMetadata) -> str | None:

--- a/scripts/tests/_common.py
+++ b/scripts/tests/_common.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -9,6 +10,41 @@ if TYPE_CHECKING:
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DICTIONARIES_ROOT = REPO_ROOT / "Mods" / "QudJP" / "Localization" / "Dictionaries"
+VALID_RELEASE_DLL_MARKER_PAYLOAD = b"\0".join(
+    [
+        b"Unity.TextMeshPro",
+        b"TextMeshProUguiFontPatch",
+        b"TmpInputFieldFontPatch",
+        b"InventoryLineFontFixer",
+        b"DelayedInventoryLineRepairScheduler",
+        b"ShouldPreserveActiveReplacementForTests",
+    ],
+)
+
+
+def write_workshop_release_zip(
+    path: Path,
+    *,
+    version: str = "0.2.0",
+    dll_payload: bytes = VALID_RELEASE_DLL_MARKER_PAYLOAD,
+) -> None:
+    """Create a minimal QudJP release ZIP fixture for Workshop tests."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "QudJP/manifest.json",
+            json.dumps({"Version": version, "PreviewImage": "preview.png"}),
+        )
+        zf.writestr("QudJP/preview.png", b"png")
+        zf.writestr("QudJP/LICENSE", "MIT License")
+        zf.writestr("QudJP/NOTICE.md", "# NOTICE")
+        zf.writestr("QudJP/Bootstrap.cs", "public static class Bootstrap {}")
+        launcher_info = zipfile.ZipInfo("QudJP/Launch CavesOfQud (Rosetta).command")
+        launcher_info.external_attr = 0o100755 << 16
+        zf.writestr(launcher_info, "#!/usr/bin/env bash\n")
+        zf.writestr("QudJP/Assemblies/QudJP.dll", dll_payload)
+        zf.writestr("QudJP/Localization/ui.json", "{}")
+        zf.writestr("QudJP/Fonts/OFL.txt", "SIL Open Font License")
 
 
 def iter_dictionary_entries(path: Path) -> Iterator[tuple[int, Mapping[str, object]]]:

--- a/scripts/tests/test_build_workshop_upload.py
+++ b/scripts/tests/test_build_workshop_upload.py
@@ -18,17 +18,11 @@ from scripts.build_workshop_upload import (
     main,
     render_vdf,
     vdf_escape,
+    verify_workshop_upload_staging,
 )
-
-_VALID_RELEASE_DLL_MARKER_PAYLOAD = b"\0".join(
-    [
-        b"Unity.TextMeshPro",
-        b"TextMeshProUguiFontPatch",
-        b"TmpInputFieldFontPatch",
-        b"InventoryLineFontFixer",
-        b"DelayedInventoryLineRepairScheduler",
-        b"ShouldPreserveActiveReplacementForTests",
-    ],
+from scripts.tests._common import (
+    VALID_RELEASE_DLL_MARKER_PAYLOAD,
+    write_workshop_release_zip,
 )
 
 
@@ -36,25 +30,10 @@ def _write_release_zip(
     path: Path,
     *,
     version: str = "0.2.0",
-    dll_payload: bytes = _VALID_RELEASE_DLL_MARKER_PAYLOAD,
+    dll_payload: bytes = VALID_RELEASE_DLL_MARKER_PAYLOAD,
 ) -> None:
     """Create a minimal QudJP release ZIP fixture."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr(
-            "QudJP/manifest.json",
-            json.dumps({"Version": version, "PreviewImage": "preview.png"}),
-        )
-        zf.writestr("QudJP/preview.png", b"png")
-        zf.writestr("QudJP/LICENSE", "MIT License")
-        zf.writestr("QudJP/NOTICE.md", "# NOTICE")
-        zf.writestr("QudJP/Bootstrap.cs", "public static class Bootstrap {}")
-        launcher_info = zipfile.ZipInfo("QudJP/Launch CavesOfQud (Rosetta).command")
-        launcher_info.external_attr = 0o100755 << 16
-        zf.writestr(launcher_info, "#!/usr/bin/env bash\n")
-        zf.writestr("QudJP/Assemblies/QudJP.dll", dll_payload)
-        zf.writestr("QudJP/Localization/ui.json", "{}")
-        zf.writestr("QudJP/Fonts/OFL.txt", "SIL Open Font License")
+    write_workshop_release_zip(path, version=version, dll_payload=dll_payload)
 
 
 def test_default_workshop_ids_are_caves_of_qud_item() -> None:
@@ -136,7 +115,7 @@ def test_render_vdf_contains_absolute_content_preview_and_changenote(tmp_path: P
         metadata,
         content_folder=content_folder,
         preview_file=preview_file,
-        changenote='v0.2.0: "release"',
+        changenote="v0.2.0: release",
         description="Caves of Qud 日本語化",
     )
 
@@ -144,8 +123,41 @@ def test_render_vdf_contains_absolute_content_preview_and_changenote(tmp_path: P
     assert '"publishedfileid" "3718988020"' in vdf
     assert f'"contentfolder" "{content_folder.resolve()}"' in vdf
     assert f'"previewfile" "{preview_file.resolve()}"' in vdf
-    assert '"changenote" "v0.2.0: \\"release\\""' in vdf
+    assert '"changenote" "v0.2.0: release"' in vdf
     assert '"description" "Caves of Qud 日本語化"' in vdf
+
+
+def test_render_vdf_rejects_quotes_in_description_or_changenote(tmp_path: Path) -> None:
+    """Steam KeyValues parsing is fragile with escaped quotes in long text fields."""
+    content_folder = tmp_path / "QudJP"
+    content_folder.mkdir()
+    preview_file = content_folder / "preview.png"
+    preview_file.write_bytes(b"png")
+    metadata = WorkshopMetadata(
+        appid="333640",
+        publishedfileid="3718988020",
+        title="Caves of Qud Japanese Mod",
+        visibility="0",
+        description_file=None,
+    )
+
+    with pytest.raises(ValueError, match=r"description.*double quote"):
+        render_vdf(
+            metadata,
+            content_folder=content_folder,
+            preview_file=preview_file,
+            changenote="v0.2.0 release",
+            description='Launch with "Rosetta"',
+        )
+
+    with pytest.raises(ValueError, match=r"changenote.*double quote"):
+        render_vdf(
+            metadata,
+            content_folder=content_folder,
+            preview_file=preview_file,
+            changenote='v0.2.0 "release"',
+            description="Caves of Qud 日本語化",
+        )
 
 
 def test_create_workshop_staging_extracts_qudjp_root(tmp_path: Path) -> None:
@@ -237,7 +249,7 @@ def test_create_workshop_staging_rejects_release_zip_with_dev_probe_markers(tmp_
     release_zip = tmp_path / "dist" / "QudJP-v0.2.0.zip"
     _write_release_zip(
         release_zip,
-        dll_payload=_VALID_RELEASE_DLL_MARKER_PAYLOAD + b"\0[QudJP] SinkObserve/v1:",
+        dll_payload=VALID_RELEASE_DLL_MARKER_PAYLOAD + b"\0[QudJP] SinkObserve/v1:",
     )
 
     with pytest.raises(
@@ -254,6 +266,77 @@ def test_create_workshop_staging_rejects_release_zip_missing_required_dll_marker
 
     with pytest.raises(ValueError, match=rf"{re.escape(str(release_zip))}.*Unity\.TextMeshPro"):
         create_workshop_staging(release_zip, tmp_path / "workshop")
+
+
+def test_verify_workshop_upload_staging_accepts_matching_release_zip(tmp_path: Path) -> None:
+    """Upload preflight accepts staging generated from the same release ZIP."""
+    release_zip = tmp_path / "dist" / "QudJP-v0.2.50.zip"
+    _write_release_zip(release_zip, version="0.2.50", dll_payload=VALID_RELEASE_DLL_MARKER_PAYLOAD)
+    content_folder, _preview = create_workshop_staging(release_zip, tmp_path / "dist" / "workshop")
+
+    findings = verify_workshop_upload_staging(release_zip, content_folder, expected_version="0.2.50")
+
+    assert findings == []
+
+
+def test_verify_workshop_upload_staging_reports_stale_content_folder(tmp_path: Path) -> None:
+    """Upload preflight reports stale staged content before steamcmd can publish it."""
+    release_zip = tmp_path / "dist" / "QudJP-v0.2.50.zip"
+    _write_release_zip(release_zip, version="0.2.50", dll_payload=VALID_RELEASE_DLL_MARKER_PAYLOAD)
+    stale_zip = tmp_path / "dist" / "QudJP-v0.2.0.zip"
+    _write_release_zip(stale_zip, version="0.2.0", dll_payload=b"old dll" + VALID_RELEASE_DLL_MARKER_PAYLOAD)
+    content_folder, _preview = create_workshop_staging(stale_zip, tmp_path / "dist" / "workshop")
+
+    findings = verify_workshop_upload_staging(release_zip, content_folder, expected_version="0.2.50")
+
+    assert findings == [
+        "staged manifest version mismatch: expected 0.2.50, got 0.2.0",
+        "staged QudJP.dll SHA256 does not match release ZIP",
+        "staged file hash mismatch: manifest.json",
+    ]
+
+
+def test_verify_workshop_upload_staging_reports_stale_localization_asset(tmp_path: Path) -> None:
+    """Upload preflight reports stale non-DLL files, not only manifest and assembly drift."""
+    release_zip = tmp_path / "dist" / "QudJP-v0.2.50.zip"
+    _write_release_zip(release_zip, version="0.2.50", dll_payload=VALID_RELEASE_DLL_MARKER_PAYLOAD)
+    content_folder, _preview = create_workshop_staging(release_zip, tmp_path / "dist" / "workshop")
+    (content_folder / "Localization" / "ui.json").write_text('{"stale": true}', encoding="utf-8")
+
+    findings = verify_workshop_upload_staging(release_zip, content_folder, expected_version="0.2.50")
+
+    assert findings == ["staged file hash mismatch: Localization/ui.json"]
+
+
+def test_verify_workshop_upload_staging_reports_missing_and_extra_files(tmp_path: Path) -> None:
+    """Upload preflight reports content set drift before steamcmd upload."""
+    release_zip = tmp_path / "dist" / "QudJP-v0.2.50.zip"
+    _write_release_zip(release_zip, version="0.2.50", dll_payload=VALID_RELEASE_DLL_MARKER_PAYLOAD)
+    content_folder, _preview = create_workshop_staging(release_zip, tmp_path / "dist" / "workshop")
+    (content_folder / "preview.png").unlink()
+    (content_folder / "stale.txt").write_text("stale", encoding="utf-8")
+
+    findings = verify_workshop_upload_staging(release_zip, content_folder, expected_version="0.2.50")
+
+    assert findings == [
+        "staged content missing file: preview.png",
+        "staged content has extra file: stale.txt",
+    ]
+
+
+def test_verify_workshop_upload_staging_reports_same_version_manifest_drift(tmp_path: Path) -> None:
+    """Upload preflight reports manifest drift even when Version still matches."""
+    release_zip = tmp_path / "dist" / "QudJP-v0.2.50.zip"
+    _write_release_zip(release_zip, version="0.2.50", dll_payload=VALID_RELEASE_DLL_MARKER_PAYLOAD)
+    content_folder, _preview = create_workshop_staging(release_zip, tmp_path / "dist" / "workshop")
+    (content_folder / "manifest.json").write_text(
+        json.dumps({"Version": "0.2.50", "PreviewImage": "old-preview.png"}),
+        encoding="utf-8",
+    )
+
+    findings = verify_workshop_upload_staging(release_zip, content_folder, expected_version="0.2.50")
+
+    assert findings == ["staged file hash mismatch: manifest.json"]
 
 
 def test_find_latest_release_zip_uses_newest_mtime(tmp_path: Path) -> None:

--- a/scripts/tests/test_release_justfile_contract.py
+++ b/scripts/tests/test_release_justfile_contract.py
@@ -15,10 +15,15 @@ def _justfile_text() -> str:
 
 
 def _download_release_zip_recipe() -> str:
+    return _recipe_body("download-release-zip")
+
+
+def _recipe_body(name: str) -> str:
     justfile = _justfile_text()
-    marker = "\ndownload-release-zip version:\n"
-    _prefix, separator, remainder = justfile.partition(marker)
-    assert separator, "download-release-zip version: recipe not found in justfile"
+    marker_pattern = rf"\n{name}(?:\s+[^:\n]+)*:\n"
+    match = re.search(marker_pattern, justfile)
+    assert match, f"{name}: recipe not found in justfile"
+    remainder = justfile[match.end() :]
     next_recipe = re.search(r"^[A-Za-z0-9_-]+(?:\s+[^:\n]+)*:\n", remainder, flags=re.MULTILINE)
     return remainder[: next_recipe.start()] if next_recipe is not None else remainder
 
@@ -47,3 +52,14 @@ def test_download_release_zip_quotes_version_argument() -> None:
 
     assert re.search(r"^version=(['\"]).*touch /tmp/qudjp-just-injection.*\1$", dry_run, re.MULTILINE)
     assert not re.search(r"^(?!version=).*;\s*touch\s+/tmp/qudjp-just-injection", dry_run, re.MULTILINE)
+
+
+def test_workshop_upload_preflight_recipe_uses_dedicated_verifier() -> None:
+    """The upload gate must verify staged content against the chosen release ZIP."""
+    recipe = _recipe_body("workshop-upload-preflight")
+
+    assert "scripts/verify_workshop_upload.py" in recipe
+    assert "--release-zip" in recipe
+    assert "--content-folder" in recipe
+    assert "--vdf" in recipe
+    assert "--expected-version" in recipe

--- a/scripts/tests/test_rosetta_launcher.py
+++ b/scripts/tests/test_rosetta_launcher.py
@@ -1,0 +1,28 @@
+"""Tests for the player-facing macOS Rosetta launcher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _launcher_text() -> str:
+    return Path("Mods/QudJP/Launch CavesOfQud (Rosetta).command").read_text(encoding="utf-8")
+
+
+def test_rosetta_launcher_uses_gui_dialogs_for_player_facing_errors() -> None:
+    """The launcher guides non-technical macOS users through Finder dialogs."""
+    launcher = _launcher_text()
+
+    assert "display dialog" in launcher
+    assert "choose file" in launcher
+    assert "CoQ.app/Contents/MacOS/CoQ" in launcher
+    assert "edit this launcher" not in launcher
+
+
+def test_rosetta_launcher_can_offer_rosetta_install_without_manual_terminal_command() -> None:
+    """Missing Rosetta is handled through the launcher, not only a printed command."""
+    launcher = _launcher_text()
+
+    assert "softwareupdate --install-rosetta --agree-to-license" in launcher
+    assert "Install Rosetta 2" in launcher
+    assert "exec arch -x86_64" in launcher

--- a/scripts/tests/test_verify_workshop_upload.py
+++ b/scripts/tests/test_verify_workshop_upload.py
@@ -69,6 +69,56 @@ def test_verify_workshop_vdf_unescapes_path_fields_before_comparison(tmp_path: P
     assert verify_workshop_vdf(vdf, content_folder=content_folder) == []
 
 
+def test_verify_workshop_vdf_ignores_escaped_newline_sequence_in_path_fields(tmp_path: Path) -> None:
+    """The escaped-newline gate does not reject Windows-style paths containing backslash-n."""
+    content_folder = tmp_path / "Steam\\newlibrary" / "QudJP"
+    content_folder.mkdir(parents=True)
+    vdf = tmp_path / "workshop_item.vdf"
+    escaped_content_folder = str(content_folder.resolve()).replace("\\", "\\\\")
+    escaped_preview_file = str((content_folder / "preview.png").resolve()).replace("\\", "\\\\")
+    vdf.write_text(
+        "\n".join(
+            [
+                '"workshopitem"',
+                "{",
+                '  "appid" "333640"',
+                '  "publishedfileid" "3718988020"',
+                f'  "contentfolder" "{escaped_content_folder}"',
+                f'  "previewfile" "{escaped_preview_file}"',
+                "}",
+            ],
+        ),
+        encoding="utf-8",
+    )
+
+    assert verify_workshop_vdf(vdf, content_folder=content_folder) == []
+
+
+def test_verify_workshop_vdf_reports_escaped_newline_in_text_fields(tmp_path: Path) -> None:
+    """The escaped-newline gate still rejects text fields that steamcmd can misparse."""
+    content_folder = tmp_path / "QudJP"
+    vdf = tmp_path / "workshop_item.vdf"
+    vdf.write_text(
+        "\n".join(
+            [
+                '"workshopitem"',
+                "{",
+                '  "appid" "333640"',
+                '  "publishedfileid" "3718988020"',
+                f'  "contentfolder" "{content_folder.resolve()}"',
+                f'  "previewfile" "{(content_folder / "preview.png").resolve()}"',
+                '  "changenote" "Line\\nBreak"',
+                "}",
+            ],
+        ),
+        encoding="utf-8",
+    )
+
+    assert verify_workshop_vdf(vdf, content_folder=content_folder) == [
+        r"VDF contains escaped newline sequences (\n); use literal multiline text",
+    ]
+
+
 def test_main_accepts_matching_staging_and_vdf(tmp_path: Path) -> None:
     """The CLI accepts upload files generated from the same release ZIP."""
     release_zip = tmp_path / "dist" / "QudJP-v0.2.50.zip"

--- a/scripts/tests/test_verify_workshop_upload.py
+++ b/scripts/tests/test_verify_workshop_upload.py
@@ -1,0 +1,151 @@
+"""Tests for the final Steam Workshop upload preflight."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from scripts.build_workshop_upload import WorkshopMetadata, create_workshop_staging, render_vdf
+from scripts.tests._common import VALID_RELEASE_DLL_MARKER_PAYLOAD, write_workshop_release_zip
+from scripts.verify_workshop_upload import main, verify_workshop_vdf
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def test_verify_workshop_vdf_reports_identity_and_escaped_text_findings(tmp_path: Path) -> None:
+    """The VDF gate catches stale targets and text that steamcmd can misparse."""
+    vdf = tmp_path / "workshop_item.vdf"
+    vdf.write_text(
+        "\n".join(
+            [
+                '"workshopitem"',
+                "{",
+                '  "appid" "333640"',
+                '  "publishedfileid" "123"',
+                f'  "contentfolder" "{tmp_path / "old"}"',
+                f'  "previewfile" "{tmp_path / "old-preview.png"}"',
+                '  "description" "Run \\"quoted\\" text"',
+                "}",
+            ],
+        ),
+        encoding="utf-8",
+    )
+
+    findings = verify_workshop_vdf(vdf, content_folder=tmp_path / "QudJP")
+
+    assert findings == [
+        "VDF publishedfileid mismatch: expected 3718988020, got 123",
+        f"VDF contentfolder mismatch: expected {(tmp_path / 'QudJP').resolve()}, got {tmp_path / 'old'}",
+        f"VDF previewfile mismatch: expected {(tmp_path / 'QudJP' / 'preview.png').resolve()}, "
+        f"got {tmp_path / 'old-preview.png'}",
+        'VDF contains escaped double quote sequences (\\"); remove double quotes from text fields',
+    ]
+
+
+def test_main_accepts_matching_staging_and_vdf(tmp_path: Path) -> None:
+    """The CLI accepts upload files generated from the same release ZIP."""
+    release_zip = tmp_path / "dist" / "QudJP-v0.2.50.zip"
+    write_workshop_release_zip(release_zip, version="0.2.50", dll_payload=VALID_RELEASE_DLL_MARKER_PAYLOAD)
+    content_folder, preview_file = create_workshop_staging(release_zip, tmp_path / "dist" / "workshop")
+    vdf = tmp_path / "dist" / "workshop" / "workshop_item.vdf"
+    vdf.write_text(
+        render_vdf(
+            WorkshopMetadata(
+                appid="333640",
+                publishedfileid="3718988020",
+                title="Caves of Qud Japanese Mod",
+                visibility="0",
+                description_file=None,
+            ),
+            content_folder=content_folder,
+            preview_file=preview_file,
+            changenote="v0.2.50 release",
+            description="Caves of Qud 日本語化",
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "--release-zip",
+            str(release_zip),
+            "--content-folder",
+            str(content_folder),
+            "--vdf",
+            str(vdf),
+            "--expected-version",
+            "0.2.50",
+        ],
+    )
+
+    assert exit_code == 0
+
+
+def test_main_rejects_stale_staging(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The CLI rejects a content folder left over from an older release."""
+    release_zip = tmp_path / "dist" / "QudJP-v0.2.50.zip"
+    write_workshop_release_zip(release_zip, version="0.2.50", dll_payload=VALID_RELEASE_DLL_MARKER_PAYLOAD)
+    stale_zip = tmp_path / "dist" / "QudJP-v0.2.0.zip"
+    write_workshop_release_zip(stale_zip, version="0.2.0", dll_payload=b"old dll" + VALID_RELEASE_DLL_MARKER_PAYLOAD)
+    content_folder, preview_file = create_workshop_staging(stale_zip, tmp_path / "dist" / "workshop")
+    vdf = tmp_path / "dist" / "workshop" / "workshop_item.vdf"
+    vdf.write_text(
+        render_vdf(
+            WorkshopMetadata(
+                appid="333640",
+                publishedfileid="3718988020",
+                title="Caves of Qud Japanese Mod",
+                visibility="0",
+                description_file=None,
+            ),
+            content_folder=content_folder,
+            preview_file=preview_file,
+            changenote="v0.2.50 release",
+            description="Caves of Qud 日本語化",
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "--release-zip",
+            str(release_zip),
+            "--content-folder",
+            str(content_folder),
+            "--vdf",
+            str(vdf),
+            "--expected-version",
+            "0.2.50",
+        ],
+    )
+
+    assert exit_code == 1
+    stderr = capsys.readouterr().err
+    assert "Error: staged manifest version mismatch: expected 0.2.50, got 0.2.0" in stderr
+    assert "Error: staged QudJP.dll SHA256 does not match release ZIP" in stderr
+
+
+def test_main_reports_missing_release_zip_without_traceback(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The operator-facing CLI reports missing release artifacts as a clean error."""
+    exit_code = main(
+        [
+            "--release-zip",
+            str(tmp_path / "missing.zip"),
+            "--content-folder",
+            str(tmp_path / "QudJP"),
+            "--vdf",
+            str(tmp_path / "workshop_item.vdf"),
+            "--expected-version",
+            "0.2.50",
+        ],
+    )
+
+    assert exit_code == 1
+    stderr = capsys.readouterr().err
+    assert stderr.startswith("Error: ")
+    assert "Traceback" not in stderr

--- a/scripts/tests/test_verify_workshop_upload.py
+++ b/scripts/tests/test_verify_workshop_upload.py
@@ -44,6 +44,31 @@ def test_verify_workshop_vdf_reports_identity_and_escaped_text_findings(tmp_path
     ]
 
 
+def test_verify_workshop_vdf_unescapes_path_fields_before_comparison(tmp_path: Path) -> None:
+    """The VDF gate accepts path fields escaped by render_vdf."""
+    content_folder = tmp_path / "Steam\\Library" / "QudJP"
+    content_folder.mkdir(parents=True)
+    vdf = tmp_path / "workshop_item.vdf"
+    escaped_content_folder = str(content_folder.resolve()).replace("\\", "\\\\")
+    escaped_preview_file = str((content_folder / "preview.png").resolve()).replace("\\", "\\\\")
+    vdf.write_text(
+        "\n".join(
+            [
+                '"workshopitem"',
+                "{",
+                '  "appid" "333640"',
+                '  "publishedfileid" "3718988020"',
+                f'  "contentfolder" "{escaped_content_folder}"',
+                f'  "previewfile" "{escaped_preview_file}"',
+                "}",
+            ],
+        ),
+        encoding="utf-8",
+    )
+
+    assert verify_workshop_vdf(vdf, content_folder=content_folder) == []
+
+
 def test_main_accepts_matching_staging_and_vdf(tmp_path: Path) -> None:
     """The CLI accepts upload files generated from the same release ZIP."""
     release_zip = tmp_path / "dist" / "QudJP-v0.2.50.zip"

--- a/scripts/verify_workshop_upload.py
+++ b/scripts/verify_workshop_upload.py
@@ -36,10 +36,23 @@ def _parse_vdf_fields(vdf_text: str) -> dict[str, str]:
     return fields
 
 
-def _append_vdf_mismatch(findings: list[str], fields: dict[str, str], key: str, expected: str) -> None:
+def _vdf_unescape(value: str) -> str:
+    """Unescape the subset emitted by build_workshop_upload.vdf_escape."""
+    return value.replace(r"\\", "\\").replace(r"\"", '"')
+
+
+def _append_vdf_mismatch(
+    findings: list[str],
+    fields: dict[str, str],
+    key: str,
+    expected: str,
+    *,
+    unescape_actual: bool = False,
+) -> None:
     """Append a standard VDF field mismatch finding."""
     actual = fields.get(key, "<missing>")
-    if actual != expected:
+    comparable_actual = _vdf_unescape(actual) if unescape_actual and actual != "<missing>" else actual
+    if comparable_actual != expected:
         findings.append(f"VDF {key} mismatch: expected {expected}, got {actual}")
 
 
@@ -54,9 +67,9 @@ def verify_workshop_vdf(vdf_path: Path, *, content_folder: Path) -> list[str]:
     _append_vdf_mismatch(findings, fields, "appid", WORKSHOP_APP_ID)
     _append_vdf_mismatch(findings, fields, "publishedfileid", WORKSHOP_PUBLISHED_FILE_ID)
     expected_content_folder = str(content_folder.resolve())
-    _append_vdf_mismatch(findings, fields, "contentfolder", expected_content_folder)
+    _append_vdf_mismatch(findings, fields, "contentfolder", expected_content_folder, unescape_actual=True)
     expected_preview_file = str((content_folder / "preview.png").resolve())
-    _append_vdf_mismatch(findings, fields, "previewfile", expected_preview_file)
+    _append_vdf_mismatch(findings, fields, "previewfile", expected_preview_file, unescape_actual=True)
     if r"\"" in vdf_text:
         findings.append('VDF contains escaped double quote sequences (\\"); remove double quotes from text fields')
     if r"\n" in vdf_text:

--- a/scripts/verify_workshop_upload.py
+++ b/scripts/verify_workshop_upload.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 _VDF_FIELD_PATTERN = re.compile(r'^\s*"(?P<key>[^"]+)"\s+"(?P<value>.*)"\s*$', re.MULTILINE)
+_VDF_TEXT_FIELD_KEYS = ("title", "description", "changenote")
 
 
 def _parse_vdf_fields(vdf_text: str) -> dict[str, str]:
@@ -72,7 +73,7 @@ def verify_workshop_vdf(vdf_path: Path, *, content_folder: Path) -> list[str]:
     _append_vdf_mismatch(findings, fields, "previewfile", expected_preview_file, unescape_actual=True)
     if r"\"" in vdf_text:
         findings.append('VDF contains escaped double quote sequences (\\"); remove double quotes from text fields')
-    if r"\n" in vdf_text:
+    if any(r"\n" in fields.get(key, "") for key in _VDF_TEXT_FIELD_KEYS):
         findings.append(r"VDF contains escaped newline sequences (\n); use literal multiline text")
     return findings
 

--- a/scripts/verify_workshop_upload.py
+++ b/scripts/verify_workshop_upload.py
@@ -1,0 +1,106 @@
+"""Verify generated Steam Workshop upload files before running steamcmd."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import zipfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+try:
+    from scripts.build_workshop_upload import (
+        WORKSHOP_APP_ID,
+        WORKSHOP_PUBLISHED_FILE_ID,
+        verify_workshop_upload_staging,
+    )
+except ModuleNotFoundError:
+    from build_workshop_upload import (
+        WORKSHOP_APP_ID,
+        WORKSHOP_PUBLISHED_FILE_ID,
+        verify_workshop_upload_staging,
+    )
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+_VDF_FIELD_PATTERN = re.compile(r'^\s*"(?P<key>[^"]+)"\s+"(?P<value>.*)"\s*$', re.MULTILINE)
+
+
+def _parse_vdf_fields(vdf_text: str) -> dict[str, str]:
+    """Parse simple quoted top-level VDF fields emitted by build_workshop_upload.py."""
+    fields: dict[str, str] = {}
+    for match in _VDF_FIELD_PATTERN.finditer(vdf_text):
+        fields[match.group("key")] = match.group("value")
+    return fields
+
+
+def _append_vdf_mismatch(findings: list[str], fields: dict[str, str], key: str, expected: str) -> None:
+    """Append a standard VDF field mismatch finding."""
+    actual = fields.get(key, "<missing>")
+    if actual != expected:
+        findings.append(f"VDF {key} mismatch: expected {expected}, got {actual}")
+
+
+def verify_workshop_vdf(vdf_path: Path, *, content_folder: Path) -> list[str]:
+    """Verify VDF identity and fragile Steam KeyValues text before upload."""
+    findings: list[str] = []
+    if not vdf_path.is_file():
+        return [f"Workshop VDF not found: {vdf_path}"]
+
+    vdf_text = vdf_path.read_text(encoding="utf-8")
+    fields = _parse_vdf_fields(vdf_text)
+    _append_vdf_mismatch(findings, fields, "appid", WORKSHOP_APP_ID)
+    _append_vdf_mismatch(findings, fields, "publishedfileid", WORKSHOP_PUBLISHED_FILE_ID)
+    expected_content_folder = str(content_folder.resolve())
+    _append_vdf_mismatch(findings, fields, "contentfolder", expected_content_folder)
+    expected_preview_file = str((content_folder / "preview.png").resolve())
+    _append_vdf_mismatch(findings, fields, "previewfile", expected_preview_file)
+    if r"\"" in vdf_text:
+        findings.append('VDF contains escaped double quote sequences (\\"); remove double quotes from text fields')
+    if r"\n" in vdf_text:
+        findings.append(r"VDF contains escaped newline sequences (\n); use literal multiline text")
+    return findings
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Verify QudJP Workshop upload staging before steamcmd upload.")
+    parser.add_argument("--release-zip", type=Path, required=True)
+    parser.add_argument("--content-folder", type=Path, default=Path("dist/workshop/QudJP"))
+    parser.add_argument("--vdf", type=Path, default=Path("dist/workshop/workshop_item.vdf"))
+    parser.add_argument("--expected-version", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the Workshop upload preflight CLI."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        findings = [
+            *verify_workshop_upload_staging(
+                args.release_zip,
+                args.content_folder,
+                expected_version=args.expected_version,
+            ),
+            *verify_workshop_vdf(args.vdf, content_folder=args.content_folder),
+        ]
+    except (FileNotFoundError, KeyError, OSError, TypeError, ValueError, zipfile.BadZipFile) as exc:
+        print(f"Error: {exc}", file=sys.stderr)  # noqa: T201
+        return 1
+    if findings:
+        for finding in findings:
+            print(f"Error: {finding}", file=sys.stderr)  # noqa: T201
+        return 1
+
+    print(  # noqa: T201
+        "Workshop upload preflight verified: "
+        f"version={args.expected_version} release_zip={args.release_zip} content_folder={args.content_folder}",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/steam/workshop_description.ja.txt
+++ b/steam/workshop_description.ja.txt
@@ -33,9 +33,10 @@ macOS Apple Silicon での注意
   * その場合は Rosetta 2 経由で Caves of Qud を起動してください。
   * この Mod には `Launch CavesOfQud (Rosetta).command` という起動用 wrapper を同梱しています。Steam Workshop のダウンロード先からダブルクリックで起動できます。
   * macOS の Steam 既定ライブラリでは、通常 `~/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020/Launch CavesOfQud (Rosetta).command` にあります。別の Steam ライブラリを使っている場合は、そのライブラリ内の `steamapps/workshop/content/333640/3718988020/` を探してください。
+  * ゲーム本体が標準の Steam ライブラリに見つからない場合、wrapper が `CoQ.app` の選択画面を表示します。Steam ライブラリ内の Caves of Qud フォルダから `CoQ.app` を選んでください。
   * Steam から通常起動した場合、この wrapper の効果は引き継がれません。Apple Silicon で翻訳が効かない場合は、毎回 wrapper から起動してください。
-  * Rosetta 2 が未インストールの場合は、ターミナルで `softwareupdate --install-rosetta --agree-to-license` を実行してください。
-  * 直接起動する場合は、ターミナルで `arch -x86_64 $HOME/Library/Application\ Support/Steam/steamapps/common/Caves\ of\ Qud/CoQ.app/Contents/MacOS/CoQ` を実行してください。
+  * Rosetta 2 が未インストールの場合、wrapper がインストール確認を表示します。表示に従って進めれば、手動でターミナル操作をする必要はありません。
+  * 上級者向けの直接起動例: `arch -x86_64 $HOME/Library/Application\ Support/Steam/steamapps/common/Caves\ of\ Qud/CoQ.app/Contents/MacOS/CoQ`
 
 報告・Contribution
 

--- a/steam/workshop_description.ja.txt
+++ b/steam/workshop_description.ja.txt
@@ -31,13 +31,11 @@ macOS Apple Silicon での注意
 
   * M1/M2/M3/M4 などの Apple Silicon Mac では、Caves of Qud をネイティブ起動すると Harmony パッチが `mprotect returned EACCES` で失敗し、この Mod の UI 翻訳が効かない場合があります。
   * その場合は Rosetta 2 経由で Caves of Qud を起動してください。
-  * この Mod には `Launch CavesOfQud (Rosetta).command` という起動用 wrapper を同梱しています。Steam Workshop のダウンロード先にある `QudJP` フォルダ内からダブルクリックで起動できます。
+  * この Mod には `Launch CavesOfQud (Rosetta).command` という起動用 wrapper を同梱しています。Steam Workshop のダウンロード先からダブルクリックで起動できます。
   * macOS の Steam 既定ライブラリでは、通常 `~/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020/Launch CavesOfQud (Rosetta).command` にあります。別の Steam ライブラリを使っている場合は、そのライブラリ内の `steamapps/workshop/content/333640/3718988020/` を探してください。
   * Steam から通常起動した場合、この wrapper の効果は引き継がれません。Apple Silicon で翻訳が効かない場合は、毎回 wrapper から起動してください。
   * Rosetta 2 が未インストールの場合は、ターミナルで `softwareupdate --install-rosetta --agree-to-license` を実行してください。
-  * 起動例:
-
-    arch -x86_64 "$HOME/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/MacOS/CoQ"
+  * 直接起動する場合は、ターミナルで `arch -x86_64 $HOME/Library/Application\ Support/Steam/steamapps/common/Caves\ of\ Qud/CoQ.app/Contents/MacOS/CoQ` を実行してください。
 
 報告・Contribution
 
@@ -57,7 +55,6 @@ Contribution も待っています！
 未対応・観測している問題
 
   * プロシージャル全般
-  * チュートリアル
   * キャラクター生成画面
   * メッセージログに表示される文字に付与される色タグのズレ
   * その他、細かい UI の表示や観測漏れなど


### PR DESCRIPTION
## Summary

- Add `just workshop-upload-preflight` and `scripts/verify_workshop_upload.py` to verify Workshop staging immediately before `steamcmd` upload.
- Compare staged Workshop content against the selected release ZIP by file set and SHA256, and validate VDF app ID, item ID, content folder, preview file, escaped quotes, and escaped newlines.
- Update Workshop release docs/report template and Rosetta guidance to avoid Steam KeyValues quote parsing failures.

## Review / Simplify

- Reviewed by a separate code-review subagent; initial blockers were fixed.
- Final review result: APPROVED / no blocking findings.
- Simplify pass applied behavior-preserving cleanup and strengthened tests for stale staging diagnostics and operator-facing errors.

## Verification

- `uv run pytest scripts/tests/test_build_workshop_upload.py scripts/tests/test_verify_workshop_upload.py scripts/tests/test_release_justfile_contract.py -q` -> 30 passed
- `uv run ruff check scripts/verify_workshop_upload.py scripts/build_workshop_upload.py scripts/tests/_common.py scripts/tests/test_verify_workshop_upload.py scripts/tests/test_build_workshop_upload.py scripts/tests/test_release_justfile_contract.py` -> passed
- `uv run python -m py_compile scripts/verify_workshop_upload.py scripts/build_workshop_upload.py` -> passed
- `just build-workshop-upload <fixture-zip> /tmp/qudjp-workshop-changenote.txt && just workshop-upload-preflight <fixture-zip> 0.2.50` -> passed
- `just python-check` -> passed
- `just python-test` -> 1014 passed, 1 skipped
- `git diff --check` -> passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Steam Workshop アップロード前の即時プレフライト検証コマンドを追加（生成物とVDFの整合性を検証）

* **ドキュメント**
  * Workshop 説明/変更点で二重引用符を避ける制約を明記
  * アップロード手順にプレフライト検証ステップを追記
  * Apple Silicon 起動例を引用符なしの arch -x86_64 表記に修正
  * リリース後の steamcmd によるダウンロード/検証コマンド例を追加

* **テスト**
  * プレフライト検証とVDF安全性に関するテストを大幅に拡充

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/620)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->