### PR TITLE
Codify pipeline and agent tooling safeguards

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/lsp-check-after-tool.sh",
+            "timeout": 180,
+            "statusMessage": "Checking C# solution load when relevant"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/lsp-check-after-tool.sh
+++ b/.codex/hooks/lsp-check-after-tool.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+payload="$(cat || true)"
+
+min_interval_seconds="${QUDJP_CODEX_LSP_HOOK_MIN_INTERVAL_SECONDS:-45}"
+state_dir="$repo_root/.artifacts/codex-hooks"
+last_run_file="$state_dir/lsp-check.last"
+lock_dir="$state_dir/lsp-check.lock"
+log_file="$state_dir/lsp-check.log"
+
+json_field() {
+  local field="$1"
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 0
+  fi
+  PAYLOAD="$payload" FIELD="$field" python3 - <<'PY'
+import json
+import os
+
+payload = os.environ.get("PAYLOAD", "")
+field = os.environ["FIELD"]
+try:
+    data = json.loads(payload)
+except json.JSONDecodeError:
+    raise SystemExit(0)
+
+value = data.get(field, "")
+if isinstance(value, str):
+    print(value)
+PY
+}
+
+emit_additional_context() {
+  local message="$1"
+  if command -v python3 >/dev/null 2>&1; then
+    MESSAGE="$message" python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({
+    "continue": True,
+    "hookSpecificOutput": {
+        "hookEventName": "PostToolUse",
+        "additionalContext": os.environ["MESSAGE"],
+    },
+}, separators=(",", ":")))
+PY
+  else
+    printf '%s\n' "$message" >&2
+  fi
+}
+
+tool_name="$(json_field tool_name)"
+
+is_interesting_tool=false
+case "$tool_name" in
+  *Write*|*Edit*|*MultiEdit*|*apply_patch*)
+    is_interesting_tool=true
+    ;;
+  *Read*)
+    if [[ "${QUDJP_CODEX_LSP_HOOK_ON_READ:-0}" == "1" ]]; then
+      is_interesting_tool=true
+    fi
+    ;;
+  Bash|*exec_command*|*multi_tool_use*)
+    if [[ "${QUDJP_CODEX_LSP_HOOK_ON_EXEC:-0}" == "1" ]]; then
+      is_interesting_tool=true
+    fi
+    ;;
+esac
+
+if [[ "${QUDJP_CODEX_LSP_HOOK_FORCE:-0}" != "1" && "$is_interesting_tool" != "true" ]]; then
+  exit 0
+fi
+
+if [[ "${QUDJP_CODEX_LSP_HOOK_FORCE:-0}" != "1" ]]; then
+  if ! printf '%s' "$payload" | grep -Eq '(\.cs([^A-Za-z0-9_]|$)|\.csproj([^A-Za-z0-9_]|$)|\.sln([^A-Za-z0-9_]|$)|dotnet-tools\.json|global\.json|Directory\.Build\.(props|targets)|Mods/QudJP/Assemblies/ReferenceStubs/)'; then
+    exit 0
+  fi
+
+fi
+
+mkdir -p "$state_dir"
+
+now="$(date +%s)"
+if [[ "${QUDJP_CODEX_LSP_HOOK_FORCE:-0}" != "1" && -f "$last_run_file" ]]; then
+  last_run="$(cat "$last_run_file" 2>/dev/null || printf '0')"
+  if [[ "$last_run" =~ ^[0-9]+$ ]] && (( now - last_run < min_interval_seconds )); then
+    exit 0
+  fi
+fi
+
+if ! mkdir "$lock_dir" 2>/dev/null; then
+  exit 0
+fi
+trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
+
+printf '%s\n' "$now" > "$last_run_file"
+
+if [[ "${QUDJP_CODEX_LSP_HOOK_DRY_RUN:-0}" == "1" ]]; then
+  printf 'QudJP Codex LSP hook: would run just lsp-check\n' >&2
+  exit 0
+fi
+
+tmp_log="$log_file.tmp"
+(
+  cd "$repo_root" || exit 1
+  just lsp-check
+) >"$tmp_log" 2>&1
+status=$?
+mv "$tmp_log" "$log_file"
+
+if (( status != 0 )); then
+  emit_additional_context "QudJP Codex LSP hook: just lsp-check failed after a relevant C# tool use. Inspect .artifacts/codex-hooks/lsp-check.log before relying on language-server diagnostics."
+fi
+
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           if [[ "$run_all" == true ]] || matches '^scripts/tools/' || matches_annals_extractor_tests; then
             roslyn_tools=true
           fi
-          if [[ "$run_all" == true ]] || matches '^(pyproject\.toml|uv\.lock|CHANGELOG\.md|Mods/QudJP/manifest\.json|docs/release-notes/)' || matches_python_scripts; then
+          if [[ "$run_all" == true ]] || matches '^(\.codex/hooks/|\.codex/hooks\.json|pyproject\.toml|uv\.lock|dotnet-tools\.json|package(-lock)?\.json|CHANGELOG\.md|Mods/QudJP/manifest\.json|docs/release-notes/)' || matches_python_scripts; then
             python=true
           fi
           if [[ "$run_all" == true ]] || matches '^(Mods/QudJP/Localization/|scripts/(check_translation_tokens|check_glossary_consistency|validate_pattern_routes)\.py|scripts/(translation_token_duplicate_baseline|glossary_consistency_baseline)\.json|justfile$)'; then
@@ -244,8 +244,8 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
 
-      - name: Install ast-grep
-        run: npm install -g @ast-grep/cli
+      - name: Install Node tool dependencies
+        run: npm ci
 
       - name: Install Python test tools
         run: pip install hypothesis pytest ruff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,9 @@ jobs:
       - name: Install Node tool dependencies
         run: npm ci
 
+      - name: Add Node tool binaries to PATH
+        run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+
       - name: Install Python test tools
         run: pip install hypothesis pytest ruff
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install Node tool dependencies
         run: npm ci
 
+      - name: Add Node tool binaries to PATH
+        run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+
       - name: Validate release identity
         id: identity
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Install Python tools
         run: pip install hypothesis pytest ruff
 
-      - name: Install ast-grep
-        run: npm install -g @ast-grep/cli
+      - name: Install Node tool dependencies
+        run: npm ci
 
       - name: Validate release identity
         id: identity

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,13 +28,22 @@ QudJP is the Japanese localization mod for Caves of Qud `1.0.4`. The repo contai
   procedures.
 - For decompiled C# exploration, use structural search with `ast-grep` before
   or alongside `rg` when call shape, argument structure, producer/sink routes,
-  wrappers, assignments, or attributes matter. Prefer `just sg-cs
+  wrappers, assignments, or attributes matter. Prefer `just ast-search-cs
   'Popup.Show($$$ARGS)'` for common C# searches; plain `rg` is still fine for
   literal text, symbol names, and file discovery.
 - When ad hoc C# exploration depends on type, receiver, overload, alias,
   inheritance, generic owner identity, or Unity/TMP property ownership, promote
   the candidate set to `just semantic-probe ...` and keep `candidate` /
   `unresolved` rows visible as uncertainty, not resolved owner proof.
+- Use `just lsp-check` as a selective C# solution-load check, not as a
+  default read-time tax. Run it after `.sln`/`.csproj`/reference-stub/dotnet
+  tool changes, when editor diagnostics disagree with build output, or before
+  relying on language-server feedback for type/overload/receiver decisions.
+- The repo-local Codex `PostToolUse` hook in `.codex/hooks.json` is a guardrail
+  for that same route: its matcher is intentionally broad, while
+  `.codex/hooks/lsp-check-after-tool.sh` does the path/tool filtering. It runs
+  `just lsp-check` only after relevant C# write-like tool use, skips plain reads
+  and shell-command reads by default, and debounces repeated checks.
 - For authoritative C# static inventories or scanner changes, use the
   repo-local Roslyn static analysis skill at
   `.codex/skills/roslyn-static-analysis/SKILL.md`. Purpose-built Roslyn

--- a/Mods/QudJP/Assemblies/AGENTS.md
+++ b/Mods/QudJP/Assemblies/AGENTS.md
@@ -2,23 +2,35 @@
 
 ## Why
 
-This area contains the shipped mod DLL and the automated tests that define Harmony patch behavior.
+This directory owns the shipped QudJP mod DLL and the tests that define C#
+patch behavior for Caves of Qud `1.0.4`.
+
+Most work here changes one of three contracts:
+
+- a Harmony target or upstream game signature
+- a translation, rendering, diagnostic, or cache behavior
+- the test harness that proves those behaviors without a live Unity runtime
 
 ## What
 
-- Main paths:
-  - `QudJP.csproj` for the `net48` mod DLL
-  - `QudJP.Tests/` for the `net10.0` test project
-  - `src/Patches/` for Harmony patch classes
-  - `src/` for translators, renderers, observability helpers, and shared utilities
-- Source of truth:
-  - patch behavior is defined by tests in `QudJP.Tests/`
-  - layer boundaries live in `docs/test-architecture.md`
-  - translation-route, ownership, runtime, and deployment rules live in `docs/RULES.md`
+- `QudJP.csproj`: `net48` mod DLL that ships with the mod.
+- `QudJP.Tests/`: `net10.0` test project and the source of truth for patch behavior.
+- `src/Patches/`: Harmony patch classes. Keep one patch class per file.
+- `src/`: translators, renderers, diagnostics, analyzers, and shared helpers.
+
+Canonical references:
+
+- `docs/test-architecture.md`: L1/L2/L2G/L3 boundaries and allowed test shapes.
+- `docs/RULES.md`: translation ownership, route decisions, fallback policy, diagnostics, markup, and route-contract test obligations.
+- `docs/workflows/runtime-evidence.md`: runtime logs, local mod sync, deployment checks, and decompiled-source tracing.
 
 ## How
 
-- Build and test:
+Start by identifying the contract being changed, then choose the narrowest proof
+layer from `docs/test-architecture.md`. Tests in `QudJP.Tests/` outrank stale
+notes or old investigations.
+
+Routine commands:
 
 ```bash
 just build
@@ -28,82 +40,65 @@ just test-l2
 just test-l2g
 ```
 
-- Run `just test-l1`, `just test-l2`, and `just test-l2g` sequentially. Parallel
-  local invocations can race on shared `ReferenceStubs`/NuGet restore outputs.
+Run `just test-l1`, `just test-l2`, and `just test-l2g` sequentially for local
+verification unless the task explicitly establishes isolated artifacts for a
+parallel run.
 
-- Prefer producer-owned or stable mid-pipeline fixes. Many sink and near-sink routes are intentionally observation-only.
-- Use `~/dev/coq-decompiled_stable/` to trace upstream producers, verify signatures, and investigate unclaimed routes.
-- When a patch reflects into upstream game members, verify the real method
-  signature in decompiled source before choosing `AccessTools.Method`
-  parameter types. C# optional arguments still appear as real parameters to
-  reflection, so a source call such as `RenderForUI()` may require resolving
-  `RenderForUI(string, bool)`. Add an L2G signature/contract test when this
-  reflection path controls runtime UI behavior.
-- For C# patch, translator, observability, or target-method changes, use structural search before editing or before finalizing the patch:
-  - use `just --list` to discover repo recipes when command routing is unclear
-  - use `just ast-search-cs '<pattern>' Mods/QudJP/Assemblies/src` to compare repo-owned call shapes
-  - use `just ast-search-cs '<pattern>'` with the default decompiled-source target when tracing upstream game producers
-- Optional examples: try patterns such as `DynamicTextObservability.RecordTransform($$$ARGS)`, `Popup.Show($$$ARGS)`, or the method/class name you are changing.
-- Use `just lsp-check` when the question is "does the repo-local C# language
-  server load this solution with the pinned SDK/tooling?" Run it after
-  `.sln`/`.csproj`/reference-stub/tool-manifest changes, when editor diagnostics
-  disagree with `dotnet build`, or before relying on language-server feedback in
-  a review. This is not a substitute for `just build`, `just test-l1`, `just
-  test-l2`, or `just test-l2g`; compiler/analyzer/test results remain the
-  behavior gate.
-- Codex has a repo-local `PostToolUse` hook at `.codex/hooks.json` that invokes
-  `.codex/hooks/lsp-check-after-tool.sh`. The Codex matcher is broad; the script
-  owns the real path/tool filtering. The hook intentionally does not run on
-  ordinary reads or shell-command reads; it triggers only for relevant C#
-  write-like tool use and applies a debounce so language-server checks do not
-  become a linear cost.
-- If structural search is intentionally skipped for C# route work, state the reason in the work note or PR summary.
-- Runtime diagnostics must route through `RuntimeDiagnostics`: use
-  `RuntimeDiagnostics.LogVerboseProbe(...)` for verbose runtime probes and
-  `RuntimeDiagnostics.LogImportant(...)` only for build, error, or
-  sink-required shipping signals. Direct probe log markers such as
-  `[QudJP] NewProbe/v1:`, `[QudJP] SinkObserve/v1:`,
-  `[QudJP] Translator: missing key`, and `no pattern for` are dev-only by
-  default and are rejected by the release DLL verifier when they remain in a
-  release artifact.
-- Dev-only probes that touch Unity, TMP, or reflection should fail closed:
-  catch probe-building exceptions inside the probe and return a no-op result so
-  observability cannot change visible translation behavior. When a probe depends
-  on `#if` guards, add L1 policy coverage for the caller guard and release
-  no-op branch.
-- Process-lifetime caches may cache only successful loads. Do not store an empty
-  result for file-missing, IO, XML/JSON parse, or other transient load failures;
-  log or surface the failure and leave the cache unset so a later runtime pass
-  can retry after deployment or file repair.
-- For `UnityEngine.Object`-derived coroutine hosts, components, transforms, or
-  UI objects, use `== null` / `!= null` when lifetime semantics matter. Pattern
-  null checks such as `is null` bypass Unity fake-null behavior.
-- Keep QJ004 as a narrow bypass guard, not a general C# logging or
-  format-string analyzer. It should detect known verbose probe markers that
-  are statically visible on direct logging calls. Do not expand it into
-  arbitrary format reconstruction, exception message inspection, or broad
-  Unity/System.Diagnostics logging API modeling unless the probe policy itself
-  changes.
-- When future probes need stronger guarantees, prefer tightening the
-  centralized `RuntimeDiagnostics` API, marker convention, release verifier, or
-  focused analyzer tests before adding broad static inference to QJ004.
-- For tooltip, TMP, or RTF display fixes:
-  - identify the upstream producer route before patching sinks; prefer
-    `Look.GenerateTooltipInformation(GameObject)` or another pre-render owner
-    when the UI route permits it
-  - preserve root contract tokens and markup as indivisible text boundaries:
-    Qud wrappers, `&`/`^` color codes, TMP/rich-text tags, `\x01`,
-    `=variable.name=`, `{0}`, and `{12:format}`
-  - prove both no-op fallback behavior and at least one route boundary with
-    tests; use L2G target-resolution coverage when the upstream game signature
-    is the contract
-  - verify both normal game-DLL builds/tests and the no-game Release build path
-    when a patch needs `#if HAS_GAME_DLL` fallback code
-- Constraints:
-  - one patch class per file in `src/Patches/`
-  - do not instantiate real game types in L1/L2 tests; use dummy targets with matching signatures
-  - L2G may use a minimal real game type invocation only for an upstream member
-    contract that cannot be proven by target/signature resolution and
-    DummyTarget behavior tests; follow `docs/test-architecture.md`
-  - runtime Harmony comes from the game; tests use HarmonyLib NuGet `2.4.2`
-  - producer or queue-gated translation patches must follow the route-contract test checklist in `docs/RULES.md`
+Use deterministic tooling before prompt-only reasoning for route and call-shape
+work:
+
+```bash
+just --list
+just ast-search-cs '<pattern>' Mods/QudJP/Assemblies/src
+just ast-search-cs '<pattern>'
+just lsp-check
+```
+
+`just ast-search-cs '<pattern>'` without a path searches the configured
+decompiled-source target. Use it with `~/dev/coq-decompiled_stable/` to trace
+upstream producers, verify signatures, and investigate unclaimed routes. Promote
+type-, receiver-, overload-, alias-, or inheritance-sensitive C# questions to
+the repo's Roslyn/static-analysis workflow described in the root `AGENTS.md`.
+
+When a patch reflects into upstream game members, verify the real signature in
+the decompiled source before choosing `AccessTools.Method` parameter types.
+C# optional arguments still appear as real reflection parameters. Add L2G
+signature or contract coverage when that reflection path controls runtime UI
+behavior.
+
+Route decisions follow `docs/RULES.md`:
+
+- prefer producer-owned or stable mid-pipeline fixes
+- treat most sink and near-sink routes as observation-only
+- do not hide dynamic or owner-routed bugs with broad dictionary entries
+- preserve Qud markup, TMP/rich-text tags, `\x01`, `=variable.name=`, and
+  numeric placeholders as indivisible contract tokens
+- prove no-op fallback behavior and at least one route boundary for tooltip,
+  TMP, RTF, producer, or queue-gated translation fixes
+
+Test boundaries follow `docs/test-architecture.md`:
+
+- L1 has no Harmony, Unity, or `Assembly-CSharp.dll` dependency.
+- L2 uses Harmony with dummy targets that match upstream signatures.
+- L2G may use the game DLL for target/signature proof.
+- L2G real game type instantiation is a narrow exception for upstream member
+  contracts that cannot be proven by target resolution plus dummy-target tests.
+- L3 runtime smoke evidence is manual and Unity-backed.
+
+Runtime diagnostics route through `RuntimeDiagnostics`. Verbose probes are
+dev-only by default; release artifacts reject direct probe markers documented in
+`docs/RULES.md`. Probes touching Unity, TMP, or reflection should fail closed so
+observability cannot change visible translation behavior.
+
+Process-lifetime caches cache only successful loads. File-missing, IO, XML/JSON
+parse, or other transient failures should leave the cache unset so a later
+runtime pass can retry after deployment or file repair.
+
+For `UnityEngine.Object`-derived coroutine hosts, components, transforms, or UI
+objects, `== null` and `!= null` preserve Unity fake-null lifetime semantics.
+Pattern checks such as `is null` do not.
+
+QJ004 is a narrow bypass guard for statically visible verbose probe markers on
+direct logging calls. Stronger future guarantees should tighten
+`RuntimeDiagnostics`, marker conventions, release verification, or focused
+analyzer tests before broadening QJ004 into a general logging analyzer.

--- a/Mods/QudJP/Assemblies/AGENTS.md
+++ b/Mods/QudJP/Assemblies/AGENTS.md
@@ -41,9 +41,22 @@ just test-l2g
   reflection path controls runtime UI behavior.
 - For C# patch, translator, observability, or target-method changes, use structural search before editing or before finalizing the patch:
   - use `just --list` to discover repo recipes when command routing is unclear
-  - use `just sg-cs '<pattern>' Mods/QudJP/Assemblies/src` to compare repo-owned call shapes
-  - use `just sg-cs '<pattern>'` with the default decompiled-source target when tracing upstream game producers
+  - use `just ast-search-cs '<pattern>' Mods/QudJP/Assemblies/src` to compare repo-owned call shapes
+  - use `just ast-search-cs '<pattern>'` with the default decompiled-source target when tracing upstream game producers
 - Optional examples: try patterns such as `DynamicTextObservability.RecordTransform($$$ARGS)`, `Popup.Show($$$ARGS)`, or the method/class name you are changing.
+- Use `just lsp-check` when the question is "does the repo-local C# language
+  server load this solution with the pinned SDK/tooling?" Run it after
+  `.sln`/`.csproj`/reference-stub/tool-manifest changes, when editor diagnostics
+  disagree with `dotnet build`, or before relying on language-server feedback in
+  a review. This is not a substitute for `just build`, `just test-l1`, `just
+  test-l2`, or `just test-l2g`; compiler/analyzer/test results remain the
+  behavior gate.
+- Codex has a repo-local `PostToolUse` hook at `.codex/hooks.json` that invokes
+  `.codex/hooks/lsp-check-after-tool.sh`. The Codex matcher is broad; the script
+  owns the real path/tool filtering. The hook intentionally does not run on
+  ordinary reads or shell-command reads; it triggers only for relevant C#
+  write-like tool use and applies a debounce so language-server checks do not
+  become a linear cost.
 - If structural search is intentionally skipped for C# route work, state the reason in the work note or PR summary.
 - Runtime diagnostics must route through `RuntimeDiagnostics`: use
   `RuntimeDiagnostics.LogVerboseProbe(...)` for verbose runtime probes and
@@ -58,6 +71,10 @@ just test-l2g
   observability cannot change visible translation behavior. When a probe depends
   on `#if` guards, add L1 policy coverage for the caller guard and release
   no-op branch.
+- Process-lifetime caches may cache only successful loads. Do not store an empty
+  result for file-missing, IO, XML/JSON parse, or other transient load failures;
+  log or surface the failure and leave the cache unset so a later runtime pass
+  can retry after deployment or file repair.
 - For `UnityEngine.Object`-derived coroutine hosts, components, transforms, or
   UI objects, use `== null` / `!= null` when lifetime semantics matter. Pattern
   null checks such as `is null` bypass Unity fake-null behavior.

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/HarmonyPatchTryCatchAnalyzerTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/HarmonyPatchTryCatchAnalyzerTests.cs
@@ -60,6 +60,35 @@ public static class SamplePatch
     }
 
     [Test]
+    public async Task NoDiagnostic_WhenPatchMethodBodyUsesBareCatchAsync()
+    {
+        var source = """
+using System.Diagnostics;
+using HarmonyLib;
+""" + HarmonyStubs + """
+[HarmonyPatch]
+public static class SamplePatch
+{
+    public static bool Prefix(ref string __result)
+    {
+        try
+        {
+            __result = "ok";
+            return false;
+        }
+        catch
+        {
+            Trace.TraceError("QudJP: SamplePatch.Prefix failed");
+            return true;
+        }
+    }
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source).ConfigureAwait(false);
+    }
+
+    [Test]
     public async Task Diagnostic_WhenPatchMethodMissingTopLevelTryCatchAsync()
     {
         var source = """

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/PipelineTranslatorEntrypointAnalyzerTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/PipelineTranslatorEntrypointAnalyzerTests.cs
@@ -1,0 +1,229 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing.NUnit;
+using NUnit.Framework;
+using QudJP.Analyzers;
+
+namespace QudJP.Analyzers.Tests;
+
+using VerifyCS = AnalyzerVerifier<PipelineTranslatorEntrypointAnalyzer>;
+
+[TestFixture]
+public sealed class PipelineTranslatorEntrypointAnalyzerTests
+{
+    [Test]
+    public async Task Diagnostic_WhenMessagePipelineCallsTranslatorDirectlyAsync()
+    {
+        const string source = """
+namespace QudJP.Patches;
+
+internal static class MessageQueueSemanticPipeline
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color)
+    {
+        return {|#0:SamplePatch.TryTranslateQueuedMessage(ref message, color)|};
+    }
+}
+
+internal static class SamplePatch
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color) => false;
+}
+""";
+
+        var expected = VerifyCS.Diagnostic(PipelineTranslatorEntrypointAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments(
+                "TryTranslateQueuedMessage",
+                "QudJP.Patches.SamplePatch.TryTranslateQueuedMessage(ref string, string?)");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task NoDiagnostic_WhenPipelineCallsTranslatorInsideExceptionCatchTryAsync()
+    {
+        const string source = """
+using System;
+
+namespace QudJP.Patches;
+
+internal static class MessageQueueSemanticPipeline
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color)
+    {
+        try
+        {
+            return SamplePatch.TryTranslateQueuedMessage(ref message, color);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}
+
+internal static class SamplePatch
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color) => false;
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task Diagnostic_WhenTranslatorCallIsInsideCatchBlockAsync()
+    {
+        const string source = """
+using System;
+
+namespace QudJP.Patches;
+
+internal static class MessageQueueSemanticPipeline
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color)
+    {
+        try
+        {
+            return false;
+        }
+        catch (Exception)
+        {
+            return {|#0:SamplePatch.TryTranslateQueuedMessage(ref message, color)|};
+        }
+    }
+}
+
+internal static class SamplePatch
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color) => false;
+}
+""";
+
+        var expected = VerifyCS.Diagnostic(PipelineTranslatorEntrypointAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments(
+                "TryTranslateQueuedMessage",
+                "QudJP.Patches.SamplePatch.TryTranslateQueuedMessage(ref string, string?)");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task Diagnostic_WhenTranslatorCallIsInsideFinallyBlockAsync()
+    {
+        const string source = """
+using System;
+
+namespace QudJP.Patches;
+
+internal static class MessageQueueSemanticPipeline
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color)
+    {
+        try
+        {
+            return false;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+        finally
+        {
+            _ = {|#0:SamplePatch.TryTranslateQueuedMessage(ref message, color)|};
+        }
+    }
+}
+
+internal static class SamplePatch
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color) => false;
+}
+""";
+
+        var expected = VerifyCS.Diagnostic(PipelineTranslatorEntrypointAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments(
+                "TryTranslateQueuedMessage",
+                "QudJP.Patches.SamplePatch.TryTranslateQueuedMessage(ref string, string?)");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task NoDiagnostic_WhenPopupPipelineUsesLocalCrashSafeHelperAsync()
+    {
+        const string source = """
+using System;
+
+namespace QudJP.Patches;
+
+internal static class PopupShowSemanticPipeline
+{
+    internal static string TranslateMessage(string source, string route)
+    {
+        if (TryTranslatePopupMessageWithFallback(SamplePatch.TryTranslatePopupMessage, source, route, out var translated))
+        {
+            return translated;
+        }
+
+        return source;
+    }
+
+    private static bool TryTranslatePopupMessageWithFallback(
+        PopupMessageTranslator translator,
+        string source,
+        string route,
+        out string translated)
+    {
+        try
+        {
+            return translator(source, route, "Popup.Show", out translated);
+        }
+        catch (Exception)
+        {
+            translated = source;
+            return false;
+        }
+    }
+
+    private delegate bool PopupMessageTranslator(string source, string route, string family, out string translated);
+}
+
+internal static class SamplePatch
+{
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        translated = source;
+        return false;
+    }
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task NoDiagnostic_OutsideSemanticPipelineAsync()
+    {
+        const string source = """
+namespace QudJP.Patches;
+
+internal static class OtherTranslator
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color)
+    {
+        return SamplePatch.TryTranslateQueuedMessage(ref message, color);
+    }
+}
+
+internal static class SamplePatch
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color) => false;
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source).ConfigureAwait(false);
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/PipelineTranslatorEntrypointAnalyzerTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/PipelineTranslatorEntrypointAnalyzerTests.cs
@@ -40,6 +40,39 @@ internal static class SamplePatch
     }
 
     [Test]
+    public async Task Diagnostic_WhenDifferentNamespaceUsesSamePipelineTypeNameAsync()
+    {
+        const string source = """
+namespace QudJP.Patches
+{
+    internal static class MessageQueueSemanticPipeline
+    {
+        internal static bool TryTranslateQueuedMessage(ref string message, string? color)
+        {
+            return {|#0:OtherNamespace.MessageQueueSemanticPipeline.TryTranslateQueuedMessage(ref message, color)|};
+        }
+    }
+}
+
+namespace OtherNamespace
+{
+    internal static class MessageQueueSemanticPipeline
+    {
+        internal static bool TryTranslateQueuedMessage(ref string message, string? color) => false;
+    }
+}
+""";
+
+        var expected = VerifyCS.Diagnostic(PipelineTranslatorEntrypointAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments(
+                "TryTranslateQueuedMessage",
+                "OtherNamespace.MessageQueueSemanticPipeline.TryTranslateQueuedMessage(ref string, string?)");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected).ConfigureAwait(false);
+    }
+
+    [Test]
     public async Task NoDiagnostic_WhenPipelineCallsTranslatorInsideExceptionCatchTryAsync()
     {
         const string source = """
@@ -131,6 +164,84 @@ internal static class SamplePatch
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task Diagnostic_WhenTryUsesFilteredExceptionCatchAsync()
+    {
+        const string source = """
+using System;
+
+namespace QudJP.Patches;
+
+internal static class MessageQueueSemanticPipeline
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color)
+    {
+        try
+        {
+            return {|#0:SamplePatch.TryTranslateQueuedMessage(ref message, color)|};
+        }
+        catch (Exception) when (message.Length > 0)
+        {
+            return false;
+        }
+    }
+}
+
+internal static class SamplePatch
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color) => false;
+}
+""";
+
+        var expected = VerifyCS.Diagnostic(PipelineTranslatorEntrypointAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments(
+                "TryTranslateQueuedMessage",
+                "QudJP.Patches.SamplePatch.TryTranslateQueuedMessage(ref string, string?)");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task Diagnostic_WhenTryCatchesNonSystemExceptionNamedExceptionAsync()
+    {
+        const string source = """
+namespace QudJP.Patches;
+
+internal static class MessageQueueSemanticPipeline
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color)
+    {
+        try
+        {
+            return {|#0:SamplePatch.TryTranslateQueuedMessage(ref message, color)|};
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}
+
+internal sealed class Exception : System.Exception
+{
+}
+
+internal static class SamplePatch
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color) => false;
+}
+""";
+
+        var expected = VerifyCS.Diagnostic(PipelineTranslatorEntrypointAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments(
+                "TryTranslateQueuedMessage",
+                "QudJP.Patches.SamplePatch.TryTranslateQueuedMessage(ref string, string?)");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected).ConfigureAwait(false);
     }
 
     [Test]

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/PipelineTranslatorEntrypointAnalyzerTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/PipelineTranslatorEntrypointAnalyzerTests.cs
@@ -72,6 +72,68 @@ internal static class SamplePatch
     }
 
     [Test]
+    public async Task NoDiagnostic_WhenEmptyCatchBlockProtectsTranslatorCallAsync()
+    {
+        const string source = """
+namespace QudJP.Patches;
+
+internal static class MessageQueueSemanticPipeline
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color)
+    {
+        try
+        {
+            return SamplePatch.TryTranslateQueuedMessage(ref message, color);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}
+
+internal static class SamplePatch
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color) => false;
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task NoDiagnostic_WhenUsingExceptionAliasProtectsTranslatorCallAsync()
+    {
+        const string source = """
+using Exception = System.Exception;
+
+namespace QudJP.Patches;
+
+internal static class MessageQueueSemanticPipeline
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color)
+    {
+        try
+        {
+            return SamplePatch.TryTranslateQueuedMessage(ref message, color);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}
+
+internal static class SamplePatch
+{
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color) => false;
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source).ConfigureAwait(false);
+    }
+
+    [Test]
     public async Task Diagnostic_WhenTranslatorCallIsInsideCatchBlockAsync()
     {
         const string source = """

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers/HarmonyPatchTryCatchAnalyzer.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers/HarmonyPatchTryCatchAnalyzer.cs
@@ -83,7 +83,7 @@ public sealed class HarmonyPatchTryCatchAnalyzer : DiagnosticAnalyzer
         var declaration = catchClause.Declaration;
         if (declaration is null)
         {
-            return false;
+            return true;
         }
 
         var typeSymbol = semanticModel.GetTypeInfo(declaration.Type, cancellationToken).Type;

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers/PipelineTranslatorEntrypointAnalyzer.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers/PipelineTranslatorEntrypointAnalyzer.cs
@@ -52,7 +52,12 @@ public sealed class PipelineTranslatorEntrypointAnalyzer : DiagnosticAnalyzer
         }
 
         var methodSymbol = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol as IMethodSymbol;
-        if (methodSymbol is null || IsSameContainingType(containingMethod, methodSymbol))
+        if (methodSymbol is null
+            || IsSameContainingType(
+                containingMethod,
+                methodSymbol,
+                context.SemanticModel,
+                context.CancellationToken))
         {
             return;
         }
@@ -80,14 +85,21 @@ public sealed class PipelineTranslatorEntrypointAnalyzer : DiagnosticAnalyzer
         };
     }
 
-    private static bool IsSameContainingType(MethodDeclarationSyntax containingMethod, IMethodSymbol methodSymbol)
+    private static bool IsSameContainingType(
+        MethodDeclarationSyntax containingMethod,
+        IMethodSymbol methodSymbol,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
         if (containingMethod.Parent is not TypeDeclarationSyntax typeDeclaration)
         {
             return false;
         }
 
-        return methodSymbol.ContainingType?.Name == typeDeclaration.Identifier.ValueText;
+        var containingTypeSymbol = semanticModel.GetDeclaredSymbol(typeDeclaration, cancellationToken);
+        return containingTypeSymbol is not null
+            && methodSymbol.ContainingType is not null
+            && SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, containingTypeSymbol);
     }
 
     private static bool IsInsideExceptionCatchTry(
@@ -119,6 +131,11 @@ public sealed class PipelineTranslatorEntrypointAnalyzer : DiagnosticAnalyzer
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
+        if (catchClause.Filter is not null)
+        {
+            return false;
+        }
+
         var declaration = catchClause.Declaration;
         if (declaration is null)
         {
@@ -126,18 +143,9 @@ public sealed class PipelineTranslatorEntrypointAnalyzer : DiagnosticAnalyzer
         }
 
         var typeSymbol = semanticModel.GetTypeInfo(declaration.Type, cancellationToken).Type;
-        return typeSymbol?.ToDisplayString() == "System.Exception"
-            || GetUnqualifiedName(declaration.Type) == "Exception";
-    }
-
-    private static string GetUnqualifiedName(TypeSyntax typeSyntax)
-    {
-        return typeSyntax switch
-        {
-            IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
-            QualifiedNameSyntax qualified => qualified.Right.Identifier.ValueText,
-            AliasQualifiedNameSyntax aliasQualified => aliasQualified.Name.Identifier.ValueText,
-            _ => typeSyntax.ToString(),
-        };
+        var systemException = semanticModel.Compilation.GetTypeByMetadataName("System.Exception");
+        return typeSymbol is not null
+            && systemException is not null
+            && SymbolEqualityComparer.Default.Equals(typeSymbol, systemException);
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers/PipelineTranslatorEntrypointAnalyzer.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers/PipelineTranslatorEntrypointAnalyzer.cs
@@ -122,7 +122,7 @@ public sealed class PipelineTranslatorEntrypointAnalyzer : DiagnosticAnalyzer
         var declaration = catchClause.Declaration;
         if (declaration is null)
         {
-            return false;
+            return true;
         }
 
         var typeSymbol = semanticModel.GetTypeInfo(declaration.Type, cancellationToken).Type;

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers/PipelineTranslatorEntrypointAnalyzer.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers/PipelineTranslatorEntrypointAnalyzer.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace QudJP.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PipelineTranslatorEntrypointAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "QJ005";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticId,
+        title: "Pipeline translator call must be crash-safe",
+        messageFormat: "Pipeline method '{0}' must call translator '{1}' through a crash-safe helper or a local try-catch",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not InvocationExpressionSyntax invocation
+            || invocation.Expression is not MemberAccessExpressionSyntax memberAccess
+            || !memberAccess.Name.Identifier.ValueText.StartsWith("TryTranslate", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var containingMethod = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        if (containingMethod is null || !IsPipelineEntrypoint(containingMethod))
+        {
+            return;
+        }
+
+        if (IsInsideExceptionCatchTry(invocation, context.SemanticModel, context.CancellationToken))
+        {
+            return;
+        }
+
+        var methodSymbol = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol as IMethodSymbol;
+        if (methodSymbol is null || IsSameContainingType(containingMethod, methodSymbol))
+        {
+            return;
+        }
+
+        var diagnostic = Diagnostic.Create(
+            Rule,
+            invocation.GetLocation(),
+            containingMethod.Identifier.ValueText,
+            methodSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    private static bool IsPipelineEntrypoint(MethodDeclarationSyntax method)
+    {
+        if (method.Parent is not TypeDeclarationSyntax typeDeclaration)
+        {
+            return false;
+        }
+
+        return typeDeclaration.Identifier.ValueText switch
+        {
+            "MessageQueueSemanticPipeline" => method.Identifier.ValueText == "TryTranslateQueuedMessage",
+            "PopupShowSemanticPipeline" => method.Identifier.ValueText == "TranslateMessage",
+            _ => false,
+        };
+    }
+
+    private static bool IsSameContainingType(MethodDeclarationSyntax containingMethod, IMethodSymbol methodSymbol)
+    {
+        if (containingMethod.Parent is not TypeDeclarationSyntax typeDeclaration)
+        {
+            return false;
+        }
+
+        return methodSymbol.ContainingType?.Name == typeDeclaration.Identifier.ValueText;
+    }
+
+    private static bool IsInsideExceptionCatchTry(
+        SyntaxNode node,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        foreach (var tryStatement in node.Ancestors().OfType<TryStatementSyntax>())
+        {
+            if (!tryStatement.Block.Span.Contains(node.SpanStart))
+            {
+                continue;
+            }
+
+            for (var index = 0; index < tryStatement.Catches.Count; index++)
+            {
+                if (IsExceptionCatch(tryStatement.Catches[index], semanticModel, cancellationToken))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsExceptionCatch(
+        CatchClauseSyntax catchClause,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var declaration = catchClause.Declaration;
+        if (declaration is null)
+        {
+            return false;
+        }
+
+        var typeSymbol = semanticModel.GetTypeInfo(declaration.Type, cancellationToken).Type;
+        return typeSymbol?.ToDisplayString() == "System.Exception"
+            || GetUnqualifiedName(declaration.Type) == "Exception";
+    }
+
+    private static string GetUnqualifiedName(TypeSyntax typeSyntax)
+    {
+        return typeSyntax switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+            QualifiedNameSyntax qualified => qualified.Right.Identifier.ValueText,
+            AliasQualifiedNameSyntax aliasQualified => aliasQualified.Name.Identifier.ValueText,
+            _ => typeSyntax.ToString(),
+        };
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs
@@ -1,73 +1,118 @@
+using System;
+using System.Diagnostics;
+
 namespace QudJP.Patches;
 
 internal static class MessageQueueSemanticPipeline
 {
+    private static readonly QueuedMessageTranslator[] Translators =
+    [
+        PhysicsApplyDischargeTranslationPatch.TryTranslateQueuedMessage,
+        AutoActTranslationPatch.TryTranslateQueuedMessage,
+        PhysicsObjectEnteringCellTranslationPatch.TryTranslateQueuedMessage,
+        CrippleApplyTranslationPatch.TryTranslateQueuedMessage,
+        GameObjectHealTranslationPatch.TryTranslateQueuedMessage,
+        ExperienceAwardXpTranslationPatch.TryTranslateQueuedMessage,
+        GameObjectMoveTranslationPatch.TryTranslateQueuedMessage,
+        GameObjectPerformThrowTranslationPatch.TryTranslateQueuedMessage,
+        GameObjectToggleActivatedAbilityTranslationPatch.TryTranslateQueuedMessage,
+        FlightTranslationPatch.TryTranslateQueuedMessage,
+        BodyTranslationPatch.TryTranslateQueuedMessage,
+        SunderMindTranslationPatch.TryTranslateQueuedMessage,
+        RealityStabilizedEventTranslationPatch.TryTranslateQueuedMessage,
+        CyberneticRejectionSyndromeTranslationPatch.TryTranslateQueuedMessage,
+        TombAnchorSystemTranslationPatch.TryTranslateQueuedMessage,
+        CyberneticsMedassistModuleTranslationPatch.TryTranslateQueuedMessage,
+        LiquidLoaderTranslationPatch.TryTranslateQueuedMessage,
+        TrollKingTranslationPatch.TryTranslateQueuedMessage,
+        MutatingTranslationPatch.TryTranslateQueuedMessage,
+        QuillsTranslationPatch.TryTranslateQueuedMessage,
+        LightManipulationTranslationPatch.TryTranslateQueuedMessage,
+        LatchesOnTranslationPatch.TryTranslateQueuedMessage,
+        AsleepOwnerTranslationPatch.TryTranslateQueuedMessage,
+        BuddingTranslationPatch.TryTranslateQueuedMessage,
+        BeguilingTranslationPatch.TryTranslateQueuedMessage,
+        SvardymSystemTranslationPatch.TryTranslateQueuedMessage,
+        PhasedTranslationPatch.TryTranslateQueuedMessage,
+        PersuasionRebukeRobotTranslationPatch.TryTranslateQueuedMessage,
+        TonicTranslationPatch.TryTranslateQueuedMessage,
+        XrlGameTranslationPatch.TryTranslateQueuedMessage,
+        BoostStatisticTranslationPatch.TryTranslateQueuedMessage,
+        EmboldenedTranslationPatch.TryTranslateQueuedMessage,
+        FungalSporeInfectionTranslationPatch.TryTranslateQueuedMessage,
+        HealingTranslationPatch.TryTranslateQueuedMessage,
+        StressedTranslationPatch.TryTranslateQueuedMessage,
+        MonochromeOnsetTranslationPatch.TryTranslateQueuedMessage,
+        IronshankOnsetTranslationPatch.TryTranslateQueuedMessage,
+        AdrenalControlTranslationPatch.TryTranslateQueuedMessage,
+        AmnesiaTranslationPatch.TryTranslateQueuedMessage,
+        BlinkingTicTranslationPatch.TryTranslateQueuedMessage,
+        BrittleBonesTranslationPatch.TryTranslateQueuedMessage,
+        ElectromagneticImpulseTranslationPatch.TryTranslateQueuedMessage,
+        FearAuraTranslationPatch.TryTranslateQueuedMessage,
+        CookingRuntimeTranslationPatch.TryTranslateQueuedMessage,
+        MeditatingTranslationPatch.TryTranslateQueuedMessage,
+        RegenerationTranslationPatch.TryTranslateQueuedMessage,
+        EffectStaticMessageTranslationPatch.TryTranslateQueuedMessage,
+        SystemStaticMessageTranslationPatch.TryTranslateQueuedMessage,
+        CombatGetDefenderHitDiceTranslationPatch.TryTranslateQueuedMessage,
+        DoorAttemptOpenTranslationPatch.TryTranslateQueuedMessage,
+        CombatMeleeAttackTranslationPatch.TryTranslateQueuedMessage,
+        GameObjectDieTranslationPatch.TryTranslateQueuedMessage,
+        GameObjectRegeneraTranslationPatch.TryTranslateQueuedMessage,
+        ClonelingVehicleTranslationPatch.TryTranslateQueuedMessage,
+        PetEitherOrExplodeTranslationPatch.TryTranslateQueuedMessage,
+        ZoneWindChangeTranslationPatch.TryTranslateQueuedMessage,
+        GameObjectSpotTranslationPatch.TryTranslateQueuedMessage,
+        XrlCoreLostSightTranslationPatch.TryTranslateQueuedMessage,
+        DeployableInfrastructureTranslationPatch.TryTranslateQueuedMessage,
+        PlayerDanceRitualTranslationPatch.TryTranslateQueuedMessage,
+        GameObjectEmitMessageTranslationPatch.TryTranslateQueuedMessage,
+        ZoneManagerTryThawZoneTranslationPatch.TryTranslateQueuedMessage,
+        ZoneManagerTickTranslationPatch.TryTranslateQueuedMessage,
+        ZoneManagerSetActiveZoneMapNotesTranslationPatch.TryTranslateQueuedMessage,
+        ZoneManagerGenerateZoneTranslationPatch.TryTranslateQueuedMessage,
+    ];
+
     internal static bool TryTranslateQueuedMessage(ref string message, string? color)
     {
-        return PhysicsApplyDischargeTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || AutoActTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || PhysicsObjectEnteringCellTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || CrippleApplyTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || GameObjectHealTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || ExperienceAwardXpTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || GameObjectMoveTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || GameObjectPerformThrowTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || GameObjectToggleActivatedAbilityTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || FlightTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || BodyTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || SunderMindTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || RealityStabilizedEventTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || CyberneticRejectionSyndromeTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || TombAnchorSystemTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || CyberneticsMedassistModuleTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || LiquidLoaderTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || TrollKingTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || MutatingTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || QuillsTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || LightManipulationTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || LatchesOnTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || AsleepOwnerTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || BuddingTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || BeguilingTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || SvardymSystemTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || PhasedTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || PersuasionRebukeRobotTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || TonicTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || XrlGameTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || BoostStatisticTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || EmboldenedTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || FungalSporeInfectionTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || HealingTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || StressedTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || MonochromeOnsetTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || IronshankOnsetTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || AdrenalControlTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || AmnesiaTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || BlinkingTicTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || BrittleBonesTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || ElectromagneticImpulseTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || FearAuraTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || CookingRuntimeTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || MeditatingTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || RegenerationTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || EffectStaticMessageTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || SystemStaticMessageTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || CombatGetDefenderHitDiceTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || DoorAttemptOpenTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || CombatMeleeAttackTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || GameObjectDieTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || GameObjectRegeneraTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || ClonelingVehicleTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || PetEitherOrExplodeTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || ZoneWindChangeTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || GameObjectSpotTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || XrlCoreLostSightTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || DeployableInfrastructureTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || PlayerDanceRitualTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || GameObjectEmitMessageTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || ZoneManagerTryThawZoneTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || ZoneManagerTickTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || ZoneManagerSetActiveZoneMapNotesTranslationPatch.TryTranslateQueuedMessage(ref message, color)
-            || ZoneManagerGenerateZoneTranslationPatch.TryTranslateQueuedMessage(ref message, color);
+        for (var index = 0; index < Translators.Length; index++)
+        {
+            if (TryTranslateQueuedMessageWithFallback(Translators[index], ref message, color))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
+
+    private static bool TryTranslateQueuedMessageWithFallback(
+        QueuedMessageTranslator translator,
+        ref string message,
+        string? color)
+    {
+        var source = message;
+
+        try
+        {
+            return translator(ref message, color);
+        }
+        catch (Exception ex)
+        {
+            message = source;
+            Trace.TraceError(
+                "QudJP: MessageQueueSemanticPipeline translator {0} failed: {1}",
+                FormatTranslatorName(translator),
+                ex);
+            return false;
+        }
+    }
+
+    private static string FormatTranslatorName(Delegate translator)
+    {
+        return translator.Method.DeclaringType?.FullName ?? translator.Method.Name;
+    }
+
+    private delegate bool QueuedMessageTranslator(ref string message, string? color);
 }

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -1,7 +1,48 @@
+using System;
+using System.Diagnostics;
+
 namespace QudJP.Patches;
 
 internal static class PopupShowSemanticPipeline
 {
+    private const string PopupShowFamily = "Popup.Show";
+
+    private static readonly PopupMessageTranslator[] Translators =
+    [
+        TryTranslatePerformOfferTradeWaterMessage,
+        TryTranslateHasNothingToTradeMessage,
+        GameObjectStatPopupTranslationPatch.TryTranslatePopupMessage,
+        GameObjectMoveTranslationPatch.TryTranslatePopupMessage,
+        GameObjectPerformThrowTranslationPatch.TryTranslatePopupMessage,
+        GameObjectPopupTranslationPatch.TryTranslatePopupMessage,
+        RealityStabilizedInterdictTranslationPatch.TryTranslatePopupMessage,
+        HackingSifrahResultTranslationPatch.TryTranslatePopupMessage,
+        QuestLifecyclePopupTranslationPatch.TryTranslatePopupMessage,
+        BodyTranslationPatch.TryTranslatePopupMessage,
+        ItemModdingSifrahTranslationPatch.TryTranslatePopupMessage,
+        SunderMindTranslationPatch.TryTranslatePopupMessage,
+        KeybindsScreenConflictTranslationPatch.TryTranslatePopupMessage,
+        AbilityManagerPopupTranslationPatch.TryTranslatePopupMessage,
+        RealityStabilizedEventTranslationPatch.TryTranslatePopupMessage,
+        GeomagneticDiscTranslationPatch.TryTranslatePopupMessage,
+        CampfireCookAvailabilityTranslationPatch.TryTranslatePopupMessage,
+        CampfirePreserveTranslationPatch.TryTranslatePopupMessage,
+        CookingRuntimeTranslationPatch.TryTranslatePopupMessage,
+        StatusScreenPopupTranslationPatch.TryTranslatePopupMessage,
+        TeleprojectorTranslationPatch.TryTranslatePopupMessage,
+        CyberneticsMedassistModuleTranslationPatch.TryTranslatePopupMessage,
+        LiquidLoaderTranslationPatch.TryTranslatePopupMessage,
+        MutatingTranslationPatch.TryTranslatePopupMessage,
+        LightManipulationTranslationPatch.TryTranslatePopupMessage,
+        AsleepOwnerTranslationPatch.TryTranslatePopupMessage,
+        BeguilingTranslationPatch.TryTranslatePopupMessage,
+        AscensionCableTranslationPatch.TryTranslatePopupMessage,
+        CarapaceTranslationPatch.TryTranslatePopupMessage,
+        NephalPropertiesTranslationPatch.TryTranslatePopupMessage,
+        IntegratedWeaponHostsTranslationPatch.TryTranslatePopupMessage,
+        FungalSporeInfectionTranslationPatch.TryTranslatePopupMessage,
+    ];
+
     internal static string TranslateMessage(string source, string route)
     {
         if (string.IsNullOrEmpty(source))
@@ -14,166 +55,68 @@ internal static class PopupShowSemanticPipeline
             return source;
         }
 
-        if (TradeUiPopupTranslationPatch.TryTranslatePerformOfferTradeWaterMessage(source, out var tradeWaterTranslated))
+        for (var index = 0; index < Translators.Length; index++)
         {
-            return tradeWaterTranslated;
-        }
-
-        if (TradeUiPopupTranslationPatch.TryTranslateHasNothingToTradeMessage(source, out var hasNothingTranslated))
-        {
-            return hasNothingTranslated;
-        }
-
-        if (GameObjectStatPopupTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var statTranslated))
-        {
-            return statTranslated;
-        }
-
-        if (GameObjectMoveTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var moveTranslated))
-        {
-            return moveTranslated;
-        }
-
-        if (GameObjectPerformThrowTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var performThrowTranslated))
-        {
-            return performThrowTranslated;
-        }
-
-        if (GameObjectPopupTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var gameObjectPopupTranslated))
-        {
-            return gameObjectPopupTranslated;
-        }
-
-        if (RealityStabilizedInterdictTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var realityStabilizedTranslated))
-        {
-            return realityStabilizedTranslated;
-        }
-
-        if (HackingSifrahResultTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var hackingSifrahTranslated))
-        {
-            return hackingSifrahTranslated;
-        }
-
-        if (QuestLifecyclePopupTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var questLifecycleTranslated))
-        {
-            return questLifecycleTranslated;
-        }
-
-        if (BodyTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var bodyTranslated))
-        {
-            return bodyTranslated;
-        }
-
-        if (ItemModdingSifrahTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var itemModdingTranslated))
-        {
-            return itemModdingTranslated;
-        }
-
-        if (SunderMindTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var sunderMindTranslated))
-        {
-            return sunderMindTranslated;
-        }
-
-        if (KeybindsScreenConflictTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var keybindsTranslated))
-        {
-            return keybindsTranslated;
-        }
-
-        if (AbilityManagerPopupTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var abilityManagerTranslated))
-        {
-            return abilityManagerTranslated;
-        }
-
-        if (RealityStabilizedEventTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var realityEventTranslated))
-        {
-            return realityEventTranslated;
-        }
-
-        if (GeomagneticDiscTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var geomagneticDiscTranslated))
-        {
-            return geomagneticDiscTranslated;
-        }
-
-        if (CampfireCookAvailabilityTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var campfireCookTranslated))
-        {
-            return campfireCookTranslated;
-        }
-
-        if (CampfirePreserveTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var campfirePreserveTranslated))
-        {
-            return campfirePreserveTranslated;
-        }
-
-        if (CookingRuntimeTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var cookingRuntimeTranslated))
-        {
-            return cookingRuntimeTranslated;
-        }
-
-        if (StatusScreenPopupTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var statusScreenTranslated))
-        {
-            return statusScreenTranslated;
-        }
-
-        if (TeleprojectorTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var teleprojectorTranslated))
-        {
-            return teleprojectorTranslated;
-        }
-
-        if (CyberneticsMedassistModuleTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var medassistTranslated))
-        {
-            return medassistTranslated;
-        }
-
-        if (LiquidLoaderTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var liquidLoaderTranslated))
-        {
-            return liquidLoaderTranslated;
-        }
-
-        if (MutatingTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var mutatingTranslated))
-        {
-            return mutatingTranslated;
-        }
-
-        if (LightManipulationTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var lightManipulationTranslated))
-        {
-            return lightManipulationTranslated;
-        }
-
-        if (AsleepOwnerTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var asleepTranslated))
-        {
-            return asleepTranslated;
-        }
-
-        if (BeguilingTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var beguilingTranslated))
-        {
-            return beguilingTranslated;
-        }
-
-        if (AscensionCableTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var ascensionCableTranslated))
-        {
-            return ascensionCableTranslated;
-        }
-
-        if (CarapaceTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var carapaceTranslated))
-        {
-            return carapaceTranslated;
-        }
-
-        if (NephalPropertiesTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var nephalTranslated))
-        {
-            return nephalTranslated;
-        }
-
-        if (IntegratedWeaponHostsTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var integratedWeaponHostsTranslated))
-        {
-            return integratedWeaponHostsTranslated;
-        }
-
-        if (FungalSporeInfectionTranslationPatch.TryTranslatePopupMessage(source, route, "Popup.Show", out var fungalSporeInfectionTranslated))
-        {
-            return fungalSporeInfectionTranslated;
+            if (TryTranslatePopupMessageWithFallback(
+                Translators[index],
+                source,
+                route,
+                out var translated))
+            {
+                return translated;
+            }
         }
 
         return PopupTranslationPatch.TranslatePopupTextForProducerRoute(source, route);
     }
+
+    private static bool TryTranslatePerformOfferTradeWaterMessage(
+        string source,
+        string route,
+        string family,
+        out string translated)
+    {
+        _ = route;
+        _ = family;
+        return TradeUiPopupTranslationPatch.TryTranslatePerformOfferTradeWaterMessage(source, out translated);
+    }
+
+    private static bool TryTranslateHasNothingToTradeMessage(
+        string source,
+        string route,
+        string family,
+        out string translated)
+    {
+        _ = route;
+        _ = family;
+        return TradeUiPopupTranslationPatch.TryTranslateHasNothingToTradeMessage(source, out translated);
+    }
+
+    private static bool TryTranslatePopupMessageWithFallback(
+        PopupMessageTranslator translator,
+        string source,
+        string route,
+        out string translated)
+    {
+        try
+        {
+            return translator(source, route, PopupShowFamily, out translated);
+        }
+        catch (Exception ex)
+        {
+            translated = source;
+            Trace.TraceError(
+                "QudJP: PopupShowSemanticPipeline translator {0} failed: {1}",
+                FormatTranslatorName(translator),
+                ex);
+            return false;
+        }
+    }
+
+    private static string FormatTranslatorName(Delegate translator)
+    {
+        return translator.Method.DeclaringType?.FullName ?? translator.Method.Name;
+    }
+
+    private delegate bool PopupMessageTranslator(string source, string route, string family, out string translated);
 }

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -439,7 +439,7 @@ PR を出すと GitHub Actions (`.github/workflows/ci.yml`) が変更ファイ�
 
 - `Mods/QudJP/Assemblies/` 変更: `.NET SDK 8.0.x + 10.0.x` をインストールし、QudJP / QudJP.Tests を Release build します。build artifact を作成した後、C# テストは `L1` / `L2` / `L2G` の matrix job で並列実行します。L2G は `QudJP.Tests.csproj` の `<Exists('$(AssemblyCSharpPath)')>` 条件付き参照により、CI 環境に `Assembly-CSharp.dll` が存在しないため自動的にスキップされます。
 - `scripts/tools/` または Annals extractor のテスト / fixture 変更: `scripts/tools/**/*.csproj` を列挙し、見つかった tool projects をすべて Release build します。
-- `scripts/` (`scripts/tools/` を除く) / `.codex/hooks/**` / `.codex/hooks.json` / `dotnet-tools.json` / `package.json` / `package-lock.json` 変更: `npm ci` で Node tool dependencies を復元し、`ruff`、`pytest` をセットアップして `ruff check scripts/` と `pytest scripts/tests/` を実行します。この Python lane は QudJP C# test matrix を待たずに並列実行されます。
+- `scripts/` (`scripts/tools/` を除く) / `.codex/hooks/**` / `.codex/hooks.json` / `dotnet-tools.json` / `package.json` / `package-lock.json` / `CHANGELOG.md` / `Mods/QudJP/manifest.json` / `docs/release-notes/` 変更: `npm ci` で Node tool dependencies を復元し、`ruff`、`pytest` をセットアップして `ruff check scripts/` と `pytest scripts/tests/` を実行します。この Python lane は QudJP C# test matrix を待たずに並列実行されます。
 - `Mods/QudJP/Localization/` 変更: release-note fragment requirement、translation-token check、glossary consistency check を実行します。
 - `pyproject.toml` / `uv.lock` 変更: Python tooling 変更として `ruff check scripts/` と `pytest scripts/tests/` を実行します。
 - CI は同一 ref の古い実行を自動キャンセルし、NuGet / pip キャッシュを使います。branch protection 用の `build` job は最後に各 lane の結果を集約する互換チェックです。

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -309,7 +309,7 @@ uv run python scripts/sync_mod.py \
 | `QJ001` | `[HarmonyPatch]` クラス内の `Prefix` / `Postfix` メソッドは、本体全体が単一の `try { } catch (Exception) { }` 文でなければならない (型無し `catch` は不可)。`TargetMethod` / `TargetMethods` は除外。 |
 | `QJ002` | メソッド呼び出しの戻り値に対する `??` null フォールバックの直前には `Trace.TraceWarning` / `Trace.TraceError` を置かなければならない (catch 内とテストコードは除外)。 |
 | `QJ003` | `Trace.TraceError` / `Trace.TraceWarning` の第 1 引数文字列は `"QudJP:"` で始まらなければならない。 |
-| `QJ005` | semantic pipeline entrypoint は他 patch の `TryTranslate*` を直接呼ばず、crash-safe helper または `try` / `catch (Exception)` 経由で呼ばなければならない。 |
+| `QJ005` | semantic pipeline entrypoint は他 patch の `TryTranslate*` を直接呼ばず、crash-safe helper または `Exception` を捕捉する `try` / `catch` (`catch (Exception)` または型省略 `catch`) 経由で呼ばなければならない。 |
 
 すべて `DiagnosticSeverity.Warning` で発行され、`<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` によりビルドエラーになります。
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -309,8 +309,29 @@ uv run python scripts/sync_mod.py \
 | `QJ001` | `[HarmonyPatch]` クラス内の `Prefix` / `Postfix` メソッドは、本体全体が単一の `try { } catch (Exception) { }` 文でなければならない (型無し `catch` は不可)。`TargetMethod` / `TargetMethods` は除外。 |
 | `QJ002` | メソッド呼び出しの戻り値に対する `??` null フォールバックの直前には `Trace.TraceWarning` / `Trace.TraceError` を置かなければならない (catch 内とテストコードは除外)。 |
 | `QJ003` | `Trace.TraceError` / `Trace.TraceWarning` の第 1 引数文字列は `"QudJP:"` で始まらなければならない。 |
+| `QJ005` | semantic pipeline entrypoint は他 patch の `TryTranslate*` を直接呼ばず、crash-safe helper または `try` / `catch (Exception)` 経由で呼ばなければならない。 |
 
 すべて `DiagnosticSeverity.Warning` で発行され、`<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` によりビルドエラーになります。
+
+補助診断:
+
+- `just ast-search-cs '<pattern>' [path]` — C# structural search (`sg-cs` は後方互換 alias)
+- `just ast-search-py '<pattern>' [path]` — Python structural search (`sg-py` は後方互換 alias)
+- `just lsp-check` — repo-local `csharp-ls` による C# solution-load diagnostics
+
+`just lsp-check` は `.sln` / `.csproj` / reference stub / dotnet tool manifest
+の変更時、または editor の診断と `dotnet build` の結果が食い違う時に使います。
+これは language-server が repo の solution を読めることを確認する補助導線であり、
+compiler / analyzer / test の代替ではありません。挙動ゲートは引き続き `just build`
+と `just test-l1` / `just test-l2` / `just test-l2g` です。
+
+Codex では repo-local hook (`.codex/hooks.json`) から
+`.codex/hooks/lsp-check-after-tool.sh` を呼びます。Codex 側の matcher は広く、
+実際の path / tool filtering は script 側で行います。この hook は relevant C#
+write-like tool use の後だけ `just lsp-check` を実行し、通常の read-only 調査や
+shell-command read では走りません。read 後にも検証したい場合は
+`QUDJP_CODEX_LSP_HOOK_ON_READ=1`、shell command 後にも検証したい場合は
+`QUDJP_CODEX_LSP_HOOK_ON_EXEC=1` を付けて明示的に使います。
 
 **エラーハンドリング規約** (fail-fast):
 
@@ -418,7 +439,7 @@ PR を出すと GitHub Actions (`.github/workflows/ci.yml`) が変更ファイ�
 
 - `Mods/QudJP/Assemblies/` 変更: `.NET SDK 8.0.x + 10.0.x` をインストールし、QudJP / QudJP.Tests を Release build します。build artifact を作成した後、C# テストは `L1` / `L2` / `L2G` の matrix job で並列実行します。L2G は `QudJP.Tests.csproj` の `<Exists('$(AssemblyCSharpPath)')>` 条件付き参照により、CI 環境に `Assembly-CSharp.dll` が存在しないため自動的にスキップされます。
 - `scripts/tools/` または Annals extractor のテスト / fixture 変更: `scripts/tools/**/*.csproj` を列挙し、見つかった tool projects をすべて Release build します。
-- `scripts/` 変更: `ast-grep`、`ruff`、`pytest` をセットアップし、`ruff check scripts/` と `pytest scripts/tests/` を実行します。この Python lane は QudJP C# test matrix を待たずに並列実行されます。
+- `scripts/` / `.codex/hooks/**` / `.codex/hooks.json` / `dotnet-tools.json` / `package.json` / `package-lock.json` 変更: `npm ci` で Node tool dependencies を復元し、`ruff`、`pytest` をセットアップして `ruff check scripts/` と `pytest scripts/tests/` を実行します。この Python lane は QudJP C# test matrix を待たずに並列実行されます。
 - `Mods/QudJP/Localization/` 変更: release-note fragment requirement、translation-token check、glossary consistency check を実行します。
 - `pyproject.toml` / `uv.lock` 変更: Python tooling 変更として `ruff check scripts/` と `pytest scripts/tests/` を実行します。
 - CI は同一 ref の古い実行を自動キャンセルし、NuGet / pip キャッシュを使います。branch protection 用の `build` job は最後に各 lane の結果を集約する互換チェックです。

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -439,7 +439,7 @@ PR を出すと GitHub Actions (`.github/workflows/ci.yml`) が変更ファイ�
 
 - `Mods/QudJP/Assemblies/` 変更: `.NET SDK 8.0.x + 10.0.x` をインストールし、QudJP / QudJP.Tests を Release build します。build artifact を作成した後、C# テストは `L1` / `L2` / `L2G` の matrix job で並列実行します。L2G は `QudJP.Tests.csproj` の `<Exists('$(AssemblyCSharpPath)')>` 条件付き参照により、CI 環境に `Assembly-CSharp.dll` が存在しないため自動的にスキップされます。
 - `scripts/tools/` または Annals extractor のテスト / fixture 変更: `scripts/tools/**/*.csproj` を列挙し、見つかった tool projects をすべて Release build します。
-- `scripts/` / `.codex/hooks/**` / `.codex/hooks.json` / `dotnet-tools.json` / `package.json` / `package-lock.json` 変更: `npm ci` で Node tool dependencies を復元し、`ruff`、`pytest` をセットアップして `ruff check scripts/` と `pytest scripts/tests/` を実行します。この Python lane は QudJP C# test matrix を待たずに並列実行されます。
+- `scripts/` (`scripts/tools/` を除く) / `.codex/hooks/**` / `.codex/hooks.json` / `dotnet-tools.json` / `package.json` / `package-lock.json` 変更: `npm ci` で Node tool dependencies を復元し、`ruff`、`pytest` をセットアップして `ruff check scripts/` と `pytest scripts/tests/` を実行します。この Python lane は QudJP C# test matrix を待たずに並列実行されます。
 - `Mods/QudJP/Localization/` 変更: release-note fragment requirement、translation-token check、glossary consistency check を実行します。
 - `pyproject.toml` / `uv.lock` 変更: Python tooling 変更として `ruff check scripts/` と `pytest scripts/tests/` を実行します。
 - CI は同一 ref の古い実行を自動キャンセルし、NuGet / pip キャッシュを使います。branch protection 用の `build` job は最後に各 lane の結果を集約する互換チェックです。

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "csharp-ls": {
+      "version": "0.24.0",
+      "commands": [
+        "csharp-ls"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/justfile
+++ b/justfile
@@ -544,16 +544,36 @@ ast-grep-smoke:
   bash scripts/agent_cycle.sh ast-grep-smoke
 
 # Run an ast-grep structural search.
-sg lang pattern path=".":
+ast-search lang pattern path=".":
   AST_GREP_PATTERN={{quote(pattern)}} AST_GREP_PATH={{quote(path)}} bash scripts/agent_cycle.sh sg {{quote(lang)}}
 
 # Search C# structure. Defaults to the decompiled game source.
-sg-cs pattern path="":
+ast-search-cs pattern path="":
   AST_GREP_PATTERN={{quote(pattern)}} AST_GREP_PATH={{quote(path)}} bash scripts/agent_cycle.sh sg csharp
 
 # Search Python structure.
-sg-py pattern path="scripts":
+ast-search-py pattern path="scripts":
   AST_GREP_PATTERN={{quote(pattern)}} AST_GREP_PATH={{quote(path)}} bash scripts/agent_cycle.sh sg python
+
+# Backward-compatible short alias for ast-search.
+sg lang pattern path=".":
+  just ast-search {{quote(lang)}} {{quote(pattern)}} {{quote(path)}}
+
+# Backward-compatible short alias for ast-search-cs.
+sg-cs pattern path="":
+  just ast-search-cs {{quote(pattern)}} {{quote(path)}}
+
+# Backward-compatible short alias for ast-search-py.
+sg-py pattern path="scripts":
+  just ast-search-py {{quote(pattern)}} {{quote(path)}}
+
+# Check that repo-local C# LSP can load the solution.
+lsp-check solution="Mods/QudJP/Assemblies/QudJP.sln":
+  bash scripts/agent_cycle.sh lsp-check {{quote(solution)}}
+
+# Backward-compatible alias for lsp-check.
+lsp-diagnostics solution="Mods/QudJP/Assemblies/QudJP.sln":
+  bash scripts/agent_cycle.sh lsp-diagnostics {{quote(solution)}}
 
 # Render skill-eval prompts from this repo's manifest.
 render-skill-evals skill="" scenario="":

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,156 @@
     "": {
       "name": "coq-japanese-stable",
       "devDependencies": {
+        "@ast-grep/cli": "^0.42.2",
         "@secretlint/secretlint-rule-pattern": "^12.3.1",
         "@secretlint/secretlint-rule-preset-recommend": "^12.2.0",
         "secretlint": "^12.2.0"
+      }
+    },
+    "node_modules/@ast-grep/cli": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli/-/cli-0.42.2.tgz",
+      "integrity": "sha512-TojScwpaM40UQyvV5n5oa8PfOPFfHSD8Xf0WppPXn1+lq73u/jwvDmP8M2Oxj5YgebIpgkDUPoMixThtqwpNBA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "ast-grep": "ast-grep",
+        "sg": "sg"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "optionalDependencies": {
+        "@ast-grep/cli-darwin-arm64": "0.42.2",
+        "@ast-grep/cli-darwin-x64": "0.42.2",
+        "@ast-grep/cli-linux-arm64-gnu": "0.42.2",
+        "@ast-grep/cli-linux-x64-gnu": "0.42.2",
+        "@ast-grep/cli-win32-arm64-msvc": "0.42.2",
+        "@ast-grep/cli-win32-ia32-msvc": "0.42.2",
+        "@ast-grep/cli-win32-x64-msvc": "0.42.2"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-arm64": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-arm64/-/cli-darwin-arm64-0.42.2.tgz",
+      "integrity": "sha512-li1RsB2fO5/qchdZHny+meg1I03xD+A5rug8axxOdqull8hdFUqxymZ5hg/tKh+/C04gyccEBgqcuJAsghuPXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-x64": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-x64/-/cli-darwin-x64-0.42.2.tgz",
+      "integrity": "sha512-oKR1bRYsmc0G287q9Xj29m3SrxohEXhArKt647MswDYbG751LHG3aaEf6TtYjcxq+jKB4XaVJ5+q1jlIgKbVWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-arm64-gnu": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-0.42.2.tgz",
+      "integrity": "sha512-dfgQcTR2SI47J1yz/MMQuA3cFu/pzsum07aLgv+QcouCJY+AJcgjZTNUd26vZ/352wTXfJ/wpfziwbbI/Z4EEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-x64-gnu": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-x64-gnu/-/cli-linux-x64-gnu-0.42.2.tgz",
+      "integrity": "sha512-ygkLM/RLEKw8btFgFIl/BrU2ji2sH79YnxIzjVIC5np9NMWWvqZ/jy2++s0YYI8Y9XLmfa1+Pi8F5zFK+3qDww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-arm64-msvc": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-0.42.2.tgz",
+      "integrity": "sha512-fThbaAvwUFfW1kAYw7xAzX/VvWMcyfeyyKyHfwQWHbkT5bjqdbnb5yFPLu0Q2Qo3bHUudYYP4WLakegkRyHSkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-ia32-msvc": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-0.42.2.tgz",
+      "integrity": "sha512-W7S+Hao/FMsXc8ZZny7YqA16J5C9O9b6UvT+0xpiWda6nNhOv0ebQHzjhtuSC/+SlV7S29uwjr+jT/T6+XmV0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-x64-msvc": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-x64-msvc/-/cli-win32-x64-msvc-0.42.2.tgz",
+      "integrity": "sha512-EPMQyUIvl4P3wqOAs9V+2LIUaLZNUQyHkLXqP+PKtGT+tS/c+IBv+/FiQ2psMHs2u4PM8tg2rnQBQ8sU0Nr+Gw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@azu/format-text": {
@@ -666,6 +813,16 @@
         }
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/editions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
@@ -741,9 +898,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "secretlint": "secretlint ."
   },
   "devDependencies": {
+    "@ast-grep/cli": "^0.42.2",
     "@secretlint/secretlint-rule-pattern": "^12.3.1",
     "@secretlint/secretlint-rule-preset-recommend": "^12.2.0",
     "secretlint": "^12.2.0"

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -28,12 +28,16 @@ just roslyn-check
 just semantic-probe --method Show --owner XRL.UI.Popup
 just semantic-probe-check
 just semantic-probe-real-smoke
+just ast-search-cs '<pattern>' [path]
+just ast-search-py '<pattern>' [path]
+just lsp-check
+.codex/hooks/lsp-check-after-tool.sh
 just static-producer-check
 just static-producer-preview
 just annals-pattern-preview
 just text-construction-inventory
-just ast-grep-smoke
 just ast-grep-check
+just ast-grep-smoke
 just render-skill-evals <repo-local-skill> <scenario>
 DOTFILES_ROOT=/path/to/dotfiles just render-skill-evals <dotfiles-skill> <scenario>
 DOTFILES_ROOT=/path/to/dotfiles just summarize-skill-evals /tmp/skill-eval-results.jsonl
@@ -56,6 +60,20 @@ just sync-mod
   Keep it exploratory: promote recurring or artifact-grade surfaces into a
   purpose-built inventory instead of treating the generic probe as a tracked
   source of truth.
+- Use `just ast-search-cs` / `just ast-search-py` for structural pattern
+  search. The older `sg-cs` / `sg-py` recipes remain aliases, but the
+  `ast-search-*` names are the preferred agent-facing entrypoints.
+- Use `just lsp-check` for repo-local C# language-server solution-load
+  diagnostics via the pinned `csharp-ls` dotnet tool. Use it when C# tooling
+  configuration changes or editor diagnostics look suspicious; do not treat it
+  as a replacement for `dotnet build`, analyzer tests, or runtime-route tests.
+- The Codex hook script `.codex/hooks/lsp-check-after-tool.sh` is intentionally
+  path- and tool-filtered behind a broad `.codex/hooks.json` `PostToolUse`
+  matcher. Keep it silent for irrelevant tool use, skip ordinary read-only C#
+  inspection unless `QUDJP_CODEX_LSP_HOOK_ON_READ=1`, skip shell-command reads
+  unless `QUDJP_CODEX_LSP_HOOK_ON_EXEC=1`, and preserve the debounce guard
+  unless there is concrete evidence that stale LSP feedback is causing missed
+  failures.
 - Roslyn tracked artifact recipes are intentionally named `*-tracked`;
   prefer preview recipes for review and validation unless the task explicitly
   owns the generated artifact.

--- a/scripts/agent_cycle.sh
+++ b/scripts/agent_cycle.sh
@@ -57,10 +57,14 @@ tool_check() {
   if ! ast_grep --version; then
     missing=1
   fi
-  if ! dotnet tool restore >/dev/null 2>&1; then
+  if ! command -v dotnet >/dev/null 2>&1; then
+    echo "missing tool: dotnet" >&2
+    missing=1
+  elif ! dotnet tool restore >/dev/null 2>&1; then
     echo "dotnet tool restore failed; csharp-ls diagnostics are unavailable." >&2
     missing=1
   elif ! dotnet tool run csharp-ls -- --version; then
+    echo "csharp-ls version check failed; csharp-ls diagnostics are unavailable." >&2
     missing=1
   fi
 

--- a/scripts/agent_cycle.sh
+++ b/scripts/agent_cycle.sh
@@ -12,7 +12,10 @@ Usage:
   scripts/agent_cycle.sh tool-check
   scripts/agent_cycle.sh ast-grep-check
   scripts/agent_cycle.sh ast-grep-smoke
+  scripts/agent_cycle.sh ast-search <lang> [pattern] [path]
   scripts/agent_cycle.sh sg <lang> [pattern] [path]
+  scripts/agent_cycle.sh lsp-check [solution]
+  scripts/agent_cycle.sh lsp-diagnostics [solution]
   scripts/agent_cycle.sh render-skill-evals [skill] [scenario]
   scripts/agent_cycle.sh summarize-skill-evals [results-jsonl]
   scripts/agent_cycle.sh retrospective-open
@@ -42,7 +45,7 @@ require_dotfiles_root() {
 
 tool_check() {
   local missing=0
-  for tool in just ast-grep "$PYTHON_BIN"; do
+  for tool in just "$PYTHON_BIN"; do
     if ! command -v "$tool" >/dev/null 2>&1; then
       echo "missing tool: $tool" >&2
       missing=1
@@ -50,6 +53,16 @@ tool_check() {
     fi
     "$tool" --version
   done
+
+  if ! ast_grep --version; then
+    missing=1
+  fi
+  if ! dotnet tool restore >/dev/null 2>&1; then
+    echo "dotnet tool restore failed; csharp-ls diagnostics are unavailable." >&2
+    missing=1
+  elif ! dotnet tool run csharp-ls -- --version; then
+    missing=1
+  fi
 
   require_file "$ROOT_DIR/scripts/render_skill_eval_prompts.py" || missing=1
   require_file "$ROOT_DIR/scripts/validate_skill_eval_results.py" || missing=1
@@ -67,6 +80,26 @@ tool_check() {
   return "$missing"
 }
 
+ast_grep() {
+  if [[ -x "$ROOT_DIR/node_modules/.bin/ast-grep" ]]; then
+    "$ROOT_DIR/node_modules/.bin/ast-grep" "$@"
+    return
+  fi
+
+  if command -v ast-grep >/dev/null 2>&1; then
+    command ast-grep "$@"
+    return
+  fi
+
+  if command -v npx >/dev/null 2>&1; then
+    npx --no-install ast-grep "$@"
+    return
+  fi
+
+  echo "missing tool: ast-grep (run npm ci, or install @ast-grep/cli)" >&2
+  return 127
+}
+
 ast_grep_check() {
   cd "$ROOT_DIR"
   require_file "$ROOT_DIR/sgconfig.yml"
@@ -80,8 +113,8 @@ ast_grep_check() {
     echo "ast-grep rules and rule tests must be added together (rules=$rule_count tests=$test_count)" >&2
     return 1
   else
-    ast-grep test --skip-snapshot-tests
-    ast-grep scan .
+    ast_grep test --skip-snapshot-tests
+    ast_grep scan .
   fi
   ast_grep_smoke
 }
@@ -140,7 +173,17 @@ structural_search() {
   fi
 
   path=$(expand_search_path "$path")
-  ast-grep run --lang "$lang" --pattern "$pattern" "$path"
+  ast_grep run --lang "$lang" --pattern "$pattern" "$path"
+}
+
+lsp_diagnostics() {
+  local solution=${1:-Mods/QudJP/Assemblies/QudJP.sln}
+  cd "$ROOT_DIR"
+  require_file "$ROOT_DIR/dotnet-tools.json"
+  require_file "$ROOT_DIR/$solution"
+
+  dotnet tool restore
+  dotnet tool run csharp-ls -- --solution "$solution" --diagnose --loglevel warning
 }
 
 render_skill_evals() {
@@ -215,8 +258,11 @@ main() {
     ast-grep-smoke)
       ast_grep_smoke
       ;;
-    sg)
+    sg|ast-search)
       structural_search "${1:-}" "${2:-}" "${3:-}"
+      ;;
+    lsp-check|lsp-diagnostics)
+      lsp_diagnostics "${1:-}"
       ;;
     render-skill-evals)
       render_skill_evals "${1:-}" "${2:-}"

--- a/scripts/tests/test_agent_cycle.py
+++ b/scripts/tests/test_agent_cycle.py
@@ -22,16 +22,18 @@ def _tool_available(name: str) -> bool:
 def _run_agent_cycle(
     *args: str,
     python_bin: str | None = None,
+    override_path: str | None = None,
     without_dotfiles_root: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     env = {**os.environ}
-    env["PATH"] = f"{NODE_BIN}{os.pathsep}{env['PATH']}"
+    path = override_path if override_path is not None else env["PATH"]
+    env["PATH"] = f"{NODE_BIN}{os.pathsep}{path}"
     if python_bin is not None:
         env["PYTHON_BIN"] = python_bin
     if without_dotfiles_root:
         env.pop("DOTFILES_ROOT", None)
     return subprocess.run(  # noqa: S603 -- tests invoke the repo-local shell script via bash
-        ["bash", str(AGENT_CYCLE), *args],  # noqa: S607
+        ["/bin/bash", str(AGENT_CYCLE), *args],
         capture_output=True,
         text=True,
         cwd=REPO_ROOT,
@@ -94,3 +96,28 @@ def test_tool_check_allows_repo_local_render_without_dotfiles_root() -> None:
 
     assert completed.returncode == 0, completed.stderr
     assert "DOTFILES_ROOT not set" in completed.stdout
+
+
+def _write_executable_stub(bin_dir: Path, name: str) -> None:
+    stub = bin_dir / name
+    stub.write_text("#!/bin/sh\nprintf '%s version\\n' \"$0\"\n", encoding="utf-8")
+    stub.chmod(0o755)
+
+
+def test_tool_check_reports_missing_dotnet_before_restore(tmp_path: Path) -> None:
+    """tool-check should distinguish a missing dotnet executable from restore failure."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for tool in ("just", "python3.12", "ast-grep"):
+        _write_executable_stub(bin_dir, tool)
+
+    completed = _run_agent_cycle(
+        "tool-check",
+        python_bin="python3.12",
+        override_path=str(bin_dir),
+        without_dotfiles_root=True,
+    )
+
+    assert completed.returncode == 1
+    assert "missing tool: dotnet" in completed.stderr
+    assert "dotnet tool restore failed" not in completed.stderr

--- a/scripts/tests/test_agent_cycle.py
+++ b/scripts/tests/test_agent_cycle.py
@@ -12,6 +12,11 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 AGENT_CYCLE = REPO_ROOT / "scripts" / "agent_cycle.sh"
+NODE_BIN = REPO_ROOT / "node_modules" / ".bin"
+
+
+def _tool_available(name: str) -> bool:
+    return shutil.which(name) is not None or (NODE_BIN / name).exists()
 
 
 def _run_agent_cycle(
@@ -19,13 +24,12 @@ def _run_agent_cycle(
     python_bin: str | None = None,
     without_dotfiles_root: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    env = None
-    if python_bin is not None or without_dotfiles_root:
-        env = {**os.environ}
-        if python_bin is not None:
-            env["PYTHON_BIN"] = python_bin
-        if without_dotfiles_root:
-            env.pop("DOTFILES_ROOT", None)
+    env = {**os.environ}
+    env["PATH"] = f"{NODE_BIN}{os.pathsep}{env['PATH']}"
+    if python_bin is not None:
+        env["PYTHON_BIN"] = python_bin
+    if without_dotfiles_root:
+        env.pop("DOTFILES_ROOT", None)
     return subprocess.run(  # noqa: S603 -- tests invoke the repo-local shell script via bash
         ["bash", str(AGENT_CYCLE), *args],  # noqa: S607
         capture_output=True,
@@ -36,7 +40,7 @@ def _run_agent_cycle(
     )
 
 
-@pytest.mark.skipif(not shutil.which("ast-grep"), reason="ast-grep CLI not available")
+@pytest.mark.skipif(not _tool_available("ast-grep"), reason="ast-grep CLI not available")
 def test_ast_grep_smoke_finds_static_producer_fixture() -> None:
     """The agent-cycle ast-grep smoke must prove structural search actually works."""
     completed = _run_agent_cycle("ast-grep-smoke")
@@ -46,7 +50,7 @@ def test_ast_grep_smoke_finds_static_producer_fixture() -> None:
     assert 'Popup.Show("Popup body", Title: "Ignored title")' in completed.stdout
 
 
-@pytest.mark.skipif(not shutil.which("ast-grep"), reason="ast-grep CLI not available")
+@pytest.mark.skipif(not _tool_available("ast-grep"), reason="ast-grep CLI not available")
 def test_ast_grep_check_reports_empty_rule_set_and_runs_smoke() -> None:
     """An empty rule directory should be explicit, not a silent 0-test pass."""
     rule_files = [
@@ -80,7 +84,10 @@ def test_render_skill_evals_supports_repo_local_skills_without_dotfiles_root() -
     assert "Scenario: `median-popup-show-owner-route`" in completed.stdout
 
 
-@pytest.mark.skipif(not shutil.which("ast-grep") or not shutil.which("just"), reason="agent tools not available")
+@pytest.mark.skipif(
+    not _tool_available("ast-grep") or not shutil.which("just") or not shutil.which("dotnet"),
+    reason="agent tools not available",
+)
 def test_tool_check_allows_repo_local_render_without_dotfiles_root() -> None:
     """tool-check should not mark repo-local skill eval rendering unhealthy."""
     completed = _run_agent_cycle("tool-check", python_bin=sys.executable, without_dotfiles_root=True)

--- a/scripts/tests/test_ci_workflow_contract.py
+++ b/scripts/tests/test_ci_workflow_contract.py
@@ -62,8 +62,12 @@ def test_ci_python_lane_restores_repo_local_node_tools() -> None:
     """Python/agent-tool tests should use package-lock pinned Node tools."""
     workflow = _workflow_text()
     python_job = _job_block(workflow, "python", "localization")
+    node_bin_path_step = 'echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"'
 
     assert "npm ci" in python_job
+    assert node_bin_path_step in python_job
+    assert python_job.index("npm ci") < python_job.index(node_bin_path_step)
+    assert python_job.index(node_bin_path_step) < python_job.index("pytest scripts/tests/")
     assert "npm install -g @ast-grep/cli" not in python_job
 
 

--- a/scripts/tests/test_ci_workflow_contract.py
+++ b/scripts/tests/test_ci_workflow_contract.py
@@ -58,6 +58,37 @@ def test_ci_runs_python_and_dotnet_lanes_as_independent_jobs() -> None:
     assert "qudjp-dotnet-test" not in python_job
 
 
+def test_ci_python_lane_restores_repo_local_node_tools() -> None:
+    """Python/agent-tool tests should use package-lock pinned Node tools."""
+    workflow = _workflow_text()
+    python_job = _job_block(workflow, "python", "localization")
+
+    assert "npm ci" in python_job
+    assert "npm install -g @ast-grep/cli" not in python_job
+
+
+def test_ci_package_lock_changes_trigger_python_tool_checks() -> None:
+    """Node tool dependency changes must exercise the Python/agent tooling lane."""
+    workflow = _workflow_text()
+
+    assert "package(-lock)?\\.json" in workflow
+
+
+def test_ci_dotnet_tool_manifest_changes_trigger_python_tool_checks() -> None:
+    """The pinned csharp-ls manifest must exercise agent tooling checks."""
+    workflow = _workflow_text()
+
+    assert "dotnet-tools\\.json" in workflow
+
+
+def test_ci_codex_hook_changes_trigger_python_tool_checks() -> None:
+    """Repo-local Codex hooks are shell/tooling and must exercise Python tests."""
+    workflow = _workflow_text()
+
+    assert "\\.codex/hooks/" in workflow
+    assert "\\.codex/hooks\\.json" in workflow
+
+
 def test_ci_installs_just_without_apt_update() -> None:
     """The justfile-only lane should avoid apt package-index overhead."""
     workflow = _workflow_text()

--- a/scripts/tests/test_ci_workflow_contract.py
+++ b/scripts/tests/test_ci_workflow_contract.py
@@ -66,6 +66,7 @@ def test_ci_python_lane_restores_repo_local_node_tools() -> None:
 
     assert "npm ci" in python_job
     assert node_bin_path_step in python_job
+    assert "pytest scripts/tests/" in python_job
     assert python_job.index("npm ci") < python_job.index(node_bin_path_step)
     assert python_job.index(node_bin_path_step) < python_job.index("pytest scripts/tests/")
     assert "npm install -g @ast-grep/cli" not in python_job

--- a/scripts/tests/test_codex_lsp_hook.py
+++ b/scripts/tests/test_codex_lsp_hook.py
@@ -1,0 +1,126 @@
+"""Tests for the repo-local Codex LSP hook."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / ".codex" / "hooks" / "lsp-check-after-tool.sh"
+HOOKS_JSON = REPO_ROOT / ".codex" / "hooks.json"
+
+
+def _run_hook(payload: dict[str, object], **env_overrides: str) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "QUDJP_CODEX_LSP_HOOK_DRY_RUN": "1",
+        "QUDJP_CODEX_LSP_HOOK_MIN_INTERVAL_SECONDS": "0",
+        **env_overrides,
+    }
+    return subprocess.run(  # noqa: S603 -- test invokes the repo-local hook via bash
+        ["bash", str(HOOK)],  # noqa: S607
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=env,
+        check=False,
+    )
+
+
+def test_codex_hooks_register_lsp_post_tool_use_hook() -> None:
+    """The project hook should be wired through Codex's PostToolUse hook format."""
+    config = json.loads(HOOKS_JSON.read_text())
+    post_tool_use = config["hooks"]["PostToolUse"][0]
+
+    assert post_tool_use["matcher"] == ".*"
+    assert post_tool_use["hooks"][0]["type"] == "command"
+    assert post_tool_use["hooks"][0]["command"] == "bash .codex/hooks/lsp-check-after-tool.sh"
+    assert post_tool_use["hooks"][0]["timeout"] >= 120
+
+
+def test_hook_runs_lsp_for_relevant_csharp_write() -> None:
+    """C# edits should trigger the LSP route, subject to the hook's debounce guard."""
+    completed = _run_hook(
+        {
+            "tool_name": "apply_patch",
+            "tool_input": {
+                "patch": "*** Update File: Mods/QudJP/Assemblies/src/Patches/Foo.cs\n"
+            },
+        }
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "would run just lsp-check" in completed.stderr
+
+
+def test_hook_skips_plain_csharp_reads_by_default() -> None:
+    """Read-only C# inspection should not pay the LSP cost unless explicitly requested."""
+    completed = _run_hook(
+        {
+            "tool_name": "Read",
+            "tool_input": {"file_path": "Mods/QudJP/Assemblies/src/Patches/Foo.cs"},
+        }
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == ""
+    assert completed.stderr == ""
+
+
+def test_hook_can_opt_into_plain_csharp_reads() -> None:
+    """Read-only C# inspection can opt into the LSP route when needed."""
+    completed = _run_hook(
+        {
+            "tool_name": "Read",
+            "tool_input": {"file_path": "Mods/QudJP/Assemblies/src/Patches/Foo.cs"},
+        },
+        QUDJP_CODEX_LSP_HOOK_ON_READ="1",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "would run just lsp-check" in completed.stderr
+
+
+def test_hook_skips_non_csharp_changes() -> None:
+    """Non-C# tool use should stay silent."""
+    completed = _run_hook(
+        {
+            "tool_name": "apply_patch",
+            "tool_input": {"patch": "*** Update File: docs/contributing.md\n"},
+        }
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == ""
+    assert completed.stderr == ""
+
+
+def test_hook_skips_exec_command_csharp_reads_by_default() -> None:
+    """Shell-based C# reads should not trigger the LSP route unless explicitly opted in."""
+    completed = _run_hook(
+        {
+            "tool_name": "exec_command",
+            "tool_input": {"cmd": "sed -n '1,80p' Mods/QudJP/Assemblies/src/Patches/Foo.cs"},
+        }
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == ""
+    assert completed.stderr == ""
+
+
+def test_hook_can_opt_into_codex_bash_tool_csharp_commands() -> None:
+    """Codex shell hook payloads may use Bash as the shell tool name."""
+    completed = _run_hook(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "sed -n '1,80p' Mods/QudJP/Assemblies/src/Patches/Foo.cs"},
+        },
+        QUDJP_CODEX_LSP_HOOK_ON_EXEC="1",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "would run just lsp-check" in completed.stderr

--- a/scripts/tests/test_release_justfile_contract.py
+++ b/scripts/tests/test_release_justfile_contract.py
@@ -63,3 +63,15 @@ def test_workshop_upload_preflight_recipe_uses_dedicated_verifier() -> None:
     assert "--content-folder" in recipe
     assert "--vdf" in recipe
     assert "--expected-version" in recipe
+
+
+def test_agent_tool_recipes_have_readable_primary_names() -> None:
+    """Agent-facing tool recipes should expose descriptive names, not only abbreviations."""
+    justfile = _justfile_text()
+
+    assert '\nast-search-cs pattern path="":' in justfile
+    assert '\nast-search-py pattern path="scripts":' in justfile
+    assert '\nlsp-check solution="Mods/QudJP/Assemblies/QudJP.sln":' in justfile
+    assert 'sg-cs pattern path="":' in justfile
+    assert "just ast-search-cs" in justfile
+    assert 'lsp-diagnostics solution="Mods/QudJP/Assemblies/QudJP.sln":' in justfile

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -37,10 +37,15 @@ def test_release_workflow_requires_main_ancestor_and_identity_validation() -> No
 def test_release_workflow_installs_python_test_tooling() -> None:
     """Release full-suite Python tests must have their external CLI dependencies."""
     workflow = _workflow_text()
+    node_bin_path_step = 'echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"'
 
     assert "pip install hypothesis pytest ruff" in workflow
     assert "npm ci" in workflow
+    assert node_bin_path_step in workflow
     assert "npm install -g @ast-grep/cli" not in workflow
+    assert "pytest scripts/tests/" in workflow
+    assert workflow.index("npm ci") < workflow.index(node_bin_path_step)
+    assert workflow.index(node_bin_path_step) < workflow.index("pytest scripts/tests/")
     assert workflow.index("npm ci") < workflow.index("pytest scripts/tests/")
 
 

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -39,8 +39,9 @@ def test_release_workflow_installs_python_test_tooling() -> None:
     workflow = _workflow_text()
 
     assert "pip install hypothesis pytest ruff" in workflow
-    assert "npm install -g @ast-grep/cli" in workflow
-    assert workflow.index("npm install -g @ast-grep/cli") < workflow.index("pytest scripts/tests/")
+    assert "npm ci" in workflow
+    assert "npm install -g @ast-grep/cli" not in workflow
+    assert workflow.index("npm ci") < workflow.index("pytest scripts/tests/")
 
 
 def test_release_workflow_creates_draft_github_release_without_steam_upload() -> None:


### PR DESCRIPTION
## Summary

- Refactor semantic popup/message pipeline dispatch into crash-safe translator arrays and add QJ005 analyzer coverage to prevent direct unsafe pipeline calls.
- Add repo-local agent tooling routes: readable `ast-search-*` recipes, pinned `csharp-ls`, `just lsp-check`, and package-lock backed ast-grep setup.
- Add repo-local Codex `PostToolUse` LSP hook with path/tool filtering, read/shell opt-ins, debounce, and contract tests.
- Update CI/release workflows and docs so package, dotnet tool, and `.codex/hooks` changes exercise the tooling lane.

## Verification

- `npm ci`
- `just lsp-check`
- `bash -n .codex/hooks/lsp-check-after-tool.sh scripts/agent_cycle.sh`
- `uv run ruff check scripts/`
- `uv run pytest scripts/tests/test_codex_lsp_hook.py scripts/tests/test_agent_cycle.py scripts/tests/test_ci_workflow_contract.py scripts/tests/test_release_justfile_contract.py scripts/tests/test_release_workflow_contract.py`
- `just pr-check` after final hook fix:
  - C# build passed
  - QudJP tests: 4161 passed
  - Roslyn tools build passed
  - `ruff check scripts/` passed
  - `pytest scripts/tests/`: 1073 passed, 1 skipped
  - localization checks passed
  - markdown report checks passed

## Review / polish

- Empirical prompt tuning was run with fresh subagents for tool-route clarity; surfaced hook/CI ambiguities were fixed and a held-out scenario passed all critical checks.
- Independent review loop converged to `APPROVE` with no findings after hook fixes.
- Simplify pass made only behavior-preserving cleanup in popup dispatch and `agent_cycle.sh`; post-simplify verification passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ツール使用後に条件付きでC# LSP読み込みを検証するリポジトリフックと実行スクリプトを追加。
  * 新しい静的解析ルール QJ005 を導入。

* **Refactor / Chores**
  * メッセージ翻訳パイプラインを例外耐性とフォールバックで再構築。
  * 構造検索／LSP検証タスクとローカル Node/.NET ツールのセットアップを整理。

* **Documentation**
  * 開発手順・ワークフロー文書を更新しフック／タスクの運用を明確化。

* **Tests**
  * LSPフック挙動、CI/ワークフロー契約、解析器関連など多数のテストを追加。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/647)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->