### PR TITLE
Close fire suppression discharge owner messages

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/FireSuppressionDischargeTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/FireSuppressionDischargeTranslationPatchTests.cs
@@ -1,0 +1,243 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class FireSuppressionDischargeTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
+        Translator.ResetForTests();
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+        DummyMessageQueue.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(null);
+        Translator.ResetForTests();
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+    }
+
+    [TestCase(
+        nameof(DummyFireSuppressionDischargeProducer.CheckFireSuppression),
+        "2 drams of {{C|gel}} discharges all over you.",
+        "{{C|gel}} 2ドラムがあなたの全身に放出された。",
+        "FireSuppressionSelf")]
+    [TestCase(
+        nameof(DummyFireSuppressionDischargeProducer.CheckFireSuppression),
+        "1 dram of {{C|gel}} discharges all over the snapjaw.",
+        "{{C|gel}} 1ドラムがsnapjawの全身に放出された。",
+        "FireSuppressionTarget")]
+    [TestCase(
+        nameof(DummyFireSuppressionDischargeProducer.TurnTick),
+        "Your {{Y|fire suppression system}} discharges 2 drams of {{C|gel}} all over you.",
+        "あなたの{{Y|fire suppression system}}が{{C|gel}} 2ドラムをあなたの全身に放出した。",
+        "CyberneticsSelf")]
+    [TestCase(
+        nameof(DummyFireSuppressionDischargeProducer.TurnTick),
+        "{{G|snapjaw}}の {{Y|fire suppression system}} discharges 1 dram of {{C|gel}} all over it.",
+        "{{G|snapjaw}}の{{Y|fire suppression system}}が{{C|gel}} 1ドラムをitの全身に放出した。",
+        "CyberneticsTarget")]
+    public void Patch_TranslatesFireSuppressionDischargeMessages_WhenOwnerPatched(
+        string methodName,
+        string source,
+        string expected,
+        string detail)
+    {
+        WithPatchedOwnerAndQueue(methodName, () =>
+        {
+            var target = new DummyFireSuppressionDischargeProducer
+            {
+                QueuedMessageToSend = source,
+            };
+
+            InvokeOwnerMethod(target, methodName);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(expected));
+                Assert.That(HitCount(detail), Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotTranslateFireSuppressionDischargeMessage_WhenOwnerAbsent()
+    {
+        WithPatchedQueueOnly(() =>
+        {
+            DummyMessageQueue.AddPlayerMessage("2 drams of {{C|gel}} discharges all over you.", null, Capitalize: false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("2 drams of {{C|gel}} discharges all over you."));
+                Assert.That(HitCount("FireSuppressionSelf"), Is.Zero);
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotRetranslateDirectMarkedMessage_WhenOwnerPatched()
+    {
+        var source = MessageFrameTranslator.MarkDirectTranslation("2 drams of {{C|gel}} discharges all over you.");
+
+        WithPatchedOwnerAndQueue(
+            nameof(DummyFireSuppressionDischargeProducer.CheckFireSuppression),
+            () =>
+            {
+                var target = new DummyFireSuppressionDischargeProducer
+                {
+                    QueuedMessageToSend = source,
+                };
+
+                target.CheckFireSuppression(null);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("2 drams of {{C|gel}} discharges all over you."));
+                    Assert.That(HitCount("FireSuppressionSelf"), Is.Zero);
+                });
+            });
+    }
+
+    [Test]
+    public void Patch_LeavesEmptyMessageUnchanged_WhenOwnerPatched()
+    {
+        WithPatchedOwnerAndQueue(
+            nameof(DummyFireSuppressionDischargeProducer.CheckFireSuppression),
+            () =>
+            {
+                var target = new DummyFireSuppressionDischargeProducer
+                {
+                    QueuedMessageToSend = string.Empty,
+                };
+
+                target.CheckFireSuppression(null);
+
+                Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(string.Empty));
+            });
+    }
+
+    private static void WithPatchedOwnerAndQueue(string methodName, Action action)
+    {
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            harmony.Patch(
+                original: RequireOwnerMethod(methodName),
+                prefix: new HarmonyMethod(RequireMethod(typeof(FireSuppressionDischargeTranslationPatch), nameof(FireSuppressionDischargeTranslationPatch.Prefix))),
+                finalizer: new HarmonyMethod(RequireMethod(typeof(FireSuppressionDischargeTranslationPatch), nameof(FireSuppressionDischargeTranslationPatch.Finalizer), typeof(Exception))));
+
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void WithPatchedQueueOnly(Action action)
+    {
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchQueue(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyMessageQueue), nameof(DummyMessageQueue.AddPlayerMessage), typeof(string), typeof(string), typeof(bool)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(CombatAndLogMessageQueuePatch), nameof(CombatAndLogMessageQueuePatch.Prefix), typeof(string).MakeByRefType(), typeof(string), typeof(bool))));
+    }
+
+    private static void InvokeOwnerMethod(DummyFireSuppressionDischargeProducer target, string methodName)
+    {
+        if (string.Equals(methodName, nameof(DummyFireSuppressionDischargeProducer.TurnTick), StringComparison.Ordinal))
+        {
+            target.TurnTick(1, 1);
+            return;
+        }
+
+        target.CheckFireSuppression(null);
+    }
+
+    private static int HitCount(string detail)
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            "MessageQueue.AddPlayerMessage",
+            nameof(FireSuppressionDischargeTranslationPatch) + "." + detail);
+    }
+
+    private static MethodInfo RequireOwnerMethod(string methodName)
+    {
+        return methodName switch
+        {
+            nameof(DummyFireSuppressionDischargeProducer.CheckFireSuppression) => RequireMethod(
+                typeof(DummyFireSuppressionDischargeProducer),
+                methodName,
+                typeof(DummyGameObject)),
+            nameof(DummyFireSuppressionDischargeProducer.TurnTick) => RequireMethod(
+                typeof(DummyFireSuppressionDischargeProducer),
+                methodName,
+                typeof(long),
+                typeof(int)),
+            _ => throw new ArgumentOutOfRangeException(nameof(methodName), methodName, null),
+        };
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameters)
+    {
+        return type.GetMethod(
+                   methodName,
+                   BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance,
+                   null,
+                   parameters,
+                   null)
+               ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private sealed class DummyFireSuppressionDischargeProducer
+    {
+        public string QueuedMessageToSend { get; set; } = string.Empty;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool CheckFireSuppression(DummyGameObject? obj)
+        {
+            _ = obj;
+            DummyMessageQueue.AddPlayerMessage(QueuedMessageToSend, null, Capitalize: false);
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void TurnTick(long timeTick, int amount)
+        {
+            _ = timeTick;
+            _ = amount;
+            DummyMessageQueue.AddPlayerMessage(QueuedMessageToSend, null, Capitalize: false);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1278,6 +1278,11 @@ public sealed class TargetMethodResolutionTests
         "XRL.World.Parts.LiquidVolume|Pour|System.Boolean|System.Boolean&|XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean|System.Int32|System.Boolean",
         "XRL.World.Parts.LiquidVolume|PerformFill|System.Boolean|XRL.World.GameObject|System.Boolean&|System.Boolean",
     })]
+    [TestCase(typeof(FireSuppressionDischargeTranslationPatch), new[]
+    {
+        "XRL.World.Parts.FireSuppressionSystem|CheckFireSuppression|System.Boolean|XRL.World.GameObject",
+        "XRL.World.Parts.CyberneticsFireSuppressionSystem|TurnTick|System.Void|System.Int64|System.Int32",
+    })]
     public void OwnerProducerTargetMethods_ResolveExpectedFullSignatures(Type patchType, string[] expectedSignatures)
     {
         var targetMethodsMethod = patchType.GetMethod("TargetMethods", BindingFlags.NonPublic | BindingFlags.Static);

--- a/Mods/QudJP/Assemblies/src/Patches/FireSuppressionDischargeTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/FireSuppressionDischargeTranslationPatch.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class FireSuppressionDischargeTranslationPatch
+{
+    private const string Context = nameof(FireSuppressionDischargeTranslationPatch);
+
+    private static readonly Regex FireSuppressionSelfPattern = new(
+        "^(?<amount>\\d+) drams? of (?<liquid>.+?) discharges all over you\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex FireSuppressionTargetPattern = new(
+        "^(?<amount>\\d+) drams? of (?<liquid>.+?) discharges all over (?<target>.+?)\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex CyberneticsSelfPattern = new(
+        "^Your (?<device>.+?) discharges (?<amount>\\d+) drams? of (?<liquid>.+?) all over you\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex CyberneticsTargetPattern = new(
+        "^(?<owner>.+(?:'s|s'|の)) (?<device>.+?) discharges (?<amount>\\d+) drams? of (?<liquid>.+?) all over (?<target>.+?)\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        foreach (var method in ResolveTarget(
+                     "XRL.World.Parts.FireSuppressionSystem",
+                     "CheckFireSuppression",
+                     ["XRL.World.GameObject"]))
+        {
+            yield return method;
+        }
+
+        foreach (var method in ResolveTarget(
+                     "XRL.World.Parts.CyberneticsFireSuppressionSystem",
+                     "TurnTick",
+                     [typeof(long), typeof(int)]))
+        {
+            yield return method;
+        }
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color)
+    {
+        _ = color;
+
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(message))
+        {
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(message, out var markedText))
+        {
+            message = markedText;
+            return true;
+        }
+
+        if (!TryTranslate(message, out var translated, out var detail))
+        {
+            return false;
+        }
+
+        DynamicTextObservability.RecordTransform("MessageQueue.AddPlayerMessage", Context + "." + detail, message, translated);
+        message = translated;
+        return true;
+    }
+
+    private static IEnumerable<MethodBase> ResolveTarget(string typeName, string methodName, Type[] parameters)
+    {
+        var targetType = AccessTools.TypeByName(typeName);
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found: {1}", Context, typeName);
+            yield break;
+        }
+
+        var method = AccessTools.Method(targetType, methodName, parameters);
+        if (method is not null)
+        {
+            yield return method;
+            yield break;
+        }
+
+        Trace.TraceError("QudJP: {0}.{1}.{2} target not found.", Context, typeName, methodName);
+    }
+
+    private static IEnumerable<MethodBase> ResolveTarget(string typeName, string methodName, string[] parameterTypeNames)
+    {
+        var parameterTypes = new Type[parameterTypeNames.Length];
+        for (var index = 0; index < parameterTypeNames.Length; index++)
+        {
+            var parameterType = AccessTools.TypeByName(parameterTypeNames[index]);
+            if (parameterType is null)
+            {
+                Trace.TraceError("QudJP: {0} parameter type not found: {1}", Context, parameterTypeNames[index]);
+                yield break;
+            }
+
+            parameterTypes[index] = parameterType;
+        }
+
+        foreach (var method in ResolveTarget(typeName, methodName, parameterTypes))
+        {
+            yield return method;
+        }
+    }
+
+    private static bool TryTranslate(string source, out string translated, out string detail)
+    {
+        if (TryBuild(
+                FireSuppressionSelfPattern,
+                source,
+                static (match, spans) => BuildSimpleDischarge(match, spans, "あなた"),
+                out translated))
+        {
+            detail = "FireSuppressionSelf";
+            return true;
+        }
+
+        if (TryBuild(
+                FireSuppressionTargetPattern,
+                source,
+                static (match, spans) => BuildSimpleDischarge(match, spans, RestoreTarget(match, spans, "target")),
+                out translated))
+        {
+            detail = "FireSuppressionTarget";
+            return true;
+        }
+
+        if (TryBuild(
+                CyberneticsSelfPattern,
+                source,
+                static (match, spans) => BuildDeviceDischarge(match, spans, "あなたの", "あなた"),
+                out translated))
+        {
+            detail = "CyberneticsSelf";
+            return true;
+        }
+
+        if (TryBuild(
+                CyberneticsTargetPattern,
+                source,
+                static (match, spans) => BuildDeviceDischarge(match, spans, RestoreOwner(match, spans, "owner"), RestoreTarget(match, spans, "target")),
+                out translated))
+        {
+            detail = "CyberneticsTarget";
+            return true;
+        }
+
+        translated = source;
+        detail = string.Empty;
+        return false;
+    }
+
+    private static bool TryBuild(
+        Regex pattern,
+        string source,
+        Func<Match, IReadOnlyList<ColorSpan>, string> build,
+        out string translated)
+    {
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
+        var match = pattern.Match(stripped);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = ColorAwareTranslationComposer.RestoreWholeSourceBoundaryWrappersPreservingTranslatedOwnership(
+            build(match, spans),
+            spans,
+            stripped.Length,
+            source);
+        return true;
+    }
+
+    private static string BuildSimpleDischarge(Match match, IReadOnlyList<ColorSpan> spans, string target)
+    {
+        return string.Concat(
+            Restore(match, spans, "liquid"),
+            ' ',
+            match.Groups["amount"].Value,
+            "ドラムが",
+            target,
+            "の全身に放出された。");
+    }
+
+    private static string BuildDeviceDischarge(Match match, IReadOnlyList<ColorSpan> spans, string owner, string target)
+    {
+        return string.Concat(
+            owner,
+            Restore(match, spans, "device"),
+            "が",
+            Restore(match, spans, "liquid"),
+            ' ',
+            match.Groups["amount"].Value,
+            "ドラムを",
+            target,
+            "の全身に放出した。");
+    }
+
+    private static string Restore(Match match, IReadOnlyList<ColorSpan> spans, string groupName)
+    {
+        var group = match.Groups[groupName];
+        return ColorAwareTranslationComposer.RestoreCapture(group.Value, spans, group).Trim();
+    }
+
+    private static string RestoreOwner(Match match, IReadOnlyList<ColorSpan> spans, string groupName)
+    {
+        var owner = Restore(match, spans, groupName);
+        return owner.EndsWith("の", StringComparison.Ordinal) ? owner : owner + " ";
+    }
+
+    private static string RestoreTarget(Match match, IReadOnlyList<ColorSpan> spans, string groupName)
+    {
+        var group = match.Groups[groupName];
+        var restored = Restore(match, spans, groupName);
+        var normalized = StringHelpers.StripLeadingEnglishArticle(group.Value.Trim(), includeCapitalizedDefiniteArticle: true);
+        if (string.Equals(normalized, group.Value.Trim(), StringComparison.Ordinal))
+        {
+            return restored;
+        }
+
+        return ColorAwareTranslationComposer.RestoreCapture(normalized, spans, group).Trim();
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs
@@ -25,6 +25,7 @@ internal static class MessageQueueSemanticPipeline
         CyberneticsMedassistModuleTranslationPatch.TryTranslateQueuedMessage,
         LiquidLoaderTranslationPatch.TryTranslateQueuedMessage,
         LiquidVolumeTranslationPatch.TryTranslateQueuedMessage,
+        FireSuppressionDischargeTranslationPatch.TryTranslateQueuedMessage,
         TrollKingTranslationPatch.TryTranslateQueuedMessage,
         MutatingTranslationPatch.TryTranslateQueuedMessage,
         QuillsTranslationPatch.TryTranslateQueuedMessage,

--- a/docs/release-notes/unreleased/issue-576-fire-suppression-discharge.md
+++ b/docs/release-notes/unreleased/issue-576-fire-suppression-discharge.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Added owner-routed Japanese translations for fire suppression discharge messages.

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -3138,7 +3138,100 @@ def _system_static_message_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _fire_suppression_discharge_families() -> tuple[CoveredOwnerFamily, ...]:
+    patch = EvidenceFile(
+        "Mods/QudJP/Assemblies/src/Patches/FireSuppressionDischargeTranslationPatch.cs",
+        (
+            "FireSuppressionDischargeTranslationPatch",
+            "TryTranslateQueuedMessage",
+        ),
+    )
+    pipeline = EvidenceFile(
+        "Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs",
+        ("FireSuppressionDischargeTranslationPatch.TryTranslateQueuedMessage",),
+    )
+    tests = EvidenceFile(
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/FireSuppressionDischargeTranslationPatchTests.cs",
+        (
+            "Patch_TranslatesFireSuppressionDischargeMessages_WhenOwnerPatched",
+            "Patch_DoesNotTranslateFireSuppressionDischargeMessage_WhenOwnerAbsent",
+            "Patch_DoesNotRetranslateDirectMarkedMessage_WhenOwnerPatched",
+            "Patch_LeavesEmptyMessageUnchanged_WhenOwnerPatched",
+        ),
+    )
+
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts/FireSuppressionSystem.cs::XRL.World.Parts.FireSuppressionSystem.CheckFireSuppression",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    patch.path,
+                    (
+                        *patch.required_substrings,
+                        "XRL.World.Parts.FireSuppressionSystem",
+                        "CheckFireSuppression",
+                        "FireSuppressionSelfPattern",
+                        "FireSuppressionTargetPattern",
+                    ),
+                ),
+                pipeline,
+                EvidenceFile(
+                    tests.path,
+                    (
+                        *tests.required_substrings,
+                        "nameof(DummyFireSuppressionDischargeProducer.CheckFireSuppression)",
+                        "2 drams of {{C|gel}} discharges all over you.",
+                        "1 dram of {{C|gel}} discharges all over the snapjaw.",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(FireSuppressionDischargeTranslationPatch)",
+                        "XRL.World.Parts.FireSuppressionSystem|CheckFireSuppression|System.Boolean|XRL.World.GameObject",
+                    ),
+                ),
+            ),
+        ),
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts/CyberneticsFireSuppressionSystem.cs::XRL.World.Parts.CyberneticsFireSuppressionSystem.TurnTick",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    patch.path,
+                    (
+                        *patch.required_substrings,
+                        "XRL.World.Parts.CyberneticsFireSuppressionSystem",
+                        "TurnTick",
+                        "CyberneticsSelfPattern",
+                        "CyberneticsTargetPattern",
+                    ),
+                ),
+                pipeline,
+                EvidenceFile(
+                    tests.path,
+                    (
+                        *tests.required_substrings,
+                        "nameof(DummyFireSuppressionDischargeProducer.TurnTick)",
+                        "Your {{Y|fire suppression system}} discharges 2 drams of {{C|gel}} all over you.",
+                        "{{G|snapjaw}}の {{Y|fire suppression system}} discharges 1 dram of {{C|gel}} all over it.",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(FireSuppressionDischargeTranslationPatch)",
+                        "XRL.World.Parts.CyberneticsFireSuppressionSystem|TurnTick|System.Void|System.Int64|System.Int32",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 COVERED_OWNER_FAMILIES: Final = (
+    *_fire_suppression_discharge_families(),
     CoveredOwnerFamily(
         family_id="XRL.World.Parts/LiquidVolume.cs::XRL.World.Parts.LiquidVolume.Pour",
         inventory_statuses=("owner_patch_required",),


### PR DESCRIPTION
## Summary
- add an owner-routed message queue translator for fire suppression discharge messages
- cover installed and cybernetics fire suppression message shapes with L2 tests
- register the two proven fire suppression owner families in the static producer closure overlay

## Closed owner families
- `XRL.World.Parts/FireSuppressionSystem.cs::XRL.World.Parts.FireSuppressionSystem.CheckFireSuppression`
  - `AddPlayerMessage(num + " " + ((num == 1) ? "dram" : "drams") + " of " + name + " discharges all over you.")`
  - `AddPlayerMessage(num + " " + ((num == 1) ? "dram" : "drams") + " of " + name + " discharges all over " + obj.the + obj.ShortDisplayName + ".")`
- `XRL.World.Parts/CyberneticsFireSuppressionSystem.cs::XRL.World.Parts.CyberneticsFireSuppressionSystem.TurnTick`
  - `AddPlayerMessage("Your " + ParentObject.DisplayNameOnlyDirect + " discharges " + num + " " + ((num == 1) ? "dram" : "drams") + " of " + name + " all over you.")`
  - `AddPlayerMessage(Grammar.MakePossessive(implantee.DisplayNameOnlyDirect) + " " + ParentObject.DisplayNameOnlyDirect + " discharges " + num + " " + ((num == 1) ? "dram" : "drams") + " of " + name + " all over " + implantee.them + ".")`

## Queue delta
- before this batch: `337 families, 940 callsites, 961 text arguments`
- after this batch: `335 families, 936 callsites, 957 text arguments`

## Validation
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~FireSuppressionDischargeTranslationPatchTests'`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures' --no-restore`
- `just test-l1`
- `just static-producer-check`
- `just static-producer-owner-queue`
- `just release-note-check origin/main HEAD`
- `git diff --check`

Issue: #576
