### PR TITLE
Harden Workshop changenote release checks

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -46,6 +46,11 @@ When asked to update the Steam Workshop item, do this first:
    and packaging changes. If the release includes localization changes, the
    first substantive section of the Steam changenote must describe those
    translation changes in user-facing terms before pipeline or tooling notes.
+   Compare the draft against the previous Workshop changenote before upload and
+   remove items that were already shipped. Rewrite repository-only terms such as
+   patch class names, scanner jargon, CI/preflight work, and staging mechanics
+   into the player-visible behavior they enabled, or omit them if there is no
+   player-visible effect.
 9. Download and verify the GitHub Release ZIP with the local release ZIP
    download recipe.
    `just release-zip-check` also runs the release DLL marker gate: the shipped
@@ -271,6 +276,15 @@ Use the previous release ref recorded before tag creation or documented in the
 release evidence report. Do not recompute it with `git describe` after the new
 release tag exists.
 
+Before building the VDF, compare the changenote with the previous shipped
+Workshop changenote and the recorded release range. Do not repeat bullets that
+were already published in the previous release. The Workshop changenote is for
+players, so describe visible translation, UI, runtime, and packaging outcomes.
+Do not include repository-only details such as owner/sink routes,
+`InventoryLine`, `TMP`, Harmony patch internals, CI/preflight changes,
+release-note fragments, staging mechanics, Roslyn probes, or semantic-probe
+status unless they are rewritten as a concrete player-facing effect.
+
 Download and verify the draft GitHub Release ZIP:
 
 ```bash
@@ -351,7 +365,9 @@ just workshop-upload-preflight \
 
 This catches stale `dist/workshop/QudJP/` contents, mismatched Workshop item
 IDs, mismatched `contentfolder`, escaped newline sequences, and escaped double
-quotes before Steam can reject or publish the wrong upload.
+quotes before Steam can reject or publish the wrong upload. It also rejects
+known implementation-facing terms in the changenote so the final Steam text
+does not expose repository jargon.
 
 ## Post-Publish Smoke
 

--- a/docs/reports/2026-05-10-workshop-v0.2.51.md
+++ b/docs/reports/2026-05-10-workshop-v0.2.51.md
@@ -1,0 +1,91 @@
+# Workshop Release v0.2.51
+
+## Identity
+
+- Version: `0.2.51`
+- Git commit: `fff54855cdd9ecc770b8341be915a418b89efd85`
+- Git tag: `v0.2.51`
+- Previous release tag/range: `v0.2.50..v0.2.51`
+- Version source: `Mods/QudJP/manifest.json`
+- GitHub Release URL: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/untagged-105159698c6b543ce361
+- Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
+- Steam app ID: `333640`
+- Published file ID: `3718988020`
+
+## Changenote
+
+```text
+v0.2.51 / fff54855cdd9
+
+主な改善:
+- 本やページ表示の日本語折り返しを改善しました。長い日本語文が英語向けの空白区切り前提で読みにくく崩れるケースを減らしています。
+- アイテム選択画面で、翻訳後もアイテム行のアイコン表示が保たれるようにしました。
+- Mod Manager などの画面下部に出るキー案内を修正しました。括弧付きキー表記を保持し、表示色まわりの警告が出にくくなっています。
+- look 系の操作ラベルを 調べる から 見る に調整し、examine 系の操作と区別しやすくしました。
+- いくつかの自動生成ポップアップ、メッセージ、UI 文言の日本語訳を追加・改善しました。
+- 歴史的な墓碑銘の冒頭文が操作コマンドのように訳される問題を修正しました。
+- macOS Apple Silicon 向け Rosetta 起動ファイルが、既定の Steam ライブラリと起動ファイル自身の場所から Caves of Qud の CoQ.app を自動探索するようになりました。見つからない場合は CoQ.app の選択画面を表示します。
+
+既知の問題:
+- 一部の自動生成テキスト、チュートリアル、キャラクター生成画面には未翻訳または不自然な訳が残る場合があります。
+- ゲーム本体のアップデートにより、一部表示やパッチが壊れる可能性があります。
+```
+
+## Artifacts
+
+- Release ZIP: `dist/release-assets/v0.2.51/QudJP-v0.2.51.zip`
+- Release ZIP SHA256: `9d031fea254c08ebec986cab99955f45c61369cf0cd85b829efc2ef6032547da`
+- GitHub Release asset: `QudJP-v0.2.51.zip`
+- GitHub Release asset SHA256: `9d031fea254c08ebec986cab99955f45c61369cf0cd85b829efc2ef6032547da`
+- Workshop content folder: `dist/workshop/QudJP/`
+- Workshop VDF: `dist/workshop/workshop_item.vdf`
+
+## Preflight
+
+- [x] `git status --short --branch`
+- [x] Release range established from previous tag, release report, changelog/GitHub release, or explicit user range
+- [x] `Mods/QudJP/manifest.json` version, `v0.2.51` tag, release ZIP name, changenote first line, and report version match
+- [x] `git rev-list -n1 v0.2.51` matches `git rev-parse HEAD`
+- [x] `git merge-base --is-ancestor "$(git rev-list -n1 v0.2.51)" origin/main`
+- [x] Draft GitHub Release created by tag workflow
+- [x] Workshop changenote compared with the previous release to remove already-shipped bullets
+- [x] Workshop changenote rewritten in player-facing terms and checked by `workshop-upload-preflight`
+- [x] `just download-release-zip 0.2.51`
+- [x] `just workshop-preflight 0.2.51`
+- [x] `just release-zip-check dist/release-assets/v0.2.51/QudJP-v0.2.51.zip`
+- [x] `just build-workshop-upload dist/release-assets/v0.2.51/QudJP-v0.2.51.zip /tmp/qudjp-workshop-changenote.txt`
+- [x] `just workshop-upload-preflight dist/release-assets/v0.2.51/QudJP-v0.2.51.zip 0.2.51`
+
+## Upload
+
+- steamcmd command: `/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_stable/dist/workshop/workshop_item.vdf +quit`
+- Upload completed at: `2026-05-11 00:39:06 JST`
+- Steam output summary: Relative VDF path failed to load; reran with absolute VDF path. Upload completed with `Committing update...Success.`
+- GitHub Release published at:
+
+## Post-Publish Smoke
+
+- [ ] Workshop page title, description, preview image, visibility, file size, and changenote checked
+- [ ] Subscribe/resubscribe checked
+- [x] `steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit`
+- [x] `just workshop-download-check 0.2.51 dist/release-assets/v0.2.51/QudJP-v0.2.51.zip`
+- [ ] Mod Manager lists QudJP with expected version and preview
+- [ ] Options screen renders Japanese text and CJK glyphs
+- [ ] One short conversation renders Japanese text and CJK glyphs
+- [ ] Fresh Player.log checked for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`
+- [ ] Non-QudJP platform SDK noise, if present, recorded in notes and not conflated with QudJP blockers
+
+## Decision
+
+- Result: GO for Steam Workshop upload. GitHub Release remains draft pending explicit publish confirmation.
+- Notes: Release prep, tag, GitHub Release artifact, Workshop staging, upload preflight, Steam upload, fresh Workshop download, manifest version check, Rosetta launcher executable check, and DLL SHA256 check are complete.
+- Rollback tag, if needed: `v0.2.50`
+
+## Retrospective
+
+### Lesson: Workshop changenotes need a player-facing quality gate
+
+- Initial failure: the first changenote draft mixed current release notes with already-shipped items and repository-only terms.
+- Final solution: the uploaded changenote was manually checked against `v0.2.50..v0.2.51`, then rewritten around visible translation, UI, runtime, and packaging effects.
+- Insight: release fragments and implementation commits are good source material, but Steam changenotes need a separate pre-upload gate because Workshop readers do not benefit from patch class names, scanner jargon, CI/preflight work, or staging mechanics.
+- Codification: follow-up PR adds a changenote internal-term check to VDF generation and upload preflight, and updates release docs/templates to require previous-release comparison.

--- a/docs/reports/2026-05-10-workshop-v0.2.51.md
+++ b/docs/reports/2026-05-10-workshop-v0.2.51.md
@@ -61,7 +61,7 @@ v0.2.51 / fff54855cdd9
 - steamcmd command: `/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +workshop_build_item <repo-root>/dist/workshop/workshop_item.vdf +quit`
 - Upload completed at: `2026-05-11 00:39:06 JST`
 - Steam output summary: Relative VDF path failed to load; reran with absolute VDF path. Upload completed with `Committing update...Success.`
-- GitHub Release published at:
+- GitHub Release published at: N/A (draft; not published yet)
 
 ## Post-Publish Smoke
 

--- a/docs/reports/2026-05-10-workshop-v0.2.51.md
+++ b/docs/reports/2026-05-10-workshop-v0.2.51.md
@@ -58,7 +58,7 @@ v0.2.51 / fff54855cdd9
 
 ## Upload
 
-- steamcmd command: `/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_stable/dist/workshop/workshop_item.vdf +quit`
+- steamcmd command: `/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +workshop_build_item <repo-root>/dist/workshop/workshop_item.vdf +quit`
 - Upload completed at: `2026-05-11 00:39:06 JST`
 - Steam output summary: Relative VDF path failed to load; reran with absolute VDF path. Upload completed with `Committing update...Success.`
 - GitHub Release published at:

--- a/docs/reports/templates/workshop-release.md
+++ b/docs/reports/templates/workshop-release.md
@@ -48,6 +48,8 @@ vX.Y.Z / <short-git-hash>
 - [ ] `git rev-list -n1 vX.Y.Z` matches `git rev-parse HEAD`
 - [ ] `git merge-base --is-ancestor "$(git rev-list -n1 vX.Y.Z)" origin/main`
 - [ ] Draft GitHub Release created by tag workflow
+- [ ] Workshop changenote compared with the previous release to remove already-shipped bullets
+- [ ] Workshop changenote rewritten in player-facing terms and checked by `workshop-upload-preflight`
 - [ ] `just download-release-zip X.Y.Z`
 - [ ] `just workshop-preflight X.Y.Z`
 - [ ] `just release-zip-check dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip`

--- a/scripts/build_workshop_upload.py
+++ b/scripts/build_workshop_upload.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import shutil
 import sys
 import zipfile
@@ -25,6 +26,25 @@ WORKSHOP_PUBLISHED_FILE_ID = "3718988020"
 _DEFAULT_STAGING_DIR = Path("dist/workshop")
 _DEFAULT_VDF_OUTPUT = _DEFAULT_STAGING_DIR / "workshop_item.vdf"
 _DEFAULT_METADATA_PATH = Path("steam/workshop_metadata.json")
+_WORKSHOP_CHANGELOG_INTERNAL_TERMS = (
+    "AGENTS.md",
+    "CHANGELOG",
+    "CI",
+    "GitHub Actions",
+    "Harmony",
+    "InventoryLine",
+    "owner-route",
+    "preflight",
+    "release-note",
+    "Roslyn",
+    "semantic-probe",
+    "sink-route",
+    "staged",
+    "staging",
+    "TMP",
+    "override",
+    "オーバーライド",
+)
 
 
 @dataclass(frozen=True)
@@ -132,6 +152,23 @@ def _reject_double_quotes(field: str, value: str) -> None:
         raise ValueError(msg)
 
 
+def _contains_term(text: str, term: str) -> bool:
+    """Return whether text contains a banned term as an implementation-facing token."""
+    if term.isascii() and term.replace(".", "").replace("-", "").replace("_", "").isalnum():
+        pattern = rf"(?<![A-Za-z0-9_]){re.escape(term)}(?![A-Za-z0-9_])"
+        return re.search(pattern, text, flags=re.IGNORECASE) is not None
+    return term.casefold() in text.casefold()
+
+
+def validate_workshop_changenote(changenote: str) -> list[str]:
+    """Find implementation-facing terms that should not ship in Workshop changenotes."""
+    return [
+        f"Workshop changenote contains internal term {term!r}; rewrite it in player-facing terms"
+        for term in sorted(_WORKSHOP_CHANGELOG_INTERNAL_TERMS, key=str.casefold)
+        if _contains_term(changenote, term)
+    ]
+
+
 def render_vdf(
     metadata: WorkshopMetadata,
     *,
@@ -145,6 +182,9 @@ def render_vdf(
         msg = "Workshop changenote must be non-empty"
         raise ValueError(msg)
     _reject_double_quotes("changenote", changenote)
+    changenote_findings = validate_workshop_changenote(changenote)
+    if changenote_findings:
+        raise ValueError("; ".join(changenote_findings))
     if description is not None:
         _reject_double_quotes("description", description)
 

--- a/scripts/tests/test_build_workshop_upload.py
+++ b/scripts/tests/test_build_workshop_upload.py
@@ -17,6 +17,7 @@ from scripts.build_workshop_upload import (
     load_metadata,
     main,
     render_vdf,
+    validate_workshop_changenote,
     vdf_escape,
     verify_workshop_upload_staging,
 )
@@ -156,6 +157,48 @@ def test_render_vdf_rejects_quotes_in_description_or_changenote(tmp_path: Path) 
             content_folder=content_folder,
             preview_file=preview_file,
             changenote='v0.2.0 "release"',
+            description="Caves of Qud 日本語化",
+        )
+
+
+def test_validate_workshop_changenote_rejects_internal_release_terms() -> None:
+    """Workshop changenotes must stay player-facing rather than implementation-facing."""
+    findings = validate_workshop_changenote(
+        "v0.2.51 / abc123\n\n"
+        "主な改善:\n"
+        "- InventoryLine の TMP override を調整しました。\n"
+        "- CI preflight を強化しました。",
+    )
+
+    assert findings == [
+        "Workshop changenote contains internal term 'CI'; rewrite it in player-facing terms",
+        "Workshop changenote contains internal term 'InventoryLine'; rewrite it in player-facing terms",
+        "Workshop changenote contains internal term 'override'; rewrite it in player-facing terms",
+        "Workshop changenote contains internal term 'preflight'; rewrite it in player-facing terms",
+        "Workshop changenote contains internal term 'TMP'; rewrite it in player-facing terms",
+    ]
+
+
+def test_render_vdf_rejects_internal_terms_in_changenote(tmp_path: Path) -> None:
+    """VDF generation refuses changenotes that describe repo internals."""
+    content_folder = tmp_path / "QudJP"
+    content_folder.mkdir()
+    preview_file = content_folder / "preview.png"
+    preview_file.write_bytes(b"png")
+    metadata = WorkshopMetadata(
+        appid="333640",
+        publishedfileid="3718988020",
+        title="Caves of Qud Japanese Mod",
+        visibility="0",
+        description_file=None,
+    )
+
+    with pytest.raises(ValueError, match="InventoryLine"):
+        render_vdf(
+            metadata,
+            content_folder=content_folder,
+            preview_file=preview_file,
+            changenote="v0.2.51 / abc123\n\n主な改善:\n- InventoryLine の表示を修正しました。",
             description="Caves of Qud 日本語化",
         )
 

--- a/scripts/tests/test_verify_workshop_upload.py
+++ b/scripts/tests/test_verify_workshop_upload.py
@@ -119,6 +119,36 @@ def test_verify_workshop_vdf_reports_escaped_newline_in_text_fields(tmp_path: Pa
     ]
 
 
+def test_verify_workshop_vdf_reports_internal_terms_in_multiline_changenote(tmp_path: Path) -> None:
+    """The final upload gate catches implementation-facing Workshop changenotes."""
+    content_folder = tmp_path / "QudJP"
+    vdf = tmp_path / "workshop_item.vdf"
+    vdf.write_text(
+        "\n".join(
+            [
+                '"workshopitem"',
+                "{",
+                '  "appid" "333640"',
+                '  "publishedfileid" "3718988020"',
+                f'  "contentfolder" "{content_folder.resolve()}"',
+                f'  "previewfile" "{(content_folder / "preview.png").resolve()}"',
+                '  "changenote" "v0.2.51 / abc123',
+                "",
+                "主な改善:",
+                '- InventoryLine の TMP override を修正しました。"',
+                "}",
+            ],
+        ),
+        encoding="utf-8",
+    )
+
+    assert verify_workshop_vdf(vdf, content_folder=content_folder) == [
+        "Workshop changenote contains internal term 'InventoryLine'; rewrite it in player-facing terms",
+        "Workshop changenote contains internal term 'override'; rewrite it in player-facing terms",
+        "Workshop changenote contains internal term 'TMP'; rewrite it in player-facing terms",
+    ]
+
+
 def test_main_accepts_matching_staging_and_vdf(tmp_path: Path) -> None:
     """The CLI accepts upload files generated from the same release ZIP."""
     release_zip = tmp_path / "dist" / "QudJP-v0.2.50.zip"

--- a/scripts/tests/test_verify_workshop_upload.py
+++ b/scripts/tests/test_verify_workshop_upload.py
@@ -149,6 +149,31 @@ def test_verify_workshop_vdf_reports_internal_terms_in_multiline_changenote(tmp_
     ]
 
 
+def test_verify_workshop_vdf_reports_malformed_text_field(tmp_path: Path) -> None:
+    """Malformed text fields are reported instead of falling back to the regex parser."""
+    content_folder = tmp_path / "QudJP"
+    vdf = tmp_path / "workshop_item.vdf"
+    vdf.write_text(
+        "\n".join(
+            [
+                '"workshopitem"',
+                "{",
+                '  "appid" "333640"',
+                '  "publishedfileid" "3718988020"',
+                f'  "contentfolder" "{content_folder.resolve()}"',
+                f'  "previewfile" "{(content_folder / "preview.png").resolve()}"',
+                '  "changenote" "unterminated changenote',
+                "}",
+            ],
+        ),
+        encoding="utf-8",
+    )
+
+    assert verify_workshop_vdf(vdf, content_folder=content_folder) == [
+        "VDF changenote field is malformed or unterminated",
+    ]
+
+
 def test_main_accepts_matching_staging_and_vdf(tmp_path: Path) -> None:
     """The CLI accepts upload files generated from the same release ZIP."""
     release_zip = tmp_path / "dist" / "QudJP-v0.2.50.zip"

--- a/scripts/verify_workshop_upload.py
+++ b/scripts/verify_workshop_upload.py
@@ -13,12 +13,14 @@ try:
     from scripts.build_workshop_upload import (
         WORKSHOP_APP_ID,
         WORKSHOP_PUBLISHED_FILE_ID,
+        validate_workshop_changenote,
         verify_workshop_upload_staging,
     )
 except ModuleNotFoundError:
     from build_workshop_upload import (
         WORKSHOP_APP_ID,
         WORKSHOP_PUBLISHED_FILE_ID,
+        validate_workshop_changenote,
         verify_workshop_upload_staging,
     )
 
@@ -40,6 +42,31 @@ def _parse_vdf_fields(vdf_text: str) -> dict[str, str]:
 def _vdf_unescape(value: str) -> str:
     """Unescape the subset emitted by build_workshop_upload.vdf_escape."""
     return value.replace(r"\\", "\\").replace(r"\"", '"')
+
+
+def _extract_vdf_field_value(vdf_text: str, key: str) -> str | None:
+    """Extract a generated VDF value, including literal multiline text fields."""
+    marker = f'"{key}" "'
+    start = vdf_text.find(marker)
+    if start == -1:
+        return None
+
+    index = start + len(marker)
+    value: list[str] = []
+    escaped = False
+    while index < len(vdf_text):
+        char = vdf_text[index]
+        if escaped:
+            value.append(f"\\{char}")
+            escaped = False
+        elif char == "\\":
+            escaped = True
+        elif char == '"':
+            return "".join(value)
+        else:
+            value.append(char)
+        index += 1
+    return None
 
 
 def _append_vdf_mismatch(
@@ -73,8 +100,14 @@ def verify_workshop_vdf(vdf_path: Path, *, content_folder: Path) -> list[str]:
     _append_vdf_mismatch(findings, fields, "previewfile", expected_preview_file, unescape_actual=True)
     if r"\"" in vdf_text:
         findings.append('VDF contains escaped double quote sequences (\\"); remove double quotes from text fields')
-    if any(r"\n" in fields.get(key, "") for key in _VDF_TEXT_FIELD_KEYS):
+    text_field_values = {
+        key: _extract_vdf_field_value(vdf_text, key) or fields.get(key, "") for key in _VDF_TEXT_FIELD_KEYS
+    }
+    if any(r"\n" in value for value in text_field_values.values()):
         findings.append(r"VDF contains escaped newline sequences (\n); use literal multiline text")
+    changenote = text_field_values.get("changenote", "")
+    if changenote:
+        findings.extend(validate_workshop_changenote(_vdf_unescape(changenote)))
     return findings
 
 

--- a/scripts/verify_workshop_upload.py
+++ b/scripts/verify_workshop_upload.py
@@ -69,6 +69,11 @@ def _extract_vdf_field_value(vdf_text: str, key: str) -> str | None:
     return None
 
 
+def _vdf_contains_field(vdf_text: str, key: str) -> bool:
+    """Return whether the VDF text contains a field marker for the given key."""
+    return f'"{key}" "' in vdf_text
+
+
 def _append_vdf_mismatch(
     findings: list[str],
     fields: dict[str, str],
@@ -100,9 +105,15 @@ def verify_workshop_vdf(vdf_path: Path, *, content_folder: Path) -> list[str]:
     _append_vdf_mismatch(findings, fields, "previewfile", expected_preview_file, unescape_actual=True)
     if r"\"" in vdf_text:
         findings.append('VDF contains escaped double quote sequences (\\"); remove double quotes from text fields')
-    text_field_values = {
-        key: _extract_vdf_field_value(vdf_text, key) or fields.get(key, "") for key in _VDF_TEXT_FIELD_KEYS
-    }
+    text_field_values: dict[str, str] = {}
+    for key in _VDF_TEXT_FIELD_KEYS:
+        extracted_value = _extract_vdf_field_value(vdf_text, key)
+        if extracted_value is None:
+            if _vdf_contains_field(vdf_text, key):
+                findings.append(f"VDF {key} field is malformed or unterminated")
+            text_field_values[key] = fields.get(key, "")
+            continue
+        text_field_values[key] = extracted_value
     if any(r"\n" in value for value in text_field_values.values()):
         findings.append(r"VDF contains escaped newline sequences (\n); use literal multiline text")
     changenote = text_field_values.get("changenote", "")


### PR DESCRIPTION
## Summary
- Record the v0.2.51 Steam Workshop release evidence and retrospective.
- Add a player-facing Workshop changenote validator to VDF generation and upload preflight.
- Update release docs and the evidence template to require previous-release comparison and jargon removal before upload.

## Verification
- `just python-check`
- `uv run pytest scripts/tests/test_build_workshop_upload.py scripts/tests/test_verify_workshop_upload.py scripts/tests/test_release_justfile_contract.py -q`
- `just python-test`
- `uv run python scripts/check_markdown_reports.py docs/reports/2026-05-10-workshop-v0.2.51.md docs/reports/templates/workshop-release.md`
- `just changelog-link-check`
- `uv run python - <<'PY' ... validate v0.2.51 report changenote ... PY`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Steam Workshop向けリリースノート作成ガイドを強化し、前回との差分照合・既出項目削除・プレイヤー向け表現への書き換え・非表示情報の除外を明確化しました
  * v0.2.51向けワークショップリリースレポートとテンプレートの事前確認チェックを追加しました

* **New Features**
  * ワークショップ用チェンジノートの自動検証を導入し、内部実装語句を検出して公開前に拒否します

* **Tests**
  * チェンジノート検証とワークショップ検証の自動テストを追加しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/643)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->