### PR TITLE
Close mutation self-target static producer popups

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
@@ -210,6 +210,7 @@ internal static class ColorRouteCatalog
             ["Mods/QudJP/Assemblies/src/Patches/AbilityBarButtonTextTranslationPatch.cs|GetDisplayNameRouteTranslator.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/GameObjectMoveTranslationPatch.cs|MessagePatternTranslator.Translate("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/GameObjectPerformThrowTranslationPatch.cs|MessagePatternTranslator.Translate("] = 1,
+            ["Mods/QudJP/Assemblies/src/Patches/MutationSelfTargetPopupTranslationPatch.cs|MessagePatternTranslator.Translate("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/GameSummaryTextTranslator.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 2,
             ["Mods/QudJP/Assemblies/src/Patches/GameSummaryTextTranslator.cs|JournalPatternTranslator.Translate("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/GameManagerUpdateSelectedAbilityPatch.cs|GetDisplayNameRouteTranslator.TranslatePreservingColors("] = 1,

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/MutationSelfTargetPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/MutationSelfTargetPopupTranslationPatchTests.cs
@@ -1,0 +1,239 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class MutationSelfTargetPopupTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
+        Translator.ResetForTests();
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(null);
+        Translator.ResetForTests();
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+    }
+
+    [TestCase(nameof(DummyMutationSelfTargetProducer.BreatherBaseCast))]
+    [TestCase(nameof(DummyMutationSelfTargetProducer.FlamingRayCast))]
+    [TestCase(nameof(DummyMutationSelfTargetProducer.FreezeBreathFireEvent))]
+    [TestCase(nameof(DummyMutationSelfTargetProducer.FreezingRayCast))]
+    public void Patch_TranslatesSelfTargetPopup_WhenOwnerPatched(string methodName)
+    {
+        UseRepositoryPatternDictionary();
+
+        WithPatchedOwnerAndPopup(methodName, () =>
+        {
+            var target = new DummyMutationSelfTargetProducer
+            {
+                PopupMessageToShow = "Are you sure you want to target yourself?",
+            };
+
+            InvokeOwnerMethod(target, methodName);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowYesNoCancelMessage, Is.EqualTo("yourselfを標的にしてもよいか？"));
+                Assert.That(HitCount(), Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotClaimSelfTargetPopup_WhenOwnerAbsent()
+    {
+        UseRepositoryPatternDictionary();
+
+        WithPatchedPopupOnly(() =>
+        {
+            _ = DummyPopupShow.ShowYesNoCancel("Are you sure you want to target yourself?");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowYesNoCancelMessage, Is.EqualTo("yourselfを標的にしてもよいか？"));
+                Assert.That(HitCount(), Is.Zero);
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
+    {
+        UseRepositoryPatternDictionary();
+        var source = MessageFrameTranslator.MarkDirectTranslation("Are you sure you want to target yourself?");
+
+        WithPatchedOwnerAndPopup(
+            nameof(DummyMutationSelfTargetProducer.BreatherBaseCast),
+            () =>
+            {
+                var target = new DummyMutationSelfTargetProducer
+                {
+                    PopupMessageToShow = source,
+                };
+
+                target.BreatherBaseCast();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyPopupShow.LastShowYesNoCancelMessage, Is.EqualTo("Are you sure you want to target yourself?"));
+                    Assert.That(HitCount(), Is.Zero);
+                });
+            });
+    }
+
+    [Test]
+    public void Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        UseRepositoryPatternDictionary();
+
+        WithPatchedOwnerAndPopup(
+            nameof(DummyMutationSelfTargetProducer.BreatherBaseCast),
+            () =>
+            {
+                var target = new DummyMutationSelfTargetProducer
+                {
+                    PopupMessageToShow = string.Empty,
+                };
+
+                target.BreatherBaseCast();
+
+                Assert.That(DummyPopupShow.LastShowYesNoCancelMessage, Is.EqualTo(string.Empty));
+            });
+    }
+
+    private static void WithPatchedOwnerAndPopup(string methodName, Action action)
+    {
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopup(harmony);
+            harmony.Patch(
+                original: RequireOwnerMethod(methodName),
+                prefix: new HarmonyMethod(RequireMethod(typeof(MutationSelfTargetPopupTranslationPatch), nameof(MutationSelfTargetPopupTranslationPatch.Prefix))),
+                finalizer: new HarmonyMethod(RequireMethod(typeof(MutationSelfTargetPopupTranslationPatch), nameof(MutationSelfTargetPopupTranslationPatch.Finalizer))));
+
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void WithPatchedPopupOnly(Action action)
+    {
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopup(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopup(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.ShowYesNoCancel)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void InvokeOwnerMethod(DummyMutationSelfTargetProducer target, string methodName)
+    {
+        _ = RequireOwnerMethod(methodName).Invoke(target, null);
+    }
+
+    private static int HitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.ProducerText." + nameof(MutationSelfTargetPopupTranslationPatch) + ".SelfTargetConfirmation");
+    }
+
+    private static MethodInfo RequireOwnerMethod(string methodName)
+    {
+        return RequireMethod(typeof(DummyMutationSelfTargetProducer), methodName);
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName)
+    {
+        return type.GetMethod(
+                   methodName,
+                   BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
+               ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private static void UseRepositoryPatternDictionary()
+    {
+        var localizationRoot = Path.GetFullPath(
+            Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "Localization"));
+        LocalizationAssetResolver.SetLocalizationRootForTests(localizationRoot);
+        Translator.SetDictionaryDirectoryForTests(Path.Combine(localizationRoot, "Dictionaries"));
+        MessagePatternTranslator.SetPatternFileForTests(null);
+    }
+
+    private sealed class DummyMutationSelfTargetProducer
+    {
+        public string PopupMessageToShow { get; set; } = string.Empty;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool BreatherBaseCast()
+        {
+            return EmitPopup();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool FlamingRayCast()
+        {
+            return EmitPopup();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool FreezeBreathFireEvent()
+        {
+            return EmitPopup();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool FreezingRayCast()
+        {
+            return EmitPopup();
+        }
+
+        private bool EmitPopup()
+        {
+            _ = DummyPopupShow.ShowYesNoCancel(PopupMessageToShow);
+            return true;
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1278,6 +1278,13 @@ public sealed class TargetMethodResolutionTests
         "XRL.World.Parts.LiquidVolume|Pour|System.Boolean|System.Boolean&|XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean|System.Int32|System.Boolean",
         "XRL.World.Parts.LiquidVolume|PerformFill|System.Boolean|XRL.World.GameObject|System.Boolean&|System.Boolean",
     })]
+    [TestCase(typeof(MutationSelfTargetPopupTranslationPatch), new[]
+    {
+        "XRL.World.Parts.Mutation.BreatherBase|Cast|System.Boolean|XRL.World.Parts.Mutation.BreatherBase",
+        "XRL.World.Parts.Mutation.FlamingRay|Cast|System.Boolean|XRL.World.Parts.Mutation.FlamingRay|System.String",
+        "XRL.World.Parts.Mutation.FreezeBreath|FireEvent|System.Boolean|XRL.World.Event",
+        "XRL.World.Parts.Mutation.FreezingRay|Cast|System.Boolean|XRL.World.Parts.Mutation.FreezingRay|System.String",
+    })]
     public void OwnerProducerTargetMethods_ResolveExpectedFullSignatures(Type patchType, string[] expectedSignatures)
     {
         var targetMethodsMethod = patchType.GetMethod("TargetMethods", BindingFlags.NonPublic | BindingFlags.Static);

--- a/Mods/QudJP/Assemblies/src/Patches/MutationSelfTargetPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/MutationSelfTargetPopupTranslationPatch.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class MutationSelfTargetPopupTranslationPatch
+{
+    private const string Context = nameof(MutationSelfTargetPopupTranslationPatch);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        var eventType = AccessTools.TypeByName("XRL.World.Event");
+        if (eventType is null)
+        {
+            Trace.TraceError("QudJP: {0} failed to resolve Event type.", Context);
+            yield break;
+        }
+
+        foreach (var method in ResolveTarget(
+                     "XRL.World.Parts.Mutation.BreatherBase",
+                     "Cast",
+                     ["XRL.World.Parts.Mutation.BreatherBase"]))
+        {
+            yield return method;
+        }
+
+        foreach (var method in ResolveTarget(
+                     "XRL.World.Parts.Mutation.FlamingRay",
+                     "Cast",
+                     ["XRL.World.Parts.Mutation.FlamingRay", typeof(string)]))
+        {
+            yield return method;
+        }
+
+        foreach (var method in ResolveTarget(
+                     "XRL.World.Parts.Mutation.FreezeBreath",
+                     "FireEvent",
+                     [eventType]))
+        {
+            yield return method;
+        }
+
+        foreach (var method in ResolveTarget(
+                     "XRL.World.Parts.Mutation.FreezingRay",
+                     "Cast",
+                     ["XRL.World.Parts.Mutation.FreezingRay", typeof(string)]))
+        {
+            yield return method;
+        }
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        _ = family;
+
+        if (!OwnerTranslationScope.IsActive(activeDepth)
+            || string.IsNullOrEmpty(source)
+            || !source.StartsWith("Are you sure you want to target ", StringComparison.Ordinal)
+            || !source.EndsWith("?", StringComparison.Ordinal))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        var patternTranslated = MessagePatternTranslator.Translate(source, route);
+        if (string.Equals(patternTranslated, source, StringComparison.Ordinal))
+        {
+            translated = source;
+            return false;
+        }
+
+        DynamicTextObservability.RecordTransform(
+            route,
+            "Popup.ProducerText." + Context + ".SelfTargetConfirmation",
+            source,
+            patternTranslated);
+        translated = patternTranslated;
+        return true;
+    }
+
+    private static IEnumerable<MethodBase> ResolveTarget(string typeName, string methodName, object[] parameterSpecs)
+    {
+        var targetType = AccessTools.TypeByName(typeName);
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found: {1}", Context, typeName);
+            yield break;
+        }
+
+        var parameters = new Type[parameterSpecs.Length];
+        for (var index = 0; index < parameterSpecs.Length; index++)
+        {
+            if (parameterSpecs[index] is Type parameterType)
+            {
+                parameters[index] = parameterType;
+                continue;
+            }
+
+            var parameterTypeName = (string)parameterSpecs[index];
+            parameterType = AccessTools.TypeByName(parameterTypeName);
+            if (parameterType is null)
+            {
+                Trace.TraceError("QudJP: {0} parameter type not found: {1}", Context, parameterTypeName);
+                yield break;
+            }
+
+            parameters[index] = parameterType;
+        }
+
+        var method = AccessTools.Method(targetType, methodName, parameters);
+        if (method is not null)
+        {
+            yield return method;
+            yield break;
+        }
+
+        Trace.TraceError("QudJP: {0}.{1}.{2} target not found.", Context, typeName, methodName);
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -14,6 +14,7 @@ internal static class PopupShowSemanticPipeline
         GameObjectStatPopupTranslationPatch.TryTranslatePopupMessage,
         GameObjectMoveTranslationPatch.TryTranslatePopupMessage,
         GameObjectPerformThrowTranslationPatch.TryTranslatePopupMessage,
+        MutationSelfTargetPopupTranslationPatch.TryTranslatePopupMessage,
         GameObjectPopupTranslationPatch.TryTranslatePopupMessage,
         RealityStabilizedInterdictTranslationPatch.TryTranslatePopupMessage,
         HackingSifrahResultTranslationPatch.TryTranslatePopupMessage,

--- a/docs/release-notes/unreleased/issue-576-mutation-self-target.md
+++ b/docs/release-notes/unreleased/issue-576-mutation-self-target.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Added owner-routed Japanese translations for mutation self-target confirmation popups.

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -3052,6 +3052,115 @@ def _effect_static_message_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _mutation_self_target_popup_families() -> tuple[CoveredOwnerFamily, ...]:
+    patch = EvidenceFile(
+        "Mods/QudJP/Assemblies/src/Patches/MutationSelfTargetPopupTranslationPatch.cs",
+        (
+            "MutationSelfTargetPopupTranslationPatch",
+            "TryTranslatePopupMessage",
+            "SelfTargetConfirmation",
+        ),
+    )
+    pipeline = EvidenceFile(
+        "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+        ("MutationSelfTargetPopupTranslationPatch.TryTranslatePopupMessage",),
+    )
+    dictionary = EvidenceFile(
+        "Mods/QudJP/Localization/Dictionaries/messages.ja.json",
+        (
+            "^Are you sure you want to target (.+?)\\\\?$",
+            "{0}を標的にしてもよいか？",  # noqa: RUF001
+        ),
+    )
+    tests = EvidenceFile(
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/MutationSelfTargetPopupTranslationPatchTests.cs",
+        (
+            "Patch_TranslatesSelfTargetPopup_WhenOwnerPatched",
+            "Patch_DoesNotClaimSelfTargetPopup_WhenOwnerAbsent",
+            "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+            "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+            "nameof(DummyMutationSelfTargetProducer.BreatherBaseCast)",
+            "nameof(DummyMutationSelfTargetProducer.FlamingRayCast)",
+            "nameof(DummyMutationSelfTargetProducer.FreezeBreathFireEvent)",
+            "nameof(DummyMutationSelfTargetProducer.FreezingRayCast)",
+        ),
+    )
+
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts.Mutation/BreatherBase.cs::XRL.World.Parts.Mutation.BreatherBase.Cast",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(patch.path, (*patch.required_substrings, "XRL.World.Parts.Mutation.BreatherBase", "Cast")),
+                pipeline,
+                dictionary,
+                tests,
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(MutationSelfTargetPopupTranslationPatch)",
+                        "XRL.World.Parts.Mutation.BreatherBase|Cast|System.Boolean|XRL.World.Parts.Mutation.BreatherBase",
+                    ),
+                ),
+            ),
+        ),
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts.Mutation/FlamingRay.cs::XRL.World.Parts.Mutation.FlamingRay.Cast",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(patch.path, (*patch.required_substrings, "XRL.World.Parts.Mutation.FlamingRay", "Cast")),
+                pipeline,
+                dictionary,
+                tests,
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(MutationSelfTargetPopupTranslationPatch)",
+                        "XRL.World.Parts.Mutation.FlamingRay|Cast|System.Boolean|XRL.World.Parts.Mutation.FlamingRay|System.String",
+                    ),
+                ),
+            ),
+        ),
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts.Mutation/FreezeBreath.cs::XRL.World.Parts.Mutation.FreezeBreath.FireEvent",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    patch.path,
+                    (*patch.required_substrings, "XRL.World.Parts.Mutation.FreezeBreath", "FireEvent"),
+                ),
+                pipeline,
+                dictionary,
+                tests,
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(MutationSelfTargetPopupTranslationPatch)",
+                        "XRL.World.Parts.Mutation.FreezeBreath|FireEvent|System.Boolean|XRL.World.Event",
+                    ),
+                ),
+            ),
+        ),
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts.Mutation/FreezingRay.cs::XRL.World.Parts.Mutation.FreezingRay.Cast",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(patch.path, (*patch.required_substrings, "XRL.World.Parts.Mutation.FreezingRay", "Cast")),
+                pipeline,
+                dictionary,
+                tests,
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(MutationSelfTargetPopupTranslationPatch)",
+                        "XRL.World.Parts.Mutation.FreezingRay|Cast|System.Boolean|XRL.World.Parts.Mutation.FreezingRay|System.String",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _system_static_message_families() -> tuple[CoveredOwnerFamily, ...]:
     tests = EvidenceFile(
         "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
@@ -3991,6 +4100,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_amnesia_families(),
     *_fixed_owner_queue_families(),
     *_effect_static_message_families(),
+    *_mutation_self_target_popup_families(),
     *_system_static_message_families(),
     CoveredOwnerFamily(
         family_id="XRL.UI/TradeUI.cs::XRL.UI.TradeUI.PerformOffer",


### PR DESCRIPTION
## Summary

Closes four issue #576 static-producer owner families for mutation self-target confirmation popups:

- `XRL.World.Parts.Mutation/BreatherBase.cs::XRL.World.Parts.Mutation.BreatherBase.Cast`
- `XRL.World.Parts.Mutation/FlamingRay.cs::XRL.World.Parts.Mutation.FlamingRay.Cast`
- `XRL.World.Parts.Mutation/FreezeBreath.cs::XRL.World.Parts.Mutation.FreezeBreath.FireEvent`
- `XRL.World.Parts.Mutation/FreezingRay.cs::XRL.World.Parts.Mutation.FreezingRay.Cast`

The patch gates mutation-owner scope and routes the existing repository pattern for `Are you sure you want to target ...?` through popup producer translation.

## Inventory Shapes Audited

- `BreatherBase.Cast`: `Popup.ShowYesNoCancel("Are you sure you want to target " + mutation.ParentObject.itself + "?")`
- `FlamingRay.Cast`: same shape with `mutation.ParentObject.itself`
- `FreezeBreath.FireEvent`: same shape with `ParentObject.itself`
- `FreezingRay.Cast`: same shape with `mutation.ParentObject.itself`

## Queue Delta

On this branch:

- `337 families, 940 callsites, 961 text arguments`
- to `333 families, 936 callsites, 957 text arguments`

Note: draft PRs #657, #658, and #659 are not included in this branch, so their closed families still appear in this branch's queue output.

## Verification

- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~MutationSelfTargetPopupTranslationPatchTests' --no-restore`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures' --no-restore`
- `just static-producer-check`
- `just static-producer-owner-queue`
- `just release-note-check origin/main HEAD`
- `git diff --check`

Related: #576
