### PR TITLE
Register Cripple static producer owner closure

### DIFF
--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -3052,6 +3052,64 @@ def _effect_static_message_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _cripple_apply_family() -> tuple[CoveredOwnerFamily, ...]:
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.World.Effects/Cripple.cs::XRL.World.Effects.Cripple.Apply",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/CrippleApplyTranslationPatch.cs",
+                    (
+                        "CrippleApplyTranslationPatch",
+                        "XRL.World.Effects.Cripple",
+                        "Apply",
+                        "TryTranslateQueuedMessage",
+                        "MessageLogProducerTranslationHelpers.TryPreparePatternMessage",
+                        "Cripple.Apply",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs",
+                    ("CrippleApplyTranslationPatch.TryTranslateQueuedMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Localization/Dictionaries/messages.ja.json",
+                    (
+                        "^You are crippled for (.+?)!$",
+                        "{t0}のあいだ手足が不自由になった！",  # noqa: RUF001
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+                    (
+                        "CrippleApply_TranslatesDurationMessage_WhenPatched",
+                        "CrippleApply_LeavesUnknownOwnerMessageUnchanged_WhenPatched",
+                        "CrippleApply_LeavesEmptyMessageUnchanged_WhenPatched",
+                        "CrippleApply_PreservesColorTaggedDurationAndQueueColor_WhenPatched",
+                        "CrippleApply_DirectMarkerPassesThroughWithoutRetranslation_WhenPatched",
+                        "CrippleApply_DoesNotTranslateQueueOnlyTraffic_WhenOwnerAbsent",
+                        "MessageQueueSemanticPipeline_TranslatesActiveOwnerMessage",
+                        "MessageQueueSemanticPipeline_DoesNotTranslateQueueOnlyTraffic_WhenOwnerAbsent",
+                        "MessageQueueSemanticPipeline_DoesNotRetranslateDirectMarkedMessage",
+                        "nameof(DummyCrippleApplyTarget.Apply)",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(CrippleApplyTranslationPatch)",
+                        "XRL.World.Effects.Cripple",
+                        "Apply",
+                        "System.Boolean",
+                        "XRL.World.GameObject",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _system_static_message_families() -> tuple[CoveredOwnerFamily, ...]:
     tests = EvidenceFile(
         "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
@@ -3991,6 +4049,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_amnesia_families(),
     *_fixed_owner_queue_families(),
     *_effect_static_message_families(),
+    *_cripple_apply_family(),
     *_system_static_message_families(),
     CoveredOwnerFamily(
         family_id="XRL.UI/TradeUI.cs::XRL.UI.TradeUI.PerformOffer",


### PR DESCRIPTION
## Summary

Closes one issue #576 static-producer owner family by registering existing owner-route evidence for `Cripple.Apply`:

- `XRL.World.Effects/Cripple.cs::XRL.World.Effects.Cripple.Apply`

This is a closure-only PR. The owner patch, queue pipeline link, production pattern dictionary entry, L2 behavior tests, and L2G target resolution evidence already exist in the repo; this PR registers that complete evidence in `scripts/static_producer_closure.py`.

## Inventory Shape Audited

- line 55 `MessageQueue.AddPlayerMessage("You are crippled for " + Duration.Things("turn") + "!", 'R')`

## Queue Delta

On this branch:

- `337 families, 940 callsites, 961 text arguments`
- to `336 families, 939 callsites, 960 text arguments`

Note: draft PRs #657 and #658 are not included in this branch, so their closed families still appear in this branch's queue output.

## Verification

- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~CrippleApply' --no-restore`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~MessageQueueSemanticPipeline_' --no-restore`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethod_ResolvesExpectedSignature' --no-restore`
- `just static-producer-check`
- `just static-producer-owner-queue`
- `git diff --check`

Related: #576
