### PR TITLE
[codex] Fix PickGameObjectLine item icons

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyPickGameObjectLineTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyPickGameObjectLineTargets.cs
@@ -53,6 +53,53 @@ internal sealed class DummyPickGameObjectLineDataTarget
     public string? hotkeyDescription { get; set; }
 }
 
+internal sealed class DummyGameSignaturePickGameObjectLineDataTarget
+{
+    public string? style { get; set; }
+
+    public object? go { get; set; }
+
+    public string category { get; set; } = string.Empty;
+
+    public bool collapsed { get; set; }
+
+    public bool indent { get; set; }
+
+    public string? hotkeyDescription { get; set; }
+}
+
+internal sealed class DummyGameSignaturePickGameObjectTargetObject
+{
+    public string DisplayName { get; set; } = string.Empty;
+
+    public bool OwnedByPlayer { get; set; }
+
+    public int Weight { get; set; }
+
+    public string ListDisplayContext { get; set; } = string.Empty;
+
+    public string IDIfAssigned { get; set; } = "item-1";
+
+    public string? LastRenderContext { get; private set; }
+
+    public bool? LastAsIfKnown { get; private set; }
+
+    public object RenderForUI(string? context = null, bool asIfKnown = false)
+    {
+        LastRenderContext = context;
+        LastAsIfKnown = asIfKnown;
+        return new DummyRenderable(DisplayName);
+    }
+
+    public int GetWeight() => Weight;
+
+    public string GetListDisplayContext(object? player)
+    {
+        _ = player;
+        return ListDisplayContext;
+    }
+}
+
 internal sealed class DummyFallbackPickGameObjectLineDataTarget
 {
     public string FallbackText { get; set; } = "pick fallback";

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PickGameObjectLineTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PickGameObjectLineTranslationPatchTests.cs
@@ -77,6 +77,48 @@ public sealed partial class Issue201OtherUiBindingPatchTests
     }
 
     [Test]
+    public void PickGameObjectLinePrefix_UpdatesIconUsingGameRenderForUiSignature_WhenPatched()
+    {
+        WriteDictionary(("Laser Pistol", "レーザーピストル"));
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyPickGameObjectLineTarget), nameof(DummyPickGameObjectLineTarget.setData)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(PickGameObjectLineTranslationPatch), nameof(PickGameObjectLineTranslationPatch.Prefix))));
+
+            var item = new DummyGameSignaturePickGameObjectTargetObject
+            {
+                DisplayName = "Laser Pistol",
+                Weight = 7,
+            };
+            var target = new DummyPickGameObjectLineTarget();
+            target.icon.FromRenderable(new DummyRenderable("stale-water-tile"));
+
+            target.setData(new DummyGameSignaturePickGameObjectLineDataTarget
+            {
+                go = item,
+                hotkeyDescription = "a",
+            });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(target.text.Text, Is.EqualTo("レーザーピストル"));
+                Assert.That(target.icon.LastRenderable, Is.InstanceOf<DummyRenderable>());
+                Assert.That(((DummyRenderable)target.icon.LastRenderable!).Tile, Is.EqualTo("Laser Pistol"));
+                Assert.That(item.LastRenderContext, Is.Null);
+                Assert.That(item.LastAsIfKnown, Is.False);
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
     public void PickGameObjectLinePrefix_FallsBackToOriginal_OnUnsupportedInput()
     {
         var harmonyId = CreateHarmonyId();

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1201,6 +1201,27 @@ public sealed class TargetMethodResolutionTests
             Assert.That(signatures, Does.Contain("XRL.CharacterBuilds.Qud.QudCyberneticsModule|DataErrors"));
         });
     }
+
+    [Test]
+    public void PickGameObjectLineIconRoute_GameObjectRenderForUiSignatureResolves()
+    {
+        var assembly = EnsureGameAssemblyLoaded();
+        var gameObjectType = assembly.GetType("XRL.World.GameObject", throwOnError: false);
+        Assert.That(gameObjectType, Is.Not.Null, "Type not found: XRL.World.GameObject");
+
+        var method = gameObjectType!.GetMethod(
+            "RenderForUI",
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            types: new[] { typeof(string), typeof(bool) },
+            modifiers: null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(method, Is.Not.Null, "GameObject.RenderForUI(string, bool) not found.");
+            Assert.That(method?.ReturnType.FullName, Is.EqualTo("XRL.World.RenderEvent"));
+        });
+    }
 #endif
 
     private static MethodBase? InvokeTargetMethod(Type patchType)

--- a/Mods/QudJP/Assemblies/src/Patches/PickGameObjectLineTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PickGameObjectLineTranslationPatch.cs
@@ -118,7 +118,7 @@ public static class PickGameObjectLineTranslationPatch
         }
 
         TrySetActive(GetMemberValue(instance, "iconSpacer"), active: true);
-        var renderable = AccessTools.Method(go.GetType(), "RenderForUI", Type.EmptyTypes)?.Invoke(go, null);
+        var renderable = InvokeRenderForUi(go);
         if (icon is not null && renderable is not null)
         {
             _ = AccessTools.Method(icon.GetType(), "FromRenderable")?.Invoke(icon, new[] { renderable });
@@ -244,6 +244,19 @@ public static class PickGameObjectLineTranslationPatch
     {
         var translated = Translator.Translate(source);
         return string.Equals(translated, source, StringComparison.Ordinal) ? source : translated;
+    }
+
+    private static object? InvokeRenderForUi(object go)
+    {
+        var type = go.GetType();
+        var method = AccessTools.Method(type, "RenderForUI", new[] { typeof(string), typeof(bool) });
+        if (method is not null)
+        {
+            return method.Invoke(go, new object?[] { null, false });
+        }
+
+        method = AccessTools.Method(type, "RenderForUI", Type.EmptyTypes);
+        return method?.Invoke(go, null);
     }
 
     private static bool ShouldNotePlayerOwned()


### PR DESCRIPTION
## Summary
- Fix PickGameObjectLine item icon updates by invoking the real game `RenderForUI(string, bool)` signature before the zero-arg fallback.
- Add a regression test that starts from a stale icon renderable and verifies the item row replaces it.
- Add an L2G contract test for `XRL.World.GameObject.RenderForUI(string, bool)`.

## Root Cause
`PickGameObjectLineTranslationPatch` replaced the upstream row binding and looked up only a zero-argument `RenderForUI` method by reflection. In the real game DLL, `GameObject.RenderForUI` is exposed as `RenderForUI(string Context = null, bool AsIfKnown = false)`, so the reflection lookup failed and recycled row icons could keep stale sprites.

## Validation
- `just build`
- `just test-l2`
- `just test-l2g`
- `git diff --check`
- Manual smoke: chest/tutorial item selection looked correct and the fresh `Player.log` showed no QudJP/RenderForUI/PickGameObject exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テストカバレッジの強化と検証フローの改善を実施しました

このリリースは主に内部テストインフラストラクチャの改善に関するものです。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/621)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->