### PR TITLE
test: codify translator dictionary test isolation

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ChargenStructuredTextTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ChargenStructuredTextTranslatorTests.cs
@@ -5,6 +5,7 @@ namespace QudJP.Tests.L1;
 
 [TestFixture]
 [Category("L1")]
+[NonParallelizable]
 public sealed class ChargenStructuredTextTranslatorTests
 {
     private string tempRoot = null!;

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DeathReasonTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DeathReasonTranslationPatchTests.cs
@@ -5,6 +5,7 @@ namespace QudJP.Tests.L1;
 
 [TestFixture]
 [Category("L1")]
+[NonParallelizable]
 public sealed class DeathReasonTranslationPatchTests
 {
     private string tempDir = null!;

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessageLogProducerTranslationHelpersTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessageLogProducerTranslationHelpersTests.cs
@@ -5,6 +5,7 @@ namespace QudJP.Tests.L1;
 
 [TestFixture]
 [Category("L1")]
+[NonParallelizable]
 public sealed class MessageLogProducerTranslationHelpersTests
 {
     private string tempDirectory = null!;

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ModManagementTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ModManagementTranslationPatchTests.cs
@@ -4,6 +4,7 @@ namespace QudJP.Tests.L1;
 
 [TestFixture]
 [Category("L1")]
+[NonParallelizable]
 public sealed class ModManagementTranslationPatchTests
 {
     [TestCase("{{y|by Example Author}}", "{{y|作者: Example Author}}")]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessageLogProducerTranslationHelpersPropertyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/Pbt/MessageLogProducerTranslationHelpersPropertyTests.cs
@@ -7,6 +7,7 @@ namespace QudJP.Tests.L1.Pbt;
 
 [TestFixture]
 [Category("L1")]
+[NonParallelizable]
 public sealed class MessageLogProducerTranslationHelpersPropertyTests
 {
     private const string ReplaySeed = "246813579,97531";

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/SinkPrereqTextFieldTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/SinkPrereqTextFieldTranslatorTests.cs
@@ -6,6 +6,7 @@ namespace QudJP.Tests.L1;
 
 [TestFixture]
 [Category("L1")]
+[NonParallelizable]
 public sealed class SinkPrereqTextFieldTranslatorTests
 {
     private string tempDir = null!;

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/SkillsAndPowersStatusScreenTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/SkillsAndPowersStatusScreenTranslationPatchTests.cs
@@ -5,6 +5,7 @@ namespace QudJP.Tests.L1;
 
 [TestFixture]
 [Category("L1")]
+[NonParallelizable]
 public sealed class SkillsAndPowersStatusScreenTranslationPatchTests
 {
     private string tempDirectory = null!;

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/SinkPrereqTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/SinkPrereqTranslationPatchTests.cs
@@ -8,6 +8,7 @@ namespace QudJP.Tests.L2;
 
 [TestFixture]
 [Category("L2")]
+[NonParallelizable]
 public sealed class SinkPrereqTranslationPatchTests
 {
     private string tempDir = null!;

--- a/scripts/tests/test_qudjp_dotnet_test_contracts.py
+++ b/scripts/tests/test_qudjp_dotnet_test_contracts.py
@@ -1,0 +1,21 @@
+"""Static contracts for QudJP NUnit test fixtures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEST_ROOT = REPO_ROOT / "Mods" / "QudJP" / "Assemblies" / "QudJP.Tests"
+
+
+def test_translator_dictionary_fixtures_are_non_parallelizable() -> None:
+    """Translator dictionary overrides mutate global state and must not run in parallel."""
+    offenders: list[str] = []
+    for path in sorted(TEST_ROOT.rglob("*.cs")):
+        text = path.read_text(encoding="utf-8")
+        if "Translator.SetDictionaryDirectoryForTests(" not in text:
+            continue
+        if "[NonParallelizable]" not in text:
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+
+    assert offenders == []

--- a/scripts/tests/test_qudjp_dotnet_test_contracts.py
+++ b/scripts/tests/test_qudjp_dotnet_test_contracts.py
@@ -2,20 +2,89 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TEST_ROOT = REPO_ROOT / "Mods" / "QudJP" / "Assemblies" / "QudJP.Tests"
+TRANSLATOR_DICTIONARY_CALL = "Translator.SetDictionaryDirectoryForTests("
+
+CLASS_DECLARATION = re.compile(r"\bclass\s+[A-Za-z_][A-Za-z0-9_]*\b")
+METHOD_DECLARATION = re.compile(
+    r"^\s*(?:public|private|protected|internal|static|async|virtual|override|sealed"
+    r"|partial|\s)+[A-Za-z_][A-Za-z0-9_<>,\[\]?]*\s+"
+    r"[A-Za-z_][A-Za-z0-9_]*\s*\("
+)
+
+
+def _has_non_parallelizable_attribute(lines: list[str], declaration_index: int) -> bool:
+    """Return whether the declaration has an immediate NonParallelizable attribute."""
+    j = declaration_index - 1
+    attribute_lines: list[str] = []
+    while j >= 0:
+        stripped = lines[j].strip()
+        if stripped == "":
+            j -= 1
+            continue
+        if not stripped.startswith("["):
+            break
+        attribute_lines.append(stripped)
+        j -= 1
+
+    return any("NonParallelizable" in line for line in attribute_lines)
+
+
+def _nearest_declaration(
+    lines: list[str],
+    line_index: int,
+    pattern: re.Pattern[str],
+    *,
+    stop_after: int = -1,
+) -> int | None:
+    """Find the nearest preceding line that matches a C# declaration pattern."""
+    for index in range(line_index, stop_after, -1):
+        if pattern.search(lines[index]):
+            return index
+    return None
 
 
 def test_translator_dictionary_fixtures_are_non_parallelizable() -> None:
     """Translator dictionary overrides mutate global state and must not run in parallel."""
+    assert TEST_ROOT.is_dir(), f"QudJP test root not found: {TEST_ROOT}"
+
     offenders: list[str] = []
     for path in sorted(TEST_ROOT.rglob("*.cs")):
         text = path.read_text(encoding="utf-8")
-        if "Translator.SetDictionaryDirectoryForTests(" not in text:
+        if TRANSLATOR_DICTIONARY_CALL not in text:
             continue
-        if "[NonParallelizable]" not in text:
-            offenders.append(str(path.relative_to(REPO_ROOT)))
+        lines = text.splitlines()
+        for call_index, line in enumerate(lines):
+            if TRANSLATOR_DICTIONARY_CALL not in line:
+                continue
 
-    assert offenders == []
+            class_index = _nearest_declaration(lines, call_index, CLASS_DECLARATION)
+            if class_index is None:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{call_index + 1}")
+                continue
+
+            method_index = _nearest_declaration(
+                lines,
+                call_index,
+                METHOD_DECLARATION,
+                stop_after=class_index,
+            )
+            if (
+                not _has_non_parallelizable_attribute(lines, class_index)
+                and (
+                    method_index is None
+                    or not _has_non_parallelizable_attribute(lines, method_index)
+                )
+            ):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{call_index + 1}")
+
+    assert not offenders, (
+        "Translator.SetDictionaryDirectoryForTests(...) mutates global translator "
+        "state. Add [NonParallelizable] to each enclosing NUnit fixture class or "
+        "test method that uses it:\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Summary
- Add a static Python contract test that rejects NUnit test files using `Translator.SetDictionaryDirectoryForTests(...)` without `[NonParallelizable]`.
- Mark existing Translator dictionary override fixtures as non-parallelizable.

## Retrospective
- Initial failure: review caught a fixture that mutates global Translator dictionary state without serializing the NUnit fixture.
- Final solution: mark that fixture non-parallelizable and encode the invariant as a deterministic repository test.
- Insight: Translator dictionary overrides are process-global test state, so reviewer memory should not be the enforcement mechanism.

## Validation
- `python3 -m pytest scripts/tests/test_qudjp_dotnet_test_contracts.py -q`
- `just python-check`
- `dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj -c Release`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 一部テストを並列実行しないように設定し、テスト実行の安定性を向上しました。
* **Chores**
  * テストの静的チェックを追加し、並列実行要件の遵守を自動検出する仕組みを導入しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/638)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->