### PR TITLE
[codex] Codify reflected game signature checks

### DIFF
--- a/Mods/QudJP/Assemblies/AGENTS.md
+++ b/Mods/QudJP/Assemblies/AGENTS.md
@@ -30,6 +30,12 @@ just test-l2g
 
 - Prefer producer-owned or stable mid-pipeline fixes. Many sink and near-sink routes are intentionally observation-only.
 - Use `~/dev/coq-decompiled_stable/` to trace upstream producers, verify signatures, and investigate unclaimed routes.
+- When a patch reflects into upstream game members, verify the real method
+  signature in decompiled source before choosing `AccessTools.Method`
+  parameter types. C# optional arguments still appear as real parameters to
+  reflection, so a source call such as `RenderForUI()` may require resolving
+  `RenderForUI(string, bool)`. Add an L2G signature/contract test when this
+  reflection path controls runtime UI behavior.
 - For C# patch, translator, observability, or target-method changes, use structural search before editing or before finalizing the patch:
   - use `just --list` to discover repo recipes when command routing is unclear
   - use `just sg-cs '<pattern>' Mods/QudJP/Assemblies/src` to compare repo-owned call shapes


### PR DESCRIPTION
## Summary
- Add an Assemblies agent instruction for reflected upstream game member calls.
- Call out that C# optional arguments still appear as real reflection parameters.
- Require L2G signature/contract coverage when reflected game API calls control runtime UI behavior.

## Why
PR #621 fixed a stale item icon bug caused by reflecting `RenderForUI` as a zero-argument method even though the real game signature is `RenderForUI(string, bool)`. This codifies that lesson where future C# patch work will see it.

## Validation
- `git diff --check`
- Scope review: `Mods/QudJP/Assemblies/AGENTS.md` only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * リフレクションベースのコードパターンに関する内部開発ガイダンスを更新しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/622)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->