### PR TITLE
Close cudgel conk owner popups

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CudgelConkPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CudgelConkPopupTranslationPatchTests.cs
@@ -1,0 +1,219 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class CudgelConkPopupTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        Translator.ResetForTests();
+        MessagePatternTranslator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        MessagePatternTranslator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+    }
+
+    [TestCase("snapjaw doesn't have anything like a head to conk.", "snapjawには殴る頭のようなものがない。")]
+    [TestCase("gelatinous wedges don't have anything like a head to conk.", "gelatinous wedgesには殴る頭のようなものがない。")]
+    public void Patch_TranslatesNoHeadPopup_WhenOwnerPatched(string source, string expected)
+    {
+        WithPatchedCudgelConk(nameof(DummyCudgelConkProducerTarget.ShowNoHeadPopup), () =>
+        {
+            var target = new DummyCudgelConkProducerTarget
+            {
+                PopupMessageToShow = source,
+            };
+
+            target.ShowNoHeadPopup();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+                Assert.That(HitCount("NoHead"), Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_TranslatesConfirmSelfConkPopup_WhenOwnerPatched()
+    {
+        WithPatchedCudgelConk(nameof(DummyCudgelConkProducerTarget.ShowConfirmSelfConkPopup), () =>
+        {
+            var target = new DummyCudgelConkProducerTarget
+            {
+                PopupMessageToShow = "Are you sure you want to conk yourself on {{C|the head}}?",
+            };
+
+            target.ShowConfirmSelfConkPopup();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowYesNoMessage, Is.EqualTo("本当にyourselfを{{C|the head}}にこん棒で殴りますか？"));
+                Assert.That(HitCount("ConfirmSelfConk"), Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotTranslateCudgelConkPopup_WhenOwnerAbsent()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchPopupShowFail(harmony);
+
+            DummyPopupShow.ShowFail("snapjaw doesn't have anything like a head to conk.");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("snapjaw doesn't have anything like a head to conk."));
+                Assert.That(HitCount("NoHead"), Is.Zero);
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
+    {
+        WithPatchedCudgelConk(nameof(DummyCudgelConkProducerTarget.ShowNoHeadPopup), () =>
+        {
+            var target = new DummyCudgelConkProducerTarget
+            {
+                PopupMessageToShow = MessageFrameTranslator.MarkDirectTranslation("snapjaw doesn't have anything like a head to conk."),
+            };
+
+            target.ShowNoHeadPopup();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("snapjaw doesn't have anything like a head to conk."));
+                Assert.That(HitCount("NoHead"), Is.Zero);
+            });
+        });
+    }
+
+    [Test]
+    public void Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        WithPatchedCudgelConk(nameof(DummyCudgelConkProducerTarget.ShowNoHeadPopup), () =>
+        {
+            var target = new DummyCudgelConkProducerTarget
+            {
+                PopupMessageToShow = string.Empty,
+            };
+
+            target.ShowNoHeadPopup();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
+                Assert.That(HitCount("NoHead"), Is.Zero);
+            });
+        });
+    }
+
+    private static void WithPatchedCudgelConk(string methodName, Action assertion)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchPopupShowFail(harmony);
+            PatchPopupShowYesNo(harmony);
+            PatchOwner(harmony, RequireMethod(typeof(DummyCudgelConkProducerTarget), methodName));
+
+            assertion();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShowFail(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.ShowFail)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void PatchPopupShowYesNo(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.ShowYesNo)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void PatchOwner(Harmony harmony, MethodInfo original)
+    {
+        harmony.Patch(
+            original: original,
+            prefix: new HarmonyMethod(RequireMethod(typeof(CudgelConkPopupTranslationPatch), nameof(CudgelConkPopupTranslationPatch.Prefix))),
+            finalizer: new HarmonyMethod(RequireMethod(typeof(CudgelConkPopupTranslationPatch), nameof(CudgelConkPopupTranslationPatch.Finalizer), typeof(Exception))));
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameterTypes)
+    {
+        if (parameterTypes.Length == 0)
+        {
+            return type.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
+                   ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+        }
+
+        return AccessTools.Method(type, methodName, parameterTypes)
+               ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+
+    private static int HitCount(string detail)
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show." + nameof(CudgelConkPopupTranslationPatch) + "." + detail);
+    }
+
+    private sealed class DummyCudgelConkProducerTarget
+    {
+        public string PopupMessageToShow { get; init; } = string.Empty;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void ShowNoHeadPopup()
+        {
+            DummyPopupShow.ShowFail(PopupMessageToShow);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void ShowConfirmSelfConkPopup()
+        {
+            DummyPopupShow.ShowYesNo(PopupMessageToShow);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -438,6 +438,7 @@ public sealed class TargetMethodResolutionTests
     [TestCase(typeof(ChairTranslationPatch), "SitDown", "XRL.World.Parts.Chair", "System.Boolean", new[] { "XRL.World.GameObject", "XRL.World.IEvent" })]
     [TestCase(typeof(StairsDownTranslationPatch), "HandleEvent", "XRL.World.Parts.StairsDown", "System.Boolean", new[] { "XRL.World.InventoryActionEvent" })]
     [TestCase(typeof(StairsUpTranslationPatch), "HandleEvent", "XRL.World.Parts.StairsUp", "System.Boolean", new[] { "XRL.World.InventoryActionEvent" })]
+    [TestCase(typeof(CudgelConkPopupTranslationPatch), "PerformConk", "XRL.World.Parts.Skill.Cudgel_Conk", "System.Boolean", new string[0])]
     [TestCase(typeof(GameSummaryScreenMenuBarsTranslationPatch), "UpdateMenuBars", "Qud.UI.GameSummaryScreen", "System.Void", new string[0])]
     [TestCase(typeof(GameSummaryScreenShowTranslationPatch), "_ShowGameSummary", "Qud.UI.GameSummaryScreen", "System.Threading.Tasks.Task`1[[System.Boolean]]", new[] { "System.String", "System.String", "System.String", "System.Boolean" })]
     [TestCase(typeof(MainMenuRowTranslationPatch), "setData", "MainMenuRow", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]
@@ -1383,6 +1384,18 @@ public sealed class TargetMethodResolutionTests
             Assert.That(FullMethodSignature(stairsDown!), Is.EqualTo("XRL.World.Parts.StairsDown|HandleEvent|System.Boolean|XRL.World.InventoryActionEvent"));
             Assert.That(stairsUp, Is.Not.Null);
             Assert.That(FullMethodSignature(stairsUp!), Is.EqualTo("XRL.World.Parts.StairsUp|HandleEvent|System.Boolean|XRL.World.InventoryActionEvent"));
+        });
+    }
+
+    [Test]
+    public void CudgelConkPopupTargetMethod_ResolvesExpectedFullSignature()
+    {
+        var method = InvokeTargetMethod(typeof(CudgelConkPopupTranslationPatch)) as MethodInfo;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(method, Is.Not.Null);
+            Assert.That(FullMethodSignature(method!), Is.EqualTo("XRL.World.Parts.Skill.Cudgel_Conk|PerformConk|System.Boolean"));
         });
     }
 

--- a/Mods/QudJP/Assemblies/src/Patches/CudgelConkPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/CudgelConkPopupTranslationPatch.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class CudgelConkPopupTranslationPatch
+{
+    private const string Context = nameof(CudgelConkPopupTranslationPatch);
+
+    private static readonly Regex NoHeadPattern =
+        new Regex(
+            "^(?<target>[\\s\\S]+?) (?:doesn't|don't) have anything like a head to conk\\.$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex ConfirmSelfConkPattern =
+        new Regex(
+            "^Are you sure you want to conk (?<target>[\\s\\S]+?) on (?<location>[\\s\\S]+)\\?$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = AccessTools.TypeByName("XRL.World.Parts.Skill.Cudgel_Conk");
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} failed to resolve target type.", Context);
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "PerformConk", Type.EmptyTypes);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.PerformConk() not found.", Context);
+        }
+
+        return method;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        var noHeadMatch = NoHeadPattern.Match(source);
+        if (noHeadMatch.Success)
+        {
+            translated = string.Concat(
+                noHeadMatch.Groups["target"].Value,
+                "には殴る頭のようなものがない。");
+            DynamicTextObservability.RecordTransform(route, family + "." + Context + ".NoHead", source, translated);
+            return true;
+        }
+
+        var confirmSelfConkMatch = ConfirmSelfConkPattern.Match(source);
+        if (confirmSelfConkMatch.Success)
+        {
+            translated = string.Concat(
+                "本当に",
+                confirmSelfConkMatch.Groups["target"].Value,
+                "を",
+                confirmSelfConkMatch.Groups["location"].Value,
+                "にこん棒で殴りますか？");
+            DynamicTextObservability.RecordTransform(route, family + "." + Context + ".ConfirmSelfConk", source, translated);
+            return true;
+        }
+
+        translated = source;
+        return false;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -27,6 +27,7 @@ internal static class PopupShowSemanticPipeline
         AbilityManagerPopupTranslationPatch.TryTranslatePopupMessage,
         RealityStabilizedEventTranslationPatch.TryTranslatePopupMessage,
         GeomagneticDiscTranslationPatch.TryTranslatePopupMessage,
+        CudgelConkPopupTranslationPatch.TryTranslatePopupMessage,
         CampfireCookAvailabilityTranslationPatch.TryTranslatePopupMessage,
         CampfirePreserveTranslationPatch.TryTranslatePopupMessage,
         CookingRuntimeTranslationPatch.TryTranslatePopupMessage,

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -4941,6 +4941,44 @@ COVERED_OWNER_FAMILIES: Final = (
             ),
         ),
     ),
+    CoveredOwnerFamily(
+        family_id="XRL.World.Parts.Skill/Cudgel_Conk.cs::XRL.World.Parts.Skill.Cudgel_Conk.PerformConk",
+        inventory_statuses=("owner_patch_required",),
+        evidence_files=(
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/CudgelConkPopupTranslationPatch.cs",
+                (
+                    "TryTranslatePopupMessage",
+                    "NoHeadPattern",
+                    "ConfirmSelfConkPattern",
+                    "XRL.World.Parts.Skill.Cudgel_Conk",
+                    "PerformConk",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                ("CudgelConkPopupTranslationPatch.TryTranslatePopupMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/CudgelConkPopupTranslationPatchTests.cs",
+                (
+                    "Patch_TranslatesNoHeadPopup_WhenOwnerPatched",
+                    "Patch_TranslatesConfirmSelfConkPopup_WhenOwnerPatched",
+                    "Patch_DoesNotTranslateCudgelConkPopup_WhenOwnerAbsent",
+                    "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+                    "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                    "nameof(DummyCudgelConkProducerTarget.ShowNoHeadPopup)",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                (
+                    "CudgelConkPopupTargetMethod_ResolvesExpectedFullSignature",
+                    "XRL.World.Parts.Skill.Cudgel_Conk|PerformConk|System.Boolean",
+                ),
+            ),
+        ),
+    ),
     *_examiner_result_popup_families(),
 )
 COVERED_OWNER_FAMILY_IDS: Final = frozenset(family.family_id for family in COVERED_OWNER_FAMILIES)


### PR DESCRIPTION
## Summary
- add an owner-scoped popup translator for Cudgel_Conk.PerformConk
- cover no-head and self-conk confirmation popups with L2 owner-route tests
- register the Cudgel_Conk.PerformConk family in static producer closure evidence

## Inventory
- XRL.World.Parts.Skill/Cudgel_Conk.cs::XRL.World.Parts.Skill.Cudgel_Conk.PerformConk
- line 128 Popup.ShowFail(combatTarget.Does("don't") + " have anything like a head to conk.")\n- line 132 Popup.ShowYesNo("Are you sure you want to conk " + combatTarget.itself + " on " + conkLocation + "?")\n\n## Validation\n- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~CudgelConkPopupTranslationPatchTests' -v minimal\n- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.CudgelConkPopupTargetMethod_ResolvesExpectedFullSignature|FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature' --no-restore -v minimal\n- just static-producer-check\n- git diff --check\n\nQueue delta: 337 families / 940 callsites / 961 text args / 308 files -> 336 families / 938 callsites / 959 text args / 307 files.