### PR TITLE
Close mutations API owner popup

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/MutationsApiTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/MutationsApiTranslationPatchTests.cs
@@ -106,6 +106,22 @@ public sealed class MutationsApiTranslationPatchTests
     }
 
     [Test]
+    public void TryTranslatePopupMessage_TranslatesBuiltInMutationTerm_WhenDictionaryMisses()
+    {
+        WriteDictionary();
+
+        var ok = TryTranslatePopupMessageDuringMutationPurchase(
+            "Are you sure you want to spend 4 mutation points to buy a new {{G|mutation}}?",
+            out var translated);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ok, Is.True);
+            Assert.That(translated, Is.EqualTo("本当に4ポイントを消費して新しい{{G|変異}}を購入しますか？"));
+        });
+    }
+
+    [Test]
     public void TryTranslatePopupMessage_ReturnsFalse_ForEmptyInput()
     {
         var ok = TryTranslatePopupMessageDuringMutationPurchase(string.Empty, out var translated);

--- a/Mods/QudJP/Assemblies/src/Patches/MutationsApiTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/MutationsApiTranslationPatch.cs
@@ -123,6 +123,19 @@ public static class MutationsApiTranslationPatch
 
         return StringHelpers.TryGetTranslationExactOrLowerAscii(termGroup.Value.Trim(), out translated)
             ? ColorAwareTranslationComposer.RestoreCapture(translated, spans, termGroup).Trim()
-            : restored;
+            : TranslateBuiltInMutationTerm(termGroup, spans, restored);
+    }
+
+    private static string TranslateBuiltInMutationTerm(Group termGroup, IReadOnlyList<ColorSpan> spans, string fallback)
+    {
+        var translated = termGroup.Value.Trim() switch
+        {
+            "mutation" or "mutations" => "変異",
+            _ => null,
+        };
+
+        return translated is null
+            ? fallback
+            : ColorAwareTranslationComposer.RestoreCapture(translated, spans, termGroup).Trim();
     }
 }

--- a/docs/release-notes/unreleased/issue-576-mutations-api-owner.md
+++ b/docs/release-notes/unreleased/issue-576-mutations-api-owner.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Added owner-route closure evidence for buying random mutations from the mutations API.

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -3138,7 +3138,52 @@ def _system_static_message_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _mutations_api_popup_families() -> tuple[CoveredOwnerFamily, ...]:
+    return (
+        CoveredOwnerFamily(
+            family_id="Qud.API/MutationsAPI.cs::Qud.API.MutationsAPI.BuyRandomMutation",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/MutationsApiTranslationPatch.cs",
+                    (
+                        "MutationsApiTranslationPatch",
+                        "BuyRandomMutation",
+                        "TryTranslatePopupMessage",
+                        "BuyPromptPattern",
+                        "TranslateBuiltInMutationTerm",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs",
+                    ("MutationsApiTranslationPatch.TryTranslatePopupMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/MutationsApiTranslationPatchTests.cs",
+                    (
+                        "BuyRandomMutation_TranslatesConfirmationMessage_WhenPatched",
+                        "BuyRandomMutation_PreservesColorTagsInConfirmationMessage_WhenPatched",
+                        "TryTranslatePopupMessage_TranslatesBuiltInMutationTerm_WhenDictionaryMisses",
+                        "TryTranslatePopupMessage_ReturnsFalse_ForEmptyInput",
+                        "TryTranslatePopupMessage_ReturnsFalse_ForDirectTranslationMarker",
+                        "Are you sure you want to spend 4 mutation points to buy a new {{G|mutation}}?",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(MutationsApiTranslationPatch)",
+                        "Qud.API.MutationsAPI",
+                        "BuyRandomMutation",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 COVERED_OWNER_FAMILIES: Final = (
+    *_mutations_api_popup_families(),
     CoveredOwnerFamily(
         family_id="XRL.World.Parts/LiquidVolume.cs::XRL.World.Parts.LiquidVolume.Pour",
         inventory_statuses=("owner_patch_required",),


### PR DESCRIPTION
## Summary
- close the existing owner-routed mutations API buy prompt coverage in the static producer overlay
- add a built-in owner-local fallback for `mutation` / `mutations` terms when no exact dictionary leaf is available
- add L2 evidence for the built-in fallback with color preservation

## Closed owner family
- `Qud.API/MutationsAPI.cs::Qud.API.MutationsAPI.BuyRandomMutation`
  - `Popup.ShowYesNo("Are you sure you want to spend " + Cost + " mutation points to buy a new " + MutationTerm + "?")`

## Queue delta
- before this batch: `337 families, 940 callsites, 961 text arguments`
- after this batch: `336 families, 939 callsites, 960 text arguments`

## Validation
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~MutationsApiTranslationPatchTests'`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature' --no-restore`
- `just static-producer-check`
- `just static-producer-owner-queue`
- `just release-note-check origin/main HEAD`
- `git diff --check`

Issue: #576
