### PR TITLE
Close supplyable host owner popups

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/SupplyableIntegratedHostPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/SupplyableIntegratedHostPopupTranslationPatchTests.cs
@@ -1,0 +1,197 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class SupplyableIntegratedHostPopupTranslationPatchTests
+{
+    private const string NoNeededSuppliesSource = "The {{Y|phase cannon}} needs no supplies.";
+    private const string NoHeldSuppliesSource = "You have no supplies that the {{Y|phase cannon}} needs.";
+    private const string PluralNoNeededSuppliesSource = "The {{Y|phase cannons}} need no supplies.";
+    private const string PluralNoHeldSuppliesSource = "You have no supplies that the {{Y|phase cannons}} need.";
+    private const string NoNeededSuppliesTranslated = "{{Y|phase cannon}}は補給品を必要としていない。";
+    private const string NoHeldSuppliesTranslated = "{{Y|phase cannon}}が必要とする補給品を持っていない。";
+    private const string PluralNoNeededSuppliesTranslated = "{{Y|phase cannons}}は補給品を必要としていない。";
+    private const string PluralNoHeldSuppliesTranslated = "{{Y|phase cannons}}が必要とする補給品を持っていない。";
+
+    [SetUp]
+    public void SetUp()
+    {
+        ResetState();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        ResetState();
+    }
+
+    private static void ResetState()
+    {
+        Translator.ResetForTests();
+        MessageFrameTranslator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TestCase(NoNeededSuppliesSource, NoNeededSuppliesTranslated, "SupplyableIntegratedHostNoNeededSupplies")]
+    [TestCase(NoHeldSuppliesSource, NoHeldSuppliesTranslated, "SupplyableIntegratedHostNoHeldSupplies")]
+    [TestCase(PluralNoNeededSuppliesSource, PluralNoNeededSuppliesTranslated, "SupplyableIntegratedHostNoNeededSupplies")]
+    [TestCase(PluralNoHeldSuppliesSource, PluralNoHeldSuppliesTranslated, "SupplyableIntegratedHostNoHeldSupplies")]
+    public void Patch_TranslatesSupplyableIntegratedHostPopup_WhenOwnerPatched(
+        string source,
+        string expected,
+        string expectedFamilySuffix)
+    {
+        RunWithOwnerAndPopupPatches(() =>
+        {
+            var target = new DummySupplyableIntegratedHostProducer
+            {
+                PopupMessageToShow = source,
+            };
+
+            target.AttemptSupply();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+                Assert.That(
+                    DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                        nameof(PopupShowTranslationPatch),
+                        "Popup.Show." + expectedFamilySuffix),
+                    Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent()
+    {
+        RunWithPopupPatchOnly(() => DummyPopupShow.Show(NoNeededSuppliesSource));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(NoNeededSuppliesSource));
+            Assert.That(GetNoNeededSuppliesHitCount(), Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void Patch_StripsDirectMarkedPopup_WhenOwnerPatched()
+    {
+        var source = MessageFrameTranslator.MarkDirectTranslation(NoNeededSuppliesSource);
+
+        RunWithOwnerAndPopupPatches(() =>
+        {
+            var target = new DummySupplyableIntegratedHostProducer
+            {
+                PopupMessageToShow = source,
+            };
+
+            target.AttemptSupply();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(NoNeededSuppliesSource));
+                Assert.That(GetNoNeededSuppliesHitCount(), Is.EqualTo(0));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        RunWithOwnerAndPopupPatches(() =>
+        {
+            var target = new DummySupplyableIntegratedHostProducer
+            {
+                PopupMessageToShow = string.Empty,
+            };
+
+            target.AttemptSupply();
+
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
+        });
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameters)
+    {
+        return (parameters.Length == 0
+                ? AccessTools.Method(type, methodName)
+                : AccessTools.Method(type, methodName, parameters))
+            ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private static void RunWithPopupPatchOnly(Action action)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchPopupShow(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void RunWithOwnerAndPopupPatches(Action action)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummySupplyableIntegratedHostProducer), nameof(DummySupplyableIntegratedHostProducer.AttemptSupply)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(SupplyableIntegratedHostPopupTranslationPatch), nameof(SupplyableIntegratedHostPopupTranslationPatch.Prefix))),
+                finalizer: new HarmonyMethod(RequireMethod(typeof(SupplyableIntegratedHostPopupTranslationPatch), nameof(SupplyableIntegratedHostPopupTranslationPatch.Finalizer), typeof(Exception))));
+            PatchPopupShow(harmony);
+            action();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShow(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.Show)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static int GetNoNeededSuppliesHitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show.SupplyableIntegratedHostNoNeededSupplies");
+    }
+
+    private sealed class DummySupplyableIntegratedHostProducer
+    {
+        public string PopupMessageToShow = string.Empty;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool AttemptSupply()
+        {
+            DummyPopupShow.Show(PopupMessageToShow);
+            return true;
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1278,6 +1278,10 @@ public sealed class TargetMethodResolutionTests
         "XRL.World.Parts.LiquidVolume|Pour|System.Boolean|System.Boolean&|XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean|System.Int32|System.Boolean",
         "XRL.World.Parts.LiquidVolume|PerformFill|System.Boolean|XRL.World.GameObject|System.Boolean&|System.Boolean",
     })]
+    [TestCase(typeof(SupplyableIntegratedHostPopupTranslationPatch), new[]
+    {
+        "XRL.World.Parts.SupplyableIntegratedHost|AttemptSupply|System.Boolean|XRL.World.GameObject",
+    })]
     public void OwnerProducerTargetMethods_ResolveExpectedFullSignatures(Type patchType, string[] expectedSignatures)
     {
         var targetMethodsMethod = patchType.GetMethod("TargetMethods", BindingFlags.NonPublic | BindingFlags.Static);

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -46,6 +46,7 @@ internal static class PopupShowSemanticPipeline
         CarapaceTranslationPatch.TryTranslatePopupMessage,
         NephalPropertiesTranslationPatch.TryTranslatePopupMessage,
         IntegratedWeaponHostsTranslationPatch.TryTranslatePopupMessage,
+        SupplyableIntegratedHostPopupTranslationPatch.TryTranslatePopupMessage,
         FungalSporeInfectionTranslationPatch.TryTranslatePopupMessage,
     ];
 

--- a/Mods/QudJP/Assemblies/src/Patches/SupplyableIntegratedHostPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/SupplyableIntegratedHostPopupTranslationPatch.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class SupplyableIntegratedHostPopupTranslationPatch
+{
+    private const string Context = nameof(SupplyableIntegratedHostPopupTranslationPatch);
+    private const string NoNeededSuppliesFamily = "SupplyableIntegratedHostNoNeededSupplies";
+    private const string NoHeldSuppliesFamily = "SupplyableIntegratedHostNoHeldSupplies";
+
+    private static readonly Regex NoNeededSuppliesPattern = new(
+        "^(?:The |the |A |a |An |an )?(?<host>.+?) needs? no supplies\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex NoHeldSuppliesPattern = new(
+        "^You have no supplies that (?:the |The |a |A |an |An )?(?<host>.+?) needs?\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        var targets = new List<MethodBase>();
+        var targetType = AccessTools.TypeByName("XRL.World.Parts.SupplyableIntegratedHost");
+        var gameObjectType = AccessTools.TypeByName("XRL.World.GameObject");
+        if (targetType is null || gameObjectType is null)
+        {
+            Trace.TraceError("QudJP: {0} target types not found.", Context);
+            return targets;
+        }
+
+        var method = AccessTools.Method(targetType, "AttemptSupply", new[] { gameObjectType });
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.AttemptSupply(GameObject) target not found.", Context);
+            return targets;
+        }
+
+        targets.Add(method);
+        return targets;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        if (!TryTranslateCore(source, out translated, out var familySuffix))
+        {
+            return false;
+        }
+
+        DynamicTextObservability.RecordTransform(route, family + "." + familySuffix, source, translated);
+        return true;
+    }
+
+    private static bool TryTranslateCore(string source, out string translated, out string familySuffix)
+    {
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
+
+        var noNeededSuppliesMatch = NoNeededSuppliesPattern.Match(stripped);
+        if (noNeededSuppliesMatch.Success)
+        {
+            var host = noNeededSuppliesMatch.Groups["host"];
+            translated = ColorAwareTranslationComposer.RestoreCapture(host.Value, spans, host).Trim()
+                + "は補給品を必要としていない。";
+            familySuffix = NoNeededSuppliesFamily;
+            return true;
+        }
+
+        var noHeldSuppliesMatch = NoHeldSuppliesPattern.Match(stripped);
+        if (noHeldSuppliesMatch.Success)
+        {
+            var host = noHeldSuppliesMatch.Groups["host"];
+            translated = ColorAwareTranslationComposer.RestoreCapture(host.Value, spans, host).Trim()
+                + "が必要とする補給品を持っていない。";
+            familySuffix = NoHeldSuppliesFamily;
+            return true;
+        }
+
+        translated = source;
+        familySuffix = string.Empty;
+        return false;
+    }
+}

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -2261,6 +2261,48 @@ def _integrated_weapon_hosts_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _supplyable_integrated_host_popup_families() -> tuple[CoveredOwnerFamily, ...]:
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts/SupplyableIntegratedHost.cs::XRL.World.Parts.SupplyableIntegratedHost.AttemptSupply",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/SupplyableIntegratedHostPopupTranslationPatch.cs",
+                    (
+                        "SupplyableIntegratedHostPopupTranslationPatch",
+                        "TryTranslatePopupMessage",
+                        "NoNeededSuppliesPattern",
+                        "NoHeldSuppliesPattern",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                    ("SupplyableIntegratedHostPopupTranslationPatch.TryTranslatePopupMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/SupplyableIntegratedHostPopupTranslationPatchTests.cs",
+                    (
+                        "Patch_TranslatesSupplyableIntegratedHostPopup_WhenOwnerPatched",
+                        "needs no supplies",
+                        "You have no supplies that the",
+                        "Patch_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent",
+                        "Patch_StripsDirectMarkedPopup_WhenOwnerPatched",
+                        "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(SupplyableIntegratedHostPopupTranslationPatch)",
+                        "XRL.World.Parts.SupplyableIntegratedHost|AttemptSupply|System.Boolean|XRL.World.GameObject",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _boost_statistic_families() -> tuple[CoveredOwnerFamily, ...]:
     common_evidence = (
         EvidenceFile(
@@ -3980,6 +4022,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_tonic_families(),
     *_xrl_game_families(),
     *_integrated_weapon_hosts_families(),
+    *_supplyable_integrated_host_popup_families(),
     *_boost_statistic_families(),
     *_emboldened_families(),
     *_fungal_spore_infection_families(),


### PR DESCRIPTION
## Summary
- Close issue-576 owner-route coverage for `SupplyableIntegratedHost.AttemptSupply` popups.
- Add a narrow owner-scoped popup translator for the no-needed-supplies and no-held-supplies shapes.
- Register closure evidence in `scripts/static_producer_closure.py` with focused L2 behavior tests and L2G target resolution.

## Inventory shapes
- `Popup.Show(ParentObject.The + ParentObject.ShortDisplayName + ParentObject.GetVerb("need") + " no supplies.")`
- `Popup.Show("You have no supplies that " + ParentObject.the + ParentObject.ShortDisplayName + ParentObject.GetVerb("need") + ".")`

## Tests
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~SupplyableIntegratedHostPopupTranslationPatchTests' --no-restore`\n- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures' --no-restore`\n- `just static-producer-check`\n- `git diff --check`\n\n## Queue delta\n- main: 337 families, 940 callsites, 961 text arguments, 308 source files\n- branch: 336 families, 938 callsites, 959 text arguments, 307 source files