### PR TITLE
Close game summary tombstone owner popups

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/GameSummaryTombstonePopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/GameSummaryTombstonePopupTranslationPatchTests.cs
@@ -1,0 +1,265 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class GameSummaryTombstonePopupTranslationPatchTests
+{
+    private const string SavedTemplate = "Your tombstone file was saved:\n\n{0}";
+    private const string ErrorTemplate = "There was an error saving: {0}";
+    private const string TombstonePath = "/tmp/Qudman-5-13-2026-2-00 AM.txt";
+    private const string SavedMessage = "Your tombstone file was saved:\n\n" + TombstonePath;
+    private const string ErrorMessage = "There was an error saving: " + TombstonePath;
+    private const string TranslatedSavedMessage = "墓碑ファイルを保存しました:\n\n" + TombstonePath;
+    private const string TranslatedErrorMessage = "保存中にエラーが発生しました: " + TombstonePath;
+
+    private static readonly UTF8Encoding Utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    private string tempDirectory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempDirectory = Path.Combine(Path.GetTempPath(), "qudjp-game-summary-tombstone-l2", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+
+        Translator.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(tempDirectory);
+        DynamicTextObservability.ResetForTests();
+        DummyPopupShow.Reset();
+
+        WriteDictionary(
+            (SavedTemplate, "墓碑ファイルを保存しました:\n\n{0}"),
+            (ErrorTemplate, "保存中にエラーが発生しました: {0}"));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        DummyPopupShow.Reset();
+
+        if (Directory.Exists(tempDirectory))
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [TestCase(nameof(DummyGameSummaryTombstoneProducer.ModernSaveTombstone), SavedMessage, TranslatedSavedMessage, "GameSummaryTombstoneSaved")]
+    [TestCase(nameof(DummyGameSummaryTombstoneProducer.ModernSaveTombstone), ErrorMessage, TranslatedErrorMessage, "GameSummaryTombstoneError")]
+    [TestCase(nameof(DummyGameSummaryTombstoneProducer.ClassicShow), SavedMessage, TranslatedSavedMessage, "GameSummaryTombstoneSaved")]
+    [TestCase(nameof(DummyGameSummaryTombstoneProducer.ClassicShow), ErrorMessage, TranslatedErrorMessage, "GameSummaryTombstoneError")]
+    public void Patch_TranslatesTombstonePopup_WhenOwnerPatched(
+        string methodName,
+        string source,
+        string expected,
+        string expectedFamilySuffix)
+    {
+        RunWithOwnerAndPopupPatches(
+            methodName,
+            () =>
+            {
+                var target = new DummyGameSummaryTombstoneProducer
+                {
+                    PopupMessageToShow = source,
+                };
+
+                InvokeOwnerMethod(target, methodName);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+                    Assert.That(
+                        DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                            nameof(PopupShowTranslationPatch),
+                            "Popup.Show." + expectedFamilySuffix),
+                        Is.EqualTo(1));
+                });
+            });
+    }
+
+    [Test]
+    public void Patch_DoesNotTranslateTombstonePopup_WhenOwnerAbsent()
+    {
+        RunWithPopupPatchOnly(() => DummyPopupShow.Show(SavedMessage));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(SavedMessage));
+            Assert.That(GetSavedHitCount(), Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void Patch_StripsDirectMarkedTombstonePopup_WhenOwnerPatched()
+    {
+        var source = MessageFrameTranslator.MarkDirectTranslation(SavedMessage);
+
+        RunWithOwnerAndPopupPatches(
+            nameof(DummyGameSummaryTombstoneProducer.ModernSaveTombstone),
+            () =>
+            {
+                var target = new DummyGameSummaryTombstoneProducer
+                {
+                    PopupMessageToShow = source,
+                };
+
+                target.ModernSaveTombstone();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(SavedMessage));
+                    Assert.That(GetSavedHitCount(), Is.EqualTo(0));
+                });
+            });
+    }
+
+    [Test]
+    public void Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        RunWithOwnerAndPopupPatches(
+            nameof(DummyGameSummaryTombstoneProducer.ModernSaveTombstone),
+            () =>
+            {
+                var target = new DummyGameSummaryTombstoneProducer
+                {
+                    PopupMessageToShow = string.Empty,
+                };
+
+                target.ModernSaveTombstone();
+
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
+            });
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameters)
+    {
+        return (parameters.Length == 0
+                ? AccessTools.Method(type, methodName)
+                : AccessTools.Method(type, methodName, parameters))
+            ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private static void RunWithPopupPatchOnly(Action action)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchPopupShow(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void RunWithOwnerAndPopupPatches(string ownerMethodName, Action action)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchOwner(harmony, ownerMethodName);
+            PatchPopupShow(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchOwner(Harmony harmony, string ownerMethodName)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyGameSummaryTombstoneProducer), ownerMethodName),
+            prefix: new HarmonyMethod(RequireMethod(typeof(GameSummaryTombstonePopupTranslationPatch), nameof(GameSummaryTombstonePopupTranslationPatch.Prefix))),
+            finalizer: new HarmonyMethod(RequireMethod(typeof(GameSummaryTombstonePopupTranslationPatch), nameof(GameSummaryTombstonePopupTranslationPatch.Finalizer), typeof(Exception))));
+    }
+
+    private static void PatchPopupShow(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.Show)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void InvokeOwnerMethod(DummyGameSummaryTombstoneProducer target, string methodName)
+    {
+        if (string.Equals(methodName, nameof(DummyGameSummaryTombstoneProducer.ClassicShow), StringComparison.Ordinal))
+        {
+            target.ClassicShow();
+            return;
+        }
+
+        target.ModernSaveTombstone();
+    }
+
+    private static int GetSavedHitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show.GameSummaryTombstoneSaved");
+    }
+
+    private void WriteDictionary(params (string key, string text)[] entries)
+    {
+        var builder = new StringBuilder();
+        builder.Append('{');
+        builder.Append("\"entries\":[");
+
+        for (var index = 0; index < entries.Length; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append('{');
+            builder.Append("\"key\":");
+            builder.Append(System.Text.Json.JsonSerializer.Serialize(entries[index].key));
+            builder.Append(',');
+            builder.Append("\"text\":");
+            builder.Append(System.Text.Json.JsonSerializer.Serialize(entries[index].text));
+            builder.Append('}');
+        }
+
+        builder.Append("]}");
+        File.WriteAllText(Path.Combine(tempDirectory, "ui-game-summary-tombstone.ja.json"), builder.ToString(), Utf8WithoutBom);
+        Translator.SetDictionaryDirectoryForTests(tempDirectory);
+    }
+
+    private sealed class DummyGameSummaryTombstoneProducer
+    {
+        public string PopupMessageToShow = string.Empty;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void ModernSaveTombstone()
+        {
+            DummyPopupShow.Show(PopupMessageToShow);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void ClassicShow()
+        {
+            DummyPopupShow.Show(PopupMessageToShow);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1278,6 +1278,11 @@ public sealed class TargetMethodResolutionTests
         "XRL.World.Parts.LiquidVolume|Pour|System.Boolean|System.Boolean&|XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean|System.Int32|System.Boolean",
         "XRL.World.Parts.LiquidVolume|PerformFill|System.Boolean|XRL.World.GameObject|System.Boolean&|System.Boolean",
     })]
+    [TestCase(typeof(GameSummaryTombstonePopupTranslationPatch), new[]
+    {
+        "Qud.UI.GameSummaryScreen|SaveTombstone|System.Void",
+        "XRL.UI.GameSummaryUI|Show|System.Void|System.Int32|System.String|System.String|System.String|System.String|System.Boolean",
+    })]
     public void OwnerProducerTargetMethods_ResolveExpectedFullSignatures(Type patchType, string[] expectedSignatures)
     {
         var targetMethodsMethod = patchType.GetMethod("TargetMethods", BindingFlags.NonPublic | BindingFlags.Static);

--- a/Mods/QudJP/Assemblies/src/Patches/GameSummaryTombstonePopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GameSummaryTombstonePopupTranslationPatch.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class GameSummaryTombstonePopupTranslationPatch
+{
+    private const string Context = nameof(GameSummaryTombstonePopupTranslationPatch);
+
+    private static readonly Regex SavedPattern = new(
+        "^Your tombstone file was saved:\\n\\n(?<path>[\\s\\S]+)$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex ErrorPattern = new(
+        "^There was an error saving: (?<path>[\\s\\S]+)$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        var targets = new List<MethodBase>();
+
+        var gameSummaryScreenType = GameTypeResolver.FindType("Qud.UI.GameSummaryScreen", "GameSummaryScreen");
+        if (gameSummaryScreenType is null)
+        {
+            Trace.TraceError("QudJP: {0} GameSummaryScreen target type not found.", Context);
+        }
+        else
+        {
+            AddTarget(targets, gameSummaryScreenType, "SaveTombstone", Type.EmptyTypes);
+        }
+
+        var gameSummaryUiType = GameTypeResolver.FindType("XRL.UI.GameSummaryUI", "GameSummaryUI");
+        if (gameSummaryUiType is null)
+        {
+            Trace.TraceError("QudJP: {0} GameSummaryUI target type not found.", Context);
+        }
+        else
+        {
+            AddTarget(
+                targets,
+                gameSummaryUiType,
+                "Show",
+                new[] { typeof(int), typeof(string), typeof(string), typeof(string), typeof(string), typeof(bool) });
+        }
+
+        return targets;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        if (TryTranslateTemplate(
+                source,
+                route,
+                family + ".GameSummaryTombstoneSaved",
+                SavedPattern,
+                "Your tombstone file was saved:\n\n{0}",
+                out translated))
+        {
+            return true;
+        }
+
+        if (TryTranslateTemplate(
+                source,
+                route,
+                family + ".GameSummaryTombstoneError",
+                ErrorPattern,
+                "There was an error saving: {0}",
+                out translated))
+        {
+            return true;
+        }
+
+        translated = source;
+        return false;
+    }
+
+    private static bool TryTranslateTemplate(
+        string source,
+        string route,
+        string family,
+        Regex pattern,
+        string key,
+        out string translated)
+    {
+        var match = pattern.Match(source);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        var template = Translator.Translate(key);
+        if (string.Equals(template, key, StringComparison.Ordinal))
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = string.Format(
+            CultureInfo.InvariantCulture,
+            template,
+            match.Groups["path"].Value);
+        DynamicTextObservability.RecordTransform(route, family, source, translated);
+        return true;
+    }
+
+    private static void AddTarget(List<MethodBase> targets, Type targetType, string methodName, Type[] parameters)
+    {
+        var method = AccessTools.Method(targetType, methodName, parameters);
+        if (method is null)
+        {
+            Trace.TraceError(
+                "QudJP: {0}.{1}.{2} target not found.",
+                Context,
+                targetType.FullName,
+                methodName);
+            return;
+        }
+
+        targets.Add(method);
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -30,6 +30,7 @@ internal static class PopupShowSemanticPipeline
         CampfireCookAvailabilityTranslationPatch.TryTranslatePopupMessage,
         CampfirePreserveTranslationPatch.TryTranslatePopupMessage,
         CookingRuntimeTranslationPatch.TryTranslatePopupMessage,
+        GameSummaryTombstonePopupTranslationPatch.TryTranslatePopupMessage,
         StatusScreenPopupTranslationPatch.TryTranslatePopupMessage,
         TeleprojectorTranslationPatch.TryTranslatePopupMessage,
         CyberneticsMedassistModuleTranslationPatch.TryTranslatePopupMessage,

--- a/Mods/QudJP/Localization/Dictionaries/ui-game-summary.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-game-summary.ja.json
@@ -68,6 +68,16 @@
       "key": "This game was played in {0} mode.",
       "context": "XRL.Core.XRLCore.GameSummary",
       "text": "このゲームは{0}モードでプレイされた。"
+    },
+    {
+      "key": "Your tombstone file was saved:\n\n{0}",
+      "context": "QudJP.GameSummary.TombstonePopup",
+      "text": "墓碑ファイルを保存しました:\n\n{0}"
+    },
+    {
+      "key": "There was an error saving: {0}",
+      "context": "QudJP.GameSummary.TombstonePopup",
+      "text": "保存中にエラーが発生しました: {0}"
     }
   ]
 }

--- a/docs/release-notes/unreleased/issue-576-game-summary-tombstone-popups.md
+++ b/docs/release-notes/unreleased/issue-576-game-summary-tombstone-popups.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Added owner-route closure for game-summary tombstone save result popups.

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -3138,7 +3138,89 @@ def _system_static_message_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _game_summary_tombstone_popup_families() -> tuple[CoveredOwnerFamily, ...]:
+    patch = EvidenceFile(
+        "Mods/QudJP/Assemblies/src/Patches/GameSummaryTombstonePopupTranslationPatch.cs",
+        (
+            "GameSummaryTombstonePopupTranslationPatch",
+            "TryTranslatePopupMessage",
+            "SavedPattern",
+            "ErrorPattern",
+        ),
+    )
+    pipeline = EvidenceFile(
+        "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+        ("GameSummaryTombstonePopupTranslationPatch.TryTranslatePopupMessage",),
+    )
+    tests = EvidenceFile(
+        "Mods/QudJP/Assemblies/QudJP.Tests/L2/GameSummaryTombstonePopupTranslationPatchTests.cs",
+        (
+            "Patch_TranslatesTombstonePopup_WhenOwnerPatched",
+            "Patch_DoesNotTranslateTombstonePopup_WhenOwnerAbsent",
+            "Patch_StripsDirectMarkedTombstonePopup_WhenOwnerPatched",
+            "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+            "Your tombstone file was saved:",
+            "There was an error saving:",
+        ),
+    )
+    dictionary = EvidenceFile(
+        "Mods/QudJP/Localization/Dictionaries/ui-game-summary.ja.json",
+        (
+            "Your tombstone file was saved:\\n\\n{0}",
+            "There was an error saving: {0}",
+            "墓碑ファイルを保存しました",
+            "保存中にエラーが発生しました",
+        ),
+    )
+
+    return (
+        CoveredOwnerFamily(
+            family_id="Qud.UI/GameSummaryScreen.cs::Qud.UI.GameSummaryScreen.SaveTombstone",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/GameSummaryTombstonePopupTranslationPatch.cs",
+                    ("Qud.UI.GameSummaryScreen", "SaveTombstone"),
+                ),
+                patch,
+                pipeline,
+                tests,
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
+                        "Qud.UI.GameSummaryScreen|SaveTombstone|System.Void",
+                    ),
+                ),
+                dictionary,
+            ),
+        ),
+        CoveredOwnerFamily(
+            family_id="XRL.UI/GameSummaryUI.cs::XRL.UI.GameSummaryUI.Show",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/GameSummaryTombstonePopupTranslationPatch.cs",
+                    ("XRL.UI.GameSummaryUI", "Show"),
+                ),
+                patch,
+                pipeline,
+                tests,
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
+                        "XRL.UI.GameSummaryUI|Show|System.Void|System.Int32|System.String|System.String|System.String|System.String|System.Boolean",
+                    ),
+                ),
+                dictionary,
+            ),
+        ),
+    )
+
+
 COVERED_OWNER_FAMILIES: Final = (
+    *_game_summary_tombstone_popup_families(),
     CoveredOwnerFamily(
         family_id="XRL.World.Parts/LiquidVolume.cs::XRL.World.Parts.LiquidVolume.Pour",
         inventory_statuses=("owner_patch_required",),


### PR DESCRIPTION
## Summary
- close issue-576 owner-route evidence for modern and classic game-summary tombstone save result popups
- add owner-scoped popup translation for saved/error tombstone file messages and production dictionary templates
- register both GameSummaryScreen.SaveTombstone and GameSummaryUI.Show families in static producer closure

## Inventory shapes
- Qud.UI/GameSummaryScreen.cs::Qud.UI.GameSummaryScreen.SaveTombstone line 210 Popup.Show saved path message
- Qud.UI/GameSummaryScreen.cs::Qud.UI.GameSummaryScreen.SaveTombstone line 214 Popup.Show error path message
- XRL.UI/GameSummaryUI.cs::XRL.UI.GameSummaryUI.Show line 156 Popup.Show saved path message
- XRL.UI/GameSummaryUI.cs::XRL.UI.GameSummaryUI.Show line 160 Popup.Show error path message

## Validation
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~GameSummaryTombstonePopupTranslationPatchTests --no-restore
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures|FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature --no-restore
- just static-producer-check
- just localization-check
- just release-note-check origin/main HEAD
- just static-producer-owner-queue: 337/940/961 -> 335/936/957
