### PR TITLE
Close Water Ritual static producer owner popups

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/WaterRitualPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/WaterRitualPopupTranslationPatchTests.cs
@@ -1,0 +1,304 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class WaterRitualPopupTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
+        Translator.ResetForTests();
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(null);
+        Translator.ResetForTests();
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+    }
+
+    [TestCase(
+        nameof(DummyWaterRitualPopupProducerTarget.WaterRitualBeginHandleEvent),
+        nameof(DummyPopupShow.ShowYesNoCancel),
+        "Do you want to play a game of Sifrah to perform the formal water ritual with {{G|Tam}}? The formal ritual can be much more impactful. If you do not play the game of Sifrah, the informal water ritual will consume 1 dram of {{B|fresh water}}.",
+        "{{G|Tam}}と正式な水の儀式を行うためにシフラーのゲームをプレイしますか？正式な儀式はより大きな影響をもたらすことがあります。シフラーをプレイしない場合、非正式な水の儀式は{{B|fresh water}}を1ドラム消費します。",
+        "FormalRitualPrompt")]
+    [TestCase(
+        nameof(DummyWaterRitualPopupProducerTarget.WaterRitualBeginHandleEvent),
+        nameof(DummyPopupShow.ShowFail),
+        "You don't have enough {{B|fresh water}} to begin the ritual.",
+        "儀式を始めるには{{B|fresh water}}が足りない。",
+        "NotEnoughLiquid")]
+    [TestCase(
+        nameof(DummyWaterRitualPopupProducerTarget.WaterRitualSkillPointHandleEvent),
+        nameof(DummyPopupShow.Show),
+        "Talking to {{Y|the warden}} rouses in you an inert truth. You once wore the frock of a child. You poured salt through the cracks of your fingers, and you watched worlds form. Can it be all so simple still?",
+        "{{Y|the warden}}との会話が、あなたの内に眠る真実を呼び覚ました。あなたはかつて子供の上着をまとっていた。指の隙間から塩を注ぎ、世界が形作られるのを見ていた。今もなお、それほど単純でありうるのだろうか？",
+        "SkillPointIntro")]
+    [TestCase(
+        nameof(DummyWaterRitualPopupProducerTarget.WaterRitualSkillPointHandleEvent),
+        nameof(DummyPopupShow.Show),
+        "You gained {{C|50}} skill points!",
+        "{{C|50}}スキルポイントを得た！",
+        "SkillPointGain")]
+    [TestCase(
+        nameof(DummyWaterRitualPopupProducerTarget.WaterRitualTinkeringRecipeHandleEvent),
+        nameof(DummyPopupShow.Show),
+        "{{G|Hortensa}} teaches you to craft the item modification {{W|sturdy}}.",
+        "{{G|Hortensa}}がアイテム改造{{W|sturdy}}の作り方を教えてくれた。",
+        "TinkeringMod")]
+    [TestCase(
+        nameof(DummyWaterRitualPopupProducerTarget.WaterRitualTinkeringRecipeHandleEvent),
+        nameof(DummyPopupShow.Show),
+        "{{G|Hortensa}} teaches you to craft {{W|spring-loaded boots}}.",
+        "{{G|Hortensa}}が{{W|spring-loaded boots}}の作り方を教えてくれた。",
+        "TinkeringRecipe")]
+    public void Patch_TranslatesWaterRitualOwnerPopups_WhenOwnerPatched(
+        string methodName,
+        string popupMethod,
+        string source,
+        string expected,
+        string detail)
+    {
+        WithPatchedOwnerAndPopup(methodName, popupMethod, () =>
+        {
+            var target = new DummyWaterRitualPopupProducerTarget
+            {
+                PopupMethod = popupMethod,
+                PopupMessageToShow = source,
+            };
+
+            InvokeOwnerMethod(target, methodName);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(LastPopupMessage(popupMethod), Is.EqualTo(expected));
+                Assert.That(HitCount(detail), Is.EqualTo(1));
+            });
+        });
+    }
+
+    [TestCase(
+        nameof(DummyWaterRitualPopupProducerTarget.WaterRitualBeginHandleEvent),
+        nameof(DummyPopupShow.ShowYesNoCancel),
+        "Do you want to play a game of Sifrah to perform the formal water ritual with {{G|Tam}}? The formal ritual can be much more impactful. If you do not play the game of Sifrah, the informal water ritual will consume 1 dram of {{B|fresh water}}.",
+        "FormalRitualPrompt")]
+    [TestCase(
+        nameof(DummyWaterRitualPopupProducerTarget.WaterRitualSkillPointHandleEvent),
+        nameof(DummyPopupShow.Show),
+        "You gained {{C|50}} skill points!",
+        "SkillPointGain")]
+    [TestCase(
+        nameof(DummyWaterRitualPopupProducerTarget.WaterRitualTinkeringRecipeHandleEvent),
+        nameof(DummyPopupShow.Show),
+        "{{G|Hortensa}} teaches you to craft {{W|spring-loaded boots}}.",
+        "TinkeringRecipe")]
+    public void Patch_DoesNotTranslateWaterRitualPopup_WhenOwnerAbsent(
+        string methodName,
+        string popupMethod,
+        string source,
+        string detail)
+    {
+        _ = methodName;
+        WithPatchedPopupOnly(popupMethod, () =>
+        {
+            InvokePopup(popupMethod, source);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(LastPopupMessage(popupMethod), Is.EqualTo(source));
+                Assert.That(HitCount(detail), Is.Zero);
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
+    {
+        const string popupMethod = nameof(DummyPopupShow.Show);
+        const string unmarked = "You gained {{C|50}} skill points!";
+        var source = MessageFrameTranslator.MarkDirectTranslation(unmarked);
+
+        WithPatchedOwnerAndPopup(
+            nameof(DummyWaterRitualPopupProducerTarget.WaterRitualSkillPointHandleEvent),
+            popupMethod,
+            () =>
+            {
+                var target = new DummyWaterRitualPopupProducerTarget
+                {
+                    PopupMethod = popupMethod,
+                    PopupMessageToShow = source,
+                };
+
+                target.WaterRitualSkillPointHandleEvent();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(unmarked));
+                    Assert.That(HitCount("SkillPointGain"), Is.Zero);
+                });
+            });
+    }
+
+    [Test]
+    public void Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        const string popupMethod = nameof(DummyPopupShow.Show);
+
+        WithPatchedOwnerAndPopup(
+            nameof(DummyWaterRitualPopupProducerTarget.WaterRitualSkillPointHandleEvent),
+            popupMethod,
+            () =>
+            {
+                var target = new DummyWaterRitualPopupProducerTarget
+                {
+                    PopupMethod = popupMethod,
+                    PopupMessageToShow = string.Empty,
+                };
+
+                target.WaterRitualSkillPointHandleEvent();
+
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
+            });
+    }
+
+    private static void WithPatchedOwnerAndPopup(string methodName, string popupMethod, Action action)
+    {
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopup(harmony, popupMethod);
+            harmony.Patch(
+                original: RequireOwnerMethod(methodName),
+                prefix: new HarmonyMethod(RequireMethod(typeof(WaterRitualPopupTranslationPatch), nameof(WaterRitualPopupTranslationPatch.Prefix))),
+                finalizer: new HarmonyMethod(RequireMethod(typeof(WaterRitualPopupTranslationPatch), nameof(WaterRitualPopupTranslationPatch.Finalizer))));
+
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void WithPatchedPopupOnly(string popupMethod, Action action)
+    {
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopup(harmony, popupMethod);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopup(Harmony harmony, string popupMethod)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), popupMethod),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void InvokeOwnerMethod(DummyWaterRitualPopupProducerTarget target, string methodName)
+    {
+        _ = RequireOwnerMethod(methodName).Invoke(target, null);
+    }
+
+    private static void InvokePopup(string popupMethod, string source)
+    {
+        if (popupMethod == nameof(DummyPopupShow.ShowYesNoCancel))
+        {
+            _ = DummyPopupShow.ShowYesNoCancel(source);
+            return;
+        }
+
+        if (popupMethod == nameof(DummyPopupShow.ShowFail))
+        {
+            DummyPopupShow.ShowFail(source);
+            return;
+        }
+
+        DummyPopupShow.Show(source);
+    }
+
+    private static string? LastPopupMessage(string popupMethod)
+    {
+        return popupMethod == nameof(DummyPopupShow.ShowYesNoCancel)
+            ? DummyPopupShow.LastShowYesNoCancelMessage
+            : DummyPopupShow.LastShowMessage;
+    }
+
+    private static int HitCount(string detail)
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.ProducerText." + nameof(WaterRitualPopupTranslationPatch) + "." + detail);
+    }
+
+    private static MethodInfo RequireOwnerMethod(string methodName)
+    {
+        return RequireMethod(typeof(DummyWaterRitualPopupProducerTarget), methodName);
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName)
+    {
+        return type.GetMethod(
+                   methodName,
+                   BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
+               ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private sealed class DummyWaterRitualPopupProducerTarget
+    {
+        public string PopupMessageToShow { get; set; } = string.Empty;
+
+        public string PopupMethod { get; set; } = nameof(DummyPopupShow.Show);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool WaterRitualBeginHandleEvent()
+        {
+            EmitPopup(nameof(WaterRitualBeginHandleEvent));
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool WaterRitualSkillPointHandleEvent()
+        {
+            EmitPopup(nameof(WaterRitualSkillPointHandleEvent));
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool WaterRitualTinkeringRecipeHandleEvent()
+        {
+            EmitPopup(nameof(WaterRitualTinkeringRecipeHandleEvent));
+            return true;
+        }
+
+        private void EmitPopup(string route)
+        {
+            _ = route;
+            WaterRitualPopupTranslationPatchTests.InvokePopup(PopupMethod, PopupMessageToShow);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1278,6 +1278,12 @@ public sealed class TargetMethodResolutionTests
         "XRL.World.Parts.LiquidVolume|Pour|System.Boolean|System.Boolean&|XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean|System.Int32|System.Boolean",
         "XRL.World.Parts.LiquidVolume|PerformFill|System.Boolean|XRL.World.GameObject|System.Boolean&|System.Boolean",
     })]
+    [TestCase(typeof(WaterRitualPopupTranslationPatch), new[]
+    {
+        "XRL.World.Conversations.Parts.WaterRitualBegin|HandleEvent|System.Boolean|XRL.World.Conversations.EnterElementEvent",
+        "XRL.World.Conversations.Parts.WaterRitualSkillPoint|HandleEvent|System.Boolean|XRL.World.Conversations.EnteredElementEvent",
+        "XRL.World.Conversations.Parts.WaterRitualTinkeringRecipe|HandleEvent|System.Boolean|XRL.World.Conversations.EnteredElementEvent",
+    })]
     public void OwnerProducerTargetMethods_ResolveExpectedFullSignatures(Type patchType, string[] expectedSignatures)
     {
         var targetMethodsMethod = patchType.GetMethod("TargetMethods", BindingFlags.NonPublic | BindingFlags.Static);

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -29,6 +29,7 @@ internal static class PopupShowSemanticPipeline
         GeomagneticDiscTranslationPatch.TryTranslatePopupMessage,
         CampfireCookAvailabilityTranslationPatch.TryTranslatePopupMessage,
         CampfirePreserveTranslationPatch.TryTranslatePopupMessage,
+        WaterRitualPopupTranslationPatch.TryTranslatePopupMessage,
         CookingRuntimeTranslationPatch.TryTranslatePopupMessage,
         StatusScreenPopupTranslationPatch.TryTranslatePopupMessage,
         TeleprojectorTranslationPatch.TryTranslatePopupMessage,

--- a/Mods/QudJP/Assemblies/src/Patches/WaterRitualPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/WaterRitualPopupTranslationPatch.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class WaterRitualPopupTranslationPatch
+{
+    private const string Context = nameof(WaterRitualPopupTranslationPatch);
+
+    private static readonly Regex FormalRitualPromptPattern = new(
+        "^Do you want to play a game of Sifrah to perform the formal water ritual with (?<speaker>.+?)\\? The formal ritual can be much more impactful\\. If you do not play the game of Sifrah, the informal water ritual will consume 1 dram of (?<liquid>.+?)\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex NotEnoughLiquidPattern = new(
+        "^You don't have enough (?<liquid>.+?) to begin the ritual\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex SkillPointIntroPattern = new(
+        "^Talking to (?<speaker>.+?) rouses in you an inert truth\\. You once wore the frock of a child\\. You poured salt through the cracks of your fingers, and you watched worlds form\\. Can it be all so simple still\\?$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex SkillPointGainPattern = new(
+        "^You gained (?<points>.+?) skill points!$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex TinkeringModPattern = new(
+        "^(?<speaker>.+?) teaches? you to craft the item modification (?<mod>.+?)\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex TinkeringRecipePattern = new(
+        "^(?<speaker>.+?) teaches? you to craft (?<recipe>.+?)\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        var enterElementEventType = AccessTools.TypeByName("XRL.World.Conversations.EnterElementEvent");
+        var enteredElementEventType = AccessTools.TypeByName("XRL.World.Conversations.EnteredElementEvent");
+        if (enterElementEventType is null || enteredElementEventType is null)
+        {
+            Trace.TraceError("QudJP: {0} failed to resolve conversation event types.", Context);
+            yield break;
+        }
+
+        foreach (var method in ResolveTarget(
+                     "XRL.World.Conversations.Parts.WaterRitualBegin",
+                     "HandleEvent",
+                     [enterElementEventType]))
+        {
+            yield return method;
+        }
+
+        foreach (var method in ResolveTarget(
+                     "XRL.World.Conversations.Parts.WaterRitualSkillPoint",
+                     "HandleEvent",
+                     [enteredElementEventType]))
+        {
+            yield return method;
+        }
+
+        foreach (var method in ResolveTarget(
+                     "XRL.World.Conversations.Parts.WaterRitualTinkeringRecipe",
+                     "HandleEvent",
+                     [enteredElementEventType]))
+        {
+            yield return method;
+        }
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        _ = family;
+
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        if (TryTranslateCore(source, out translated, out var detail))
+        {
+            DynamicTextObservability.RecordTransform(route, "Popup.ProducerText." + Context + "." + detail, source, translated);
+            return true;
+        }
+
+        translated = source;
+        return false;
+    }
+
+    private static IEnumerable<MethodBase> ResolveTarget(string typeName, string methodName, Type[] parameters)
+    {
+        var targetType = AccessTools.TypeByName(typeName);
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found: {1}", Context, typeName);
+            yield break;
+        }
+
+        var method = AccessTools.Method(targetType, methodName, parameters);
+        if (method is not null)
+        {
+            yield return method;
+            yield break;
+        }
+
+        Trace.TraceError("QudJP: {0}.{1}.{2} target not found.", Context, typeName, methodName);
+    }
+
+    private static bool TryTranslateCore(string source, out string translated, out string detail)
+    {
+        if (TryTranslatePattern(
+                FormalRitualPromptPattern,
+                source,
+                (match, spans) =>
+                    $"{Restore(match, spans, "speaker")}と正式な水の儀式を行うためにシフラーのゲームをプレイしますか？正式な儀式はより大きな影響をもたらすことがあります。シフラーをプレイしない場合、非正式な水の儀式は{Restore(match, spans, "liquid")}を1ドラム消費します。",
+                out translated))
+        {
+            detail = "FormalRitualPrompt";
+            return true;
+        }
+
+        if (TryTranslatePattern(
+                NotEnoughLiquidPattern,
+                source,
+                (match, spans) => $"儀式を始めるには{Restore(match, spans, "liquid")}が足りない。",
+                out translated))
+        {
+            detail = "NotEnoughLiquid";
+            return true;
+        }
+
+        if (TryTranslatePattern(
+                SkillPointIntroPattern,
+                source,
+                (match, spans) =>
+                    $"{Restore(match, spans, "speaker")}との会話が、あなたの内に眠る真実を呼び覚ました。あなたはかつて子供の上着をまとっていた。指の隙間から塩を注ぎ、世界が形作られるのを見ていた。今もなお、それほど単純でありうるのだろうか？",
+                out translated))
+        {
+            detail = "SkillPointIntro";
+            return true;
+        }
+
+        if (TryTranslatePattern(
+                SkillPointGainPattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "points")}スキルポイントを得た！",
+                out translated))
+        {
+            detail = "SkillPointGain";
+            return true;
+        }
+
+        if (TryTranslatePattern(
+                TinkeringModPattern,
+                source,
+                (match, spans) =>
+                    $"{Restore(match, spans, "speaker")}がアイテム改造{Restore(match, spans, "mod")}の作り方を教えてくれた。",
+                out translated))
+        {
+            detail = "TinkeringMod";
+            return true;
+        }
+
+        if (TryTranslatePattern(
+                TinkeringRecipePattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "speaker")}が{Restore(match, spans, "recipe")}の作り方を教えてくれた。",
+                out translated))
+        {
+            detail = "TinkeringRecipe";
+            return true;
+        }
+
+        translated = source;
+        detail = string.Empty;
+        return false;
+    }
+
+    private static bool TryTranslatePattern(
+        Regex pattern,
+        string source,
+        Func<Match, IReadOnlyList<ColorSpan>, string> translate,
+        out string translated)
+    {
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
+        var match = pattern.Match(stripped);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = ColorAwareTranslationComposer.RestoreWholeSourceBoundaryWrappersPreservingTranslatedOwnership(
+            translate(match, spans),
+            spans,
+            stripped.Length,
+            source);
+        return true;
+    }
+
+    private static string Restore(Match match, IReadOnlyList<ColorSpan> spans, string groupName)
+    {
+        var group = match.Groups[groupName];
+        return ColorAwareTranslationComposer.RestoreCapture(group.Value, spans, group).Trim();
+    }
+}

--- a/docs/release-notes/unreleased/issue-576-water-ritual-owner.md
+++ b/docs/release-notes/unreleased/issue-576-water-ritual-owner.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Added owner-routed Japanese translations for Water Ritual begin, skill point, and tinkering recipe popups.

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -942,6 +942,131 @@ def _cooking_runtime_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _water_ritual_popup_families() -> tuple[CoveredOwnerFamily, ...]:
+    patch = EvidenceFile(
+        "Mods/QudJP/Assemblies/src/Patches/WaterRitualPopupTranslationPatch.cs",
+        (
+            "WaterRitualPopupTranslationPatch",
+            "TryTranslatePopupMessage",
+        ),
+    )
+    pipeline = EvidenceFile(
+        "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+        ("WaterRitualPopupTranslationPatch.TryTranslatePopupMessage",),
+    )
+    tests_common = (
+        "Patch_TranslatesWaterRitualOwnerPopups_WhenOwnerPatched",
+        "Patch_DoesNotTranslateWaterRitualPopup_WhenOwnerAbsent",
+        "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+        "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+    )
+
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.World.Conversations.Parts/WaterRitualBegin.cs::XRL.World.Conversations.Parts.WaterRitualBegin.HandleEvent",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    patch.path,
+                    (
+                        *patch.required_substrings,
+                        "WaterRitualBegin",
+                        "FormalRitualPromptPattern",
+                        "NotEnoughLiquidPattern",
+                    ),
+                ),
+                pipeline,
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/WaterRitualPopupTranslationPatchTests.cs",
+                    (
+                        *tests_common,
+                        "nameof(DummyWaterRitualPopupProducerTarget.WaterRitualBeginHandleEvent)",
+                        "FormalRitualPrompt",
+                        "NotEnoughLiquid",
+                        "Do you want to play a game of Sifrah to perform the formal water ritual",
+                        "You don't have enough {{B|fresh water}} to begin the ritual.",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(WaterRitualPopupTranslationPatch)",
+                        "XRL.World.Conversations.Parts.WaterRitualBegin|HandleEvent|System.Boolean|XRL.World.Conversations.EnterElementEvent",
+                    ),
+                ),
+            ),
+        ),
+        CoveredOwnerFamily(
+            family_id="XRL.World.Conversations.Parts/WaterRitualSkillPoint.cs::XRL.World.Conversations.Parts.WaterRitualSkillPoint.HandleEvent",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    patch.path,
+                    (
+                        *patch.required_substrings,
+                        "WaterRitualSkillPoint",
+                        "SkillPointIntroPattern",
+                        "SkillPointGainPattern",
+                    ),
+                ),
+                pipeline,
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/WaterRitualPopupTranslationPatchTests.cs",
+                    (
+                        *tests_common,
+                        "nameof(DummyWaterRitualPopupProducerTarget.WaterRitualSkillPointHandleEvent)",
+                        "SkillPointIntro",
+                        "SkillPointGain",
+                        "Talking to {{Y|the warden}} rouses in you an inert truth.",
+                        "You gained {{C|50}} skill points!",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(WaterRitualPopupTranslationPatch)",
+                        "XRL.World.Conversations.Parts.WaterRitualSkillPoint|HandleEvent|System.Boolean|XRL.World.Conversations.EnteredElementEvent",
+                    ),
+                ),
+            ),
+        ),
+        CoveredOwnerFamily(
+            family_id="XRL.World.Conversations.Parts/WaterRitualTinkeringRecipe.cs::XRL.World.Conversations.Parts.WaterRitualTinkeringRecipe.HandleEvent",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    patch.path,
+                    (
+                        *patch.required_substrings,
+                        "WaterRitualTinkeringRecipe",
+                        "TinkeringModPattern",
+                        "TinkeringRecipePattern",
+                    ),
+                ),
+                pipeline,
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/WaterRitualPopupTranslationPatchTests.cs",
+                    (
+                        *tests_common,
+                        "nameof(DummyWaterRitualPopupProducerTarget.WaterRitualTinkeringRecipeHandleEvent)",
+                        "TinkeringMod",
+                        "TinkeringRecipe",
+                        "{{G|Hortensa}} teaches you to craft the item modification {{W|sturdy}}.",
+                        "{{G|Hortensa}} teaches you to craft {{W|spring-loaded boots}}.",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(WaterRitualPopupTranslationPatch)",
+                        "XRL.World.Conversations.Parts.WaterRitualTinkeringRecipe|HandleEvent|System.Boolean|XRL.World.Conversations.EnteredElementEvent",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _status_screen_popup_families() -> tuple[CoveredOwnerFamily, ...]:
     patch = EvidenceFile(
         "Mods/QudJP/Assemblies/src/Patches/StatusScreenPopupTranslationPatch.cs",
@@ -3953,6 +4078,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_keybinds_screen_conflict_families(),
     *_ability_manager_popup_families(),
     *_cooking_runtime_families(),
+    *_water_ritual_popup_families(),
     *_status_screen_popup_families(),
     *_campfire_preserve_families(),
     *_reality_stabilized_event_families(),


### PR DESCRIPTION
## Summary

Closes three issue #576 static-producer owner families for Water Ritual popups with a focused owner-routed popup patch:

- `XRL.World.Conversations.Parts/WaterRitualBegin.cs::XRL.World.Conversations.Parts.WaterRitualBegin.HandleEvent`
- `XRL.World.Conversations.Parts/WaterRitualSkillPoint.cs::XRL.World.Conversations.Parts.WaterRitualSkillPoint.HandleEvent`
- `XRL.World.Conversations.Parts/WaterRitualTinkeringRecipe.cs::XRL.World.Conversations.Parts.WaterRitualTinkeringRecipe.HandleEvent`

## Inventory Shapes Audited

- `WaterRitualBegin.HandleEvent`
  - `Popup.ShowYesNoCancel("Do you want to play a game of Sifrah ... with " + The.Speaker.t(...) + "... consume 1 dram of " + WaterRitual.LiquidName + ".")`
  - `Popup.ShowFail("You don't have enough " + WaterRitual.Liquid.GetName() + " to begin the ritual.")`
- `WaterRitualSkillPoint.HandleEvent`
  - `Popup.Show("Talking to " + The.Speaker.T(...) + " rouses in you an inert truth...")`
  - `Popup.Show("You gained {{C|" + Points + "}} skill points!")`
- `WaterRitualTinkeringRecipe.HandleEvent`
  - `Popup.Show(The.Speaker.Does("teach", ...) + " you to craft the item modification {{W|" + Data.DisplayName + "}}.")`
  - `Popup.Show(The.Speaker.Does("teach", ...) + " you to craft " + ... + ".")`

Explicitly deferred from this PR: `WaterRitualBuySecret.*`, `WaterRitualRandomMutation`, and other Water Ritual owner families not covered by the three-family batch above.

## Queue Delta

On this branch:

- `337 families, 940 callsites, 961 text arguments`
- to `334 families, 934 callsites, 955 text arguments`

Note: the earlier combat-skill batch is still in draft PR #657 and is not included in this branch, so those families still appear in this branch's queue output.

## Verification

- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~WaterRitualPopupTranslationPatchTests' --no-restore`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures' --no-restore`
- `just static-producer-check`
- `just static-producer-owner-queue`
- `git diff --check`
- `just release-note-check origin/main HEAD`

Related: #576
