### PR TITLE
Close mechanical wings owner popups

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/MechanicalWingsPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/MechanicalWingsPopupTranslationPatchTests.cs
@@ -1,0 +1,226 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class MechanicalWingsPopupTranslationPatchTests
+{
+    private const string StartupSource = "The {{Y|mechanical wings}} are still starting up.";
+    private const string UnresponsiveSource = "The {{Y|mechanical wings}} are unresponsive.";
+    private const string SingularStartupSource = "The {{Y|gyrocopter backpack}} is still starting up.";
+    private const string SingularUnresponsiveSource = "The {{Y|gyrocopter backpack}} is unresponsive.";
+    private const string StartupTranslated = "{{Y|mechanical wings}}はまだ起動中だ";
+    private const string UnresponsiveTranslated = "{{Y|mechanical wings}}は反応しなくなった。";
+    private const string SingularStartupTranslated = "{{Y|gyrocopter backpack}}はまだ起動中だ";
+    private const string SingularUnresponsiveTranslated = "{{Y|gyrocopter backpack}}は反応しなくなった。";
+
+    [SetUp]
+    public void SetUp()
+    {
+        Translator.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(RepositoryDictionaryDirectory());
+        MessageFrameTranslator.ResetForTests();
+        MessageFrameTranslator.SetDictionaryPathForTests(RepositoryMessageFramePath());
+        DynamicTextObservability.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        MessageFrameTranslator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TestCase(StartupSource, StartupTranslated, "MechanicalWingsStartup")]
+    [TestCase(UnresponsiveSource, UnresponsiveTranslated, "MechanicalWingsUnresponsive")]
+    [TestCase(SingularStartupSource, SingularStartupTranslated, "MechanicalWingsStartup")]
+    [TestCase(SingularUnresponsiveSource, SingularUnresponsiveTranslated, "MechanicalWingsUnresponsive")]
+    public void Patch_TranslatesMechanicalWingsStartupPopup_WhenOwnerPatched(
+        string source,
+        string expected,
+        string expectedFamilySuffix)
+    {
+        RunWithOwnerAndPopupPatches(() =>
+        {
+            var target = new DummyMechanicalWingsProducer
+            {
+                PopupMessageToShow = source,
+            };
+
+            target.TryStartup();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+                Assert.That(
+                    DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                        nameof(PopupShowTranslationPatch),
+                        "Popup.Show." + expectedFamilySuffix),
+                    Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent()
+    {
+        RunWithPopupPatchOnly(() => DummyPopupShow.Show(StartupSource));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(StartupSource));
+            Assert.That(GetStartupHitCount(), Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void Patch_StripsDirectMarkedPopup_WhenOwnerPatched()
+    {
+        var source = MessageFrameTranslator.MarkDirectTranslation(StartupSource);
+
+        RunWithOwnerAndPopupPatches(() =>
+        {
+            var target = new DummyMechanicalWingsProducer
+            {
+                PopupMessageToShow = source,
+            };
+
+            target.TryStartup();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(StartupSource));
+                Assert.That(GetStartupHitCount(), Is.EqualTo(0));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        RunWithOwnerAndPopupPatches(() =>
+        {
+            var target = new DummyMechanicalWingsProducer
+            {
+                PopupMessageToShow = string.Empty,
+            };
+
+            target.TryStartup();
+
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
+        });
+    }
+
+    private static string RepositoryDictionaryDirectory()
+    {
+        return Path.GetFullPath(
+            Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "Localization",
+                "Dictionaries"));
+    }
+
+    private static string RepositoryMessageFramePath()
+    {
+        return Path.GetFullPath(
+            Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "Localization",
+                "MessageFrames",
+                "verbs.ja.json"));
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameters)
+    {
+        return (parameters.Length == 0
+                ? AccessTools.Method(type, methodName)
+                : AccessTools.Method(type, methodName, parameters))
+            ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private static void RunWithPopupPatchOnly(Action action)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchPopupShow(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void RunWithOwnerAndPopupPatches(Action action)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyMechanicalWingsProducer), nameof(DummyMechanicalWingsProducer.TryStartup)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(MechanicalWingsPopupTranslationPatch), nameof(MechanicalWingsPopupTranslationPatch.Prefix))),
+                finalizer: new HarmonyMethod(RequireMethod(typeof(MechanicalWingsPopupTranslationPatch), nameof(MechanicalWingsPopupTranslationPatch.Finalizer), typeof(Exception))));
+            PatchPopupShow(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShow(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.Show)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static int GetStartupHitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show.MechanicalWingsStartup");
+    }
+
+    private sealed class DummyMechanicalWingsProducer
+    {
+        public string PopupMessageToShow = string.Empty;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool TryStartup()
+        {
+            DummyPopupShow.ShowFail(PopupMessageToShow);
+            return false;
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1278,6 +1278,10 @@ public sealed class TargetMethodResolutionTests
         "XRL.World.Parts.LiquidVolume|Pour|System.Boolean|System.Boolean&|XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean|System.Int32|System.Boolean",
         "XRL.World.Parts.LiquidVolume|PerformFill|System.Boolean|XRL.World.GameObject|System.Boolean&|System.Boolean",
     })]
+    [TestCase(typeof(MechanicalWingsPopupTranslationPatch), new[]
+    {
+        "XRL.World.Parts.MechanicalWings|TryStartup|System.Boolean",
+    })]
     public void OwnerProducerTargetMethods_ResolveExpectedFullSignatures(Type patchType, string[] expectedSignatures)
     {
         var targetMethodsMethod = patchType.GetMethod("TargetMethods", BindingFlags.NonPublic | BindingFlags.Static);

--- a/Mods/QudJP/Assemblies/src/Patches/MechanicalWingsPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/MechanicalWingsPopupTranslationPatch.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class MechanicalWingsPopupTranslationPatch
+{
+    private const string Context = nameof(MechanicalWingsPopupTranslationPatch);
+    private const string StartupFamily = "MechanicalWingsStartup";
+    private const string UnresponsiveFamily = "MechanicalWingsUnresponsive";
+
+    private static readonly Regex StatusPattern = new(
+        "^(?:The |the |A |a |An |an )?(?<subject>.+?) (?:is|are) (?<extra>still starting up|unresponsive)(?<endmark>[.!])?$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        var targets = new List<MethodBase>();
+        var targetType = AccessTools.TypeByName("XRL.World.Parts.MechanicalWings");
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found.", Context);
+            return targets;
+        }
+
+        var method = AccessTools.Method(targetType, "TryStartup", Type.EmptyTypes);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.TryStartup target not found.", Context);
+            return targets;
+        }
+
+        targets.Add(method);
+        return targets;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        if (!TryTranslateCore(source, out translated))
+        {
+            return false;
+        }
+
+        DynamicTextObservability.RecordTransform(route, family + "." + GetFamilySuffix(source), source, translated);
+        return true;
+    }
+
+    private static bool TryTranslateCore(string source, out string translated)
+    {
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
+        var match = StatusPattern.Match(stripped);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        var subject = ColorAwareTranslationComposer.RestoreCapture(
+            match.Groups["subject"].Value,
+            spans,
+            match.Groups["subject"]).Trim();
+        var extra = match.Groups["extra"].Value;
+        var endmark = match.Groups["endmark"].Success ? match.Groups["endmark"].Value : null;
+        return MessageFrameTranslator.TryTranslateXDidY(subject, "are", extra, endmark, out translated);
+    }
+
+    private static string GetFamilySuffix(string source)
+    {
+        var stripped = ColorAwareTranslationComposer.GetVisibleText(source);
+        return stripped.Contains("still starting up")
+            ? StartupFamily
+            : UnresponsiveFamily;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -46,6 +46,7 @@ internal static class PopupShowSemanticPipeline
         CarapaceTranslationPatch.TryTranslatePopupMessage,
         NephalPropertiesTranslationPatch.TryTranslatePopupMessage,
         IntegratedWeaponHostsTranslationPatch.TryTranslatePopupMessage,
+        MechanicalWingsPopupTranslationPatch.TryTranslatePopupMessage,
         FungalSporeInfectionTranslationPatch.TryTranslatePopupMessage,
     ];
 

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -2261,6 +2261,53 @@ def _integrated_weapon_hosts_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _mechanical_wings_popup_families() -> tuple[CoveredOwnerFamily, ...]:
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts/MechanicalWings.cs::XRL.World.Parts.MechanicalWings.TryStartup",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/MechanicalWingsPopupTranslationPatch.cs",
+                    (
+                        "MechanicalWingsPopupTranslationPatch",
+                        "TryTranslatePopupMessage",
+                        "MessageFrameTranslator.TryTranslateXDidY",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                    ("MechanicalWingsPopupTranslationPatch.TryTranslatePopupMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/MechanicalWingsPopupTranslationPatchTests.cs",
+                    (
+                        "Patch_TranslatesMechanicalWingsStartupPopup_WhenOwnerPatched",
+                        "Patch_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent",
+                        "Patch_StripsDirectMarkedPopup_WhenOwnerPatched",
+                        "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                        "mechanical wings",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(MechanicalWingsPopupTranslationPatch)",
+                        "XRL.World.Parts.MechanicalWings|TryStartup|System.Boolean",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Localization/MessageFrames/verbs.ja.json",
+                    (
+                        '"extra": "still starting up"',
+                        '"extra": "unresponsive"',
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _boost_statistic_families() -> tuple[CoveredOwnerFamily, ...]:
     common_evidence = (
         EvidenceFile(
@@ -3980,6 +4027,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_tonic_families(),
     *_xrl_game_families(),
     *_integrated_weapon_hosts_families(),
+    *_mechanical_wings_popup_families(),
     *_boost_statistic_families(),
     *_emboldened_families(),
     *_fungal_spore_infection_families(),


### PR DESCRIPTION
## Summary
- Close issue-576 owner-route coverage for `XRL.World.Parts.MechanicalWings.TryStartup` popups.
- Add a narrow owner-scoped popup translator for the two inventoried `ShowFail` shapes: `still starting up` and `unresponsive`.
- Register closure evidence in `scripts/static_producer_closure.py` using existing `MessageFrames/verbs.ja.json` production coverage.

## Inventory shapes
- `Popup.ShowFail(ParentObject.The + ParentObject.ShortDisplayName + ParentObject.Is + " still starting up.")`
- `Popup.ShowFail(ParentObject.The + ParentObject.ShortDisplayName + ParentObject.Is + " unresponsive.")`

## Tests
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~MechanicalWingsPopupTranslationPatchTests' --no-restore`\n- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures' --no-restore`\n- `just static-producer-check`\n- `git diff --check`\n\n## Queue delta\n- main: 337 families, 940 callsites, 961 text arguments, 308 source files\n- branch: 336 families, 938 callsites, 959 text arguments, 307 source files