### PR TITLE
Close combat skill static producer owner routes

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
@@ -2717,6 +2717,87 @@ public sealed class CombatAndLogMessageQueuePatchTests
     }
 
     [TestCase(
+        "You kick at {{G|phase spider}}, but the kick passes through {{G|it}}.",
+        "{{G|phase spider}}を蹴ろうとしたが、蹴りは{{G|it}}を通り抜けた。")]
+    [TestCase(
+        "snapjaw kicks at you, but the kick passes through you.",
+        "snapjawがあなたを蹴ろうとしたが、蹴りはあなたを通り抜けた。")]
+    [TestCase(
+        "snapjaw kicks at phase spider, but the kick passes through it.",
+        "snapjawがphase spiderを蹴ろうとしたが、蹴りはitを通り抜けた。")]
+    [TestCase(
+        "You kick at snapjaw, but snapjaw holds its ground.",
+        "snapjawを蹴ろうとしたが、snapjawは踏みとどまった。")]
+    [TestCase(
+        "snapjaw kicks at you, but you hold your ground.",
+        "snapjawがあなたを蹴ろうとしたが、あなたは踏みとどまった。")]
+    [TestCase(
+        "snapjaw kicks at {{G|glowfish}}, but {{G|glowfish}} holds its ground.",
+        "snapjawが{{G|glowfish}}を蹴ろうとしたが、{{G|glowfish}}は踏みとどまった。")]
+    [TestCase("You kick snapjaw backwards.", "snapjawを後ろへ蹴り飛ばした。")]
+    [TestCase("snapjaw kicks you backwards.", "snapjawがあなたを後ろへ蹴り飛ばした。")]
+    [TestCase("snapjaw kicks glowfish backwards.", "snapjawがglowfishを後ろへ蹴り飛ばした。")]
+    [TestCase(
+        "The momentum from your charge causes your {{Y|battle axe}} to cleave deeper through {{R|snapjaw's armor}}.",
+        "突撃の勢いで{{Y|battle axe}}が{{R|snapjaw's armor}}をさらに深く切り裂いた。")]
+    [TestCase("You cleave through snapjaw's armor.", "snapjaw's armorを切り裂いた。")]
+    [TestCase("snapjaw cleaves through your armor.", "snapjawがあなたのarmorを切り裂いた。")]
+    [TestCase("snapjaw cleaves through glowfish's armor.", "snapjawがglowfish's armorを切り裂いた。")]
+    [TestCase("You shook off the stun.", "スタンを振り払った。")]
+    [TestCase("You shook off the dazing.", "朦朧を振り払った。")]
+    [TestCase("The snapjaw shook off the stun.", "The snapjawはスタンを振り払った。")]
+    [TestCase("The snapjaw shook off the dazing.", "The snapjawは朦朧を振り払った。")]
+    [TestCase(
+        "A supernal force helps you shake off the effect!",
+        "超自然的な力が効果を振り払う助けとなった！")]
+    [TestCase(
+        "A supernal force helps you shake off being confused!",
+        "超自然的な力がconfused状態を振り払う助けとなった！")]
+    [TestCase(
+        "A supernal force helps you shake off a mental state!",
+        "超自然的な力が精神状態を振り払う助けとなった！")]
+    public void CombatSkillMessages_TranslateInventoriedQueuedShapes_WhenOwnerPatched(string source, string expected)
+    {
+        AssertCombatSkillQueuedMessage(source, expected);
+    }
+
+    [TestCase("snapjaw kicks at you, but the kick passes through you.")]
+    [TestCase("You cleave through snapjaw's armor.")]
+    [TestCase("You shook off the stun.")]
+    [TestCase("A supernal force helps you shake off the effect!")]
+    public void CombatSkillMessages_DoNotTranslateQueueOnlyTraffic_WhenOwnerAbsent(string source)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+
+            DummyMessageQueue.AddPlayerMessage(source, null, Capitalize: false);
+
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(source));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void CombatSkillMessages_DoNotRetranslateDirectMarkedQueuedMessage_WhenOwnerPatched()
+    {
+        AssertCombatSkillQueuedMessage(
+            MessageFrameTranslator.MarkDirectTranslation("You cleave through snapjaw's armor."),
+            "You cleave through snapjaw's armor.");
+    }
+
+    [Test]
+    public void CombatSkillMessages_LeavesEmptyQueuedMessageUnchanged_WhenOwnerPatched()
+    {
+        AssertCombatSkillQueuedMessage(string.Empty, string.Empty);
+    }
+
+    [TestCase(
         nameof(DummyLatchesOnTarget.HandleEvent),
         "Since {{R|the hook}} is still latched onto {{G|the snapjaw}}, releasing {{R|it}} leaves {{R|it}} in {{G|its possession}}!",
         "{{G|the snapjaw}}",
@@ -7565,6 +7646,33 @@ public sealed class CombatAndLogMessageQueuePatchTests
                 harmony,
                 RequireMethod(typeof(DummySimpleOwnerQueueTarget), nameof(DummySimpleOwnerQueueTarget.FireEvent), typeof(DummyEvent)),
                 patchType);
+
+            var target = new DummySimpleOwnerQueueTarget
+            {
+                MessageToSend = message,
+            };
+
+            _ = target.FireEvent(new DummyEvent());
+
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(expected));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void AssertCombatSkillQueuedMessage(string message, string expected)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(typeof(DummySimpleOwnerQueueTarget), nameof(DummySimpleOwnerQueueTarget.FireEvent), typeof(DummyEvent)),
+                typeof(CombatSkillMessageTranslationPatch));
 
             var target = new DummySimpleOwnerQueueTarget
             {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1278,6 +1278,14 @@ public sealed class TargetMethodResolutionTests
         "XRL.World.Parts.LiquidVolume|Pour|System.Boolean|System.Boolean&|XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean|System.Int32|System.Boolean",
         "XRL.World.Parts.LiquidVolume|PerformFill|System.Boolean|XRL.World.GameObject|System.Boolean&|System.Boolean",
     })]
+    [TestCase(typeof(CombatSkillMessageTranslationPatch), new[]
+    {
+        "XRL.World.Parts.Skill.Tactics_Kickback|HandleEvent|System.Boolean|XRL.World.BeforeFireMissileWeaponsEvent",
+        "XRL.World.Parts.Skill.Axe_Cleave|PerformCleave|System.Void|XRL.World.GameObject|XRL.World.GameObject|XRL.World.GameObject|System.String|System.String|System.Int32|System.Int32|System.Nullable`1[[System.Int32]]",
+        "XRL.World.Parts.Skill.Endurance_ShakeItOff|FireEvent|System.Boolean|XRL.World.Event",
+        "XRL.World.Parts.Skill.TenfoldPath_Ret|HandleEvent|System.Boolean|XRL.World.ApplyEffectEvent",
+        "XRL.World.Parts.Skill.TenfoldPath_Ret|HandleEvent|System.Boolean|XRL.World.EndTurnEvent",
+    })]
     public void OwnerProducerTargetMethods_ResolveExpectedFullSignatures(Type patchType, string[] expectedSignatures)
     {
         var targetMethodsMethod = patchType.GetMethod("TargetMethods", BindingFlags.NonPublic | BindingFlags.Static);

--- a/Mods/QudJP/Assemblies/src/Patches/CombatSkillMessageTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/CombatSkillMessageTranslationPatch.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class CombatSkillMessageTranslationPatch
+{
+    private const string Context = nameof(CombatSkillMessageTranslationPatch);
+
+    private static readonly Regex KickPassesThroughYouPattern = new(
+        "^(?<actor>.+?) kicks? at you, but the kick passes through you\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex YouKickPassesThroughPattern = new(
+        "^You kick at (?<target>.+?), but the kick passes through (?<pronoun>.+?)\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex ActorKickPassesThroughPattern = new(
+        "^(?<actor>.+?) kicks? at (?<target>.+?), but the kick passes through (?<pronoun>.+?)\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex KickAtYouHoldGroundPattern = new(
+        "^(?<actor>.+?) kicks? at you, but you hold your ground\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex YouKickTargetHoldsGroundPattern = new(
+        "^You kick at (?<target>.+?), but (?<holder>.+?) holds? (?<possessive>.+?) ground\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex ActorKickTargetHoldsGroundPattern = new(
+        "^(?<actor>.+?) kicks? at (?<target>.+?), but (?<holder>.+?) holds? (?<possessive>.+?) ground\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex YouKickBackPattern = new(
+        "^You kick (?<target>.+?) backwards\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex ActorKicksYouBackPattern = new(
+        "^(?<actor>.+?) kicks? you backwards\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex ActorKicksTargetBackPattern = new(
+        "^(?<actor>.+?) kicks? (?<target>.+?) backwards\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex ChargeCleavePattern = new(
+        "^The momentum from your charge causes your (?<weapon>.+?) to cleave deeper through (?<target>.+?)\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex YouCleavePattern = new(
+        "^You cleave through (?<target>.+?)\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex ActorCleavesYourPattern = new(
+        "^(?<actor>.+?) cleaves? through your (?<part>.+?)\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex ActorCleavesTargetPattern = new(
+        "^(?<actor>.+?) cleaves? through (?<target>.+?)\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex ShookOffStunPattern = new(
+        "^(?<actor>.+?) shook off the stun\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex ShookOffDazingPattern = new(
+        "^(?<actor>.+?) shook off the dazing\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex SupernalStatePattern = new(
+        "^A supernal force helps you shake off being (?<state>.+?)!$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        var eventType = AccessTools.TypeByName("XRL.World.Event");
+        var gameObjectType = AccessTools.TypeByName("XRL.World.GameObject");
+        var beforeFireMissileWeaponsEventType = AccessTools.TypeByName("XRL.World.BeforeFireMissileWeaponsEvent");
+        var applyEffectEventType = AccessTools.TypeByName("XRL.World.ApplyEffectEvent");
+        var endTurnEventType = AccessTools.TypeByName("XRL.World.EndTurnEvent");
+        if (eventType is null
+            || gameObjectType is null
+            || beforeFireMissileWeaponsEventType is null
+            || applyEffectEventType is null
+            || endTurnEventType is null)
+        {
+            Trace.TraceError("QudJP: {0} failed to resolve required event or GameObject types.", Context);
+            yield break;
+        }
+
+        foreach (var method in ResolveTargets(
+                     "XRL.World.Parts.Skill.Tactics_Kickback",
+                     "HandleEvent",
+                     [beforeFireMissileWeaponsEventType]))
+        {
+            yield return method;
+        }
+
+        foreach (var method in ResolveTargets(
+                     "XRL.World.Parts.Skill.Axe_Cleave",
+                     "PerformCleave",
+                     [gameObjectType, gameObjectType, gameObjectType, typeof(string), typeof(string), typeof(int), typeof(int), typeof(int?)]))
+        {
+            yield return method;
+        }
+
+        foreach (var method in ResolveTargets(
+                     "XRL.World.Parts.Skill.Endurance_ShakeItOff",
+                     "FireEvent",
+                     [eventType]))
+        {
+            yield return method;
+        }
+
+        foreach (var method in ResolveTargets(
+                     "XRL.World.Parts.Skill.TenfoldPath_Ret",
+                     "HandleEvent",
+                     [applyEffectEventType]))
+        {
+            yield return method;
+        }
+
+        foreach (var method in ResolveTargets(
+                     "XRL.World.Parts.Skill.TenfoldPath_Ret",
+                     "HandleEvent",
+                     [endTurnEventType]))
+        {
+            yield return method;
+        }
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color)
+    {
+        _ = color;
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(message))
+        {
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(message, out var markedText))
+        {
+            message = markedText;
+            return true;
+        }
+
+        if (!TryTranslateCore(message, out var translated))
+        {
+            return false;
+        }
+
+        DynamicTextObservability.RecordTransform("MessageQueue.AddPlayerMessage", Context, message, translated);
+        message = MessageFrameTranslator.MarkDirectTranslation(translated);
+        return true;
+    }
+
+    private static IEnumerable<MethodBase> ResolveTargets(string typeName, string methodName, Type[] parameters)
+    {
+        var targetType = AccessTools.TypeByName(typeName);
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found: {1}", Context, typeName);
+            yield break;
+        }
+
+        var method = AccessTools.Method(targetType, methodName, parameters);
+        if (method is not null)
+        {
+            yield return method;
+            yield break;
+        }
+
+        Trace.TraceError("QudJP: {0}.{1}.{2} target not found.", Context, typeName, methodName);
+    }
+
+    private static bool TryTranslateCore(string source, out string translated)
+    {
+        if (TryTranslateFixed(source, out translated))
+        {
+            return true;
+        }
+
+        return TryTranslatePattern(
+            KickPassesThroughYouPattern,
+            source,
+            (match, spans) => $"{Restore(match, spans, "actor")}があなたを蹴ろうとしたが、蹴りはあなたを通り抜けた。",
+            out translated)
+            || TryTranslatePattern(
+                YouKickPassesThroughPattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "target")}を蹴ろうとしたが、蹴りは{Restore(match, spans, "pronoun")}を通り抜けた。",
+                out translated)
+            || TryTranslatePattern(
+                ActorKickPassesThroughPattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "actor")}が{Restore(match, spans, "target")}を蹴ろうとしたが、蹴りは{Restore(match, spans, "pronoun")}を通り抜けた。",
+                out translated)
+            || TryTranslatePattern(
+                KickAtYouHoldGroundPattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "actor")}があなたを蹴ろうとしたが、あなたは踏みとどまった。",
+                out translated)
+            || TryTranslatePattern(
+                YouKickTargetHoldsGroundPattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "target")}を蹴ろうとしたが、{Restore(match, spans, "holder")}は踏みとどまった。",
+                out translated)
+            || TryTranslatePattern(
+                ActorKickTargetHoldsGroundPattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "actor")}が{Restore(match, spans, "target")}を蹴ろうとしたが、{Restore(match, spans, "holder")}は踏みとどまった。",
+                out translated)
+            || TryTranslatePattern(
+                YouKickBackPattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "target")}を後ろへ蹴り飛ばした。",
+                out translated)
+            || TryTranslatePattern(
+                ActorKicksYouBackPattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "actor")}があなたを後ろへ蹴り飛ばした。",
+                out translated)
+            || TryTranslatePattern(
+                ActorKicksTargetBackPattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "actor")}が{Restore(match, spans, "target")}を後ろへ蹴り飛ばした。",
+                out translated)
+            || TryTranslatePattern(
+                ChargeCleavePattern,
+                source,
+                (match, spans) => $"突撃の勢いで{Restore(match, spans, "weapon")}が{Restore(match, spans, "target")}をさらに深く切り裂いた。",
+                out translated)
+            || TryTranslatePattern(
+                YouCleavePattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "target")}を切り裂いた。",
+                out translated)
+            || TryTranslatePattern(
+                ActorCleavesYourPattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "actor")}があなたの{Restore(match, spans, "part")}を切り裂いた。",
+                out translated)
+            || TryTranslatePattern(
+                ActorCleavesTargetPattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "actor")}が{Restore(match, spans, "target")}を切り裂いた。",
+                out translated)
+            || TryTranslatePattern(
+                ShookOffStunPattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "actor")}はスタンを振り払った。",
+                out translated)
+            || TryTranslatePattern(
+                ShookOffDazingPattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "actor")}は朦朧を振り払った。",
+                out translated)
+            || TryTranslatePattern(
+                SupernalStatePattern,
+                source,
+                (match, spans) => $"超自然的な力が{Restore(match, spans, "state")}状態を振り払う助けとなった！",
+                out translated);
+    }
+
+    private static bool TryTranslateFixed(string source, out string translated)
+    {
+        translated = source switch
+        {
+            "You shook off the stun." => "スタンを振り払った。",
+            "You shook off the dazing." => "朦朧を振り払った。",
+            "A supernal force helps you shake off the effect!" => "超自然的な力が効果を振り払う助けとなった！",
+            "A supernal force helps you shake off a mental state!" => "超自然的な力が精神状態を振り払う助けとなった！",
+            _ => string.Empty,
+        };
+        return translated.Length > 0;
+    }
+
+    private static bool TryTranslatePattern(
+        Regex pattern,
+        string source,
+        Func<Match, IReadOnlyList<ColorSpan>, string> translate,
+        out string translated)
+    {
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
+        var match = pattern.Match(stripped);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = ColorAwareTranslationComposer.RestoreWholeSourceBoundaryWrappersPreservingTranslatedOwnership(
+            translate(match, spans),
+            spans,
+            stripped.Length,
+            source);
+        return true;
+    }
+
+    private static string Restore(Match match, IReadOnlyList<ColorSpan> spans, string groupName)
+    {
+        var group = match.Groups[groupName];
+        return ColorAwareTranslationComposer.RestoreCapture(group.Value, spans, group).Trim();
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs
@@ -29,6 +29,7 @@ internal static class MessageQueueSemanticPipeline
         MutatingTranslationPatch.TryTranslateQueuedMessage,
         QuillsTranslationPatch.TryTranslateQueuedMessage,
         LightManipulationTranslationPatch.TryTranslateQueuedMessage,
+        CombatSkillMessageTranslationPatch.TryTranslateQueuedMessage,
         LatchesOnTranslationPatch.TryTranslateQueuedMessage,
         AsleepOwnerTranslationPatch.TryTranslateQueuedMessage,
         EnclosingTranslationPatch.TryTranslateQueuedMessage,

--- a/docs/release-notes/unreleased/issue-576-combat-skill-owner.md
+++ b/docs/release-notes/unreleased/issue-576-combat-skill-owner.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Registered audited combat skill owner-message translations for static producer coverage.

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -3993,6 +3993,127 @@ COVERED_OWNER_FAMILIES: Final = (
     *_effect_static_message_families(),
     *_system_static_message_families(),
     CoveredOwnerFamily(
+        family_id="XRL.World.Parts.Skill/Tactics_Kickback.cs::XRL.World.Parts.Skill.Tactics_Kickback.HandleEvent",
+        inventory_statuses=("owner_patch_required",),
+        evidence_files=(
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/CombatSkillMessageTranslationPatch.cs",
+                ("Tactics_Kickback", "TryTranslateQueuedMessage", "KickPassesThroughYouPattern"),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs",
+                ("CombatSkillMessageTranslationPatch.TryTranslateQueuedMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+                (
+                    "CombatSkillMessages_TranslateInventoriedQueuedShapes_WhenOwnerPatched",
+                    "CombatSkillMessages_DoNotTranslateQueueOnlyTraffic_WhenOwnerAbsent",
+                    "CombatSkillMessages_DoNotRetranslateDirectMarkedQueuedMessage_WhenOwnerPatched",
+                    "CombatSkillMessages_LeavesEmptyQueuedMessageUnchanged_WhenOwnerPatched",
+                    "You kick at {{G|phase spider}}, but the kick passes through {{G|it}}.",
+                    "snapjaw kicks glowfish backwards.",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                (
+                    "typeof(CombatSkillMessageTranslationPatch)",
+                    "XRL.World.Parts.Skill.Tactics_Kickback|HandleEvent|System.Boolean|XRL.World.BeforeFireMissileWeaponsEvent",
+                ),
+            ),
+        ),
+    ),
+    CoveredOwnerFamily(
+        family_id="XRL.World.Parts.Skill/Axe_Cleave.cs::XRL.World.Parts.Skill.Axe_Cleave.PerformCleave",
+        inventory_statuses=("owner_patch_required",),
+        evidence_files=(
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/CombatSkillMessageTranslationPatch.cs",
+                ("Axe_Cleave", "ChargeCleavePattern", "ActorCleavesTargetPattern"),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs",
+                ("CombatSkillMessageTranslationPatch.TryTranslateQueuedMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+                (
+                    "CombatSkillMessages_TranslateInventoriedQueuedShapes_WhenOwnerPatched",
+                    "cleave deeper through {{R|snapjaw's armor}}.",
+                    "snapjaw cleaves through glowfish's armor.",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                (
+                    "typeof(CombatSkillMessageTranslationPatch)",
+                    "XRL.World.Parts.Skill.Axe_Cleave|PerformCleave|System.Void|XRL.World.GameObject|XRL.World.GameObject|XRL.World.GameObject|System.String|System.String|System.Int32|System.Int32|System.Nullable`1[[System.Int32]]",
+                ),
+            ),
+        ),
+    ),
+    CoveredOwnerFamily(
+        family_id="XRL.World.Parts.Skill/Endurance_ShakeItOff.cs::XRL.World.Parts.Skill.Endurance_ShakeItOff.FireEvent",
+        inventory_statuses=("owner_patch_required",),
+        evidence_files=(
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/CombatSkillMessageTranslationPatch.cs",
+                ("Endurance_ShakeItOff", "ShookOffStunPattern", "ShookOffDazingPattern"),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs",
+                ("CombatSkillMessageTranslationPatch.TryTranslateQueuedMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+                (
+                    "CombatSkillMessages_TranslateInventoriedQueuedShapes_WhenOwnerPatched",
+                    "You shook off the stun.",
+                    "The snapjaw shook off the dazing.",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                (
+                    "typeof(CombatSkillMessageTranslationPatch)",
+                    "XRL.World.Parts.Skill.Endurance_ShakeItOff|FireEvent|System.Boolean|XRL.World.Event",
+                ),
+            ),
+        ),
+    ),
+    CoveredOwnerFamily(
+        family_id="XRL.World.Parts.Skill/TenfoldPath_Ret.cs::XRL.World.Parts.Skill.TenfoldPath_Ret.HandleEvent",
+        inventory_statuses=("owner_patch_required",),
+        evidence_files=(
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/CombatSkillMessageTranslationPatch.cs",
+                ("TenfoldPath_Ret", "SupernalStatePattern", "A supernal force helps you shake off a mental state!"),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs",
+                ("CombatSkillMessageTranslationPatch.TryTranslateQueuedMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+                (
+                    "CombatSkillMessages_TranslateInventoriedQueuedShapes_WhenOwnerPatched",
+                    "A supernal force helps you shake off the effect!",
+                    "A supernal force helps you shake off being confused!",
+                    "A supernal force helps you shake off a mental state!",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                (
+                    "typeof(CombatSkillMessageTranslationPatch)",
+                    "XRL.World.Parts.Skill.TenfoldPath_Ret|HandleEvent|System.Boolean|XRL.World.ApplyEffectEvent",
+                    "XRL.World.Parts.Skill.TenfoldPath_Ret|HandleEvent|System.Boolean|XRL.World.EndTurnEvent",
+                ),
+            ),
+        ),
+    ),
+    CoveredOwnerFamily(
         family_id="XRL.UI/TradeUI.cs::XRL.UI.TradeUI.PerformOffer",
         inventory_statuses=("needs_family_review",),
         evidence_files=(


### PR DESCRIPTION
## Summary
- Adds owner-routed queue translations for combat skill messages from Tactics_Kickback, Axe_Cleave, Endurance_ShakeItOff, and TenfoldPath_Ret.
- Adds focused L2 owner/negative/direct-marker/empty coverage and L2G target signature evidence for the combat skill owner patch.
- Registers the four fully covered owner_patch_required families in scripts/static_producer_closure.py.

## Inventory shapes audited
- Tactics_Kickback.HandleEvent: 9 AddPlayerMessage callsites, all owner_patch_required.
- Axe_Cleave.PerformCleave: 5 AddPlayerMessage callsites, all owner_patch_required.
- Endurance_ShakeItOff.FireEvent: 4 AddPlayerMessage callsites, all owner_patch_required.
- TenfoldPath_Ret.HandleEvent: 4 AddPlayerMessage callsites, all owner_patch_required.

## Queue delta
- Before: 337 families / 940 callsites / 961 text args.
- After: 333 families / 918 callsites / 939 text args.
- Delta: -4 families / -22 callsites / -22 text args.

## Verification
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~CombatAndLogMessageQueuePatchTests.CombatSkillMessages' --no-restore
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures' --no-restore
- just static-producer-check
- just static-producer-owner-queue

Related to #576.