### PR TITLE
Close location finder owner popups

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/LocationFinderPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/LocationFinderPopupTranslationPatchTests.cs
@@ -1,0 +1,231 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class LocationFinderPopupTranslationPatchTests
+{
+    private const string DiscoverSource = "You discover {{Y|some forgotten ruins}}!";
+    private const string TravelSource = "You traveled to {{Y|some forgotten ruins}}!";
+    private const string DiscoverTranslated = "{{Y|some forgotten ruins}}を発見した！";
+    private const string TravelTranslated = "{{Y|some forgotten ruins}}へ移動した！";
+
+    private static readonly UTF8Encoding Utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    private string tempDirectory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempDirectory = Path.Combine(Path.GetTempPath(), "qudjp-location-finder-l2", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+
+        Translator.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(tempDirectory);
+        DynamicTextObservability.ResetForTests();
+        DummyPopupShow.Reset();
+
+        WriteDictionary(
+            ("You discover {0}!", "{0}を発見した！"),
+            ("You traveled to {0}!", "{0}へ移動した！"));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        DummyPopupShow.Reset();
+
+        if (Directory.Exists(tempDirectory))
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [TestCase(DiscoverSource, DiscoverTranslated, "LocationFinderDiscover")]
+    [TestCase(TravelSource, TravelTranslated, "LocationFinderTravel")]
+    public void Patch_TranslatesLocationFinderPopup_WhenOwnerPatched(
+        string source,
+        string expected,
+        string expectedFamilySuffix)
+    {
+        RunWithOwnerAndPopupPatches(() =>
+        {
+            var target = new DummyLocationFinderProducer
+            {
+                PopupMessageToShow = source,
+            };
+
+            target.TriggerFind();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+                Assert.That(
+                    DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                        nameof(PopupShowTranslationPatch),
+                        "Popup.Show." + expectedFamilySuffix),
+                    Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotRecordOwnerRoute_WhenOwnerAbsent()
+    {
+        RunWithPopupPatchOnly(() => DummyPopupShow.Show(DiscoverSource));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(DiscoverTranslated));
+            Assert.That(GetDiscoverHitCount(), Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void Patch_StripsDirectMarkedPopup_WhenOwnerPatched()
+    {
+        var source = MessageFrameTranslator.MarkDirectTranslation(DiscoverSource);
+
+        RunWithOwnerAndPopupPatches(() =>
+        {
+            var target = new DummyLocationFinderProducer
+            {
+                PopupMessageToShow = source,
+            };
+
+            target.TriggerFind();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(DiscoverSource));
+                Assert.That(GetDiscoverHitCount(), Is.EqualTo(0));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        RunWithOwnerAndPopupPatches(() =>
+        {
+            var target = new DummyLocationFinderProducer
+            {
+                PopupMessageToShow = string.Empty,
+            };
+
+            target.TriggerFind();
+
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
+        });
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameters)
+    {
+        return (parameters.Length == 0
+                ? AccessTools.Method(type, methodName)
+                : AccessTools.Method(type, methodName, parameters))
+            ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private static void RunWithPopupPatchOnly(Action action)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchPopupShow(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void RunWithOwnerAndPopupPatches(Action action)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyLocationFinderProducer), nameof(DummyLocationFinderProducer.TriggerFind)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(LocationFinderPopupTranslationPatch), nameof(LocationFinderPopupTranslationPatch.Prefix))),
+                finalizer: new HarmonyMethod(RequireMethod(typeof(LocationFinderPopupTranslationPatch), nameof(LocationFinderPopupTranslationPatch.Finalizer), typeof(Exception))));
+            PatchPopupShow(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShow(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.Show)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static int GetDiscoverHitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show.LocationFinderDiscover");
+    }
+
+    private void WriteDictionary(params (string key, string text)[] entries)
+    {
+        var builder = new StringBuilder();
+        builder.Append('{');
+        builder.Append("\"entries\":[");
+
+        for (var index = 0; index < entries.Length; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append('{');
+            builder.Append("\"key\":");
+            builder.Append(System.Text.Json.JsonSerializer.Serialize(entries[index].key));
+            builder.Append(',');
+            builder.Append("\"text\":");
+            builder.Append(System.Text.Json.JsonSerializer.Serialize(entries[index].text));
+            builder.Append('}');
+        }
+
+        builder.Append("]}");
+        File.WriteAllText(Path.Combine(tempDirectory, "location-finder.ja.json"), builder.ToString(), Utf8WithoutBom);
+        Translator.SetDictionaryDirectoryForTests(tempDirectory);
+    }
+
+    private sealed class DummyLocationFinderProducer
+    {
+        public string PopupMessageToShow = string.Empty;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void TriggerFind()
+        {
+            DummyPopupShow.Show(PopupMessageToShow);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1278,6 +1278,10 @@ public sealed class TargetMethodResolutionTests
         "XRL.World.Parts.LiquidVolume|Pour|System.Boolean|System.Boolean&|XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean|System.Int32|System.Boolean",
         "XRL.World.Parts.LiquidVolume|PerformFill|System.Boolean|XRL.World.GameObject|System.Boolean&|System.Boolean",
     })]
+    [TestCase(typeof(LocationFinderPopupTranslationPatch), new[]
+    {
+        "XRL.World.Parts.LocationFinder|TriggerFind|System.Void",
+    })]
     public void OwnerProducerTargetMethods_ResolveExpectedFullSignatures(Type patchType, string[] expectedSignatures)
     {
         var targetMethodsMethod = patchType.GetMethod("TargetMethods", BindingFlags.NonPublic | BindingFlags.Static);

--- a/Mods/QudJP/Assemblies/src/Patches/LocationFinderPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/LocationFinderPopupTranslationPatch.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class LocationFinderPopupTranslationPatch
+{
+    private const string Context = nameof(LocationFinderPopupTranslationPatch);
+
+    private static readonly Regex DiscoverPattern = new(
+        "^You discover (?<location>[\\s\\S]+)!$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex TravelPattern = new(
+        "^You traveled to (?<location>[\\s\\S]+)!$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        var targets = new List<MethodBase>();
+        var targetType = GameTypeResolver.FindType("XRL.World.Parts.LocationFinder", "LocationFinder");
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found.", Context);
+            return targets;
+        }
+
+        var method = AccessTools.Method(targetType, "TriggerFind", Type.EmptyTypes);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.TriggerFind target not found.", Context);
+            return targets;
+        }
+
+        targets.Add(method);
+        return targets;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        if (TryTranslateTemplate(
+                source,
+                route,
+                family + ".LocationFinderDiscover",
+                DiscoverPattern,
+                "You discover {0}!",
+                out translated))
+        {
+            return true;
+        }
+
+        if (TryTranslateTemplate(
+                source,
+                route,
+                family + ".LocationFinderTravel",
+                TravelPattern,
+                "You traveled to {0}!",
+                out translated))
+        {
+            return true;
+        }
+
+        translated = source;
+        return false;
+    }
+
+    private static bool TryTranslateTemplate(
+        string source,
+        string route,
+        string family,
+        Regex pattern,
+        string key,
+        out string translated)
+    {
+        var match = pattern.Match(source);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        var template = Translator.Translate(key);
+        if (string.Equals(template, key, StringComparison.Ordinal))
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = string.Format(CultureInfo.InvariantCulture, template, match.Groups["location"].Value);
+        DynamicTextObservability.RecordTransform(route, family, source, translated);
+        return true;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -35,6 +35,7 @@ internal static class PopupShowSemanticPipeline
         CyberneticsMedassistModuleTranslationPatch.TryTranslatePopupMessage,
         LiquidLoaderTranslationPatch.TryTranslatePopupMessage,
         LiquidVolumeTranslationPatch.TryTranslatePopupMessage,
+        LocationFinderPopupTranslationPatch.TryTranslatePopupMessage,
         MutatingTranslationPatch.TryTranslatePopupMessage,
         LightManipulationTranslationPatch.TryTranslatePopupMessage,
         AsleepOwnerTranslationPatch.TryTranslatePopupMessage,

--- a/Mods/QudJP/Localization/Dictionaries/world-parts.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/world-parts.ja.json
@@ -3103,6 +3103,11 @@
             "key": "You are cured of ironshank.",
             "context": "XRL.World.Effects.Ironshank",
             "text": "アイアンシャンクが治った。"
+        },
+        {
+            "key": "You traveled to {0}!",
+            "context": "XRL.World.Parts.XRL.World.Parts.LocationFinder",
+            "text": "{0}へ移動した！"
         }
     ]
 }

--- a/docs/release-notes/unreleased/issue-576-location-finder-popups.md
+++ b/docs/release-notes/unreleased/issue-576-location-finder-popups.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Added owner-route closure for location finder discovery and travel popups.

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -3138,7 +3138,61 @@ def _system_static_message_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _location_finder_popup_families() -> tuple[CoveredOwnerFamily, ...]:
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts/LocationFinder.cs::XRL.World.Parts.LocationFinder.TriggerFind",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/LocationFinderPopupTranslationPatch.cs",
+                    (
+                        "LocationFinderPopupTranslationPatch",
+                        "XRL.World.Parts.LocationFinder",
+                        "TriggerFind",
+                        "TryTranslatePopupMessage",
+                        "LocationFinderDiscover",
+                        "LocationFinderTravel",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                    ("LocationFinderPopupTranslationPatch.TryTranslatePopupMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/LocationFinderPopupTranslationPatchTests.cs",
+                    (
+                        "Patch_TranslatesLocationFinderPopup_WhenOwnerPatched",
+                        "Patch_DoesNotRecordOwnerRoute_WhenOwnerAbsent",
+                        "Patch_StripsDirectMarkedPopup_WhenOwnerPatched",
+                        "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                        "You discover {{Y|some forgotten ruins}}!",
+                        "You traveled to {{Y|some forgotten ruins}}!",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
+                        "XRL.World.Parts.LocationFinder|TriggerFind|System.Void",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Localization/Dictionaries/world-parts.ja.json",
+                    (
+                        "You discover {0}!",
+                        "You traveled to {0}!",
+                        "{0}を発見した！",  # noqa: RUF001
+                        "{0}へ移動した！",  # noqa: RUF001
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 COVERED_OWNER_FAMILIES: Final = (
+    *_location_finder_popup_families(),
     CoveredOwnerFamily(
         family_id="XRL.World.Parts/LiquidVolume.cs::XRL.World.Parts.LiquidVolume.Pour",
         inventory_statuses=("owner_patch_required",),


### PR DESCRIPTION
## Summary
- close issue-576 owner-route evidence for LocationFinder.TriggerFind discovery/travel popups
- add owner-scoped popup translation for `You discover {0}!` and `You traveled to {0}!`
- add production dictionary coverage for the travel popup template and register the family in static producer closure

## Inventory shapes
- XRL.World.Parts/LocationFinder.cs::XRL.World.Parts.LocationFinder.TriggerFind line 83 Popup.Show discovery message
- XRL.World.Parts/LocationFinder.cs::XRL.World.Parts.LocationFinder.TriggerFind line 93 Popup.Show travel message

## Deferred
- Same-method JournalAPI.AddAccomplishment strings are not part of this Popup.Show inventory family and were left untouched.

## Validation
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~LocationFinderPopupTranslationPatchTests
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures --no-restore
- just static-producer-check
- just translation-token-check
- just localization-check
- uv run python scripts/release_notes.py check-fragment --base-ref origin/main --head-ref HEAD
- just static-producer-owner-queue: 337/940/961 -> 336/938/959
