### PR TITLE
Close Grit Gate terminal alarm owner message

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/GritGateTerminalScreenMessageTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/GritGateTerminalScreenMessageTranslationPatchTests.cs
@@ -1,0 +1,214 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class GritGateTerminalScreenMessageTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        Translator.ResetForTests();
+        ScopedDictionaryLookup.ResetForTests();
+        Translator.SetDictionaryDirectoryForTests(GetRepositoryDictionaryDirectory());
+        MessagePatternTranslator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+        DummyMessageQueue.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        ScopedDictionaryLookup.ResetForTests();
+        MessagePatternTranslator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+    }
+
+    [Test]
+    public void Activate_TranslatesConstructorDelegateAlarmMessage_WhenOwnerPatched()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(harmony);
+
+            var target = new DummyGritGateTerminalScreenMessageTarget();
+
+            target.Activate();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("防衛線に警報が鳴り響いた。"));
+                Assert.That(HitCount(), Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void Activate_DoesNotTranslateAlarmMessage_WhenOwnerAbsent()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchQueue(harmony);
+
+            DummyMessageQueue.AddPlayerMessage("Alarms blare across the enclave.", null, Capitalize: false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("Alarms blare across the enclave."));
+                Assert.That(HitCount(), Is.Zero);
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void Activate_DoesNotRetranslateDirectMarkedAlarmMessage_WhenOwnerPatched()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(harmony);
+
+            var target = new DummyGritGateTerminalScreenMessageTarget
+            {
+                MessageToSend = MessageFrameTranslator.MarkDirectTranslation("Alarms blare across the enclave."),
+            };
+
+            target.Activate();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("Alarms blare across the enclave."));
+                Assert.That(HitCount(), Is.Zero);
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void Activate_LeavesEmptyMessageUnchanged_WhenOwnerPatched()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(harmony);
+
+            var target = new DummyGritGateTerminalScreenMessageTarget
+            {
+                MessageToSend = string.Empty,
+            };
+
+            target.Activate();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(string.Empty));
+                Assert.That(HitCount(), Is.Zero);
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchQueue(Harmony harmony)
+    {
+        var original = RequireMethod(typeof(DummyMessageQueue), nameof(DummyMessageQueue.AddPlayerMessage), typeof(string), typeof(string), typeof(bool));
+        harmony.Patch(
+            original: original,
+            prefix: new HarmonyMethod(RequireMethod(typeof(CombatAndLogMessageQueuePatch), nameof(CombatAndLogMessageQueuePatch.Prefix), typeof(string).MakeByRefType(), typeof(string), typeof(bool))));
+        harmony.Patch(
+            original: original,
+            prefix: new HarmonyMethod(RequireMethod(typeof(MessageLogPatch), nameof(MessageLogPatch.Prefix), typeof(string).MakeByRefType(), typeof(string), typeof(bool))));
+    }
+
+    private static void PatchOwner(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyGritGateTerminalScreenMessageTarget), nameof(DummyGritGateTerminalScreenMessageTarget.Activate)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(GritGateTerminalScreenMessageTranslationPatch), nameof(GritGateTerminalScreenMessageTranslationPatch.Prefix))),
+            finalizer: new HarmonyMethod(RequireMethod(typeof(GritGateTerminalScreenMessageTranslationPatch), nameof(GritGateTerminalScreenMessageTranslationPatch.Finalizer), typeof(Exception))));
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameterTypes)
+    {
+        if (parameterTypes.Length == 0)
+        {
+            return type.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
+                   ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+        }
+
+        return AccessTools.Method(type, methodName, parameterTypes)
+               ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+
+    private static int HitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            "MessageQueue.AddPlayerMessage",
+            nameof(GritGateTerminalScreenMessageTranslationPatch) + ".ConstructorDelegateAlarm");
+    }
+
+    private static string GetRepositoryDictionaryDirectory()
+    {
+        return Path.GetFullPath(
+            Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "Localization",
+                "Dictionaries"));
+    }
+
+    private sealed class DummyGritGateTerminalScreenMessageTarget
+    {
+        public string MessageToSend { get; init; } = "Alarms blare across the enclave.";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Activate()
+        {
+            DummyMessageQueue.AddPlayerMessage(MessageToSend, null, Capitalize: false);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -438,6 +438,7 @@ public sealed class TargetMethodResolutionTests
     [TestCase(typeof(ChairTranslationPatch), "SitDown", "XRL.World.Parts.Chair", "System.Boolean", new[] { "XRL.World.GameObject", "XRL.World.IEvent" })]
     [TestCase(typeof(StairsDownTranslationPatch), "HandleEvent", "XRL.World.Parts.StairsDown", "System.Boolean", new[] { "XRL.World.InventoryActionEvent" })]
     [TestCase(typeof(StairsUpTranslationPatch), "HandleEvent", "XRL.World.Parts.StairsUp", "System.Boolean", new[] { "XRL.World.InventoryActionEvent" })]
+    [TestCase(typeof(GritGateTerminalScreenMessageTranslationPatch), "Activate", "XRL.UI.GritGateTerminalScreenMessage", "System.Void", new string[0])]
     [TestCase(typeof(GameSummaryScreenMenuBarsTranslationPatch), "UpdateMenuBars", "Qud.UI.GameSummaryScreen", "System.Void", new string[0])]
     [TestCase(typeof(GameSummaryScreenShowTranslationPatch), "_ShowGameSummary", "Qud.UI.GameSummaryScreen", "System.Threading.Tasks.Task`1[[System.Boolean]]", new[] { "System.String", "System.String", "System.String", "System.Boolean" })]
     [TestCase(typeof(MainMenuRowTranslationPatch), "setData", "MainMenuRow", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]
@@ -1383,6 +1384,18 @@ public sealed class TargetMethodResolutionTests
             Assert.That(FullMethodSignature(stairsDown!), Is.EqualTo("XRL.World.Parts.StairsDown|HandleEvent|System.Boolean|XRL.World.InventoryActionEvent"));
             Assert.That(stairsUp, Is.Not.Null);
             Assert.That(FullMethodSignature(stairsUp!), Is.EqualTo("XRL.World.Parts.StairsUp|HandleEvent|System.Boolean|XRL.World.InventoryActionEvent"));
+        });
+    }
+
+    [Test]
+    public void GritGateTerminalScreenMessageTargetMethod_ResolvesExpectedFullSignature()
+    {
+        var method = InvokeTargetMethod(typeof(GritGateTerminalScreenMessageTranslationPatch)) as MethodInfo;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(method, Is.Not.Null);
+            Assert.That(FullMethodSignature(method!), Is.EqualTo("XRL.UI.GritGateTerminalScreenMessage|Activate|System.Void"));
         });
     }
 

--- a/Mods/QudJP/Assemblies/src/Patches/GritGateTerminalScreenMessageTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GritGateTerminalScreenMessageTranslationPatch.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class GritGateTerminalScreenMessageTranslationPatch
+{
+    private const string Context = nameof(GritGateTerminalScreenMessageTranslationPatch);
+    private const string AlarmMessage = "Alarms blare across the enclave.";
+    private const string AlarmContext = "XRL.UI.GritGateTerminalScreenMessage";
+    private const string DictionaryFile = "ui-messagelog-world.ja.json";
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = AccessTools.TypeByName("XRL.UI.GritGateTerminalScreenMessage");
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} failed to resolve target type.", Context);
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "Activate", Type.EmptyTypes);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.Activate() not found.", Context);
+        }
+
+        return method;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslateQueuedMessage(ref string message, string? color)
+    {
+        _ = color;
+
+        if (!OwnerTranslationScope.IsActive(activeDepth)
+            || string.IsNullOrEmpty(message)
+            || MessageFrameTranslator.TryStripDirectTranslationMarker(message, out _)
+            || !string.Equals(message, AlarmMessage, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var translated = ScopedDictionaryLookup.TranslateExactOrLowerAsciiForContextOnly(
+            message,
+            AlarmContext,
+            DictionaryFile);
+        if (string.IsNullOrEmpty(translated) || string.Equals(translated, message, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var translatedText = translated!;
+        DynamicTextObservability.RecordTransform(
+            "MessageQueue.AddPlayerMessage",
+            Context + ".ConstructorDelegateAlarm",
+            message,
+            translatedText);
+        message = MessageFrameTranslator.MarkDirectTranslation(translatedText);
+        return true;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs
@@ -58,6 +58,7 @@ internal static class MessageQueueSemanticPipeline
         EffectStaticMessageTranslationPatch.TryTranslateQueuedMessage,
         SystemStaticMessageTranslationPatch.TryTranslateQueuedMessage,
         CombatTextSurfaceTranslationPatch.TryTranslateQueuedMessage,
+        GritGateTerminalScreenMessageTranslationPatch.TryTranslateQueuedMessage,
         DoorAttemptOpenTranslationPatch.TryTranslateQueuedMessage,
         GameObjectDieTranslationPatch.TryTranslateQueuedMessage,
         GameObjectRegeneraTranslationPatch.TryTranslateQueuedMessage,

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -4941,6 +4941,52 @@ COVERED_OWNER_FAMILIES: Final = (
             ),
         ),
     ),
+    CoveredOwnerFamily(
+        family_id="XRL.UI/GritGateTerminalScreenMessage.cs::XRL.UI.GritGateTerminalScreenMessage.GritGateTerminalScreenMessage",
+        inventory_statuses=("owner_patch_required",),
+        evidence_files=(
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/GritGateTerminalScreenMessageTranslationPatch.cs",
+                (
+                    "TryTranslateQueuedMessage",
+                    "AlarmMessage",
+                    "XRL.UI.GritGateTerminalScreenMessage",
+                    "Activate",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs",
+                ("GritGateTerminalScreenMessageTranslationPatch.TryTranslateQueuedMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Localization/Dictionaries/ui-messagelog-world.ja.json",
+                (
+                    "Alarms blare across the enclave.",
+                    "XRL.UI.GritGateTerminalScreenMessage",
+                    "防衛線に警報が鳴り響いた。",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/GritGateTerminalScreenMessageTranslationPatchTests.cs",
+                (
+                    "Activate_TranslatesConstructorDelegateAlarmMessage_WhenOwnerPatched",
+                    "Activate_DoesNotTranslateAlarmMessage_WhenOwnerAbsent",
+                    "Activate_DoesNotRetranslateDirectMarkedAlarmMessage_WhenOwnerPatched",
+                    "Activate_LeavesEmptyMessageUnchanged_WhenOwnerPatched",
+                    "nameof(DummyGritGateTerminalScreenMessageTarget.Activate)",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                (
+                    "GritGateTerminalScreenMessageTargetMethod_ResolvesExpectedFullSignature",
+                    "XRL.UI.GritGateTerminalScreenMessage|Activate|System.Void",
+                    "XRL.UI.GritGateTerminalScreenMessage",
+                    "GritGateTerminalScreenMessage",
+                ),
+            ),
+        ),
+    ),
     *_examiner_result_popup_families(),
 )
 COVERED_OWNER_FAMILY_IDS: Final = frozenset(family.family_id for family in COVERED_OWNER_FAMILIES)


### PR DESCRIPTION
## Summary
- add an owner-scoped queue translator for the GritGateTerminalScreenMessage alarm
- target Activate because the inventoried constructor callsite is emitted from the constructor-created option delegate
- register dictionary-backed closure evidence for the fixed AddPlayerMessage callsite

## Inventory
- XRL.UI/GritGateTerminalScreenMessage.cs::XRL.UI.GritGateTerminalScreenMessage.GritGateTerminalScreenMessage
- line 22 AddPlayerMessage("Alarms blare across the enclave.")

## Validation
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~GritGateTerminalScreenMessageTranslationPatchTests' --no-restore -v minimal\n- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.GritGateTerminalScreenMessageTargetMethod_ResolvesExpectedFullSignature|FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature' --no-restore -v minimal\n- just static-producer-check\n- git diff --check\n\nQueue delta: 337 families / 940 callsites / 961 text args / 308 files -> 336 families / 939 callsites / 960 text args / 307 files.