### PR TITLE
[codex] Document Apple Silicon Harmony workaround

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudJPModTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudJPModTests.cs
@@ -269,6 +269,8 @@ public sealed class QudJPModTests
             Assert.That(output, Does.Contain("Harmony patching complete: 0 method(s) patched."));
             Assert.That(output, Does.Contain("mprotect returned EACCES"));
             Assert.That(output, Does.Contain("arch -x86_64"));
+            Assert.That(output, Does.Contain("0Harmony.dll"));
+            Assert.That(output, Does.Contain("Harmony 2.4.2"));
         });
     }
 

--- a/Mods/QudJP/Assemblies/src/QudJPMod.cs
+++ b/Mods/QudJP/Assemblies/src/QudJPMod.cs
@@ -666,8 +666,11 @@ public static class QudJPMod
             {
                 RuntimeDiagnostics.LogWarning(
                     "[QudJP] Warning: Harmony patched zero methods. On Apple Silicon macOS, "
-                    + "'mprotect returned EACCES' in Player.log means the game was launched natively; "
-                    + "launch Caves of Qud with Rosetta 2, for example: arch -x86_64 <CoQ binary>.");
+                    + "'mprotect returned EACCES' in Player.log usually means the game-bundled "
+                    + "0Harmony.dll cannot patch under native ARM64; launch Caves of Qud with "
+                    + "Rosetta 2 as the recommended workaround, for example: arch -x86_64 "
+                    + "<CoQ binary>. Advanced users can also back up and replace the game "
+                    + "Managed/0Harmony.dll with Harmony 2.4.2.");
             }
         }
         catch (Exception ex)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Caves of Qud は完全な英語ローカライゼーション API が整備さ�
 
 ## macOS Apple Silicon
 
-M1/M2/M3/M4 などの Apple Silicon Mac では、Caves of Qud をネイティブ起動すると Harmony patch が `mprotect returned EACCES` で失敗し、QudJP の UI 翻訳が効かない場合があります。その場合は Rosetta 2 経由で起動してください。
+M1/M2/M3/M4 などの Apple Silicon Mac では、Caves of Qud をネイティブ起動すると、ゲーム本体側の `0Harmony.dll` が原因で Harmony patch が `mprotect returned EACCES` により失敗し、QudJP の UI 翻訳が効かない場合があります。
+
+QudJP では Rosetta 2 経由での起動を推奨します。QudJP は `0Harmony.dll` を同梱・上書きしません。
 
 Steam Workshop 版と GitHub Release ZIP には `QudJP/Launch CavesOfQud (Rosetta).command` を同梱しています。ダブルクリックで Caves of Qud を Rosetta 経由で起動できます。macOS の Steam 既定ライブラリでは、Workshop 版の wrapper は次の場所にあります。
 
@@ -43,6 +45,14 @@ Rosetta 2 が未インストールの場合、wrapper が macOS の確認ダイ�
 ```bash
 arch -x86_64 $HOME/Library/Application\ Support/Steam/steamapps/common/Caves\ of\ Qud/CoQ.app/Contents/MacOS/CoQ
 ```
+
+上級者向けの別手段として、ゲーム本体側の `0Harmony.dll` を Harmony 2.4.2 に差し替えると、Apple Silicon ネイティブ起動でも動作したという報告があります。通常は上記の Rosetta 起動を使ってください。手動差し替えを行う場合は、CoQ を終了し、[Harmony 2.4.2](https://github.com/pardeike/Harmony/releases/tag/v2.4.2.0) の `Harmony-Fat.2.4.2.0.zip` から `net48/0Harmony.dll` を取り出して、次のファイルをバックアップ後に置き換えます。
+
+```text
+~/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll
+```
+
+これはゲーム本体ファイルの手動変更です。Steam の整合性確認・再インストール・ゲーム更新で元に戻る可能性があります。
 
 ## Current Release Sources
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -147,7 +147,7 @@ For inventory / equipment display checks, follow the runtime evidence rules in
 
 ### Apple Silicon / Rosetta
 
-- On Apple Silicon, in-game verification must run under Rosetta 2
+- On Apple Silicon, repo-owned in-game verification must run under Rosetta 2
 - For local repo verification, use `scripts/launch_rosetta.sh` or the root
   `Launch CavesOfQud (Rosetta).command`
 - For player-facing builds, the release ZIP and Workshop content include
@@ -168,10 +168,18 @@ For inventory / equipment display checks, follow the runtime evidence rules in
 - `arch -x86_64 .../CoQ` is a one-shot launch path. It does not persist to
   future Steam launches, so Apple Silicon users should use the wrapper each
   time unless they have separately configured a reliable Rosetta launch path.
+- QudJP does not bundle or overwrite the game's `0Harmony.dll`; Rosetta 2 is
+  the recommended player-facing workaround. Advanced users may choose to back up
+  the game file and replace
+  `CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll` with the
+  `net48/0Harmony.dll` from Harmony `v2.4.2.0` to run native ARM64. Treat this
+  as a user-managed game-file change; Steam verification, reinstall, or game
+  updates may revert it.
 - Do not use native ARM64 runtime logs as localization observability evidence
 - If `Player.log` contains `mprotect returned EACCES` or QudJP reports
   `Harmony patching complete: 0 method(s) patched`, treat that run as native
-  ARM64 and ask for a Rosetta-backed retry before triaging localization routes.
+  ARM64 with an unsupported game-bundled Harmony runtime and ask for a
+  Rosetta-backed retry before triaging localization routes.
 
 ### Troubleshooting
 
@@ -182,7 +190,7 @@ For inventory / equipment display checks, follow the runtime evidence rules in
 | Japanese text shows as tofu squares | CJK font not bundled | Verify Fonts directory is deployed |
 | DLL load error | `QudJP.dll` not built | Run `just deploy-mod` |
 | No QudJP traces in Player.log | Bootstrap.cs not deployed or failed to compile | Verify `Bootstrap.cs` exists in game `Mods/QudJP/` directory; check Player.log for compile errors |
-| Apple Silicon: title/UI text stays English and `mprotect returned EACCES` appears | Native ARM64 launch blocked Harmony patching | Launch through `Launch CavesOfQud (Rosetta).command` or `arch -x86_64 .../CoQ` |
+| Apple Silicon: title/UI text stays English and `mprotect returned EACCES` appears | Native ARM64 launch blocked Harmony patching through the game-bundled `0Harmony.dll` | Launch through `Launch CavesOfQud (Rosetta).command` or `arch -x86_64 .../CoQ`; advanced users may back up and replace the game `0Harmony.dll` with Harmony 2.4.2 |
 
 ---
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -378,7 +378,9 @@ After Steam finishes processing the item:
    - For Apple Silicon support, confirm the description mentions
      `Launch CavesOfQud (Rosetta).command`, Rosetta 2, Finder double-click use,
      the `CoQ.app` picker fallback, and a quote-free `arch -x86_64` launch
-     example for advanced users.
+     example for advanced users. It should also say QudJP does not bundle or
+     overwrite `0Harmony.dll`, and mention the user-managed Harmony 2.4.2 game
+     DLL replacement path as an advanced native ARM64 workaround.
 2. Subscribe to the item from a clean Steam client state or unsubscribe and
    resubscribe if updating an existing item.
 3. Validate the downloaded Workshop item against the staged content:

--- a/steam/workshop_description.ja.txt
+++ b/steam/workshop_description.ja.txt
@@ -29,14 +29,15 @@ Caves of Qud を日本語で遊ぶための非公式ファン制作 Mod です�
 
 macOS Apple Silicon での注意
 
-  * M1/M2/M3/M4 などの Apple Silicon Mac では、Caves of Qud をネイティブ起動すると Harmony パッチが `mprotect returned EACCES` で失敗し、この Mod の UI 翻訳が効かない場合があります。
-  * その場合は Rosetta 2 経由で Caves of Qud を起動してください。
+  * M1/M2/M3/M4 などの Apple Silicon Mac では、Caves of Qud をネイティブ起動すると、ゲーム本体側の `0Harmony.dll` が原因で Harmony パッチが `mprotect returned EACCES` により失敗し、この Mod の UI 翻訳が効かない場合があります。
+  * QudJP では Rosetta 2 経由での起動を推奨します。QudJP は `0Harmony.dll` を同梱・上書きしません。
   * この Mod には `Launch CavesOfQud (Rosetta).command` という起動用 wrapper を同梱しています。Steam Workshop のダウンロード先からダブルクリックで起動できます。
   * macOS の Steam 既定ライブラリでは、通常 `~/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020/Launch CavesOfQud (Rosetta).command` にあります。別の Steam ライブラリを使っている場合は、そのライブラリ内の `steamapps/workshop/content/333640/3718988020/` を探してください。
   * ゲーム本体は、まず既定の Steam ライブラリと wrapper 自身が置かれている Workshop フォルダから同じ Steam ライブラリ内を探します。それでも見つからない場合、wrapper が `CoQ.app` の選択画面を表示します。Steam ライブラリ内の Caves of Qud フォルダから `CoQ.app` を選んでください。
   * Steam から通常起動した場合、この wrapper の効果は引き継がれません。Apple Silicon で翻訳が効かない場合は、毎回 wrapper から起動してください。
   * Rosetta 2 が未インストールの場合、wrapper がインストール確認を表示します。表示に従って進めれば、手動でターミナル操作をする必要はありません。
   * 上級者向けの直接起動例: `arch -x86_64 $HOME/Library/Application\ Support/Steam/steamapps/common/Caves\ of\ Qud/CoQ.app/Contents/MacOS/CoQ`
+  * 上級者向けの別手段として、ゲーム本体側の `0Harmony.dll` を Harmony 2.4.2 に差し替えると Apple Silicon ネイティブ起動でも動作したという報告があります。通常は上記の Rosetta 起動を使ってください。手動差し替えを行う場合は、CoQ を終了し、https://github.com/pardeike/Harmony/releases/tag/v2.4.2.0 の `Harmony-Fat.2.4.2.0.zip` から `net48/0Harmony.dll` を取り出して、`~/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll` をバックアップ後に置き換えてください。Steam の整合性確認・再インストール・ゲーム更新で元に戻る可能性があります。
 
 報告・Contribution
 


### PR DESCRIPTION
## Summary

- Add Apple Silicon guidance that keeps Rosetta 2 as the recommended workaround for game-bundled Harmony patch failures.
- Document the advanced Harmony 2.4.2 game DLL replacement path without making QudJP overwrite 0Harmony.dll.
- Update the zero-patched-methods runtime warning and its L2 coverage.

## Review

- Reviewed the diff for source-of-truth consistency and corrected the release smoke wording so native ARM64 runs still do not count as standard L3 evidence.
- No blocking findings remain.

## Validation

- `just build`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter TestCategory=L2`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント更新**
  * macOS Apple Silicon ユーザー向けサポート情報を拡充
  * Harmony パッチ失敗時の対処方法を明確化（Rosetta 2 経由での起動推奨、上級ユーザー向けの代替手順を追加）
  * デプロイメント・リリースガイドおよび Steam ワークショップ説明を更新

* **テスト**
  * Apple Silicon/Rosetta トラブルシューティング検証テストを更新

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/644)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->