### PR TITLE
Prepare QudJP v0.2.51 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           if [[ "$run_all" == true ]] || matches '^scripts/tools/' || matches_annals_extractor_tests; then
             roslyn_tools=true
           fi
-          if [[ "$run_all" == true ]] || matches '^(pyproject\.toml|uv\.lock)$' || matches_python_scripts; then
+          if [[ "$run_all" == true ]] || matches '^(pyproject\.toml|uv\.lock|CHANGELOG\.md|Mods/QudJP/manifest\.json|docs/release-notes/)' || matches_python_scripts; then
             python=true
           fi
           if [[ "$run_all" == true ]] || matches '^(Mods/QudJP/Localization/|scripts/(check_translation_tokens|check_glossary_consistency|validate_pattern_routes)\.py|scripts/(translation_token_duplicate_baseline|glossary_consistency_baseline)\.json|justfile$)'; then
@@ -257,6 +257,9 @@ jobs:
       - name: Test Python
         if: hashFiles('scripts/tests/**/*.py') != ''
         run: pytest scripts/tests/
+
+      - name: Check CHANGELOG release links
+        run: python scripts/release_notes.py check-changelog-links
 
   localization:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.2.51] - 2026-05-10
+
+### Changed
+
+- UI コマンドの日本語ラベルについて、look 系の操作と examine 系の操作を区別しやすくしました。
+
+### Fixed
+
+- 複数の自動生成ポップアップ・メッセージ経路に不足していた日本語 owner-route 翻訳を追加しました。
+- 歴史的な墓碑銘の冒頭文を、UI の look コマンドではなく物語文として訳すようにしました。
+- インベントリ UI 更新後に InventoryLine の TMP 表示が崩れる問題を修復しました。
+- インベントリの追加操作コンテキストメニューラベルを日本語化しました。
+- Mod Manager 下部コンテキストのホットキー表示で、括弧付きキー表記を保持し、不明な color-code 警告が出ないようにしました。
+- 実行時辞書の重複キー診断を通常起動ログへ出しすぎないようにし、テキストを変える重複だけを override として扱うようにしました。
+- `あなたは a ...` のような翻訳済み動的メッセージに残る英語冠詞を除去しました。
+- スナップジョー関連の日本語表記を `スナップジョー` に統一しました。
+
+---
+
 ## [0.2.50] - 2026-05-09
 
 ### Changed
@@ -267,7 +286,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.2.50...HEAD
+[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.2.51...HEAD
+[0.2.51]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.51
 [0.2.50]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.50
 [0.2.46]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.46
 [0.2.45]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.45

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.2.50",
+  "Version": "0.2.51",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/release-notes/unreleased/issue-493-static-producer-ui.md
+++ b/docs/release-notes/unreleased/issue-493-static-producer-ui.md
@@ -1,8 +1,0 @@
-### Changed
-
-- Improve Japanese UI command labels by distinguishing look actions from examine actions.
-
-### Fixed
-
-- Add missing Japanese owner-route translations for several generated popup and message texts.
-- Translate a historic tomb inscription opener as a narrative phrase instead of a UI look command.

--- a/docs/release-notes/unreleased/issue-603-inventory-ui.md
+++ b/docs/release-notes/unreleased/issue-603-inventory-ui.md
@@ -1,4 +1,0 @@
-### Fixed
-
-- Restore InventoryLine TMP rendering after the inventory UI refresh regression.
-- Translate additional inventory action context menu labels.

--- a/docs/release-notes/unreleased/issue-637-bottom-context-hotkeys.md
+++ b/docs/release-notes/unreleased/issue-637-bottom-context-hotkeys.md
@@ -1,4 +1,0 @@
-### Fixed
-
-- Fix Mod Manager bottom-context hotkey labels so nested key prompts keep their bracketed key text and no longer trigger unknown color-code warnings.
-- Reduce runtime dictionary-noise logging by treating only text-changing duplicate keys as overrides and keeping duplicate diagnostics out of the normal Player.log startup path.

--- a/docs/release-notes/unreleased/snapjaw-article-capture.md
+++ b/docs/release-notes/unreleased/snapjaw-article-capture.md
@@ -1,4 +1,0 @@
-### Fixed
-
-- Remove stray English articles from translated dynamic message captures such as `あなたは a ...`.
-- Standardize snapjaw-related Japanese text on `スナップジョー`.

--- a/justfile
+++ b/justfile
@@ -103,6 +103,10 @@ translation-token-baseline:
 release-note-check base_ref="origin/main" head_ref="HEAD":
   {{python}} scripts/release_notes.py check-fragment --base-ref "{{base_ref}}" --head-ref "{{head_ref}}"
 
+# Check that CHANGELOG release headings have matching footer links.
+changelog-link-check:
+  {{python}} scripts/release_notes.py check-changelog-links
+
 # Check changed Markdown reports for recurring GitHub rendering pitfalls.
 markdown-report-check base_ref="origin/main" head_ref="HEAD":
   {{python}} scripts/check_markdown_reports.py --base-ref "{{base_ref}}" --head-ref "{{head_ref}}"
@@ -324,10 +328,10 @@ runtime-evidence-check: test-l1
   uv run pytest scripts/tests/test_triage_integration.py -q -k sample_log_smoke
 
 # Run the broad local verification gate.
-check: build test-l1 test-l2 test-l2g python-check python-test localization-check translation-token-check markdown-report-check localization-coverage-map-check
+check: build test-l1 test-l2 test-l2g python-check python-test localization-check translation-token-check changelog-link-check markdown-report-check localization-coverage-map-check
 
 # Run the CI-like PR gate before pushing broad C#, script, or localization changes.
-pr-check base_ref="origin/main" head_ref="HEAD": ci-dotnet roslyn-build python-check python-test localization-check translation-token-check localization-coverage-map-check
+pr-check base_ref="origin/main" head_ref="HEAD": ci-dotnet roslyn-build python-check python-test localization-check translation-token-check changelog-link-check localization-coverage-map-check
   {{python}} scripts/release_notes.py check-fragment --base-ref "{{base_ref}}" --head-ref "{{head_ref}}"
   {{python}} scripts/check_markdown_reports.py --base-ref "{{base_ref}}" --head-ref "{{head_ref}}"
 

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -20,6 +20,7 @@ _NAME_STATUS_RENAMED_PATH_INDEX = 2
 _NAME_STATUS_MIN_PATH_FIELDS = 2
 _NAME_STATUS_MIN_RENAME_FIELDS = 3
 _RENAMED_OR_COPIED_STATUSES = ("R", "C")
+_DEFAULT_REPOSITORY_URL = "https://github.com/ToaruPen/coq-japanese_stable"
 
 
 class ReleaseNoteError(ValueError):
@@ -177,6 +178,48 @@ def extract_changelog_entry(changelog_path: Path, version: str) -> str:
     return re.sub(r"\n---\s*$", "", entry).rstrip()
 
 
+def validate_changelog_release_links(
+    changelog_path: Path,
+    *,
+    repository_url: str = _DEFAULT_REPOSITORY_URL,
+) -> None:
+    """Validate CHANGELOG release heading links and Unreleased comparison."""
+    if not changelog_path.is_file():
+        msg = f"CHANGELOG file not found: {changelog_path}"
+        raise ReleaseNoteError(msg)
+
+    text = changelog_path.read_text(encoding="utf-8")
+    versions = [
+        match.group(1)
+        for match in re.finditer(
+            r"^## \[([0-9]+\.[0-9]+\.[0-9]+)\](?:\s+[-\u2013\u2014]\s+.+)?$",
+            text,
+            flags=re.MULTILINE,
+        )
+    ]
+    if not versions:
+        msg = "CHANGELOG.md has no release entries"
+        raise ReleaseNoteError(msg)
+
+    links: dict[str, str] = {}
+    for label, url in re.findall(r"^\[([^\]]+)\]:\s+(\S+)\s*$", text, flags=re.MULTILINE):
+        if label in links:
+            msg = f"duplicate CHANGELOG link label: {label}"
+            raise ReleaseNoteError(msg)
+        links[label] = url
+    latest_version = versions[0]
+    expected_unreleased = f"{repository_url}/compare/v{latest_version}...HEAD"
+    if links.get("Unreleased") != expected_unreleased:
+        msg = f"[Unreleased] link must point to {expected_unreleased}"
+        raise ReleaseNoteError(msg)
+
+    for version in versions:
+        expected_release = f"{repository_url}/releases/tag/v{version}"
+        if links.get(version) != expected_release:
+            msg = f"[{version}] link must point to {expected_release}"
+            raise ReleaseNoteError(msg)
+
+
 def _render_section_lines(fragments: ReleaseNoteFragments) -> list[str]:
     lines: list[str] = []
     for section in SECTION_ORDER:
@@ -285,7 +328,50 @@ def build_parser() -> argparse.ArgumentParser:
     extract_parser.add_argument("--changelog", type=Path, default=Path("CHANGELOG.md"))
     extract_parser.add_argument("--output", type=Path)
 
+    check_changelog_parser = subparsers.add_parser(
+        "check-changelog-links",
+        help="Validate CHANGELOG release link definitions.",
+    )
+    check_changelog_parser.add_argument("--changelog", type=Path, default=Path("CHANGELOG.md"))
+    check_changelog_parser.add_argument("--repository-url", default=_DEFAULT_REPOSITORY_URL)
+
     return parser
+
+
+def _run_check_fragment(args: argparse.Namespace) -> int:
+    changed_files = args.changed_file or git_changed_files(args.base_ref, args.head_ref)
+    check_fragment_requirement(changed_files, fragments_dir=args.fragments_dir)
+    return 0
+
+
+def _run_render(args: argparse.Namespace) -> int:
+    fragments = _require_fragments(args.fragments_dir)
+    changelog = render_changelog_entry(version=args.version, release_date=args.date, fragments=fragments)
+    workshop = render_workshop_changenote(version=args.version, fragments=fragments)
+    if args.changelog_output is None and args.workshop_output is None:
+        print(changelog)  # noqa: T201
+        print("---")  # noqa: T201
+        print(workshop)  # noqa: T201
+        return 0
+    if args.changelog_output is not None:
+        _write_output(args.changelog_output, changelog)
+    if args.workshop_output is not None:
+        _write_output(args.workshop_output, workshop)
+    return 0
+
+
+def _run_extract_changelog(args: argparse.Namespace) -> int:
+    entry = extract_changelog_entry(args.changelog, args.version)
+    if args.output is None:
+        print(entry)  # noqa: T201
+        return 0
+    _write_output(args.output, entry)
+    return 0
+
+
+def _run_check_changelog_links(args: argparse.Namespace) -> int:
+    validate_changelog_release_links(args.changelog, repository_url=args.repository_url)
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -293,35 +379,16 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     try:
         args = parser.parse_args(argv)
-        if args.command == "check-fragment":
-            changed_files = args.changed_file or git_changed_files(args.base_ref, args.head_ref)
-            check_fragment_requirement(changed_files, fragments_dir=args.fragments_dir)
-            return 0
-        if args.command == "render":
-            fragments = _require_fragments(args.fragments_dir)
-            changelog = render_changelog_entry(version=args.version, release_date=args.date, fragments=fragments)
-            workshop = render_workshop_changenote(version=args.version, fragments=fragments)
-            if args.changelog_output is None and args.workshop_output is None:
-                print(changelog)  # noqa: T201
-                print("---")  # noqa: T201
-                print(workshop)  # noqa: T201
-                return 0
-            if args.changelog_output is not None:
-                _write_output(args.changelog_output, changelog)
-            if args.workshop_output is not None:
-                _write_output(args.workshop_output, workshop)
-            return 0
-        if args.command == "extract-changelog":
-            entry = extract_changelog_entry(args.changelog, args.version)
-            if args.output is None:
-                print(entry)  # noqa: T201
-                return 0
-            _write_output(args.output, entry)
-            return 0
+        handlers = {
+            "check-fragment": _run_check_fragment,
+            "render": _run_render,
+            "extract-changelog": _run_extract_changelog,
+            "check-changelog-links": _run_check_changelog_links,
+        }
+        return handlers[args.command](args)
     except ReleaseNoteError as exc:
         print(f"error: {exc}", file=sys.stderr)  # noqa: T201
         return 1
-    raise AssertionError(args.command)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_release_notes.py
+++ b/scripts/tests/test_release_notes.py
@@ -18,6 +18,7 @@ from scripts.release_notes import (
     main,
     render_changelog_entry,
     render_workshop_changenote,
+    validate_changelog_release_links,
 )
 
 if TYPE_CHECKING:
@@ -130,6 +131,67 @@ def test_extract_changelog_entry_rejects_missing_version(tmp_path: Path) -> None
 
     with pytest.raises(ReleaseNoteError, match="CHANGELOG entry"):
         extract_changelog_entry(changelog, "1.2.3")
+
+
+def test_validate_changelog_release_links_rejects_stale_footer(tmp_path: Path) -> None:
+    """Release entries require matching footer links and Unreleased comparison."""
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "---\n\n"
+        "## [1.2.4] - 2026-05-06\n\n"
+        "### Fixed\n\n"
+        "- Fix release links.\n\n"
+        "---\n\n"
+        "## [1.2.3] - 2026-05-05\n\n"
+        "### Fixed\n\n"
+        "- Older fix.\n\n"
+        "[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v1.2.3...HEAD\n"
+        "[1.2.3]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v1.2.3\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ReleaseNoteError, match=r"\[Unreleased\].*v1\.2\.4"):
+        validate_changelog_release_links(changelog)
+
+
+def test_validate_changelog_release_links_accepts_em_dash_release_date(tmp_path: Path) -> None:
+    """Release heading dates can use common dash variants."""
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "---\n\n"
+        "## [1.2.4] — 2026-05-06\n\n"
+        "### Fixed\n\n"
+        "- Fix release links.\n\n"
+        "[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v1.2.4...HEAD\n"
+        "[1.2.4]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v1.2.4\n",
+        encoding="utf-8",
+    )
+
+    validate_changelog_release_links(changelog)
+
+
+def test_validate_changelog_release_links_rejects_duplicate_footer_labels(tmp_path: Path) -> None:
+    """Duplicate footer labels are rejected instead of silently overwritten."""
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "---\n\n"
+        "## [1.2.4] - 2026-05-06\n\n"
+        "### Fixed\n\n"
+        "- Fix release links.\n\n"
+        "[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v1.2.4...HEAD\n"
+        "[1.2.4]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v1.2.4\n"
+        "[1.2.4]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v1.2.4\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ReleaseNoteError, match=r"duplicate.*1\.2\.4"):
+        validate_changelog_release_links(changelog)
 
 
 def test_main_extracts_changelog_entry(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- bump QudJP manifest to 0.2.51
- add the 0.2.51 changelog entry
- consume released note fragments

## Checks
- just python-check
- just python-test-filter release_notes
- npx secretlint .
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 日本語ローカライズの複数修正（「見る」と「調べる」のラベル区別、所有者ルートの自動生成メッセージ翻訳、史跡碑文の語調調整、翻訳内の英語冠詞除去、スナップジョー表記の標準化）
  * インベントリ表示の安定化とコンテキストホットキー表示の改善

* **ドキュメント**
  * CHANGELOGに v0.2.51 リリース項目を追加し、リリース参照リンクを更新

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/642)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/642)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->