### PR TITLE
Close floating equipment owner popups

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/FloatingEquipmentPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/FloatingEquipmentPopupTranslationPatchTests.cs
@@ -1,0 +1,244 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class FloatingEquipmentPopupTranslationPatchTests
+{
+    private const string CeaseSource = "The {{Y|hover boots}} cease floating near you.";
+    private const string FallSource = "The {{Y|hover boots}} fall to the ground.";
+    private const string PickSource = "The {{Y|magnetized dagger}} falls to the ground; you pick it up.";
+    private const string ScoopSource = "The {{Y|floating orb}} falls to the ground; you scoop it up.";
+    private const string CeaseTranslated = "{{Y|hover boots}}はあなたの近くで浮遊するのをやめた";
+    private const string FallTranslated = "{{Y|hover boots}}は地面に倒れた。";
+    private const string PickTranslated = "{{Y|magnetized dagger}}は地面に落ちた。あなたはそれを拾った。";
+    private const string ScoopTranslated = "{{Y|floating orb}}は地面に落ちた。あなたはそれをすくい上げた。";
+
+    [SetUp]
+    public void SetUp()
+    {
+        Translator.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(RepositoryDictionaryDirectory());
+        MessageFrameTranslator.ResetForTests();
+        MessageFrameTranslator.SetDictionaryPathForTests(RepositoryMessageFramePath());
+        DynamicTextObservability.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        MessageFrameTranslator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TestCase(nameof(DummyFloatingEquipmentProducer.PoweredCheckFloating), CeaseSource, CeaseTranslated, "FloatingEquipmentCease")]
+    [TestCase(nameof(DummyFloatingEquipmentProducer.PoweredCheckFloating), FallSource, FallTranslated, "FloatingEquipmentFall")]
+    [TestCase(nameof(DummyFloatingEquipmentProducer.PoweredCheckFloating), ScoopSource, ScoopTranslated, "FloatingEquipmentFall")]
+    [TestCase(nameof(DummyFloatingEquipmentProducer.MagnetizedCheckFloating), PickSource, PickTranslated, "FloatingEquipmentFall")]
+    [TestCase(nameof(DummyFloatingEquipmentProducer.MagnetizedCheckFloating), FallSource, FallTranslated, "FloatingEquipmentFall")]
+    public void Patch_TranslatesFloatingEquipmentPopup_WhenOwnerPatched(
+        string methodName,
+        string source,
+        string expected,
+        string expectedFamilySuffix)
+    {
+        RunWithOwnerAndPopupPatches(methodName, () =>
+        {
+            var target = new DummyFloatingEquipmentProducer
+            {
+                PopupMessageToShow = source,
+            };
+
+            InvokeProducer(target, methodName);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+                Assert.That(
+                    DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                        nameof(PopupShowTranslationPatch),
+                        "Popup.Show." + expectedFamilySuffix),
+                    Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent()
+    {
+        RunWithPopupPatchOnly(() => DummyPopupShow.Show(CeaseSource));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(CeaseSource));
+            Assert.That(GetCeaseHitCount(), Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void Patch_StripsDirectMarkedPopup_WhenOwnerPatched()
+    {
+        var source = MessageFrameTranslator.MarkDirectTranslation(CeaseSource);
+
+        RunWithOwnerAndPopupPatches(nameof(DummyFloatingEquipmentProducer.PoweredCheckFloating), () =>
+        {
+            var target = new DummyFloatingEquipmentProducer
+            {
+                PopupMessageToShow = source,
+            };
+
+            target.PoweredCheckFloating();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(CeaseSource));
+                Assert.That(GetCeaseHitCount(), Is.EqualTo(0));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        RunWithOwnerAndPopupPatches(nameof(DummyFloatingEquipmentProducer.PoweredCheckFloating), () =>
+        {
+            var target = new DummyFloatingEquipmentProducer
+            {
+                PopupMessageToShow = string.Empty,
+            };
+
+            target.PoweredCheckFloating();
+
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
+        });
+    }
+
+    private static string RepositoryDictionaryDirectory()
+    {
+        return Path.GetFullPath(
+            Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "Localization",
+                "Dictionaries"));
+    }
+
+    private static string RepositoryMessageFramePath()
+    {
+        return Path.GetFullPath(
+            Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "Localization",
+                "MessageFrames",
+                "verbs.ja.json"));
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameters)
+    {
+        return (parameters.Length == 0
+                ? AccessTools.Method(type, methodName)
+                : AccessTools.Method(type, methodName, parameters))
+            ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private static void RunWithPopupPatchOnly(Action action)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchPopupShow(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void RunWithOwnerAndPopupPatches(string methodName, Action action)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyFloatingEquipmentProducer), methodName),
+                prefix: new HarmonyMethod(RequireMethod(typeof(FloatingEquipmentPopupTranslationPatch), nameof(FloatingEquipmentPopupTranslationPatch.Prefix))),
+                finalizer: new HarmonyMethod(RequireMethod(typeof(FloatingEquipmentPopupTranslationPatch), nameof(FloatingEquipmentPopupTranslationPatch.Finalizer), typeof(Exception))));
+            PatchPopupShow(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShow(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.Show)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void InvokeProducer(DummyFloatingEquipmentProducer target, string methodName)
+    {
+        if (methodName == nameof(DummyFloatingEquipmentProducer.PoweredCheckFloating))
+        {
+            target.PoweredCheckFloating();
+            return;
+        }
+
+        target.MagnetizedCheckFloating();
+    }
+
+    private static int GetCeaseHitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show.FloatingEquipmentCease");
+    }
+
+    private sealed class DummyFloatingEquipmentProducer
+    {
+        public string PopupMessageToShow = string.Empty;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void PoweredCheckFloating()
+        {
+            DummyPopupShow.Show(PopupMessageToShow);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void MagnetizedCheckFloating()
+        {
+            DummyPopupShow.Show(PopupMessageToShow);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1278,6 +1278,11 @@ public sealed class TargetMethodResolutionTests
         "XRL.World.Parts.LiquidVolume|Pour|System.Boolean|System.Boolean&|XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean|System.Int32|System.Boolean",
         "XRL.World.Parts.LiquidVolume|PerformFill|System.Boolean|XRL.World.GameObject|System.Boolean&|System.Boolean",
     })]
+    [TestCase(typeof(FloatingEquipmentPopupTranslationPatch), new[]
+    {
+        "XRL.World.Parts.PoweredFloating|CheckFloating|System.Void",
+        "XRL.World.Parts.ModMagnetized|CheckFloating|System.Void",
+    })]
     public void OwnerProducerTargetMethods_ResolveExpectedFullSignatures(Type patchType, string[] expectedSignatures)
     {
         var targetMethodsMethod = patchType.GetMethod("TargetMethods", BindingFlags.NonPublic | BindingFlags.Static);

--- a/Mods/QudJP/Assemblies/src/Patches/FloatingEquipmentPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/FloatingEquipmentPopupTranslationPatch.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class FloatingEquipmentPopupTranslationPatch
+{
+    private const string Context = nameof(FloatingEquipmentPopupTranslationPatch);
+    private const string CeaseFamily = "FloatingEquipmentCease";
+    private const string FallFamily = "FloatingEquipmentFall";
+
+    private static readonly Regex FloatingStatusPattern = new(
+        "^(?:The |the |A |a |An |an )?(?<subject>.+?) (?<verb>ceases?|falls?) (?<extra>floating near you|to the ground(?:; you (?:pick|scoop) .+? up)?)(?<endmark>[.!])?$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        var targets = new List<MethodBase>();
+        AddTarget(targets, "XRL.World.Parts.PoweredFloating", "CheckFloating");
+        AddTarget(targets, "XRL.World.Parts.ModMagnetized", "CheckFloating");
+        return targets;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        if (!TryTranslateCore(source, out translated))
+        {
+            return false;
+        }
+
+        DynamicTextObservability.RecordTransform(route, family + "." + GetFamilySuffix(source), source, translated);
+        return true;
+    }
+
+    private static void AddTarget(List<MethodBase> targets, string typeName, string methodName)
+    {
+        var targetType = AccessTools.TypeByName(typeName);
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type {1} not found.", Context, typeName);
+            return;
+        }
+
+        var method = AccessTools.Method(targetType, methodName, Type.EmptyTypes);
+        if (method is not null)
+        {
+            targets.Add(method);
+            return;
+        }
+
+        Trace.TraceError("QudJP: {0}.{1}.{2} target not found.", Context, typeName, methodName);
+    }
+
+    private static bool TryTranslateCore(string source, out string translated)
+    {
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
+        var match = FloatingStatusPattern.Match(stripped);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        var subject = ColorAwareTranslationComposer.RestoreCapture(
+            match.Groups["subject"].Value,
+            spans,
+            match.Groups["subject"]).Trim();
+        var verb = match.Groups["verb"].Value.StartsWith("cease", StringComparison.Ordinal) ? "cease" : "fall";
+        var extra = match.Groups["extra"].Value;
+        var endmark = match.Groups["endmark"].Success ? match.Groups["endmark"].Value : null;
+        return MessageFrameTranslator.TryTranslateXDidY(subject, verb, extra, endmark, out translated);
+    }
+
+    private static string GetFamilySuffix(string source)
+    {
+        var stripped = ColorAwareTranslationComposer.GetVisibleText(source);
+        return stripped.Contains("floating near you") ? CeaseFamily : FallFamily;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -46,6 +46,7 @@ internal static class PopupShowSemanticPipeline
         CarapaceTranslationPatch.TryTranslatePopupMessage,
         NephalPropertiesTranslationPatch.TryTranslatePopupMessage,
         IntegratedWeaponHostsTranslationPatch.TryTranslatePopupMessage,
+        FloatingEquipmentPopupTranslationPatch.TryTranslatePopupMessage,
         FungalSporeInfectionTranslationPatch.TryTranslatePopupMessage,
     ];
 

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -2261,6 +2261,85 @@ def _integrated_weapon_hosts_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _floating_equipment_popup_families() -> tuple[CoveredOwnerFamily, ...]:
+    common_evidence = (
+        EvidenceFile(
+            "Mods/QudJP/Assemblies/src/Patches/FloatingEquipmentPopupTranslationPatch.cs",
+            (
+                "FloatingEquipmentPopupTranslationPatch",
+                "TryTranslatePopupMessage",
+                "MessageFrameTranslator.TryTranslateXDidY",
+            ),
+        ),
+        EvidenceFile(
+            "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+            ("FloatingEquipmentPopupTranslationPatch.TryTranslatePopupMessage",),
+        ),
+        EvidenceFile(
+            "Mods/QudJP/Localization/MessageFrames/verbs.ja.json",
+            (
+                '"extra": "floating near you"',
+                '"extra": "to the ground; you pick {0} up"',
+                '"extra": "to the ground; you scoop {0} up"',
+            ),
+        ),
+    )
+
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts/PoweredFloating.cs::XRL.World.Parts.PoweredFloating.CheckFloating",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                *common_evidence,
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/FloatingEquipmentPopupTranslationPatchTests.cs",
+                    (
+                        "Patch_TranslatesFloatingEquipmentPopup_WhenOwnerPatched",
+                        "PoweredCheckFloating",
+                        "cease floating near you",
+                        "scoop it up",
+                        "Patch_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent",
+                        "Patch_StripsDirectMarkedPopup_WhenOwnerPatched",
+                        "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(FloatingEquipmentPopupTranslationPatch)",
+                        "XRL.World.Parts.PoweredFloating|CheckFloating|System.Void",
+                    ),
+                ),
+            ),
+        ),
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts/ModMagnetized.cs::XRL.World.Parts.ModMagnetized.CheckFloating",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                *common_evidence,
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/FloatingEquipmentPopupTranslationPatchTests.cs",
+                    (
+                        "Patch_TranslatesFloatingEquipmentPopup_WhenOwnerPatched",
+                        "MagnetizedCheckFloating",
+                        "pick it up",
+                        "Patch_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent",
+                        "Patch_StripsDirectMarkedPopup_WhenOwnerPatched",
+                        "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(FloatingEquipmentPopupTranslationPatch)",
+                        "XRL.World.Parts.ModMagnetized|CheckFloating|System.Void",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _boost_statistic_families() -> tuple[CoveredOwnerFamily, ...]:
     common_evidence = (
         EvidenceFile(
@@ -3980,6 +4059,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_tonic_families(),
     *_xrl_game_families(),
     *_integrated_weapon_hosts_families(),
+    *_floating_equipment_popup_families(),
     *_boost_statistic_families(),
     *_emboldened_families(),
     *_fungal_spore_infection_families(),


### PR DESCRIPTION
## Summary
- Close issue-576 owner-route coverage for powered and magnetized floating equipment popups.
- Add a narrow owner-scoped popup translator for `PoweredFloating.CheckFloating` and `ModMagnetized.CheckFloating`.
- Register closure evidence against existing `MessageFrames/verbs.ja.json` coverage for cease/fall/pick/scoop shapes.

## Inventory shapes
- `PoweredFloating.CheckFloating`: `cease floating near you`, `fall to the ground; you scoop ... up`, `fall to the ground`
- `ModMagnetized.CheckFloating`: `fall to the ground; you pick ... up`, `fall to the ground`

## Tests
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~FloatingEquipmentPopupTranslationPatchTests' --no-restore`\n- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures' --no-restore`\n- `just static-producer-check`\n- `git diff --check`\n\n## Queue delta\n- main: 337 families, 940 callsites, 961 text arguments, 308 source files\n- branch: 335 families, 935 callsites, 956 text arguments, 306 source files