### PR TITLE
Close data disk learn owner popups

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/DataDiskLearnPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/DataDiskLearnPopupTranslationPatchTests.cs
@@ -1,0 +1,206 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class DataDiskLearnPopupTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        Translator.ResetForTests();
+        MessagePatternTranslator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        MessagePatternTranslator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+    }
+
+    [Test]
+    public void Patch_TranslatesItemModificationLearnPopup_WhenOwnerPatched()
+    {
+        WithPatchedDataDiskHandleEvent(() =>
+        {
+            var target = new DummyDataDiskProducerTarget
+            {
+                PopupMessageToShow = "You learn the item modification {{W|counterweighted}}.",
+            };
+
+            _ = target.HandleEvent(new DummyInventoryActionEvent());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("アイテム改造{{W|counterweighted}}を習得した。"));
+                Assert.That(HitCount("ItemModification"), Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_TranslatesBuildRecipeLearnPopup_WhenOwnerPatched()
+    {
+        WithPatchedDataDiskHandleEvent(() =>
+        {
+            var target = new DummyDataDiskProducerTarget
+            {
+                PopupMessageToShow = "You learn to build {{C|laser pistols}}.",
+            };
+
+            _ = target.HandleEvent(new DummyInventoryActionEvent());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("{{C|laser pistols}}を作成する方法を習得した。"));
+                Assert.That(HitCount("BuildRecipe"), Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotTranslateDataDiskLearnPopup_WhenOwnerAbsent()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchPopupShow(harmony);
+
+            DummyPopupShow.Show("You learn to build laser pistols.");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("You learn to build laser pistols."));
+                Assert.That(HitCount("BuildRecipe"), Is.Zero);
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
+    {
+        WithPatchedDataDiskHandleEvent(() =>
+        {
+            var target = new DummyDataDiskProducerTarget
+            {
+                PopupMessageToShow = MessageFrameTranslator.MarkDirectTranslation("You learn to build laser pistols."),
+            };
+
+            _ = target.HandleEvent(new DummyInventoryActionEvent());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("You learn to build laser pistols."));
+                Assert.That(HitCount("BuildRecipe"), Is.Zero);
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        WithPatchedDataDiskHandleEvent(() =>
+        {
+            var target = new DummyDataDiskProducerTarget
+            {
+                PopupMessageToShow = string.Empty,
+            };
+
+            _ = target.HandleEvent(new DummyInventoryActionEvent());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
+                Assert.That(HitCount("BuildRecipe"), Is.Zero);
+            });
+        });
+    }
+
+    private static void WithPatchedDataDiskHandleEvent(Action assertion)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchPopupShow(harmony);
+            PatchOwner(harmony);
+
+            assertion();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShow(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.Show)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void PatchOwner(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyDataDiskProducerTarget), nameof(DummyDataDiskProducerTarget.HandleEvent), typeof(DummyInventoryActionEvent)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(DataDiskLearnPopupTranslationPatch), nameof(DataDiskLearnPopupTranslationPatch.Prefix))),
+            finalizer: new HarmonyMethod(RequireMethod(typeof(DataDiskLearnPopupTranslationPatch), nameof(DataDiskLearnPopupTranslationPatch.Finalizer), typeof(Exception))));
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameterTypes)
+    {
+        if (parameterTypes.Length == 0)
+        {
+            return type.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
+                   ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+        }
+
+        return AccessTools.Method(type, methodName, parameterTypes)
+               ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+
+    private static int HitCount(string detail)
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show." + nameof(DataDiskLearnPopupTranslationPatch) + "." + detail);
+    }
+
+    private sealed class DummyDataDiskProducerTarget
+    {
+        public string PopupMessageToShow { get; init; } = string.Empty;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool HandleEvent(DummyInventoryActionEvent e)
+        {
+            _ = e;
+            DummyPopupShow.Show(PopupMessageToShow);
+            return true;
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -438,6 +438,7 @@ public sealed class TargetMethodResolutionTests
     [TestCase(typeof(ChairTranslationPatch), "SitDown", "XRL.World.Parts.Chair", "System.Boolean", new[] { "XRL.World.GameObject", "XRL.World.IEvent" })]
     [TestCase(typeof(StairsDownTranslationPatch), "HandleEvent", "XRL.World.Parts.StairsDown", "System.Boolean", new[] { "XRL.World.InventoryActionEvent" })]
     [TestCase(typeof(StairsUpTranslationPatch), "HandleEvent", "XRL.World.Parts.StairsUp", "System.Boolean", new[] { "XRL.World.InventoryActionEvent" })]
+    [TestCase(typeof(DataDiskLearnPopupTranslationPatch), "HandleEvent", "XRL.World.Parts.DataDisk", "System.Boolean", new[] { "XRL.World.InventoryActionEvent" })]
     [TestCase(typeof(GameSummaryScreenMenuBarsTranslationPatch), "UpdateMenuBars", "Qud.UI.GameSummaryScreen", "System.Void", new string[0])]
     [TestCase(typeof(GameSummaryScreenShowTranslationPatch), "_ShowGameSummary", "Qud.UI.GameSummaryScreen", "System.Threading.Tasks.Task`1[[System.Boolean]]", new[] { "System.String", "System.String", "System.String", "System.Boolean" })]
     [TestCase(typeof(MainMenuRowTranslationPatch), "setData", "MainMenuRow", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]
@@ -1383,6 +1384,18 @@ public sealed class TargetMethodResolutionTests
             Assert.That(FullMethodSignature(stairsDown!), Is.EqualTo("XRL.World.Parts.StairsDown|HandleEvent|System.Boolean|XRL.World.InventoryActionEvent"));
             Assert.That(stairsUp, Is.Not.Null);
             Assert.That(FullMethodSignature(stairsUp!), Is.EqualTo("XRL.World.Parts.StairsUp|HandleEvent|System.Boolean|XRL.World.InventoryActionEvent"));
+        });
+    }
+
+    [Test]
+    public void DataDiskLearnPopupTargetMethod_ResolvesExpectedFullSignature()
+    {
+        var method = InvokeTargetMethod(typeof(DataDiskLearnPopupTranslationPatch)) as MethodInfo;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(method, Is.Not.Null);
+            Assert.That(FullMethodSignature(method!), Is.EqualTo("XRL.World.Parts.DataDisk|HandleEvent|System.Boolean|XRL.World.InventoryActionEvent"));
         });
     }
 

--- a/Mods/QudJP/Assemblies/src/Patches/DataDiskLearnPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/DataDiskLearnPopupTranslationPatch.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class DataDiskLearnPopupTranslationPatch
+{
+    private const string Context = nameof(DataDiskLearnPopupTranslationPatch);
+
+    private static readonly Regex ItemModificationPattern =
+        new Regex(
+            "^You learn the item modification \\{\\{W\\|(?<mod>[\\s\\S]+)\\}\\}\\.$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex BuildRecipePattern =
+        new Regex(
+            "^You learn to build (?<item>[\\s\\S]+)\\.$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = AccessTools.TypeByName("XRL.World.Parts.DataDisk");
+        var inventoryActionEventType = AccessTools.TypeByName("XRL.World.InventoryActionEvent");
+        if (targetType is null || inventoryActionEventType is null)
+        {
+            Trace.TraceError("QudJP: {0} failed to resolve target types.", Context);
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "HandleEvent", [inventoryActionEventType]);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.HandleEvent(InventoryActionEvent) not found.", Context);
+        }
+
+        return method;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        var itemModificationMatch = ItemModificationPattern.Match(source);
+        if (itemModificationMatch.Success)
+        {
+            translated = string.Concat(
+                "アイテム改造{{W|",
+                itemModificationMatch.Groups["mod"].Value,
+                "}}を習得した。");
+            DynamicTextObservability.RecordTransform(route, family + "." + Context + ".ItemModification", source, translated);
+            return true;
+        }
+
+        var buildRecipeMatch = BuildRecipePattern.Match(source);
+        if (buildRecipeMatch.Success)
+        {
+            translated = string.Concat(
+                buildRecipeMatch.Groups["item"].Value,
+                "を作成する方法を習得した。");
+            DynamicTextObservability.RecordTransform(route, family + "." + Context + ".BuildRecipe", source, translated);
+            return true;
+        }
+
+        translated = source;
+        return false;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -30,6 +30,7 @@ internal static class PopupShowSemanticPipeline
         CampfireCookAvailabilityTranslationPatch.TryTranslatePopupMessage,
         CampfirePreserveTranslationPatch.TryTranslatePopupMessage,
         CookingRuntimeTranslationPatch.TryTranslatePopupMessage,
+        DataDiskLearnPopupTranslationPatch.TryTranslatePopupMessage,
         StatusScreenPopupTranslationPatch.TryTranslatePopupMessage,
         TeleprojectorTranslationPatch.TryTranslatePopupMessage,
         CyberneticsMedassistModuleTranslationPatch.TryTranslatePopupMessage,

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -4941,6 +4941,44 @@ COVERED_OWNER_FAMILIES: Final = (
             ),
         ),
     ),
+    CoveredOwnerFamily(
+        family_id="XRL.World.Parts/DataDisk.cs::XRL.World.Parts.DataDisk.HandleEvent",
+        inventory_statuses=("owner_patch_required",),
+        evidence_files=(
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/DataDiskLearnPopupTranslationPatch.cs",
+                (
+                    "TryTranslatePopupMessage",
+                    "ItemModificationPattern",
+                    "BuildRecipePattern",
+                    "XRL.World.Parts.DataDisk",
+                    "HandleEvent",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                ("DataDiskLearnPopupTranslationPatch.TryTranslatePopupMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/DataDiskLearnPopupTranslationPatchTests.cs",
+                (
+                    "Patch_TranslatesItemModificationLearnPopup_WhenOwnerPatched",
+                    "Patch_TranslatesBuildRecipeLearnPopup_WhenOwnerPatched",
+                    "Patch_DoesNotTranslateDataDiskLearnPopup_WhenOwnerAbsent",
+                    "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+                    "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                    "nameof(DummyDataDiskProducerTarget.HandleEvent)",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                (
+                    "DataDiskLearnPopupTargetMethod_ResolvesExpectedFullSignature",
+                    "XRL.World.Parts.DataDisk|HandleEvent|System.Boolean|XRL.World.InventoryActionEvent",
+                ),
+            ),
+        ),
+    ),
     *_examiner_result_popup_families(),
 )
 COVERED_OWNER_FAMILY_IDS: Final = frozenset(family.family_id for family in COVERED_OWNER_FAMILIES)


### PR DESCRIPTION
## Summary
- add an owner-scoped popup translator for DataDisk learn messages
- cover item modification and build recipe learn popups with L2 owner-route tests
- register the DataDisk.HandleEvent family in static producer closure evidence

## Inventory
- XRL.World.Parts/DataDisk.cs::XRL.World.Parts.DataDisk.HandleEvent
- line 217 Popup.Show("You learn the item modification {{W|" + Data.DisplayName + "}}.")
- line 225 Popup.Show("You learn to build " + ... + ".")

## Validation
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~DataDiskLearnPopupTranslationPatchTests' -v minimal\n- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.DataDiskLearnPopupTargetMethod_ResolvesExpectedFullSignature|FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature' --no-restore -v minimal\n- just static-producer-check\n- git diff --check\n\nQueue delta: 337 families / 940 callsites / 961 text args / 308 files -> 336 families / 938 callsites / 959 text args / 307 files.