### PR TITLE
[codex] Codify static producer closure evidence rules

### DIFF
--- a/.codex/skills/qudjp-static-producer-closure/SKILL.md
+++ b/.codex/skills/qudjp-static-producer-closure/SKILL.md
@@ -113,7 +113,11 @@ split/deferred with a reason.
    - negative coverage for queue-only or owner-absent traffic when applicable,
    - direct marker and empty input handling,
    - color/capture preservation when the family can carry markup,
-   - L2G target/signature resolution for Harmony patches.
+   - L2G target/signature resolution for Harmony patches. Owner-patch closure
+     evidence in `scripts/static_producer_closure.py` must include
+     family-specific target tokens: prefer a full
+     `DeclaringType|Method|Return|...` signature, or include both the exact
+     upstream declaring type and member name.
 
 7. **Verify and report.**
    - Run the focused L1/L2/L2G tests touched by the batch.
@@ -134,6 +138,9 @@ split/deferred with a reason.
 
 - Do not register coverage from substring evidence alone; evidence files must
   contain tests that exercise the inventoried shapes.
+- Do not use only `typeof(Patch)` plus parameter-only signatures or shared test
+  names in `EvidenceFile.required_substrings`; those can match unrelated
+  families in the same patch.
 - Do not let a temporary pattern dictionary prove production coverage.
 - Do not treat a sink or generic popup/message fallback as owner coverage.
 - Do not close a mixed `needs_family_review` family without first naming the

--- a/Mods/QudJP/Assemblies/AGENTS.md
+++ b/Mods/QudJP/Assemblies/AGENTS.md
@@ -28,6 +28,9 @@ just test-l2
 just test-l2g
 ```
 
+- Run `just test-l1`, `just test-l2`, and `just test-l2g` sequentially. Parallel
+  local invocations can race on shared `ReferenceStubs`/NuGet restore outputs.
+
 - Prefer producer-owned or stable mid-pipeline fixes. Many sink and near-sink routes are intentionally observation-only.
 - Use `~/dev/coq-decompiled_stable/` to trace upstream producers, verify signatures, and investigate unclaimed routes.
 - When a patch reflects into upstream game members, verify the real method

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -89,7 +89,7 @@ COVERED_OWNER_FAMILIES: Final = (
             ),
             EvidenceFile(
                 "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
-                ("typeof(GameObjectHealTranslationPatch)", '"Heal"'),
+                ("typeof(GameObjectHealTranslationPatch)", '"Heal"', '"XRL.World.GameObject"'),
             ),
         ),
     ),
@@ -149,7 +149,11 @@ COVERED_OWNER_FAMILIES: Final = (
             ),
             EvidenceFile(
                 "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
-                ("typeof(PetEitherOrExplodeTranslationPatch)", '"explode"'),
+                (
+                    "typeof(PetEitherOrExplodeTranslationPatch)",
+                    '"explode"',
+                    '"XRL.World.Parts.PetEitherOr"',
+                ),
             ),
         ),
     ),
@@ -178,7 +182,7 @@ COVERED_OWNER_FAMILIES: Final = (
             ),
             EvidenceFile(
                 "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
-                ("typeof(ZoneWindChangeTranslationPatch)", '"WindChange"'),
+                ("typeof(ZoneWindChangeTranslationPatch)", '"WindChange"', '"XRL.World.Zone"'),
             ),
         ),
     ),

--- a/scripts/tests/test_static_producer_closure.py
+++ b/scripts/tests/test_static_producer_closure.py
@@ -45,7 +45,14 @@ def _member_name_from_family_id(family_id: str) -> str:
 def _is_owner_target_resolution_token(
     token: str, *, declaring_type: str, member_name: str
 ) -> bool:
-    return "|" in token and declaring_type in token and member_name in token
+    parts = token.split("|")
+    return len(parts) >= 3 and parts[0] == declaring_type and parts[1] == member_name
+
+
+def _unquoted_token(token: str) -> str:
+    if len(token) >= 2 and token[0] == token[-1] == '"':
+        return token[1:-1]
+    return token
 
 
 def test_owner_patch_l2g_evidence_is_family_specific() -> None:
@@ -58,9 +65,20 @@ def test_owner_patch_l2g_evidence_is_family_specific() -> None:
 
         declaring_type = _declaring_type_from_family_id(family.family_id)
         member_name = _member_name_from_family_id(family.family_id)
-        for evidence in family.evidence_files:
-            if not evidence.path.endswith("L2G/TargetMethodResolutionTests.cs"):
-                continue
+        l2g_evidence_files = [
+            evidence
+            for evidence in family.evidence_files
+            if evidence.path.endswith("L2G/TargetMethodResolutionTests.cs")
+        ]
+
+        if not l2g_evidence_files:
+            problems.append(f"{family.family_id}: missing L2G target resolution evidence")
+            continue
+
+        for evidence in l2g_evidence_files:
+            normalized_tokens = [
+                _unquoted_token(token) for token in evidence.required_substrings
+            ]
 
             has_full_target_token = any(
                 _is_owner_target_resolution_token(
@@ -69,9 +87,9 @@ def test_owner_patch_l2g_evidence_is_family_specific() -> None:
                 for token in evidence.required_substrings
             )
             has_declaring_type = any(
-                declaring_type in token for token in evidence.required_substrings
+                token == declaring_type for token in normalized_tokens
             )
-            has_member_name = any(member_name in token for token in evidence.required_substrings)
+            has_member_name = any(token == member_name for token in normalized_tokens)
 
             if not has_full_target_token and not (has_declaring_type and has_member_name):
                 problem = (

--- a/scripts/tests/test_static_producer_closure.py
+++ b/scripts/tests/test_static_producer_closure.py
@@ -34,6 +34,55 @@ def test_covered_owner_families_have_current_source_and_test_evidence() -> None:
     assert errors == []
 
 
+def _declaring_type_from_family_id(family_id: str) -> str:
+    return family_id.split("::", maxsplit=1)[1].rsplit(".", maxsplit=1)[0]
+
+
+def _member_name_from_family_id(family_id: str) -> str:
+    return family_id.rsplit(".", maxsplit=1)[1]
+
+
+def _is_owner_target_resolution_token(
+    token: str, *, declaring_type: str, member_name: str
+) -> bool:
+    return "|" in token and declaring_type in token and member_name in token
+
+
+def test_owner_patch_l2g_evidence_is_family_specific() -> None:
+    """Owner-patch L2G evidence must identify the upstream owner method."""
+    problems: list[str] = []
+
+    for family in COVERED_OWNER_FAMILIES:
+        if family.inventory_statuses != ("owner_patch_required",):
+            continue
+
+        declaring_type = _declaring_type_from_family_id(family.family_id)
+        member_name = _member_name_from_family_id(family.family_id)
+        for evidence in family.evidence_files:
+            if not evidence.path.endswith("L2G/TargetMethodResolutionTests.cs"):
+                continue
+
+            has_full_target_token = any(
+                _is_owner_target_resolution_token(
+                    token, declaring_type=declaring_type, member_name=member_name
+                )
+                for token in evidence.required_substrings
+            )
+            has_declaring_type = any(
+                declaring_type in token for token in evidence.required_substrings
+            )
+            has_member_name = any(member_name in token for token in evidence.required_substrings)
+
+            if not has_full_target_token and not (has_declaring_type and has_member_name):
+                problem = (
+                    f"{family.family_id}: L2G evidence must include a full target signature "
+                    f"or both the upstream declaring type and member name"
+                )
+                problems.append(problem)
+
+    assert problems == []
+
+
 def test_covered_owner_families_are_removed_from_owner_action_queue() -> None:
     """Covered owner families must not remain in the owner implementation queue."""
     inventory = load_inventory(TRACKED_INVENTORY)


### PR DESCRIPTION
## Summary
- Add a deterministic static-producer closure test requiring owner-patch L2G evidence to identify the upstream owner method.
- Tighten existing closure evidence tokens for older owner-patch entries.
- Codify the retrospective guidance in the static-producer skill and Assemblies AGENTS guidance.

## Why
The previous static-producer closure workflow could rely on weak evidence tokens such as patch type names or shared target-resolution tests. This makes future closure entries require family-specific target evidence before they can be treated as covered.

## Validation
- `just static-producer-check`
- `just python-check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * スキル文書で最小証拠要件を強化し、ファミリー固有のトークン要件と注意点を明確化しました
  * ビルド/テスト実行ガイダンスを更新し、順次実行を推奨する旨を追記しました

* **テスト**
  * 所有者パッチの証拠がファミリー固有であることを検証する新しいテストを追加しました

* **チョア**
  * 証拠判定要件を拡張する更新をスクリプトに反映しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/627)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->