### PR TITLE
Add opt-in native Apple Silicon Harmony helpers

### DIFF
--- a/Mods/QudJP/Install Native Apple Silicon Harmony.command
+++ b/Mods/QudJP/Install Native Apple Silicon Harmony.command
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Install Harmony 2.4.2 into the Caves of Qud app as an explicit opt-in native
+# Apple Silicon workaround. This script mutates the game install only after a
+# Finder-visible confirmation and creates a restorable backup first.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TITLE="QudJP Native Apple Silicon Harmony"
+HARMONY_VERSION="2.4.2"
+HARMONY_FULL_VERSION="2.4.2.0"
+HARMONY_ZIP_NAME="Harmony-Fat.2.4.2.0.zip"
+HARMONY_ZIP_URL="https://github.com/pardeike/Harmony/releases/download/v2.4.2.0/${HARMONY_ZIP_NAME}"
+EXPECTED_DLL_SHA256="77e6901ecc606aec66c2a972782a3779e4f50c037d2d165eb7ececdd4d8f794d"
+BACKUP_NAME="0Harmony.dll.qudjp-backup-before-2.4.2"
+HARMONY_RELATIVE_PATH="CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll"
+HARMONY_APP_SUFFIX="/CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll"
+INSTALLED_MOD_SUFFIX="/CoQ.app/Contents/Resources/Data/StreamingAssets/Mods/QudJP"
+WORKSHOP_SUFFIX="/steamapps/workshop/content/333640/3718988020"
+
+show_message() {
+  local message="$1"
+  if command -v osascript >/dev/null 2>&1; then
+    osascript -e "display dialog $(quote_osa "${message}") buttons {\"OK\"} default button \"OK\" with title $(quote_osa "${TITLE}")" >/dev/null
+  else
+    printf '%s\n' "${message}" >&2
+  fi
+}
+
+fail() {
+  show_message "$1"
+  exit 1
+}
+
+quote_osa() {
+  local text="$1"
+  text="${text//\\/\\\\}"
+  text="${text//\"/\\\"}"
+  text="${text//$'\n'/\\n}"
+  printf '"%s"' "${text}"
+}
+
+confirm_install() {
+  local target="$1"
+  local message
+  message="Caves of Qud のゲーム本体ファイルを変更して、0Harmony.dll を Harmony 2.4.2 に置き換えます。\n\n対象:\n${target}\n\n変更前の DLL は同じフォルダの ${BACKUP_NAME} にバックアップします。\n\n問題が出た場合は同梱の Restore Game Harmony.command で元に戻してください。\n\n続行しますか？"
+  if command -v osascript >/dev/null 2>&1; then
+    osascript -e "display dialog $(quote_osa "${message}") buttons {\"キャンセル\", \"Harmony 2.4.2 をインストール\"} default button \"キャンセル\" cancel button \"キャンセル\" with title $(quote_osa "${TITLE}")" >/dev/null
+  else
+    printf '%s\n' "${message}" >&2
+    read -r -p "Type INSTALL to continue: " answer
+    [[ "${answer}" == "INSTALL" ]] || exit 0
+  fi
+}
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || fail "必要なコマンドが見つかりません: $1"
+}
+
+append_candidate() {
+  local candidate="$1"
+  [[ -n "${candidate}" ]] || return 0
+  [[ -f "${candidate}" ]] || return 0
+  printf '%s\n' "${candidate}"
+}
+
+infer_from_workshop_location() {
+  if [[ "${SCRIPT_DIR}" == *"${WORKSHOP_SUFFIX}"* ]]; then
+    local steam_root="${SCRIPT_DIR%%"${WORKSHOP_SUFFIX}"*}/steamapps"
+    append_candidate "${steam_root}/common/Caves of Qud/${HARMONY_RELATIVE_PATH}"
+  fi
+}
+
+infer_from_installed_mod_location() {
+  if [[ "${SCRIPT_DIR}" == *"${INSTALLED_MOD_SUFFIX}" ]]; then
+    local app_root="${SCRIPT_DIR%"${INSTALLED_MOD_SUFFIX}"}"
+    append_candidate "${app_root}${HARMONY_APP_SUFFIX}"
+  fi
+}
+
+default_candidates() {
+  infer_from_installed_mod_location
+  infer_from_workshop_location
+  append_candidate "${HOME}/Library/Application Support/Steam/steamapps/common/Caves of Qud/${HARMONY_RELATIVE_PATH}"
+}
+
+choose_harmony_dll() {
+  if command -v osascript >/dev/null 2>&1; then
+    osascript <<'OSA'
+set selectedFile to choose file with prompt "Caves of Qud の CoQ.app 内にある Managed/0Harmony.dll を選択してください。" of type {"dll"}
+POSIX path of selectedFile
+OSA
+  else
+    read -r -p "Path to CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll: " selected
+    printf '%s\n' "${selected}"
+  fi
+}
+
+resolve_target() {
+  local first_candidate
+  first_candidate="$(default_candidates | head -n 1 || true)"
+  if [[ -n "${first_candidate}" ]]; then
+    printf '%s\n' "${first_candidate}"
+    return 0
+  fi
+
+  local chosen
+  chosen="$(choose_harmony_dll)"
+  [[ -n "${chosen}" ]] || fail "0Harmony.dll が選択されませんでした。"
+  printf '%s\n' "${chosen}"
+}
+
+validate_target() {
+  local target="$1"
+  [[ -f "${target}" ]] || fail "0Harmony.dll が見つかりません:\n${target}"
+  [[ "${target}" == *"${HARMONY_APP_SUFFIX}" ]] || fail "選択されたファイルは Caves of Qud の Managed/0Harmony.dll ではありません:\n${target}"
+}
+
+read_harmony_identity() {
+  local target="$1"
+  strings -a "${target}" 2>/dev/null | grep -m 1 '0Harmony, Version=' || true
+}
+
+download_harmony() {
+  local temp_dir="$1"
+  local zip_path="${temp_dir}/${HARMONY_ZIP_NAME}"
+  curl --location --fail --output "${zip_path}" "${HARMONY_ZIP_URL}"
+  unzip -q "${zip_path}" net48/0Harmony.dll -d "${temp_dir}/extracted"
+
+  local dll_path="${temp_dir}/extracted/net48/0Harmony.dll"
+  [[ -f "${dll_path}" ]] || fail "Harmony ${HARMONY_VERSION} の 0Harmony.dll を ZIP から展開できませんでした。"
+
+  local actual_sha
+  actual_sha="$(shasum -a 256 "${dll_path}" | awk '{print $1}')"
+  [[ "${actual_sha}" == "${EXPECTED_DLL_SHA256}" ]] || fail "Harmony ${HARMONY_VERSION} DLL の SHA256 が一致しません。\nexpected: ${EXPECTED_DLL_SHA256}\nactual: ${actual_sha}"
+
+  printf '%s\n' "${dll_path}"
+}
+
+main() {
+  [[ "$(uname -s)" == "Darwin" ]] || fail "このスクリプトは macOS 用です。"
+  require_tool curl
+  require_tool unzip
+  require_tool shasum
+  require_tool strings
+
+  local target
+  target="$(resolve_target)"
+  validate_target "${target}"
+
+  local identity
+  identity="$(read_harmony_identity "${target}")"
+  if [[ "${identity}" == *"Version=${HARMONY_FULL_VERSION}"* ]]; then
+    show_message "対象の 0Harmony.dll はすでに Harmony ${HARMONY_VERSION} です。\n\n${target}"
+    exit 0
+  fi
+
+  confirm_install "${target}"
+
+  local backup="${target%0Harmony.dll}${BACKUP_NAME}"
+  if [[ ! -f "${backup}" ]]; then
+    cp "${target}" "${backup}"
+  fi
+
+  local temp_dir
+  temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/qudjp-harmony.XXXXXX")"
+  trap 'rm -rf "${temp_dir}"' EXIT
+
+  local new_dll
+  new_dll="$(download_harmony "${temp_dir}")"
+  cp "${new_dll}" "${target}"
+
+  show_message "Harmony ${HARMONY_VERSION} をインストールしました。\n\n対象:\n${target}\n\nバックアップ:\n${backup}\n\nCaves of Qud を native Apple Silicon で起動して QudJP の翻訳が有効か確認してください。"
+}
+
+main "$@"

--- a/Mods/QudJP/Install Native Apple Silicon Harmony.command
+++ b/Mods/QudJP/Install Native Apple Silicon Harmony.command
@@ -124,7 +124,11 @@ read_harmony_identity() {
 download_harmony() {
   local temp_dir="$1"
   local zip_path="${temp_dir}/${HARMONY_ZIP_NAME}"
-  curl --location --fail --output "${zip_path}" "${HARMONY_ZIP_URL}"
+  curl --proto '=https' --tlsv1.2 \
+    --location --fail \
+    --retry 3 --retry-delay 2 --retry-all-errors \
+    --connect-timeout 10 --max-time 180 \
+    --output "${zip_path}" "${HARMONY_ZIP_URL}"
   unzip -q "${zip_path}" net48/0Harmony.dll -d "${temp_dir}/extracted"
 
   local dll_path="${temp_dir}/extracted/net48/0Harmony.dll"

--- a/Mods/QudJP/Restore Game Harmony.command
+++ b/Mods/QudJP/Restore Game Harmony.command
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Restore the Caves of Qud game-bundled Harmony DLL from the backup created by
+# "Install Native Apple Silicon Harmony.command".
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TITLE="QudJP Native Apple Silicon Harmony Restore"
+BACKUP_NAME="0Harmony.dll.qudjp-backup-before-2.4.2"
+HARMONY_RELATIVE_PATH="CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll"
+HARMONY_APP_SUFFIX="/CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll"
+INSTALLED_MOD_SUFFIX="/CoQ.app/Contents/Resources/Data/StreamingAssets/Mods/QudJP"
+WORKSHOP_SUFFIX="/steamapps/workshop/content/333640/3718988020"
+
+quote_osa() {
+  local text="$1"
+  text="${text//\\/\\\\}"
+  text="${text//\"/\\\"}"
+  text="${text//$'\n'/\\n}"
+  printf '"%s"' "${text}"
+}
+
+show_message() {
+  local message="$1"
+  if command -v osascript >/dev/null 2>&1; then
+    osascript -e "display dialog $(quote_osa "${message}") buttons {\"OK\"} default button \"OK\" with title $(quote_osa "${TITLE}")" >/dev/null
+  else
+    printf '%s\n' "${message}" >&2
+  fi
+}
+
+fail() {
+  show_message "$1"
+  exit 1
+}
+
+confirm_restore() {
+  local target="$1"
+  local backup="$2"
+  local message
+  message="QudJP が作成したバックアップから Caves of Qud の 0Harmony.dll を復元します。\n\n対象:\n${target}\n\nバックアップ:\n${backup}\n\n続行しますか？"
+  if command -v osascript >/dev/null 2>&1; then
+    osascript -e "display dialog $(quote_osa "${message}") buttons {\"キャンセル\", \"元に戻す\"} default button \"キャンセル\" cancel button \"キャンセル\" with title $(quote_osa "${TITLE}")" >/dev/null
+  else
+    printf '%s\n' "${message}" >&2
+    read -r -p "Type RESTORE to continue: " answer
+    [[ "${answer}" == "RESTORE" ]] || exit 0
+  fi
+}
+
+append_candidate() {
+  local candidate="$1"
+  [[ -n "${candidate}" ]] || return 0
+  [[ -f "${candidate}" ]] || return 0
+  printf '%s\n' "${candidate}"
+}
+
+infer_from_workshop_location() {
+  if [[ "${SCRIPT_DIR}" == *"${WORKSHOP_SUFFIX}"* ]]; then
+    local steam_root="${SCRIPT_DIR%%"${WORKSHOP_SUFFIX}"*}/steamapps"
+    append_candidate "${steam_root}/common/Caves of Qud/${HARMONY_RELATIVE_PATH}"
+  fi
+}
+
+infer_from_installed_mod_location() {
+  if [[ "${SCRIPT_DIR}" == *"${INSTALLED_MOD_SUFFIX}" ]]; then
+    local app_root="${SCRIPT_DIR%"${INSTALLED_MOD_SUFFIX}"}"
+    append_candidate "${app_root}${HARMONY_APP_SUFFIX}"
+  fi
+}
+
+default_candidates() {
+  infer_from_installed_mod_location
+  infer_from_workshop_location
+  append_candidate "${HOME}/Library/Application Support/Steam/steamapps/common/Caves of Qud/${HARMONY_RELATIVE_PATH}"
+}
+
+choose_harmony_dll() {
+  if command -v osascript >/dev/null 2>&1; then
+    osascript <<'OSA'
+set selectedFile to choose file with prompt "復元対象の CoQ.app 内にある Managed/0Harmony.dll を選択してください。" of type {"dll"}
+POSIX path of selectedFile
+OSA
+  else
+    read -r -p "Path to CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll: " selected
+    printf '%s\n' "${selected}"
+  fi
+}
+
+resolve_target() {
+  local first_candidate
+  first_candidate="$(default_candidates | head -n 1 || true)"
+  if [[ -n "${first_candidate}" ]]; then
+    printf '%s\n' "${first_candidate}"
+    return 0
+  fi
+
+  local chosen
+  chosen="$(choose_harmony_dll)"
+  [[ -n "${chosen}" ]] || fail "0Harmony.dll が選択されませんでした。"
+  printf '%s\n' "${chosen}"
+}
+
+validate_target() {
+  local target="$1"
+  [[ -f "${target}" ]] || fail "0Harmony.dll が見つかりません:\n${target}"
+  [[ "${target}" == *"${HARMONY_APP_SUFFIX}" ]] || fail "選択されたファイルは Caves of Qud の Managed/0Harmony.dll ではありません:\n${target}"
+}
+
+main() {
+  [[ "$(uname -s)" == "Darwin" ]] || fail "このスクリプトは macOS 用です。"
+
+  local target
+  target="$(resolve_target)"
+  validate_target "${target}"
+
+  local backup="${target%0Harmony.dll}${BACKUP_NAME}"
+  [[ -f "${backup}" ]] || fail "QudJP のバックアップが見つかりません。\n\n先に Install Native Apple Silicon Harmony.command で作成されたバックアップだけを復元できます。\n\n期待した場所:\n${backup}"
+
+  confirm_restore "${target}" "${backup}"
+  cp "${backup}" "${target}"
+
+  show_message "Caves of Qud の 0Harmony.dll をバックアップから復元しました。\n\n対象:\n${target}"
+}
+
+main "$@"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Caves of Qud は完全な英語ローカライゼーション API が整備さ�
 
 M1/M2/M3/M4 などの Apple Silicon Mac では、Caves of Qud をネイティブ起動すると、ゲーム本体側の `0Harmony.dll` が原因で Harmony patch が `mprotect returned EACCES` により失敗し、QudJP の UI 翻訳が効かない場合があります。
 
-QudJP では Rosetta 2 経由での起動を推奨します。QudJP は `0Harmony.dll` を同梱・上書きしません。
+QudJP では Rosetta 2 経由での起動を推奨します。QudJP は `0Harmony.dll` を自動では同梱・上書きしません。
 
 Steam Workshop 版と GitHub Release ZIP には `QudJP/Launch CavesOfQud (Rosetta).command` を同梱しています。ダブルクリックで Caves of Qud を Rosetta 経由で起動できます。macOS の Steam 既定ライブラリでは、Workshop 版の wrapper は次の場所にあります。
 
@@ -46,7 +46,11 @@ Rosetta 2 が未インストールの場合、wrapper が macOS の確認ダイ�
 arch -x86_64 $HOME/Library/Application\ Support/Steam/steamapps/common/Caves\ of\ Qud/CoQ.app/Contents/MacOS/CoQ
 ```
 
-上級者向けの別手段として、ゲーム本体側の `0Harmony.dll` を Harmony 2.4.2 に差し替えると、Apple Silicon ネイティブ起動でも動作したという報告があります。通常は上記の Rosetta 起動を使ってください。手動差し替えを行う場合は、CoQ を終了し、[Harmony 2.4.2](https://github.com/pardeike/Harmony/releases/tag/v2.4.2.0) の `Harmony-Fat.2.4.2.0.zip` から `net48/0Harmony.dll` を取り出して、次のファイルをバックアップ後に置き換えます。
+上級者向けの別手段として、ゲーム本体側の `0Harmony.dll` を Harmony 2.4.2 に差し替えると、Apple Silicon ネイティブ起動でも動作することを確認しています。通常は上記の Rosetta 起動を使ってください。
+
+Steam Workshop 版と GitHub Release ZIP には、明示的に実行した場合だけこの差し替えを行う `Install Native Apple Silicon Harmony.command` と、元に戻す `Restore Game Harmony.command` を同梱しています。これらはまず配置場所から Caves of Qud を探し、見つからない場合は `0Harmony.dll` の選択画面を表示します。
+
+手動差し替えを行う場合は、CoQ を終了し、[Harmony 2.4.2](https://github.com/pardeike/Harmony/releases/tag/v2.4.2.0) の `Harmony-Fat.2.4.2.0.zip` から `net48/0Harmony.dll` を取り出して、次のファイルをバックアップ後に置き換えます。
 
 ```text
 ~/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -168,9 +168,14 @@ For inventory / equipment display checks, follow the runtime evidence rules in
 - `arch -x86_64 .../CoQ` is a one-shot launch path. It does not persist to
   future Steam launches, so Apple Silicon users should use the wrapper each
   time unless they have separately configured a reliable Rosetta launch path.
-- QudJP does not bundle or overwrite the game's `0Harmony.dll`; Rosetta 2 is
-  the recommended player-facing workaround. Advanced users may choose to back up
-  the game file and replace
+- QudJP does not automatically bundle or overwrite the game's `0Harmony.dll`;
+  Rosetta 2 is the recommended player-facing workaround. Release and Workshop
+  builds may include opt-in `Install Native Apple Silicon Harmony.command` and
+  `Restore Game Harmony.command` helpers. These helpers must only mutate the
+  game file after explicit user confirmation, must create a backup first, must
+  restore only from the QudJP-named backup, and must fall back to a file picker
+  if they cannot infer the target from their installed location or the default
+  Steam path. Advanced users may choose to back up the game file and replace
   `CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll` with the
   `net48/0Harmony.dll` from Harmony `v2.4.2.0` to run native ARM64. Treat this
   as a user-managed game-file change; Steam verification, reinstall, or game

--- a/docs/release-notes/unreleased/harmony-native-helper-scripts.md
+++ b/docs/release-notes/unreleased/harmony-native-helper-scripts.md
@@ -1,0 +1,1 @@
+- Added opt-in macOS helper scripts for advanced Apple Silicon users who want to try the Harmony 2.4.2 native ARM64 workaround, plus a restore helper to put the game DLL back from QudJP's backup.

--- a/docs/release-notes/unreleased/harmony-native-helper-scripts.md
+++ b/docs/release-notes/unreleased/harmony-native-helper-scripts.md
@@ -1,1 +1,3 @@
+### Added
+
 - Added opt-in macOS helper scripts for advanced Apple Silicon users who want to try the Harmony 2.4.2 native ARM64 workaround, plus a restore helper to put the game DLL back from QudJP's backup.

--- a/docs/release.md
+++ b/docs/release.md
@@ -379,8 +379,10 @@ After Steam finishes processing the item:
      `Launch CavesOfQud (Rosetta).command`, Rosetta 2, Finder double-click use,
      the `CoQ.app` picker fallback, and a quote-free `arch -x86_64` launch
      example for advanced users. It should also say QudJP does not bundle or
-     overwrite `0Harmony.dll`, and mention the user-managed Harmony 2.4.2 game
-     DLL replacement path as an advanced native ARM64 workaround.
+     overwrite `0Harmony.dll` automatically, and mention the opt-in
+     `Install Native Apple Silicon Harmony.command` /
+     `Restore Game Harmony.command` helpers plus the user-managed Harmony 2.4.2
+     game DLL replacement path as an advanced native ARM64 workaround.
 2. Subscribe to the item from a clean Steam client state or unsubscribe and
    resubscribe if updating an existing item.
 3. Validate the downloaded Workshop item against the staged content:
@@ -398,6 +400,11 @@ After Steam finishes processing the item:
    is executable in the downloaded `QudJP` folder. The launcher should guide
    player-facing failures with macOS dialogs rather than requiring manual script
    edits.
+   Also confirm `Install Native Apple Silicon Harmony.command` and
+   `Restore Game Harmony.command` exist and are executable. They should be
+   opt-in only, create/consume the QudJP backup file, infer the game path from
+   Workshop or installed-mod location when possible, and offer a manual
+   `0Harmony.dll` file picker fallback.
    On the default macOS Steam library, the downloaded Workshop folder is usually
    `~/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020/`.
 4. Launch the game, enable only QudJP for the smoke pass, and restart.

--- a/docs/reports/2026-05-12-harmony-2.4.2-native-arm64-verification.md
+++ b/docs/reports/2026-05-12-harmony-2.4.2-native-arm64-verification.md
@@ -1,0 +1,115 @@
+# Harmony 2.4.2 native ARM64 verification
+
+Date: 2026-05-12 JST
+
+## Summary
+
+Community feedback reported that replacing the game-bundled `0Harmony.dll`
+with Harmony `2.4.2` makes QudJP work under native Apple Silicon and may reduce
+CPU usage compared with Rosetta.
+
+Local verification on an Apple M4 Mac confirms the functional part:
+
+- Caves of Qud bundled Harmony is `0Harmony, Version=2.2.2.0`.
+- Native ARM64 with the bundled Harmony `2.2.2.0` still fails with
+  `mprotect returned EACCES`.
+- Native ARM64 with Harmony `2.4.2.0` successfully applies QudJP patches.
+- Startup to the main-game marker is much faster with native ARM64 +
+  Harmony `2.4.2.0` than Rosetta + Harmony `2.2.2.0`.
+
+The CPU reduction claim was not confirmed in this local measurement. In a
+release-equivalent QudJP build, the 30-second main-menu CPU-time window was
+higher for native ARM64 + Harmony `2.4.2.0` than for Rosetta + Harmony
+`2.2.2.0`. Treat the community CPU report as plausible but environment- and
+measurement-dependent until confirmed with a longer gameplay scenario and a
+more controlled Activity Monitor / `powermetrics` capture.
+
+## Sources
+
+- Steam Workshop discussion page 2, posts #17-#20:
+  <https://steamcommunity.com/workshop/filedetails/discussion/3718988020/837250028234869281/?ctp=2>
+- Harmony `2.4.2.0` release:
+  <https://github.com/pardeike/Harmony/releases/tag/v2.4.2.0>
+- Harmony `2.4.0.0` release notes include Apple Silicon / arm64 support:
+  <https://github.com/pardeike/Harmony/releases/tag/v2.4.0.0>
+
+## Environment
+
+- Host: Apple M4, `Mac16,10`
+- OS kernel: Darwin `25.4.0`, `arm64`
+- Game reference copy:
+  `~/Games/CavesOfQud-stable-ref/CoQ.app`
+- Runtime mod path:
+  `~/Games/CavesOfQud-stable-ref/CoQ.app/Contents/Resources/Data/StreamingAssets/Mods/QudJP`
+- Original game Harmony SHA256:
+  `0de0118c8f1d4408de389ca33b46d2ff7778f3a8541b430cae729ec913d899c7`
+- Harmony `2.4.2.0` `net48/0Harmony.dll` SHA256:
+  `77e6901ecc606aec66c2a972782a3779e4f50c037d2d165eb7ececdd4d8f794d`
+
+The stable reference copy was restored to the original Harmony `2.2.2.0` DLL
+after verification.
+
+## Evidence
+
+Artifacts were written under:
+
+```text
+.sisyphus/evidence/harmony-rosetta-perf/
+```
+
+Relevant local artifact files:
+
+- `native-harmony-2.2.2-summary.md`
+- `rosetta-harmony-2.2.2-summary.md`
+- `native-harmony-2.4.2-summary.md`
+- `release-rosetta-harmony-2.2.2-mainmenu-cputime.json`
+- `release-native-harmony-2.4.2-mainmenu-cputime.json`
+
+## Results
+
+| profile | result |
+| --- | --- |
+| native ARM64 + Harmony `2.2.2.0` | Failed with `mprotect returned EACCES`; status `harmony_failed` at 2789 ms |
+| Rosetta + Harmony `2.2.2.0` | Ready 3/3; `707 method(s) patched`; median ready time 26414 ms |
+| native ARM64 + Harmony `2.4.2.0` | Ready 3/3; `707 method(s) patched`; median ready time 4822 ms |
+
+Startup timing improvement:
+
+- `runner.elapsed_until_ready`: 26414 ms -> 4822 ms, about 5.5x faster.
+- `harmony.apply_patch_types`: 18103 ms -> 2472 ms, about 7.3x faster.
+
+Release-equivalent main-menu CPU-time window:
+
+| profile | marker time | CPU window | CPU time | computed CPU |
+| --- | ---: | ---: | ---: | ---: |
+| Rosetta + Harmony `2.2.2.0` | 29717 ms | 30.007 s | 34.77 s | 115.872% |
+| native ARM64 + Harmony `2.4.2.0` | 6853 ms | 30.005 s | 50.35 s | 167.803% |
+
+## Interpretation
+
+Harmony `2.4.2.0` is a valid workaround for the Apple Silicon native Harmony
+failure in this environment. It eliminates the `mprotect returned EACCES`
+failure and applies the same number of QudJP patches as Rosetta.
+
+The strongest confirmed benefit is startup and patch-application time. The
+specific claim that native ARM64 + Harmony `2.4.2.0` halves CPU usage compared
+with Rosetta was not reproduced by this measurement. A likely reason is that
+main-menu CPU is dominated by the Unity/game render loop, not only Harmony
+patching, and native ARM64 may render at a different effective cadence than the
+Rosetta run.
+
+## Recommendation
+
+Keep QudJP's user-facing guidance conservative:
+
+- Continue recommending the bundled Rosetta launcher as the default Apple
+  Silicon path because it does not mutate game files.
+- Keep Harmony `2.4.2.0` replacement documented as an advanced user-managed
+  workaround.
+- Do not ship `0Harmony.dll` or overwrite it automatically from the mod unless
+  Caves of Qud itself adopts that contract or we prove a safe loader-level
+  approach.
+
+If we continue this line of work, the next useful measurement is a repeatable
+in-game idle scenario after loading the same save, with a longer CPU/power
+capture window and release QudJP only.

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -10,6 +10,8 @@ needs:
 - ``QudJP/NOTICE.md``
 - ``QudJP/Bootstrap.cs``
 - ``QudJP/Launch CavesOfQud (Rosetta).command`` when present
+- ``QudJP/Install Native Apple Silicon Harmony.command`` when present
+- ``QudJP/Restore Game Harmony.command`` when present
 - ``QudJP/Assemblies/QudJP.dll``
 - ``QudJP/Localization/**/*.xml``
 - ``QudJP/Localization/**/*.json``
@@ -34,6 +36,11 @@ except ModuleNotFoundError:
 
 _LOCALIZATION_ASSET_SUFFIXES = {".json", ".txt", ".xml"}
 _ROSETTA_LAUNCHER_NAME = "Launch CavesOfQud (Rosetta).command"
+_MACOS_HELPER_COMMAND_NAMES = (
+    _ROSETTA_LAUNCHER_NAME,
+    "Install Native Apple Silicon Harmony.command",
+    "Restore Game Harmony.command",
+)
 
 
 def _find_project_root() -> Path:
@@ -174,6 +181,21 @@ def _write_executable_zip_member(zip_file: zipfile.ZipFile, source_path: Path, a
     zip_file.getinfo(archive_name).external_attr = 0o100755 << 16
 
 
+def _write_optional_macos_helper_commands(
+    zip_file: zipfile.ZipFile,
+    mod_root: Path,
+) -> list[str]:
+    """Write present macOS helper scripts to the ZIP as executable members."""
+    members: list[str] = []
+    for helper_name in _MACOS_HELPER_COMMAND_NAMES:
+        helper_path = mod_root / helper_name
+        if helper_path.is_file():
+            archive_name = f"QudJP/{helper_name}"
+            _write_executable_zip_member(zip_file, helper_path, archive_name)
+            members.append(archive_name)
+    return members
+
+
 def create_zip(
     output_path: Path,
     manifest_path: Path,
@@ -236,12 +258,8 @@ def create_zip(
             zf.write(bootstrap_path, arc_bootstrap)
             members.append(arc_bootstrap)
 
-        # macOS helper launcher for Apple Silicon users who need Rosetta.
-        rosetta_launcher_path = manifest_path.parent / _ROSETTA_LAUNCHER_NAME
-        if rosetta_launcher_path.exists():
-            arc_rosetta_launcher = f"QudJP/{_ROSETTA_LAUNCHER_NAME}"
-            _write_executable_zip_member(zf, rosetta_launcher_path, arc_rosetta_launcher)
-            members.append(arc_rosetta_launcher)
+        # macOS helper scripts for Apple Silicon users.
+        members.extend(_write_optional_macos_helper_commands(zf, manifest_path.parent))
 
         # Localization files
         for file_path in localization_files:

--- a/scripts/build_workshop_upload.py
+++ b/scripts/build_workshop_upload.py
@@ -231,6 +231,8 @@ def _validate_release_zip_members(zip_path: Path, members: list[str]) -> None:
         "QudJP/preview.png",
         "QudJP/Bootstrap.cs",
         "QudJP/Launch CavesOfQud (Rosetta).command",
+        "QudJP/Install Native Apple Silicon Harmony.command",
+        "QudJP/Restore Game Harmony.command",
         "QudJP/Assemblies/QudJP.dll",
     }
     required_prefixes = {

--- a/scripts/sync_mod.py
+++ b/scripts/sync_mod.py
@@ -16,11 +16,17 @@ from pathlib import Path
 # the game compiles to discover and initialize QudJP.dll.  We use an
 # include-first strategy: explicitly allow the needed files, then exclude
 # everything else.
+_MACOS_HELPER_COMMAND_NAMES: tuple[str, ...] = (
+    "Launch CavesOfQud (Rosetta).command",
+    "Install Native Apple Silicon Harmony.command",
+    "Restore Game Harmony.command",
+)
+
 _RSYNC_INCLUDES: tuple[str, ...] = (
     "manifest.json",
     "preview.png",
     "Bootstrap.cs",
-    "Launch CavesOfQud (Rosetta).command",
+    *_MACOS_HELPER_COMMAND_NAMES,
     "Assemblies/",
     "Assemblies/QudJP.dll",
     "Localization/",
@@ -36,6 +42,9 @@ _RSYNC_INCLUDES: tuple[str, ...] = (
 )
 
 _RSYNC_EXCLUDES: tuple[str, ...] = ("*",)
+_MACOS_HELPER_COMMANDS: tuple[Path, ...] = tuple(
+    Path(helper_name) for helper_name in _MACOS_HELPER_COMMAND_NAMES
+)
 _LOCAL_ONLY_FILES: tuple[Path, ...] = (Path("workshop.json"),)
 _LOCALIZATION_ASSET_SUFFIXES = {".json", ".txt", ".xml"}
 _WINDOWS_DRIVE_PREFIX_LENGTH = 2
@@ -189,7 +198,7 @@ def _iter_sync_files(source: Path, *, exclude_fonts: bool) -> list[Path]:
         Path("manifest.json"),
         Path("preview.png"),
         Path("Bootstrap.cs"),
-        Path("Launch CavesOfQud (Rosetta).command"),
+        *_MACOS_HELPER_COMMANDS,
         Path("Assemblies") / "QudJP.dll",
     ):
         candidate = source / relative

--- a/scripts/tests/_common.py
+++ b/scripts/tests/_common.py
@@ -22,6 +22,12 @@ VALID_RELEASE_DLL_MARKER_PAYLOAD = b"\0".join(
 )
 
 
+def _write_executable_member(zf: zipfile.ZipFile, name: str, payload: str) -> None:
+    info = zipfile.ZipInfo(name)
+    info.external_attr = 0o100755 << 16
+    zf.writestr(info, payload)
+
+
 def write_workshop_release_zip(
     path: Path,
     *,
@@ -39,9 +45,21 @@ def write_workshop_release_zip(
         zf.writestr("QudJP/LICENSE", "MIT License")
         zf.writestr("QudJP/NOTICE.md", "# NOTICE")
         zf.writestr("QudJP/Bootstrap.cs", "public static class Bootstrap {}")
-        launcher_info = zipfile.ZipInfo("QudJP/Launch CavesOfQud (Rosetta).command")
-        launcher_info.external_attr = 0o100755 << 16
-        zf.writestr(launcher_info, "#!/usr/bin/env bash\n")
+        _write_executable_member(
+            zf,
+            "QudJP/Launch CavesOfQud (Rosetta).command",
+            "#!/usr/bin/env bash\n",
+        )
+        _write_executable_member(
+            zf,
+            "QudJP/Install Native Apple Silicon Harmony.command",
+            "#!/usr/bin/env bash\n",
+        )
+        _write_executable_member(
+            zf,
+            "QudJP/Restore Game Harmony.command",
+            "#!/usr/bin/env bash\n",
+        )
         zf.writestr("QudJP/Assemblies/QudJP.dll", dll_payload)
         zf.writestr("QudJP/Localization/ui.json", "{}")
         zf.writestr("QudJP/Fonts/OFL.txt", "SIL Open Font License")

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -469,6 +469,36 @@ class TestCreateZip:
         assert "QudJP/Launch CavesOfQud (Rosetta).command" in members
         assert info.external_attr >> 16 & 0o111
 
+    def test_zip_contains_native_harmony_helpers_when_present(self, tmp_path: Path) -> None:
+        """ZIP contains opt-in native Apple Silicon Harmony helpers when present."""
+        output, manifest, dll, loc_dir, loc_files, legal_files = self._make_inputs(
+            tmp_path,
+        )
+        install = manifest.parent / "Install Native Apple Silicon Harmony.command"
+        restore = manifest.parent / "Restore Game Harmony.command"
+        install.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        restore.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+
+        members = create_zip(
+            output,
+            manifest,
+            dll,
+            loc_dir,
+            loc_files,
+            legal_files=legal_files,
+        )
+        with zipfile.ZipFile(output) as zf:
+            names = zf.namelist()
+            install_info = zf.getinfo("QudJP/Install Native Apple Silicon Harmony.command")
+            restore_info = zf.getinfo("QudJP/Restore Game Harmony.command")
+
+        assert "QudJP/Install Native Apple Silicon Harmony.command" in names
+        assert "QudJP/Restore Game Harmony.command" in names
+        assert "QudJP/Install Native Apple Silicon Harmony.command" in members
+        assert "QudJP/Restore Game Harmony.command" in members
+        assert install_info.external_attr >> 16 & 0o111
+        assert restore_info.external_attr >> 16 & 0o111
+
     def test_zip_contains_compliance_files(self, tmp_path: Path) -> None:
         """ZIP contains LICENSE and NOTICE.md at the archive root."""
         output, manifest, dll, loc_dir, loc_files, legal_files = self._make_inputs(

--- a/scripts/tests/test_build_workshop_upload.py
+++ b/scripts/tests/test_build_workshop_upload.py
@@ -216,6 +216,8 @@ def test_create_workshop_staging_extracts_qudjp_root(tmp_path: Path) -> None:
     assert (content_folder / "Assemblies" / "QudJP.dll").is_file()
     assert (content_folder / "Localization" / "ui.json").is_file()
     assert os.access(content_folder / "Launch CavesOfQud (Rosetta).command", os.X_OK)
+    assert os.access(content_folder / "Install Native Apple Silicon Harmony.command", os.X_OK)
+    assert os.access(content_folder / "Restore Game Harmony.command", os.X_OK)
     assert preview_file == content_folder / "preview.png"
 
 

--- a/scripts/tests/test_harmony_native_scripts.py
+++ b/scripts/tests/test_harmony_native_scripts.py
@@ -50,7 +50,9 @@ def test_native_harmony_install_is_explicit_opt_in_and_restorable() -> None:
     assert "0Harmony.dll.qudjp-backup-before-2.4.2" in installer
     assert "Harmony-Fat.2.4.2.0.zip" in installer
     assert "77e6901ecc606aec66c2a972782a3779e4f50c037d2d165eb7ececdd4d8f794d" in installer
-    assert "curl --location --fail" in installer
+    assert "curl --proto '=https' --tlsv1.2" in installer
+    assert "--retry 3 --retry-delay 2 --retry-all-errors" in installer
+    assert "--connect-timeout 10 --max-time 180" in installer
     assert "unzip" in installer
     assert "CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll" in installer
     assert "Restore Game Harmony.command" in installer

--- a/scripts/tests/test_harmony_native_scripts.py
+++ b/scripts/tests/test_harmony_native_scripts.py
@@ -1,0 +1,108 @@
+"""Tests for opt-in native Apple Silicon Harmony helper scripts."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_INSTALL_SCRIPT = Path("Mods/QudJP/Install Native Apple Silicon Harmony.command")
+_RESTORE_SCRIPT = Path("Mods/QudJP/Restore Game Harmony.command")
+
+
+def _script_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("script_path", [_INSTALL_SCRIPT, _RESTORE_SCRIPT])
+def test_native_harmony_scripts_are_valid_bash(script_path: Path) -> None:
+    """The distributed opt-in helpers remain valid for macOS /bin/bash."""
+    subprocess.run(["/bin/bash", "-n", str(script_path)], check=True)  # noqa: S603 -- fixed test command
+
+
+def _assert_common_discovery_contract(script_text: str) -> None:
+    assert "infer_from_workshop_location" in script_text
+    assert "infer_from_installed_mod_location" in script_text
+    assert "steamapps/workshop/content/333640/3718988020" in script_text
+    assert "CoQ.app/Contents/Resources/Data/StreamingAssets/Mods/QudJP" in script_text
+    assert "Library/Application Support/Steam/steamapps/common/Caves of Qud" in script_text
+    assert "CavesOfQud-stable-ref" not in script_text
+    assert "choose file" in script_text
+    assert "Managed/0Harmony.dll" in script_text
+    assert '[[ "${target}" == *"${HARMONY_APP_SUFFIX}" ]]' in script_text
+
+
+def _assert_in_order(text: str, *needles: str) -> None:
+    position = -1
+    for needle in needles:
+        next_position = text.find(needle, position + 1)
+        assert next_position != -1, needle
+        position = next_position
+
+
+def test_native_harmony_install_is_explicit_opt_in_and_restorable() -> None:
+    """The installer must never silently replace the game Harmony DLL."""
+    installer = _script_text(_INSTALL_SCRIPT)
+
+    assert "display dialog" in installer
+    assert "Harmony 2.4.2" in installer
+    assert "0Harmony.dll.qudjp-backup-before-2.4.2" in installer
+    assert "Harmony-Fat.2.4.2.0.zip" in installer
+    assert "77e6901ecc606aec66c2a972782a3779e4f50c037d2d165eb7ececdd4d8f794d" in installer
+    assert "curl --location --fail" in installer
+    assert "unzip" in installer
+    assert "CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll" in installer
+    assert "Restore Game Harmony.command" in installer
+
+
+def test_native_harmony_install_infers_target_or_prompts_for_manual_selection() -> None:
+    """The installer mirrors the Rosetta launcher's self-location first workflow."""
+    installer = _script_text(_INSTALL_SCRIPT)
+
+    _assert_common_discovery_contract(installer)
+
+
+def test_native_harmony_install_confirms_before_mutating_game_dll() -> None:
+    """The installer confirms, backs up, verifies, and only then replaces the DLL."""
+    installer = _script_text(_INSTALL_SCRIPT)
+
+    _assert_in_order(
+        installer,
+        'confirm_install "${target}"',
+        'cp "${target}" "${backup}"',
+        'new_dll="$(download_harmony "${temp_dir}")"',
+        'cp "${new_dll}" "${target}"',
+    )
+
+
+def test_native_harmony_restore_uses_only_the_qudjp_backup() -> None:
+    """The restore helper must restore from QudJP's named backup file only."""
+    restorer = _script_text(_RESTORE_SCRIPT)
+
+    assert "display dialog" in restorer
+    assert "0Harmony.dll.qudjp-backup-before-2.4.2" in restorer
+    assert "CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll" in restorer
+    assert "cp " in restorer
+    assert "curl" not in restorer
+    assert "github.com/pardeike/Harmony" not in restorer
+
+
+def test_native_harmony_restore_infers_target_or_prompts_for_manual_selection() -> None:
+    """The restore helper uses the same discovery and manual fallback path."""
+    restorer = _script_text(_RESTORE_SCRIPT)
+
+    _assert_common_discovery_contract(restorer)
+
+
+def test_native_harmony_restore_confirms_and_uses_only_the_named_backup() -> None:
+    """The restore helper confirms after checking the QudJP backup path."""
+    restorer = _script_text(_RESTORE_SCRIPT)
+
+    _assert_in_order(
+        restorer,
+        'local backup="${target%0Harmony.dll}${BACKUP_NAME}"',
+        '[[ -f "${backup}" ]] || fail',
+        'confirm_restore "${target}" "${backup}"',
+        'cp "${backup}" "${target}"',
+    )

--- a/scripts/tests/test_sync_mod.py
+++ b/scripts/tests/test_sync_mod.py
@@ -248,6 +248,14 @@ class TestRunSync:
             '#!/usr/bin/env bash\nexec arch -x86_64 "$HOME/game/CoQ"\n',
             encoding="utf-8",
         )
+        (source / "Install Native Apple Silicon Harmony.command").write_text(
+            "#!/usr/bin/env bash\nexit 0\n",
+            encoding="utf-8",
+        )
+        (source / "Restore Game Harmony.command").write_text(
+            "#!/usr/bin/env bash\nexit 0\n",
+            encoding="utf-8",
+        )
         (source / "src.cs").write_text("// do not copy", encoding="utf-8")
         destination.mkdir()
         (destination / "stale.txt").write_text("stale", encoding="utf-8")
@@ -260,6 +268,8 @@ class TestRunSync:
         assert (destination / "preview.png").exists()
         assert (destination / "Bootstrap.cs").exists()
         assert (destination / "Launch CavesOfQud (Rosetta).command").exists()
+        assert (destination / "Install Native Apple Silicon Harmony.command").exists()
+        assert (destination / "Restore Game Harmony.command").exists()
         assert (destination / "Assemblies" / "QudJP.dll").exists()
         assert (destination / "Localization" / "Creatures.jp.xml").exists()
         assert (destination / "Localization" / "ui.ja.json").exists()

--- a/steam/workshop_description.ja.txt
+++ b/steam/workshop_description.ja.txt
@@ -30,14 +30,16 @@ Caves of Qud を日本語で遊ぶための非公式ファン制作 Mod です�
 macOS Apple Silicon での注意
 
   * M1/M2/M3/M4 などの Apple Silicon Mac では、Caves of Qud をネイティブ起動すると、ゲーム本体側の `0Harmony.dll` が原因で Harmony パッチが `mprotect returned EACCES` により失敗し、この Mod の UI 翻訳が効かない場合があります。
-  * QudJP では Rosetta 2 経由での起動を推奨します。QudJP は `0Harmony.dll` を同梱・上書きしません。
+  * QudJP では Rosetta 2 経由での起動を推奨します。QudJP は `0Harmony.dll` を自動では同梱・上書きしません。
   * この Mod には `Launch CavesOfQud (Rosetta).command` という起動用 wrapper を同梱しています。Steam Workshop のダウンロード先からダブルクリックで起動できます。
   * macOS の Steam 既定ライブラリでは、通常 `~/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020/Launch CavesOfQud (Rosetta).command` にあります。別の Steam ライブラリを使っている場合は、そのライブラリ内の `steamapps/workshop/content/333640/3718988020/` を探してください。
   * ゲーム本体は、まず既定の Steam ライブラリと wrapper 自身が置かれている Workshop フォルダから同じ Steam ライブラリ内を探します。それでも見つからない場合、wrapper が `CoQ.app` の選択画面を表示します。Steam ライブラリ内の Caves of Qud フォルダから `CoQ.app` を選んでください。
   * Steam から通常起動した場合、この wrapper の効果は引き継がれません。Apple Silicon で翻訳が効かない場合は、毎回 wrapper から起動してください。
   * Rosetta 2 が未インストールの場合、wrapper がインストール確認を表示します。表示に従って進めれば、手動でターミナル操作をする必要はありません。
   * 上級者向けの直接起動例: `arch -x86_64 $HOME/Library/Application\ Support/Steam/steamapps/common/Caves\ of\ Qud/CoQ.app/Contents/MacOS/CoQ`
-  * 上級者向けの別手段として、ゲーム本体側の `0Harmony.dll` を Harmony 2.4.2 に差し替えると Apple Silicon ネイティブ起動でも動作したという報告があります。通常は上記の Rosetta 起動を使ってください。手動差し替えを行う場合は、CoQ を終了し、https://github.com/pardeike/Harmony/releases/tag/v2.4.2.0 の `Harmony-Fat.2.4.2.0.zip` から `net48/0Harmony.dll` を取り出して、`~/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll` をバックアップ後に置き換えてください。Steam の整合性確認・再インストール・ゲーム更新で元に戻る可能性があります。
+  * 上級者向けの別手段として、ゲーム本体側の `0Harmony.dll` を Harmony 2.4.2 に差し替えると Apple Silicon ネイティブ起動でも動作することを確認しています。通常は上記の Rosetta 起動を使ってください。
+  * この Mod には、明示的に実行した場合だけ差し替える `Install Native Apple Silicon Harmony.command` と、元に戻す `Restore Game Harmony.command` も同梱しています。これらはまず配置場所から Caves of Qud を探し、見つからない場合は `0Harmony.dll` の選択画面を表示します。
+  * 手動差し替えを行う場合は、CoQ を終了し、https://github.com/pardeike/Harmony/releases/tag/v2.4.2.0 の `Harmony-Fat.2.4.2.0.zip` から `net48/0Harmony.dll` を取り出して、`~/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll` をバックアップ後に置き換えてください。Steam の整合性確認・再インストール・ゲーム更新で元に戻る可能性があります。
 
 報告・Contribution
 


### PR DESCRIPTION
## Summary
- Add opt-in macOS Apple Silicon helpers to install Harmony 2.4.2 and restore the QudJP-created backup.
- Include the helpers in release ZIP, sync, and Workshop staging validation while preserving executable bits.
- Document the conservative Rosetta-first guidance and record the Harmony 2.4.2 native ARM64 verification results.

## Verification
- /bin/bash -n Mods/QudJP/Install Native Apple Silicon Harmony.command && /bin/bash -n Mods/QudJP/Restore Game Harmony.command
- shellcheck Mods/QudJP/Install Native Apple Silicon Harmony.command Mods/QudJP/Restore Game Harmony.command
- just python-check
- just python-test-filter 'harmony_native_scripts or build_release or build_workshop_upload or sync_mod'
- just python-test
- just build-release
- just build-workshop-upload dist/QudJP-v0.2.51.zip /tmp/qudjp-harmony-helper-changenote.txt
- just workshop-upload-preflight dist/QudJP-v0.2.51.zip 0.2.51
- git diff --check / git diff --cached --check
- just markdown-report-check origin/main HEAD
- just release-note-check origin/main HEAD

## Review
- Independent review: APPROVE, followed by a behavior-preserving polish pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * macOS（Apple Silicon）向けのオプション補助スクリプトを追加：Harmony 2.4.2 への置換インストーラと復元ツール（明示的同意・自動バックアップ付き）
  * リリース配布にこれらの補助スクリプトを含めるように変更

* **ドキュメント**
  * README／各種ドキュメントとリリースノートを更新して、Apple Silicon向け手順と注意事項、復元手順を明記

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/646)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->