### PR TITLE
Close old save continue menu owner popups

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
@@ -137,6 +137,10 @@ internal static class ColorRouteCatalog
     internal static readonly SortedDictionary<string, GenericPopupProducerRouteAllowance> GenericPopupProducerRouteAllowlist =
         new SortedDictionary<string, GenericPopupProducerRouteAllowance>(StringComparer.Ordinal)
         {
+            ["Mods/QudJP/Assemblies/src/Patches/OldSaveContinueMenuPopupTranslationPatch.cs|PopupTranslationPatch.TranslatePopupTextForProducerRoute("] =
+                new(
+                    1,
+                    "OldSaveContinueMenu is the owner-specific route for MainMenu/SaveManagement continue-menu old-save popups; it runs only inside that owner scope."),
             ["Mods/QudJP/Assemblies/src/Patches/PopupAskNumberTranslationPatch.cs|PopupTranslationPatch.TranslatePopupTextForProducerRoute("] =
                 new(
                     1,
@@ -234,6 +238,7 @@ internal static class ColorRouteCatalog
             ["Mods/QudJP/Assemblies/src/Patches/MessageLogProducerTranslationHelpers.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 5,
             ["Mods/QudJP/Assemblies/src/Patches/MessageLogProducerTranslationHelpers.cs|MessagePatternTranslator.Translate("] = 4,
             ["Mods/QudJP/Assemblies/src/Patches/OptionsLocalizationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
+            ["Mods/QudJP/Assemblies/src/Patches/OldSaveContinueMenuPopupTranslationPatch.cs|PopupTranslationPatch.TranslatePopupTextForProducerRoute("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/PopupAskNumberTranslationPatch.cs|PopupTranslationPatch.TranslatePopupTextForProducerRoute("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/PopupAskStringTranslationPatch.cs|PopupTranslationPatch.TranslatePopupTextForProducerRoute("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/PopupGetPopupOptionTranslationPatch.cs|PopupTranslationPatch.TranslatePopupMenuItemTextForProducerRoute("] = 1,

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/OldSaveContinueMenuPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/OldSaveContinueMenuPopupTranslationPatchTests.cs
@@ -1,0 +1,276 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class OldSaveContinueMenuPopupTranslationPatchTests
+{
+    private const string OldSaveTemplate =
+        "That save file looks like it's from an older save format revision ({0}). Sorry!\nYou can probably change to a previous branch in your game client and get it to load if you want to finish it off.";
+
+    private const string OldSaveMessage =
+        "That save file looks like it's from an older save format revision (2.0.3). Sorry!\n\nYou can probably change to a previous branch in your game client and get it to load if you want to finish it off.";
+
+    private const string TranslatedOldSaveMessage =
+        "このセーブデータは古いフォーマット（2.0.3）のようです。\nゲームクライアントで以前のブランチに切り替えれば読み込める可能性があります。";
+
+    private const string TranslatedOldSaveTemplate =
+        "このセーブデータは古いフォーマット（{0}）のようです。\nゲームクライアントで以前のブランチに切り替えれば読み込める可能性があります。";
+
+    private string tempDirectory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempDirectory = Path.Combine(Path.GetTempPath(), "qudjp-old-save-popup-l2", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
+        Translator.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(tempDirectory);
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+        DummyPopupShow.Reset();
+
+        WriteDictionary((OldSaveTemplate, TranslatedOldSaveTemplate));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(null);
+        Translator.ResetForTests();
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+
+        if (Directory.Exists(tempDirectory))
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [TestCase(nameof(DummyOldSaveContinueMenuProducer.MainMenuContinueMenu))]
+    [TestCase(nameof(DummyOldSaveContinueMenuProducer.SaveManagementContinueMenu))]
+    public void Patch_TranslatesOldSavePopup_WhenOwnerPatched(string methodName)
+    {
+        WithPatchedOwnerAndPopup(methodName, () =>
+        {
+            var target = new DummyOldSaveContinueMenuProducer
+            {
+                PopupMessageToShow = OldSaveMessage,
+            };
+
+            InvokeOwnerMethod(target, methodName);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowAsyncMessage, Is.EqualTo(TranslatedOldSaveMessage));
+                Assert.That(HitCount(), Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotRecordOwnerRoute_WhenOwnerAbsent()
+    {
+        WithPatchedPopupOnly(() =>
+        {
+            _ = DummyPopupShow.ShowAsync(OldSaveMessage);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowAsyncMessage, Is.EqualTo(TranslatedOldSaveMessage));
+                Assert.That(HitCount(), Is.Zero);
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
+    {
+        var source = MessageFrameTranslator.MarkDirectTranslation(OldSaveMessage);
+
+        WithPatchedOwnerAndPopup(
+            nameof(DummyOldSaveContinueMenuProducer.MainMenuContinueMenu),
+            () =>
+            {
+                var target = new DummyOldSaveContinueMenuProducer
+                {
+                    PopupMessageToShow = source,
+                };
+
+                target.MainMenuContinueMenu();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyPopupShow.LastShowAsyncMessage, Is.EqualTo(OldSaveMessage));
+                    Assert.That(HitCount(), Is.Zero);
+                });
+            });
+    }
+
+    [Test]
+    public void Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        WithPatchedOwnerAndPopup(
+            nameof(DummyOldSaveContinueMenuProducer.MainMenuContinueMenu),
+            () =>
+            {
+                var target = new DummyOldSaveContinueMenuProducer
+                {
+                    PopupMessageToShow = string.Empty,
+                };
+
+                target.MainMenuContinueMenu();
+
+                Assert.That(DummyPopupShow.LastShowAsyncMessage, Is.EqualTo(string.Empty));
+            });
+    }
+
+    private static void WithPatchedOwnerAndPopup(string methodName, Action action)
+    {
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShowAsync(harmony);
+            harmony.Patch(
+                original: RequireOwnerMethod(methodName),
+                prefix: new HarmonyMethod(RequireMethod(typeof(OldSaveContinueMenuPopupTranslationPatch), nameof(OldSaveContinueMenuPopupTranslationPatch.Prefix))),
+                finalizer: new HarmonyMethod(RequireMethod(typeof(OldSaveContinueMenuPopupTranslationPatch), nameof(OldSaveContinueMenuPopupTranslationPatch.Finalizer), typeof(Exception))));
+
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void WithPatchedPopupOnly(Action action)
+    {
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShowAsync(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShowAsync(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(
+                typeof(DummyPopupShow),
+                nameof(DummyPopupShow.ShowAsync),
+                typeof(string),
+                typeof(bool),
+                typeof(bool),
+                typeof(bool),
+                typeof(bool),
+                typeof(bool)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix), typeof(string).MakeByRefType())));
+    }
+
+    private static void InvokeOwnerMethod(DummyOldSaveContinueMenuProducer target, string methodName)
+    {
+        if (string.Equals(methodName, nameof(DummyOldSaveContinueMenuProducer.SaveManagementContinueMenu), StringComparison.Ordinal))
+        {
+            target.SaveManagementContinueMenu();
+            return;
+        }
+
+        target.MainMenuContinueMenu();
+    }
+
+    private static int HitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            "Popup.Show." + nameof(OldSaveContinueMenuPopupTranslationPatch),
+            "Popup.ProducerText.XRLCoreOldSave");
+    }
+
+    private void WriteDictionary(params (string key, string text)[] entries)
+    {
+        var builder = new StringBuilder();
+        builder.Append("{\"entries\":[");
+
+        for (var index = 0; index < entries.Length; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append("{\"key\":\"");
+            builder.Append(EscapeJson(entries[index].key));
+            builder.Append("\",\"text\":\"");
+            builder.Append(EscapeJson(entries[index].text));
+            builder.Append("\"}");
+        }
+
+        builder.Append("]}");
+        builder.AppendLine();
+
+        File.WriteAllText(
+            Path.Combine(tempDirectory, "old-save-popup-l2.ja.json"),
+            builder.ToString(),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private static string EscapeJson(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\t", "\\t", StringComparison.Ordinal);
+    }
+
+    private static MethodInfo RequireOwnerMethod(string methodName)
+    {
+        return RequireMethod(typeof(DummyOldSaveContinueMenuProducer), methodName);
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameters)
+    {
+        return type.GetMethod(
+                   methodName,
+                   BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance,
+                   null,
+                   parameters,
+                   null)
+               ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private sealed class DummyOldSaveContinueMenuProducer
+    {
+        public string PopupMessageToShow { get; set; } = string.Empty;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void MainMenuContinueMenu()
+        {
+            _ = DummyPopupShow.ShowAsync(PopupMessageToShow);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void SaveManagementContinueMenu()
+        {
+            _ = DummyPopupShow.ShowAsync(PopupMessageToShow);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1278,6 +1278,11 @@ public sealed class TargetMethodResolutionTests
         "XRL.World.Parts.LiquidVolume|Pour|System.Boolean|System.Boolean&|XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean|System.Int32|System.Boolean",
         "XRL.World.Parts.LiquidVolume|PerformFill|System.Boolean|XRL.World.GameObject|System.Boolean&|System.Boolean",
     })]
+    [TestCase(typeof(OldSaveContinueMenuPopupTranslationPatch), new[]
+    {
+        "Qud.UI.MainMenu|ContinueMenu|System.Threading.Tasks.Task`1[[XRL.XRLGame]]",
+        "Qud.UI.SaveManagement|ContinueMenu|System.Threading.Tasks.Task`1[[XRL.XRLGame]]",
+    })]
     public void OwnerProducerTargetMethods_ResolveExpectedFullSignatures(Type patchType, string[] expectedSignatures)
     {
         var targetMethodsMethod = patchType.GetMethod("TargetMethods", BindingFlags.NonPublic | BindingFlags.Static);

--- a/Mods/QudJP/Assemblies/src/Patches/OldSaveContinueMenuPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/OldSaveContinueMenuPopupTranslationPatch.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class OldSaveContinueMenuPopupTranslationPatch
+{
+    private const string Context = nameof(OldSaveContinueMenuPopupTranslationPatch);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        foreach (var method in ResolveTarget("Qud.UI.MainMenu", "ContinueMenu"))
+        {
+            yield return method;
+        }
+
+        foreach (var method in ResolveTarget("Qud.UI.SaveManagement", "ContinueMenu"))
+        {
+            yield return method;
+        }
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = PopupTranslationPatch.TranslatePopupTextForProducerRoute(source, family + "." + Context);
+        return !string.Equals(translated, source, StringComparison.Ordinal);
+    }
+
+    private static IEnumerable<MethodBase> ResolveTarget(string typeName, string methodName)
+    {
+        var targetType = AccessTools.TypeByName(typeName);
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found: {1}", Context, typeName);
+            yield break;
+        }
+
+        var method = AccessTools.Method(targetType, methodName, Type.EmptyTypes);
+        if (method is not null)
+        {
+            yield return method;
+            yield break;
+        }
+
+        Trace.TraceError("QudJP: {0}.{1}.{2} target not found.", Context, typeName, methodName);
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -15,6 +15,7 @@ internal static class PopupShowSemanticPipeline
         GameObjectMoveTranslationPatch.TryTranslatePopupMessage,
         GameObjectPerformThrowTranslationPatch.TryTranslatePopupMessage,
         GameObjectPopupTranslationPatch.TryTranslatePopupMessage,
+        OldSaveContinueMenuPopupTranslationPatch.TryTranslatePopupMessage,
         RealityStabilizedInterdictTranslationPatch.TryTranslatePopupMessage,
         HackingSifrahResultTranslationPatch.TryTranslatePopupMessage,
         QuestLifecyclePopupTranslationPatch.TryTranslatePopupMessage,

--- a/docs/release-notes/unreleased/issue-576-old-save-owner-popups.md
+++ b/docs/release-notes/unreleased/issue-576-old-save-owner-popups.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Added owner-route closure evidence for old-save continue menu popups.

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -3138,7 +3138,103 @@ def _system_static_message_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _old_save_continue_menu_popup_families() -> tuple[CoveredOwnerFamily, ...]:
+    patch = EvidenceFile(
+        "Mods/QudJP/Assemblies/src/Patches/OldSaveContinueMenuPopupTranslationPatch.cs",
+        (
+            "OldSaveContinueMenuPopupTranslationPatch",
+            "TryTranslatePopupMessage",
+            "TranslatePopupTextForProducerRoute",
+        ),
+    )
+    pipeline = EvidenceFile(
+        "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+        ("OldSaveContinueMenuPopupTranslationPatch.TryTranslatePopupMessage",),
+    )
+    tests = EvidenceFile(
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/OldSaveContinueMenuPopupTranslationPatchTests.cs",
+        (
+            "Patch_TranslatesOldSavePopup_WhenOwnerPatched",
+            "Patch_DoesNotRecordOwnerRoute_WhenOwnerAbsent",
+            "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+            "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+            "That save file looks like it's from an older save format revision (2.0.3). Sorry!",
+        ),
+    )
+    dictionary = EvidenceFile(
+        "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+        (
+            "That save file looks like it's from an older save format revision ({0}). Sorry!",
+            "このセーブデータは古いフォーマット（{0}）のようです。",  # noqa: RUF001
+        ),
+    )
+
+    return (
+        CoveredOwnerFamily(
+            family_id="Qud.UI/MainMenu.cs::Qud.UI.MainMenu.ContinueMenu",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    patch.path,
+                    (
+                        *patch.required_substrings,
+                        "Qud.UI.MainMenu",
+                        "ContinueMenu",
+                    ),
+                ),
+                pipeline,
+                EvidenceFile(
+                    tests.path,
+                    (
+                        *tests.required_substrings,
+                        "nameof(DummyOldSaveContinueMenuProducer.MainMenuContinueMenu)",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(OldSaveContinueMenuPopupTranslationPatch)",
+                        "Qud.UI.MainMenu|ContinueMenu|System.Threading.Tasks.Task`1[[XRL.XRLGame]]",
+                    ),
+                ),
+                dictionary,
+            ),
+        ),
+        CoveredOwnerFamily(
+            family_id="Qud.UI/SaveManagement.cs::Qud.UI.SaveManagement.ContinueMenu",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    patch.path,
+                    (
+                        *patch.required_substrings,
+                        "Qud.UI.SaveManagement",
+                        "ContinueMenu",
+                    ),
+                ),
+                pipeline,
+                EvidenceFile(
+                    tests.path,
+                    (
+                        *tests.required_substrings,
+                        "nameof(DummyOldSaveContinueMenuProducer.SaveManagementContinueMenu)",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(OldSaveContinueMenuPopupTranslationPatch)",
+                        "Qud.UI.SaveManagement|ContinueMenu|System.Threading.Tasks.Task`1[[XRL.XRLGame]]",
+                    ),
+                ),
+                dictionary,
+            ),
+        ),
+    )
+
+
 COVERED_OWNER_FAMILIES: Final = (
+    *_old_save_continue_menu_popup_families(),
     CoveredOwnerFamily(
         family_id="XRL.World.Parts/LiquidVolume.cs::XRL.World.Parts.LiquidVolume.Pour",
         inventory_statuses=("owner_patch_required",),


### PR DESCRIPTION
## Summary
- add an owner-routed popup scope for old-save continue menu warnings
- cover MainMenu and SaveManagement `ContinueMenu` popup producers with L2 and L2G evidence
- register the two proven old-save continue menu owner families in the static producer closure overlay

## Closed owner families
- `Qud.UI/MainMenu.cs::Qud.UI.MainMenu.ContinueMenu`
  - `Popup.ShowAsync("That save file looks like it's from an older save format revision (" + info.json.GameVersion + "). Sorry!\n\nYou can probably change to a previous branch in your game client and get it to load if you want to finish it off.")`
- `Qud.UI/SaveManagement.cs::Qud.UI.SaveManagement.ContinueMenu`
  - `Popup.ShowAsync("That save file looks like it's from an older save format revision (" + info.json.GameVersion + "). Sorry!\n\nYou can probably change to a previous branch in your game client and get it to load if you want to finish it off.")`

## Queue delta
- before this batch: `337 families, 940 callsites, 961 text arguments`
- after this batch: `335 families, 938 callsites, 959 text arguments`

## Validation
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~OldSaveContinueMenuPopupTranslationPatchTests' --no-restore`
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures' --no-restore`
- `just static-producer-check`
- `just static-producer-owner-queue`
- `just release-note-check origin/main HEAD`
- `git diff --check`

Issue: #576
