### PR TITLE
[codex] Add owner popup closure helpers

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/BeguilingSifrahTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/BeguilingSifrahTranslationPatchTests.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using HarmonyLib;
 using QudJP.Patches;
 using QudJP.Tests.DummyTargets;
 
@@ -56,134 +55,90 @@ public sealed class BeguilingSifrahTranslationPatchTests
         string expected,
         string detail)
     {
-        var harmonyId = CreateHarmonyId();
-        var harmony = new Harmony(harmonyId);
-
-        try
-        {
-            PatchPopupShow(harmony);
-            PatchOwner(harmony, RequireOwnerMethod(methodName));
-
-            var target = new DummyBeguilingSifrahProducerTarget
+        OwnerPopupRouteTestHarness.WithPatchedPopupOwner(
+            typeof(BeguilingSifrahTranslationPatch),
+            RequireOwnerMethod(methodName),
+            () =>
             {
-                PopupMessageToShow = source,
-            };
+                var target = new DummyBeguilingSifrahProducerTarget
+                {
+                    PopupMessageToShow = source,
+                };
 
-            InvokeOwnerMethod(target, methodName);
+                InvokeOwnerMethod(target, methodName);
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
-                Assert.That(BeguilingHitCount(detail), Is.EqualTo(1));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+                    Assert.That(BeguilingHitCount(detail), Is.EqualTo(1));
+                });
             });
-        }
-        finally
-        {
-            harmony.UnpatchAll(harmonyId);
-        }
     }
 
     [Test]
     public void Patch_DoesNotTranslateBeguilingPopup_WhenOwnerAbsent()
     {
-        var harmonyId = CreateHarmonyId();
-        var harmony = new Harmony(harmonyId);
-
-        try
-        {
-            PatchPopupShow(harmony);
-
-            const string source = "Your coquetry does not impress {{Y|砂漠の隠者}}.";
-            DummyPopupShow.Show(source);
-
-            Assert.Multiple(() =>
+        OwnerPopupRouteTestHarness.WithPatchedPopupOnly(
+            () =>
             {
-                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(source));
-                Assert.That(BeguilingHitCount("Failure"), Is.Zero);
+                const string source = "Your coquetry does not impress {{Y|砂漠の隠者}}.";
+                DummyPopupShow.Show(source);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(source));
+                    Assert.That(BeguilingHitCount("Failure"), Is.Zero);
+                });
             });
-        }
-        finally
-        {
-            harmony.UnpatchAll(harmonyId);
-        }
     }
 
     [Test]
     public void Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
     {
-        var harmonyId = CreateHarmonyId();
-        var harmony = new Harmony(harmonyId);
-
-        try
-        {
-            PatchPopupShow(harmony);
-            PatchOwner(harmony, RequireOwnerMethod(nameof(DummyBeguilingSifrahProducerTarget.ResultFailure)));
-
-            var source = MessageFrameTranslator.MarkDirectTranslation("Your coquetry does not impress {{Y|砂漠の隠者}}.");
-            var target = new DummyBeguilingSifrahProducerTarget
+        OwnerPopupRouteTestHarness.WithPatchedPopupOwner(
+            typeof(BeguilingSifrahTranslationPatch),
+            RequireOwnerMethod(nameof(DummyBeguilingSifrahProducerTarget.ResultFailure)),
+            () =>
             {
-                PopupMessageToShow = source,
-            };
+                var source = MessageFrameTranslator.MarkDirectTranslation("Your coquetry does not impress {{Y|砂漠の隠者}}.");
+                var target = new DummyBeguilingSifrahProducerTarget
+                {
+                    PopupMessageToShow = source,
+                };
 
-            target.ResultFailure(new DummyGameObject());
+                target.ResultFailure(new DummyGameObject());
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("Your coquetry does not impress {{Y|砂漠の隠者}}."));
-                Assert.That(BeguilingHitCount("Failure"), Is.Zero);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("Your coquetry does not impress {{Y|砂漠の隠者}}."));
+                    Assert.That(BeguilingHitCount("Failure"), Is.Zero);
+                });
             });
-        }
-        finally
-        {
-            harmony.UnpatchAll(harmonyId);
-        }
     }
 
     [Test]
     public void Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
     {
-        var harmonyId = CreateHarmonyId();
-        var harmony = new Harmony(harmonyId);
-
-        try
-        {
-            PatchPopupShow(harmony);
-            PatchOwner(harmony, RequireOwnerMethod(nameof(DummyBeguilingSifrahProducerTarget.ResultFailure)));
-
-            var target = new DummyBeguilingSifrahProducerTarget();
-
-            target.ResultFailure(new DummyGameObject());
-
-            Assert.Multiple(() =>
+        OwnerPopupRouteTestHarness.WithPatchedPopupOwner(
+            typeof(BeguilingSifrahTranslationPatch),
+            RequireOwnerMethod(nameof(DummyBeguilingSifrahProducerTarget.ResultFailure)),
+            () =>
             {
-                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
-                Assert.That(BeguilingHitCount("Failure"), Is.Zero);
+                var target = new DummyBeguilingSifrahProducerTarget();
+
+                target.ResultFailure(new DummyGameObject());
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
+                    Assert.That(BeguilingHitCount("Failure"), Is.Zero);
+                });
             });
-        }
-        finally
-        {
-            harmony.UnpatchAll(harmonyId);
-        }
-    }
-
-    private static void PatchPopupShow(Harmony harmony)
-    {
-        harmony.Patch(
-            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.Show)),
-            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
-    }
-
-    private static void PatchOwner(Harmony harmony, MethodInfo original)
-    {
-        harmony.Patch(
-            original: original,
-            prefix: new HarmonyMethod(RequireMethod(typeof(BeguilingSifrahTranslationPatch), nameof(BeguilingSifrahTranslationPatch.Prefix))),
-            finalizer: new HarmonyMethod(RequireMethod(typeof(BeguilingSifrahTranslationPatch), nameof(BeguilingSifrahTranslationPatch.Finalizer), typeof(Exception))));
     }
 
     private static MethodInfo RequireOwnerMethod(string methodName)
     {
-        return RequireMethod(typeof(DummyBeguilingSifrahProducerTarget), methodName, typeof(DummyGameObject));
+        return OwnerPopupRouteTestHarness.RequireMethod(typeof(DummyBeguilingSifrahProducerTarget), methodName, typeof(DummyGameObject));
     }
 
     private static void InvokeOwnerMethod(DummyBeguilingSifrahProducerTarget target, string methodName)
@@ -193,25 +148,6 @@ public sealed class BeguilingSifrahTranslationPatchTests
 
     private static int BeguilingHitCount(string detail)
     {
-        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
-            nameof(PopupShowTranslationPatch),
-            "Popup.ProducerText." + nameof(BeguilingSifrahTranslationPatch) + "." + detail);
-    }
-
-    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameterTypes)
-    {
-        if (parameterTypes.Length == 0)
-        {
-            return type.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
-                   ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
-        }
-
-        return AccessTools.Method(type, methodName, parameterTypes)
-               ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
-    }
-
-    private static string CreateHarmonyId()
-    {
-        return $"qudjp.tests.{Guid.NewGuid():N}";
+        return OwnerPopupRouteTestHarness.RouteHitCount(typeof(BeguilingSifrahTranslationPatch), detail);
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/OwnerPopupRouteTestHarness.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/OwnerPopupRouteTestHarness.cs
@@ -1,0 +1,81 @@
+using System.Reflection;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+internal static class OwnerPopupRouteTestHarness
+{
+    public static void WithPatchedPopupOwner(Type patchType, MethodInfo ownerMethod, Action action)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchPopupShow(harmony);
+            PatchOwner(harmony, patchType, ownerMethod);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    public static void WithPatchedPopupOnly(Action action)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchPopupShow(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    public static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameterTypes)
+    {
+        if (parameterTypes.Length == 0)
+        {
+            return type.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
+                   ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+        }
+
+        return AccessTools.Method(type, methodName, parameterTypes)
+               ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    public static int RouteHitCount(Type patchType, string detail)
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.ProducerText." + patchType.Name + "." + detail);
+    }
+
+    private static void PatchPopupShow(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.Show)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void PatchOwner(Harmony harmony, Type patchType, MethodInfo original)
+    {
+        harmony.Patch(
+            original: original,
+            prefix: new HarmonyMethod(RequireMethod(patchType, "Prefix")),
+            finalizer: new HarmonyMethod(RequireMethod(patchType, "Finalizer", typeof(Exception))));
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ProselytizationSifrahTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ProselytizationSifrahTranslationPatchTests.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using HarmonyLib;
 using QudJP.Patches;
 using QudJP.Tests.DummyTargets;
 
@@ -56,134 +55,90 @@ public sealed class ProselytizationSifrahTranslationPatchTests
         string expected,
         string detail)
     {
-        var harmonyId = CreateHarmonyId();
-        var harmony = new Harmony(harmonyId);
-
-        try
-        {
-            PatchPopupShow(harmony);
-            PatchOwner(harmony, RequireOwnerMethod(methodName));
-
-            var target = new DummyProselytizationSifrahProducerTarget
+        OwnerPopupRouteTestHarness.WithPatchedPopupOwner(
+            typeof(ProselytizationSifrahTranslationPatch),
+            RequireOwnerMethod(methodName),
+            () =>
             {
-                PopupMessageToShow = source,
-            };
+                var target = new DummyProselytizationSifrahProducerTarget
+                {
+                    PopupMessageToShow = source,
+                };
 
-            InvokeOwnerMethod(target, methodName);
+                InvokeOwnerMethod(target, methodName);
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
-                Assert.That(ProselytizationHitCount(detail), Is.EqualTo(1));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+                    Assert.That(ProselytizationHitCount(detail), Is.EqualTo(1));
+                });
             });
-        }
-        finally
-        {
-            harmony.UnpatchAll(harmonyId);
-        }
     }
 
     [Test]
     public void Patch_DoesNotTranslateProselytizationPopup_WhenOwnerAbsent()
     {
-        var harmonyId = CreateHarmonyId();
-        var harmony = new Harmony(harmonyId);
-
-        try
-        {
-            PatchPopupShow(harmony);
-
-            const string source = "{{Y|砂漠の隠者}} is unconvinced by your pleas.";
-            DummyPopupShow.Show(source);
-
-            Assert.Multiple(() =>
+        OwnerPopupRouteTestHarness.WithPatchedPopupOnly(
+            () =>
             {
-                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(source));
-                Assert.That(ProselytizationHitCount("Failure"), Is.Zero);
+                const string source = "{{Y|砂漠の隠者}} is unconvinced by your pleas.";
+                DummyPopupShow.Show(source);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(source));
+                    Assert.That(ProselytizationHitCount("Failure"), Is.Zero);
+                });
             });
-        }
-        finally
-        {
-            harmony.UnpatchAll(harmonyId);
-        }
     }
 
     [Test]
     public void Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
     {
-        var harmonyId = CreateHarmonyId();
-        var harmony = new Harmony(harmonyId);
-
-        try
-        {
-            PatchPopupShow(harmony);
-            PatchOwner(harmony, RequireOwnerMethod(nameof(DummyProselytizationSifrahProducerTarget.ResultFailure)));
-
-            var source = MessageFrameTranslator.MarkDirectTranslation("{{Y|砂漠の隠者}} is unconvinced by your pleas.");
-            var target = new DummyProselytizationSifrahProducerTarget
+        OwnerPopupRouteTestHarness.WithPatchedPopupOwner(
+            typeof(ProselytizationSifrahTranslationPatch),
+            RequireOwnerMethod(nameof(DummyProselytizationSifrahProducerTarget.ResultFailure)),
+            () =>
             {
-                PopupMessageToShow = source,
-            };
+                var source = MessageFrameTranslator.MarkDirectTranslation("{{Y|砂漠の隠者}} is unconvinced by your pleas.");
+                var target = new DummyProselytizationSifrahProducerTarget
+                {
+                    PopupMessageToShow = source,
+                };
 
-            target.ResultFailure(new DummyGameObject());
+                target.ResultFailure(new DummyGameObject());
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("{{Y|砂漠の隠者}} is unconvinced by your pleas."));
-                Assert.That(ProselytizationHitCount("Failure"), Is.Zero);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("{{Y|砂漠の隠者}} is unconvinced by your pleas."));
+                    Assert.That(ProselytizationHitCount("Failure"), Is.Zero);
+                });
             });
-        }
-        finally
-        {
-            harmony.UnpatchAll(harmonyId);
-        }
     }
 
     [Test]
     public void Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
     {
-        var harmonyId = CreateHarmonyId();
-        var harmony = new Harmony(harmonyId);
-
-        try
-        {
-            PatchPopupShow(harmony);
-            PatchOwner(harmony, RequireOwnerMethod(nameof(DummyProselytizationSifrahProducerTarget.ResultFailure)));
-
-            var target = new DummyProselytizationSifrahProducerTarget();
-
-            target.ResultFailure(new DummyGameObject());
-
-            Assert.Multiple(() =>
+        OwnerPopupRouteTestHarness.WithPatchedPopupOwner(
+            typeof(ProselytizationSifrahTranslationPatch),
+            RequireOwnerMethod(nameof(DummyProselytizationSifrahProducerTarget.ResultFailure)),
+            () =>
             {
-                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
-                Assert.That(ProselytizationHitCount("Failure"), Is.Zero);
+                var target = new DummyProselytizationSifrahProducerTarget();
+
+                target.ResultFailure(new DummyGameObject());
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
+                    Assert.That(ProselytizationHitCount("Failure"), Is.Zero);
+                });
             });
-        }
-        finally
-        {
-            harmony.UnpatchAll(harmonyId);
-        }
-    }
-
-    private static void PatchPopupShow(Harmony harmony)
-    {
-        harmony.Patch(
-            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.Show)),
-            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
-    }
-
-    private static void PatchOwner(Harmony harmony, MethodInfo original)
-    {
-        harmony.Patch(
-            original: original,
-            prefix: new HarmonyMethod(RequireMethod(typeof(ProselytizationSifrahTranslationPatch), nameof(ProselytizationSifrahTranslationPatch.Prefix))),
-            finalizer: new HarmonyMethod(RequireMethod(typeof(ProselytizationSifrahTranslationPatch), nameof(ProselytizationSifrahTranslationPatch.Finalizer), typeof(Exception))));
     }
 
     private static MethodInfo RequireOwnerMethod(string methodName)
     {
-        return RequireMethod(typeof(DummyProselytizationSifrahProducerTarget), methodName, typeof(DummyGameObject));
+        return OwnerPopupRouteTestHarness.RequireMethod(typeof(DummyProselytizationSifrahProducerTarget), methodName, typeof(DummyGameObject));
     }
 
     private static void InvokeOwnerMethod(DummyProselytizationSifrahProducerTarget target, string methodName)
@@ -193,25 +148,6 @@ public sealed class ProselytizationSifrahTranslationPatchTests
 
     private static int ProselytizationHitCount(string detail)
     {
-        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
-            nameof(PopupShowTranslationPatch),
-            "Popup.ProducerText." + nameof(ProselytizationSifrahTranslationPatch) + "." + detail);
-    }
-
-    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameterTypes)
-    {
-        if (parameterTypes.Length == 0)
-        {
-            return type.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
-                   ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
-        }
-
-        return AccessTools.Method(type, methodName, parameterTypes)
-               ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
-    }
-
-    private static string CreateHarmonyId()
-    {
-        return $"qudjp.tests.{Guid.NewGuid():N}";
+        return OwnerPopupRouteTestHarness.RouteHitCount(typeof(ProselytizationSifrahTranslationPatch), detail);
     }
 }

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -67,6 +67,82 @@ class CoveredOwnerFamily:
     evidence_files: tuple[EvidenceFile, ...]
 
 
+@dataclass(frozen=True)
+class OwnerPopupRouteEvidenceSpec:
+    """Shared evidence anchors for owner-popup route closure."""
+
+    patch_file: str
+    patch_type: str
+    test_file: str
+    positive_test: str
+    negative_test: str
+    direct_marker_test: str
+    empty_test: str
+
+
+@dataclass(frozen=True)
+class SifrahResultPopupFamilySpec:
+    """Shared metadata for Sifrah result popup closure families."""
+
+    source_file: str
+    type_name: str
+    evidence: OwnerPopupRouteEvidenceSpec
+    target_type_name: str
+    method_details: tuple[tuple[str, str], ...]
+
+
+def _owner_popup_route_evidence(
+    *,
+    spec: OwnerPopupRouteEvidenceSpec,
+    target_method_token: str,
+    full_signature: str,
+    patch_required_substrings: tuple[str, ...],
+) -> tuple[EvidenceFile, ...]:
+    return (
+        EvidenceFile(
+            spec.patch_file,
+            ("TryTranslatePopupMessage", *patch_required_substrings),
+        ),
+        EvidenceFile(
+            "Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs",
+            (f"{spec.patch_type}.TryTranslatePopupMessage",),
+        ),
+        EvidenceFile(
+            spec.test_file,
+            (
+                spec.positive_test,
+                spec.negative_test,
+                spec.direct_marker_test,
+                spec.empty_test,
+                target_method_token,
+            ),
+        ),
+        EvidenceFile(
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+            (
+                "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
+                full_signature,
+            ),
+        ),
+    )
+
+
+def _sifrah_result_popup_families(spec: SifrahResultPopupFamilySpec) -> tuple[CoveredOwnerFamily, ...]:
+    return tuple(
+        CoveredOwnerFamily(
+            family_id=f"{spec.source_file}::{spec.type_name}.{method_name}",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=_owner_popup_route_evidence(
+                spec=spec.evidence,
+                target_method_token=f"nameof({spec.target_type_name}.{method_name})",
+                full_signature=f"{spec.type_name}|{method_name}|System.Void|XRL.World.GameObject",
+                patch_required_substrings=(method_name, detail),
+            ),
+        )
+        for method_name, detail in spec.method_details
+    )
+
+
 def _hacking_sifrah_result_families() -> tuple[CoveredOwnerFamily, ...]:
     target_sets = (
         (
@@ -4035,313 +4111,49 @@ COVERED_OWNER_FAMILIES: Final = (
             ),
         ),
     ),
-    CoveredOwnerFamily(
-        family_id="XRL.World/BeguilingSifrah.cs::XRL.World.BeguilingSifrah.ResultCriticalFailure",
-        inventory_statuses=("owner_patch_required",),
-        evidence_files=(
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/BeguilingSifrahTranslationPatch.cs",
-                ("TryTranslatePopupMessage", "ResultCriticalFailure", "CriticalFailure"),
+    *_sifrah_result_popup_families(
+        SifrahResultPopupFamilySpec(
+            source_file="XRL.World/BeguilingSifrah.cs",
+            type_name="XRL.World.BeguilingSifrah",
+            evidence=OwnerPopupRouteEvidenceSpec(
+                patch_file="Mods/QudJP/Assemblies/src/Patches/BeguilingSifrahTranslationPatch.cs",
+                patch_type="BeguilingSifrahTranslationPatch",
+                test_file="Mods/QudJP/Assemblies/QudJP.Tests/L2/BeguilingSifrahTranslationPatchTests.cs",
+                positive_test="Patch_TranslatesBeguilingResultPopups_WhenOwnerPatched",
+                negative_test="Patch_DoesNotTranslateBeguilingPopup_WhenOwnerAbsent",
+                direct_marker_test="Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+                empty_test="Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
             ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs",
-                ("BeguilingSifrahTranslationPatch.TryTranslatePopupMessage",),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2/BeguilingSifrahTranslationPatchTests.cs",
-                (
-                    "Patch_TranslatesBeguilingResultPopups_WhenOwnerPatched",
-                    "Patch_DoesNotTranslateBeguilingPopup_WhenOwnerAbsent",
-                    "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
-                    "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
-                    "nameof(DummyBeguilingSifrahProducerTarget.ResultCriticalFailure)",
-                ),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
-                (
-                    "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
-                    "XRL.World.BeguilingSifrah|ResultCriticalFailure|System.Void|XRL.World.GameObject",
-                ),
+            target_type_name="DummyBeguilingSifrahProducerTarget",
+            method_details=(
+                ("ResultCriticalFailure", "CriticalFailure"),
+                ("ResultFailure", "Failure"),
+                ("ResultPartialSuccess", "PartialSuccess"),
+                ("ResultSuccess", "InterestedButUnable"),
+                ("ResultExceptionalSuccess", "InterestedButUnable"),
             ),
         ),
     ),
-    CoveredOwnerFamily(
-        family_id="XRL.World/BeguilingSifrah.cs::XRL.World.BeguilingSifrah.ResultFailure",
-        inventory_statuses=("owner_patch_required",),
-        evidence_files=(
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/BeguilingSifrahTranslationPatch.cs",
-                ("TryTranslatePopupMessage", "ResultFailure", "Failure"),
+    *_sifrah_result_popup_families(
+        SifrahResultPopupFamilySpec(
+            source_file="XRL.World/ProselytizationSifrah.cs",
+            type_name="XRL.World.ProselytizationSifrah",
+            evidence=OwnerPopupRouteEvidenceSpec(
+                patch_file="Mods/QudJP/Assemblies/src/Patches/ProselytizationSifrahTranslationPatch.cs",
+                patch_type="ProselytizationSifrahTranslationPatch",
+                test_file="Mods/QudJP/Assemblies/QudJP.Tests/L2/ProselytizationSifrahTranslationPatchTests.cs",
+                positive_test="Patch_TranslatesProselytizationResultPopups_WhenOwnerPatched",
+                negative_test="Patch_DoesNotTranslateProselytizationPopup_WhenOwnerAbsent",
+                direct_marker_test="Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+                empty_test="Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
             ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs",
-                ("BeguilingSifrahTranslationPatch.TryTranslatePopupMessage",),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2/BeguilingSifrahTranslationPatchTests.cs",
-                (
-                    "Patch_TranslatesBeguilingResultPopups_WhenOwnerPatched",
-                    "Patch_DoesNotTranslateBeguilingPopup_WhenOwnerAbsent",
-                    "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
-                    "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
-                    "nameof(DummyBeguilingSifrahProducerTarget.ResultFailure)",
-                ),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
-                (
-                    "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
-                    "XRL.World.BeguilingSifrah|ResultFailure|System.Void|XRL.World.GameObject",
-                ),
-            ),
-        ),
-    ),
-    CoveredOwnerFamily(
-        family_id="XRL.World/BeguilingSifrah.cs::XRL.World.BeguilingSifrah.ResultPartialSuccess",
-        inventory_statuses=("owner_patch_required",),
-        evidence_files=(
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/BeguilingSifrahTranslationPatch.cs",
-                ("TryTranslatePopupMessage", "ResultPartialSuccess", "PartialSuccess"),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs",
-                ("BeguilingSifrahTranslationPatch.TryTranslatePopupMessage",),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2/BeguilingSifrahTranslationPatchTests.cs",
-                (
-                    "Patch_TranslatesBeguilingResultPopups_WhenOwnerPatched",
-                    "Patch_DoesNotTranslateBeguilingPopup_WhenOwnerAbsent",
-                    "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
-                    "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
-                    "nameof(DummyBeguilingSifrahProducerTarget.ResultPartialSuccess)",
-                ),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
-                (
-                    "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
-                    "XRL.World.BeguilingSifrah|ResultPartialSuccess|System.Void|XRL.World.GameObject",
-                ),
-            ),
-        ),
-    ),
-    CoveredOwnerFamily(
-        family_id="XRL.World/BeguilingSifrah.cs::XRL.World.BeguilingSifrah.ResultSuccess",
-        inventory_statuses=("owner_patch_required",),
-        evidence_files=(
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/BeguilingSifrahTranslationPatch.cs",
-                ("TryTranslatePopupMessage", "ResultSuccess", "InterestedButUnable"),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs",
-                ("BeguilingSifrahTranslationPatch.TryTranslatePopupMessage",),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2/BeguilingSifrahTranslationPatchTests.cs",
-                (
-                    "Patch_TranslatesBeguilingResultPopups_WhenOwnerPatched",
-                    "Patch_DoesNotTranslateBeguilingPopup_WhenOwnerAbsent",
-                    "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
-                    "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
-                    "nameof(DummyBeguilingSifrahProducerTarget.ResultSuccess)",
-                ),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
-                (
-                    "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
-                    "XRL.World.BeguilingSifrah|ResultSuccess|System.Void|XRL.World.GameObject",
-                ),
-            ),
-        ),
-    ),
-    CoveredOwnerFamily(
-        family_id="XRL.World/BeguilingSifrah.cs::XRL.World.BeguilingSifrah.ResultExceptionalSuccess",
-        inventory_statuses=("owner_patch_required",),
-        evidence_files=(
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/BeguilingSifrahTranslationPatch.cs",
-                ("TryTranslatePopupMessage", "ResultExceptionalSuccess", "InterestedButUnable"),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs",
-                ("BeguilingSifrahTranslationPatch.TryTranslatePopupMessage",),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2/BeguilingSifrahTranslationPatchTests.cs",
-                (
-                    "Patch_TranslatesBeguilingResultPopups_WhenOwnerPatched",
-                    "Patch_DoesNotTranslateBeguilingPopup_WhenOwnerAbsent",
-                    "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
-                    "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
-                    "nameof(DummyBeguilingSifrahProducerTarget.ResultExceptionalSuccess)",
-                ),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
-                (
-                    "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
-                    "XRL.World.BeguilingSifrah|ResultExceptionalSuccess|System.Void|XRL.World.GameObject",
-                ),
-            ),
-        ),
-    ),
-    CoveredOwnerFamily(
-        family_id="XRL.World/ProselytizationSifrah.cs::XRL.World.ProselytizationSifrah.ResultCriticalFailure",
-        inventory_statuses=("owner_patch_required",),
-        evidence_files=(
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/ProselytizationSifrahTranslationPatch.cs",
-                ("TryTranslatePopupMessage", "ResultCriticalFailure", "CriticalFailure"),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs",
-                ("ProselytizationSifrahTranslationPatch.TryTranslatePopupMessage",),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2/ProselytizationSifrahTranslationPatchTests.cs",
-                (
-                    "Patch_TranslatesProselytizationResultPopups_WhenOwnerPatched",
-                    "Patch_DoesNotTranslateProselytizationPopup_WhenOwnerAbsent",
-                    "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
-                    "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
-                    "nameof(DummyProselytizationSifrahProducerTarget.ResultCriticalFailure)",
-                ),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
-                (
-                    "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
-                    "XRL.World.ProselytizationSifrah|ResultCriticalFailure|System.Void|XRL.World.GameObject",
-                ),
-            ),
-        ),
-    ),
-    CoveredOwnerFamily(
-        family_id="XRL.World/ProselytizationSifrah.cs::XRL.World.ProselytizationSifrah.ResultFailure",
-        inventory_statuses=("owner_patch_required",),
-        evidence_files=(
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/ProselytizationSifrahTranslationPatch.cs",
-                ("TryTranslatePopupMessage", "ResultFailure", "Failure"),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs",
-                ("ProselytizationSifrahTranslationPatch.TryTranslatePopupMessage",),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2/ProselytizationSifrahTranslationPatchTests.cs",
-                (
-                    "Patch_TranslatesProselytizationResultPopups_WhenOwnerPatched",
-                    "Patch_DoesNotTranslateProselytizationPopup_WhenOwnerAbsent",
-                    "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
-                    "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
-                    "nameof(DummyProselytizationSifrahProducerTarget.ResultFailure)",
-                ),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
-                (
-                    "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
-                    "XRL.World.ProselytizationSifrah|ResultFailure|System.Void|XRL.World.GameObject",
-                ),
-            ),
-        ),
-    ),
-    CoveredOwnerFamily(
-        family_id="XRL.World/ProselytizationSifrah.cs::XRL.World.ProselytizationSifrah.ResultPartialSuccess",
-        inventory_statuses=("owner_patch_required",),
-        evidence_files=(
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/ProselytizationSifrahTranslationPatch.cs",
-                ("TryTranslatePopupMessage", "ResultPartialSuccess", "PartialSuccess"),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs",
-                ("ProselytizationSifrahTranslationPatch.TryTranslatePopupMessage",),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2/ProselytizationSifrahTranslationPatchTests.cs",
-                (
-                    "Patch_TranslatesProselytizationResultPopups_WhenOwnerPatched",
-                    "Patch_DoesNotTranslateProselytizationPopup_WhenOwnerAbsent",
-                    "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
-                    "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
-                    "nameof(DummyProselytizationSifrahProducerTarget.ResultPartialSuccess)",
-                ),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
-                (
-                    "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
-                    "XRL.World.ProselytizationSifrah|ResultPartialSuccess|System.Void|XRL.World.GameObject",
-                ),
-            ),
-        ),
-    ),
-    CoveredOwnerFamily(
-        family_id="XRL.World/ProselytizationSifrah.cs::XRL.World.ProselytizationSifrah.ResultSuccess",
-        inventory_statuses=("owner_patch_required",),
-        evidence_files=(
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/ProselytizationSifrahTranslationPatch.cs",
-                ("TryTranslatePopupMessage", "ResultSuccess", "SympatheticButUnable"),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs",
-                ("ProselytizationSifrahTranslationPatch.TryTranslatePopupMessage",),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2/ProselytizationSifrahTranslationPatchTests.cs",
-                (
-                    "Patch_TranslatesProselytizationResultPopups_WhenOwnerPatched",
-                    "Patch_DoesNotTranslateProselytizationPopup_WhenOwnerAbsent",
-                    "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
-                    "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
-                    "nameof(DummyProselytizationSifrahProducerTarget.ResultSuccess)",
-                ),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
-                (
-                    "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
-                    "XRL.World.ProselytizationSifrah|ResultSuccess|System.Void|XRL.World.GameObject",
-                ),
-            ),
-        ),
-    ),
-    CoveredOwnerFamily(
-        family_id="XRL.World/ProselytizationSifrah.cs::XRL.World.ProselytizationSifrah.ResultExceptionalSuccess",
-        inventory_statuses=("owner_patch_required",),
-        evidence_files=(
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/ProselytizationSifrahTranslationPatch.cs",
-                ("TryTranslatePopupMessage", "ResultExceptionalSuccess", "SympatheticButUnable"),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs",
-                ("ProselytizationSifrahTranslationPatch.TryTranslatePopupMessage",),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2/ProselytizationSifrahTranslationPatchTests.cs",
-                (
-                    "Patch_TranslatesProselytizationResultPopups_WhenOwnerPatched",
-                    "Patch_DoesNotTranslateProselytizationPopup_WhenOwnerAbsent",
-                    "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
-                    "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
-                    "nameof(DummyProselytizationSifrahProducerTarget.ResultExceptionalSuccess)",
-                ),
-            ),
-            EvidenceFile(
-                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
-                (
-                    "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
-                    "XRL.World.ProselytizationSifrah|ResultExceptionalSuccess|System.Void|XRL.World.GameObject",
-                ),
+            target_type_name="DummyProselytizationSifrahProducerTarget",
+            method_details=(
+                ("ResultCriticalFailure", "CriticalFailure"),
+                ("ResultFailure", "Failure"),
+                ("ResultPartialSuccess", "PartialSuccess"),
+                ("ResultSuccess", "SympatheticButUnable"),
+                ("ResultExceptionalSuccess", "SympatheticButUnable"),
             ),
         ),
     ),


### PR DESCRIPTION
## Summary
- add a shared L2 owner-popup route harness for Harmony owner + Popup.Show test setup
- refactor Beguiling/Proselytization Sifrah popup tests onto the harness
- add static producer closure helper specs for repeated Sifrah result popup evidence entries

## Notes
- Helper-only change for Issue #576 follow-up batching.
- No localization asset or closure queue delta intended.

## Validation
- `just static-producer-check`
- `just test-l2`
- `git diff --check`

Refs #576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テストインフラストラクチャを改善し、共有テストハーネスを導入しました。これにより、テストの保守性と再利用性が向上しました。

* **Chores**
  * スクリプトユーティリティを再構成し、再利用可能なヘルパー関数を追加しました。コード組織を最適化しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/649)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->