### PR TITLE
Document nested Harmony owner scope handling

### DIFF
--- a/Mods/QudJP/Assemblies/AGENTS.md
+++ b/Mods/QudJP/Assemblies/AGENTS.md
@@ -66,6 +66,13 @@ C# optional arguments still appear as real reflection parameters. Add L2G
 signature or contract coverage when that reflection path controls runtime UI
 behavior.
 
+When a Harmony owner scope stores more than a boolean active flag, such as a
+thread-static declaring type, member name, object identity, or route key, save
+and restore the previous values with Harmony `__state` or an explicit stack.
+An `activeDepth` counter alone is only safe for boolean scope gates; nested
+owner calls can otherwise overwrite the outer route context. Add an L2 nested
+owner-scope test when a patch introduces or changes that state.
+
 Route decisions follow `docs/RULES.md`:
 
 - prefer producer-owned or stable mid-pipeline fixes


### PR DESCRIPTION
## Summary
- Codify the retrospective lesson that thread-static Harmony owner scopes carrying route identity must restore previous state with `__state` or an explicit stack.
- Require an L2 nested owner-scope test when introducing or changing that state.

## Verification
- `git diff --check` passed.

## Notes
- Documentation-only update under `Mods/QudJP/Assemblies/AGENTS.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * 開発者向けのガイダンスドキュメントを更新しました。パッチやモッド開発時の状態管理に関する詳細な指示と、テスト要件の情報を追加しています。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/654)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->