### PR TITLE
Close high scores delete owner popup

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/HighScoresDeletePopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/HighScoresDeletePopupTranslationPatchTests.cs
@@ -1,0 +1,182 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class HighScoresDeletePopupTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        Translator.ResetForTests();
+        MessagePatternTranslator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Translator.ResetForTests();
+        MessagePatternTranslator.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+    }
+
+    [Test]
+    public void HandleDelete_TranslatesDeleteConfirmationPopup_WhenOwnerPatched()
+    {
+        WithPatchedHandleDelete(() =>
+        {
+            var target = new DummyHighScoresDeleteTarget
+            {
+                PopupMessageToShow = "Are you sure you want to delete this?\n\n{{W|Marizah}} died in 12,345 turns",
+            };
+
+            target.HandleDelete();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowYesNoAsyncMessage, Is.EqualTo("本当にこれを削除しますか？\n\n{{W|Marizah}} died in 12,345 turns"));
+                Assert.That(HitCount(), Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    public void HandleDelete_DoesNotTranslateDeleteConfirmationPopup_WhenOwnerAbsent()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchPopupShowYesNoAsync(harmony);
+
+            _ = DummyPopupShow.ShowYesNoAsync("Are you sure you want to delete this?\n\nMarizah died in 12,345 turns")
+                .GetAwaiter()
+                .GetResult();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowYesNoAsyncMessage, Is.EqualTo("Are you sure you want to delete this?\n\nMarizah died in 12,345 turns"));
+                Assert.That(HitCount(), Is.Zero);
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void HandleDelete_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
+    {
+        WithPatchedHandleDelete(() =>
+        {
+            var target = new DummyHighScoresDeleteTarget
+            {
+                PopupMessageToShow = MessageFrameTranslator.MarkDirectTranslation(
+                    "Are you sure you want to delete this?\n\nMarizah died in 12,345 turns"),
+            };
+
+            target.HandleDelete();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowYesNoAsyncMessage, Is.EqualTo("Are you sure you want to delete this?\n\nMarizah died in 12,345 turns"));
+                Assert.That(HitCount(), Is.Zero);
+            });
+        });
+    }
+
+    [Test]
+    public void HandleDelete_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        WithPatchedHandleDelete(() =>
+        {
+            var target = new DummyHighScoresDeleteTarget
+            {
+                PopupMessageToShow = string.Empty,
+            };
+
+            target.HandleDelete();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowYesNoAsyncMessage, Is.EqualTo(string.Empty));
+                Assert.That(HitCount(), Is.Zero);
+            });
+        });
+    }
+
+    private static void WithPatchedHandleDelete(Action assertion)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            PatchPopupShowYesNoAsync(harmony);
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyHighScoresDeleteTarget), nameof(DummyHighScoresDeleteTarget.HandleDelete)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(HighScoresDeletePopupTranslationPatch), nameof(HighScoresDeletePopupTranslationPatch.Prefix))),
+                finalizer: new HarmonyMethod(RequireMethod(typeof(HighScoresDeletePopupTranslationPatch), nameof(HighScoresDeletePopupTranslationPatch.Finalizer), typeof(Exception))));
+
+            assertion();
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShowYesNoAsync(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.ShowYesNoAsync)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameterTypes)
+    {
+        if (parameterTypes.Length == 0)
+        {
+            return type.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
+                   ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+        }
+
+        return AccessTools.Method(type, methodName, parameterTypes)
+               ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+
+    private static int HitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show." + nameof(HighScoresDeletePopupTranslationPatch) + ".DeleteConfirmation");
+    }
+
+    private sealed class DummyHighScoresDeleteTarget
+    {
+        public string PopupMessageToShow { get; init; } = string.Empty;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void HandleDelete()
+        {
+            _ = DummyPopupShow.ShowYesNoAsync(PopupMessageToShow).GetAwaiter().GetResult();
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -438,6 +438,7 @@ public sealed class TargetMethodResolutionTests
     [TestCase(typeof(ChairTranslationPatch), "SitDown", "XRL.World.Parts.Chair", "System.Boolean", new[] { "XRL.World.GameObject", "XRL.World.IEvent" })]
     [TestCase(typeof(StairsDownTranslationPatch), "HandleEvent", "XRL.World.Parts.StairsDown", "System.Boolean", new[] { "XRL.World.InventoryActionEvent" })]
     [TestCase(typeof(StairsUpTranslationPatch), "HandleEvent", "XRL.World.Parts.StairsUp", "System.Boolean", new[] { "XRL.World.InventoryActionEvent" })]
+    [TestCase(typeof(HighScoresDeletePopupTranslationPatch), "HandleDelete", "Qud.UI.HighScoresScreen", "System.Void", new string[0])]
     [TestCase(typeof(GameSummaryScreenMenuBarsTranslationPatch), "UpdateMenuBars", "Qud.UI.GameSummaryScreen", "System.Void", new string[0])]
     [TestCase(typeof(GameSummaryScreenShowTranslationPatch), "_ShowGameSummary", "Qud.UI.GameSummaryScreen", "System.Threading.Tasks.Task`1[[System.Boolean]]", new[] { "System.String", "System.String", "System.String", "System.Boolean" })]
     [TestCase(typeof(MainMenuRowTranslationPatch), "setData", "MainMenuRow", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]
@@ -1383,6 +1384,18 @@ public sealed class TargetMethodResolutionTests
             Assert.That(FullMethodSignature(stairsDown!), Is.EqualTo("XRL.World.Parts.StairsDown|HandleEvent|System.Boolean|XRL.World.InventoryActionEvent"));
             Assert.That(stairsUp, Is.Not.Null);
             Assert.That(FullMethodSignature(stairsUp!), Is.EqualTo("XRL.World.Parts.StairsUp|HandleEvent|System.Boolean|XRL.World.InventoryActionEvent"));
+        });
+    }
+
+    [Test]
+    public void HighScoresDeletePopupTargetMethod_ResolvesExpectedFullSignature()
+    {
+        var method = InvokeTargetMethod(typeof(HighScoresDeletePopupTranslationPatch)) as MethodInfo;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(method, Is.Not.Null);
+            Assert.That(FullMethodSignature(method!), Is.EqualTo("Qud.UI.HighScoresScreen|HandleDelete|System.Void"));
         });
     }
 

--- a/Mods/QudJP/Assemblies/src/Patches/HighScoresDeletePopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/HighScoresDeletePopupTranslationPatch.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class HighScoresDeletePopupTranslationPatch
+{
+    private const string Context = nameof(HighScoresDeletePopupTranslationPatch);
+
+    private static readonly Regex DeleteConfirmationPattern =
+        new Regex(
+            "^Are you sure you want to delete this\\?\\n\\n(?<detail>[\\s\\S]+)$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = GameTypeResolver.FindType("Qud.UI.HighScoresScreen", "HighScoresScreen");
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} failed to resolve target type.", Context);
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "HandleDelete", Type.EmptyTypes);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.HandleDelete() not found.", Context);
+        }
+
+        return method;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        var match = DeleteConfirmationPattern.Match(source);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = string.Concat(
+            "本当にこれを削除しますか？\n\n",
+            match.Groups["detail"].Value);
+        DynamicTextObservability.RecordTransform(route, family + "." + Context + ".DeleteConfirmation", source, translated);
+        return true;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -27,6 +27,7 @@ internal static class PopupShowSemanticPipeline
         AbilityManagerPopupTranslationPatch.TryTranslatePopupMessage,
         RealityStabilizedEventTranslationPatch.TryTranslatePopupMessage,
         GeomagneticDiscTranslationPatch.TryTranslatePopupMessage,
+        HighScoresDeletePopupTranslationPatch.TryTranslatePopupMessage,
         CampfireCookAvailabilityTranslationPatch.TryTranslatePopupMessage,
         CampfirePreserveTranslationPatch.TryTranslatePopupMessage,
         CookingRuntimeTranslationPatch.TryTranslatePopupMessage,

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -4941,6 +4941,42 @@ COVERED_OWNER_FAMILIES: Final = (
             ),
         ),
     ),
+    CoveredOwnerFamily(
+        family_id="Qud.UI/HighScoresScreen.cs::Qud.UI.HighScoresScreen.HandleDelete",
+        inventory_statuses=("owner_patch_required",),
+        evidence_files=(
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/HighScoresDeletePopupTranslationPatch.cs",
+                (
+                    "TryTranslatePopupMessage",
+                    "DeleteConfirmationPattern",
+                    "Qud.UI.HighScoresScreen",
+                    "HandleDelete",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                ("HighScoresDeletePopupTranslationPatch.TryTranslatePopupMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/HighScoresDeletePopupTranslationPatchTests.cs",
+                (
+                    "HandleDelete_TranslatesDeleteConfirmationPopup_WhenOwnerPatched",
+                    "HandleDelete_DoesNotTranslateDeleteConfirmationPopup_WhenOwnerAbsent",
+                    "HandleDelete_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+                    "HandleDelete_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                    "nameof(DummyHighScoresDeleteTarget.HandleDelete)",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                (
+                    "HighScoresDeletePopupTargetMethod_ResolvesExpectedFullSignature",
+                    "Qud.UI.HighScoresScreen|HandleDelete|System.Void",
+                ),
+            ),
+        ),
+    ),
     *_examiner_result_popup_families(),
 )
 COVERED_OWNER_FAMILY_IDS: Final = frozenset(family.family_id for family in COVERED_OWNER_FAMILIES)


### PR DESCRIPTION
## Summary
- add an owner-scoped popup translator for HighScoresScreen.HandleDelete
- translate the fixed delete-confirmation frame while preserving the score detail line
- register the HighScoresScreen.HandleDelete family in static producer closure evidence

## Inventory
- Qud.UI/HighScoresScreen.cs::Qud.UI.HighScoresScreen.HandleDelete
- line 514 Popup.ShowYesNoAsync("Are you sure you want to delete this?\n\n" + score.entry.Details.Split(...)[0])

## Validation
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~HighScoresDeletePopupTranslationPatchTests' -v minimal\n- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.HighScoresDeletePopupTargetMethod_ResolvesExpectedFullSignature|FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature' --no-restore -v minimal\n- just static-producer-check\n- git diff --check\n\nQueue delta: 337 families / 940 callsites / 961 text args / 308 files -> 336 families / 939 callsites / 960 text args / 307 files.