### PR TITLE
Close Golem quest selection owner popups

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/GolemQuestSelectionPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/GolemQuestSelectionPopupTranslationPatchTests.cs
@@ -1,0 +1,208 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class GolemQuestSelectionPopupTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
+        Translator.ResetForTests();
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(null);
+        Translator.ResetForTests();
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+    }
+
+    [TestCase(
+        nameof(DummyGolemQuestSelectionProducer.WishSpec),
+        "No blueprint by ID '{{W|missing-body}}' found.",
+        "ID '{{W|missing-body}}' のブループリントが見つからない。",
+        "MissingBlueprint")]
+    [TestCase(
+        nameof(DummyGolemQuestSelectionProducer.Pick),
+        "You have nothing that meets the requirement of the {{Y|armament}}.",
+        "{{Y|armament}}の要件を満たすものを持っていない。",
+        "MissingRequirement")]
+    public void Patch_TranslatesGolemSelectionPopups_WhenOwnerPatched(
+        string methodName,
+        string source,
+        string expected,
+        string detail)
+    {
+        WithPatchedOwnerAndPopup(methodName, () =>
+        {
+            var target = new DummyGolemQuestSelectionProducer
+            {
+                PopupMessageToShow = source,
+            };
+
+            InvokeOwnerMethod(target, methodName);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+                Assert.That(HitCount(detail), Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotTranslateGolemSelectionPopup_WhenOwnerAbsent()
+    {
+        WithPatchedPopupOnly(() =>
+        {
+            DummyPopupShow.ShowFail("No blueprint by ID '{{W|missing-body}}' found.");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("No blueprint by ID '{{W|missing-body}}' found."));
+                Assert.That(HitCount("MissingBlueprint"), Is.Zero);
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
+    {
+        var source = MessageFrameTranslator.MarkDirectTranslation("No blueprint by ID '{{W|missing-body}}' found.");
+
+        WithPatchedOwnerAndPopup(
+            nameof(DummyGolemQuestSelectionProducer.WishSpec),
+            () =>
+            {
+                var target = new DummyGolemQuestSelectionProducer
+                {
+                    PopupMessageToShow = source,
+                };
+
+                target.WishSpec();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("No blueprint by ID '{{W|missing-body}}' found."));
+                    Assert.That(HitCount("MissingBlueprint"), Is.Zero);
+                });
+            });
+    }
+
+    [Test]
+    public void Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        WithPatchedOwnerAndPopup(
+            nameof(DummyGolemQuestSelectionProducer.WishSpec),
+            () =>
+            {
+                var target = new DummyGolemQuestSelectionProducer
+                {
+                    PopupMessageToShow = string.Empty,
+                };
+
+                target.WishSpec();
+
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
+            });
+    }
+
+    private static void WithPatchedOwnerAndPopup(string methodName, Action action)
+    {
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopup(harmony);
+            harmony.Patch(
+                original: RequireOwnerMethod(methodName),
+                prefix: new HarmonyMethod(RequireMethod(typeof(GolemQuestSelectionPopupTranslationPatch), nameof(GolemQuestSelectionPopupTranslationPatch.Prefix))),
+                finalizer: new HarmonyMethod(RequireMethod(typeof(GolemQuestSelectionPopupTranslationPatch), nameof(GolemQuestSelectionPopupTranslationPatch.Finalizer))));
+
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void WithPatchedPopupOnly(Action action)
+    {
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopup(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopup(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.ShowFail)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void InvokeOwnerMethod(DummyGolemQuestSelectionProducer target, string methodName)
+    {
+        _ = RequireOwnerMethod(methodName).Invoke(target, null);
+    }
+
+    private static int HitCount(string detail)
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.ProducerText." + nameof(GolemQuestSelectionPopupTranslationPatch) + "." + detail);
+    }
+
+    private static MethodInfo RequireOwnerMethod(string methodName)
+    {
+        return RequireMethod(typeof(DummyGolemQuestSelectionProducer), methodName);
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName)
+    {
+        return type.GetMethod(
+                   methodName,
+                   BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
+               ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private sealed class DummyGolemQuestSelectionProducer
+    {
+        public string PopupMessageToShow { get; set; } = string.Empty;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void WishSpec()
+        {
+            DummyPopupShow.ShowFail(PopupMessageToShow);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Pick()
+        {
+            DummyPopupShow.ShowFail(PopupMessageToShow);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1278,6 +1278,12 @@ public sealed class TargetMethodResolutionTests
         "XRL.World.Parts.LiquidVolume|Pour|System.Boolean|System.Boolean&|XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean|System.Int32|System.Boolean",
         "XRL.World.Parts.LiquidVolume|PerformFill|System.Boolean|XRL.World.GameObject|System.Boolean&|System.Boolean",
     })]
+    [TestCase(typeof(GolemQuestSelectionPopupTranslationPatch), new[]
+    {
+        "XRL.World.Quests.GolemQuest.GolemBodySelection|WishSpec|System.Void|System.String",
+        // Evidence anchor for the generic owner family: XRL.World.Quests.GolemQuest.GolemMaterialSelection.Pick.
+        "XRL.World.Quests.GolemQuest.GolemMaterialSelection`2|Pick|System.Void",
+    })]
     public void OwnerProducerTargetMethods_ResolveExpectedFullSignatures(Type patchType, string[] expectedSignatures)
     {
         var targetMethodsMethod = patchType.GetMethod("TargetMethods", BindingFlags.NonPublic | BindingFlags.Static);

--- a/Mods/QudJP/Assemblies/src/Patches/GolemQuestSelectionPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GolemQuestSelectionPopupTranslationPatch.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class GolemQuestSelectionPopupTranslationPatch
+{
+    private const string Context = nameof(GolemQuestSelectionPopupTranslationPatch);
+
+    private static readonly Regex MissingBlueprintPattern = new(
+        "^No blueprint by ID '(?<id>.+?)' found\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex MissingRequirementPattern = new(
+        "^You have nothing that meets the requirement of the (?<requirement>.+?)\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        foreach (var method in ResolveTarget(
+                     "XRL.World.Quests.GolemQuest.GolemBodySelection",
+                     "WishSpec",
+                     [typeof(string)]))
+        {
+            yield return method;
+        }
+
+        foreach (var method in ResolveTarget(
+                     "XRL.World.Quests.GolemQuest.GolemMaterialSelection`2",
+                     "Pick",
+                     Type.EmptyTypes))
+        {
+            yield return method;
+        }
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        _ = family;
+
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        if (TryTranslateCore(source, out translated, out var detail))
+        {
+            DynamicTextObservability.RecordTransform(
+                route,
+                "Popup.ProducerText." + Context + "." + detail,
+                source,
+                translated);
+            return true;
+        }
+
+        translated = source;
+        return false;
+    }
+
+    private static IEnumerable<MethodBase> ResolveTarget(string typeName, string methodName, Type[] parameters)
+    {
+        var targetType = AccessTools.TypeByName(typeName);
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found: {1}", Context, typeName);
+            yield break;
+        }
+
+        var method = AccessTools.Method(targetType, methodName, parameters);
+        if (method is not null)
+        {
+            yield return method;
+            yield break;
+        }
+
+        Trace.TraceError("QudJP: {0}.{1}.{2} target not found.", Context, typeName, methodName);
+    }
+
+    private static bool TryTranslateCore(string source, out string translated, out string detail)
+    {
+        if (TryTranslatePattern(
+                MissingBlueprintPattern,
+                source,
+                (match, spans) => $"ID '{Restore(match, spans, "id")}' のブループリントが見つからない。",
+                out translated))
+        {
+            detail = "MissingBlueprint";
+            return true;
+        }
+
+        if (TryTranslatePattern(
+                MissingRequirementPattern,
+                source,
+                (match, spans) => $"{Restore(match, spans, "requirement")}の要件を満たすものを持っていない。",
+                out translated))
+        {
+            detail = "MissingRequirement";
+            return true;
+        }
+
+        translated = source;
+        detail = string.Empty;
+        return false;
+    }
+
+    private static bool TryTranslatePattern(
+        Regex pattern,
+        string source,
+        Func<Match, IReadOnlyList<ColorSpan>, string> translate,
+        out string translated)
+    {
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
+        var match = pattern.Match(stripped);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = ColorAwareTranslationComposer.RestoreWholeSourceBoundaryWrappersPreservingTranslatedOwnership(
+            translate(match, spans),
+            spans,
+            stripped.Length,
+            source);
+        return true;
+    }
+
+    private static string Restore(Match match, IReadOnlyList<ColorSpan> spans, string groupName)
+    {
+        var group = match.Groups[groupName];
+        return ColorAwareTranslationComposer.RestoreCapture(group.Value, spans, group).Trim();
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -15,6 +15,7 @@ internal static class PopupShowSemanticPipeline
         GameObjectMoveTranslationPatch.TryTranslatePopupMessage,
         GameObjectPerformThrowTranslationPatch.TryTranslatePopupMessage,
         GameObjectPopupTranslationPatch.TryTranslatePopupMessage,
+        GolemQuestSelectionPopupTranslationPatch.TryTranslatePopupMessage,
         RealityStabilizedInterdictTranslationPatch.TryTranslatePopupMessage,
         HackingSifrahResultTranslationPatch.TryTranslatePopupMessage,
         QuestLifecyclePopupTranslationPatch.TryTranslatePopupMessage,

--- a/docs/release-notes/unreleased/issue-576-golem-selection-popups.md
+++ b/docs/release-notes/unreleased/issue-576-golem-selection-popups.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Added owner-routed Japanese translations for Golem quest selection failure popups.

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -3052,6 +3052,98 @@ def _effect_static_message_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _golem_quest_selection_popup_families() -> tuple[CoveredOwnerFamily, ...]:
+    patch = EvidenceFile(
+        "Mods/QudJP/Assemblies/src/Patches/GolemQuestSelectionPopupTranslationPatch.cs",
+        (
+            "GolemQuestSelectionPopupTranslationPatch",
+            "TryTranslatePopupMessage",
+        ),
+    )
+    pipeline = EvidenceFile(
+        "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+        ("GolemQuestSelectionPopupTranslationPatch.TryTranslatePopupMessage",),
+    )
+    tests = EvidenceFile(
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/GolemQuestSelectionPopupTranslationPatchTests.cs",
+        (
+            "Patch_TranslatesGolemSelectionPopups_WhenOwnerPatched",
+            "Patch_DoesNotTranslateGolemSelectionPopup_WhenOwnerAbsent",
+            "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+            "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+            "nameof(DummyGolemQuestSelectionProducer.WishSpec)",
+            "nameof(DummyGolemQuestSelectionProducer.Pick)",
+        ),
+    )
+
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.World.Quests.GolemQuest/GolemBodySelection.cs::XRL.World.Quests.GolemQuest.GolemBodySelection.WishSpec",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    patch.path,
+                    (
+                        *patch.required_substrings,
+                        "XRL.World.Quests.GolemQuest.GolemBodySelection",
+                        "WishSpec",
+                        "MissingBlueprintPattern",
+                        "MissingBlueprint",
+                    ),
+                ),
+                pipeline,
+                EvidenceFile(
+                    tests.path,
+                    (
+                        *tests.required_substrings,
+                        "No blueprint by ID '{{W|missing-body}}' found.",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(GolemQuestSelectionPopupTranslationPatch)",
+                        "XRL.World.Quests.GolemQuest.GolemBodySelection|WishSpec|System.Void|System.String",
+                    ),
+                ),
+            ),
+        ),
+        CoveredOwnerFamily(
+            family_id="XRL.World.Quests.GolemQuest/GolemMaterialSelection.cs::XRL.World.Quests.GolemQuest.GolemMaterialSelection.Pick",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    patch.path,
+                    (
+                        *patch.required_substrings,
+                        "XRL.World.Quests.GolemQuest.GolemMaterialSelection`2",
+                        "Pick",
+                        "MissingRequirementPattern",
+                        "MissingRequirement",
+                    ),
+                ),
+                pipeline,
+                EvidenceFile(
+                    tests.path,
+                    (
+                        *tests.required_substrings,
+                        "You have nothing that meets the requirement of the {{Y|armament}}.",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(GolemQuestSelectionPopupTranslationPatch)",
+                        "XRL.World.Quests.GolemQuest.GolemMaterialSelection",
+                        "Pick",
+                        "XRL.World.Quests.GolemQuest.GolemMaterialSelection`2|Pick|System.Void",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _system_static_message_families() -> tuple[CoveredOwnerFamily, ...]:
     tests = EvidenceFile(
         "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
@@ -3991,6 +4083,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_amnesia_families(),
     *_fixed_owner_queue_families(),
     *_effect_static_message_families(),
+    *_golem_quest_selection_popup_families(),
     *_system_static_message_families(),
     CoveredOwnerFamily(
         family_id="XRL.UI/TradeUI.cs::XRL.UI.TradeUI.PerformOffer",


### PR DESCRIPTION
## Summary
- add an owner-routed popup translator for Golem quest selection failures
- cover missing body blueprint and missing material requirement popup shapes with L2 tests
- register the two proven Golem selection owner families in the static producer closure overlay

## Closed owner families
- `XRL.World.Quests.GolemQuest/GolemBodySelection.cs::XRL.World.Quests.GolemQuest.GolemBodySelection.WishSpec`
  - `Popup.ShowFail("No blueprint by ID '" + Value + "' found.")`
- `XRL.World.Quests.GolemQuest/GolemMaterialSelection.cs::XRL.World.Quests.GolemQuest.GolemMaterialSelection.Pick`
  - `Popup.ShowFail("You have nothing that meets the requirement of the " + DisplayName + ".")`

## Queue delta
- before this batch: `337 families, 940 callsites, 961 text arguments`
- after this batch: `335 families, 938 callsites, 959 text arguments`

## Validation
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~GolemQuestSelectionPopupTranslationPatchTests' --no-restore`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures' --no-restore`
- `just static-producer-check`
- `just static-producer-owner-queue`
- `just release-note-check origin/main HEAD`
- `git diff --check`

Issue: #576
