### PR TITLE
Close Grit Gate knowledge owner popup

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyGritGateTerminalTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyGritGateTerminalTargets.cs
@@ -1,0 +1,14 @@
+using System.Runtime.CompilerServices;
+
+namespace QudJP.Tests.DummyTargets;
+
+internal static class DummyGritGateTerminalKnowledgeTarget
+{
+    public static string PopupMessageToShow { get; set; } = string.Empty;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Activate()
+    {
+        DummyPopupShow.Show(PopupMessageToShow);
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/GritGateTerminalKnowledgePopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/GritGateTerminalKnowledgePopupTranslationPatchTests.cs
@@ -1,0 +1,159 @@
+using System.Reflection;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class GritGateTerminalKnowledgePopupTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        GritGateTerminalKnowledgePopupTranslationPatch.ResetForTests();
+        DummyPopupShow.Reset();
+        DummyGritGateTerminalKnowledgeTarget.PopupMessageToShow = string.Empty;
+        DynamicTextObservability.ResetForTests();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        GritGateTerminalKnowledgePopupTranslationPatch.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+    }
+
+    [Test]
+    public void Activate_TranslatesInsightPopup_WhenOwnerPatched()
+    {
+        const string source = "Ereshkigal delivers insight from the Thin World:\n\nThe location of {{Y|Bethesda Susa}}";
+        const string expected = "エレシュキガルは薄界からの洞察を授ける:\n\nThe location of {{Y|Bethesda Susa}}";
+
+        AssertPopupMessage(source, expected);
+
+        Assert.That(
+            DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                nameof(PopupShowTranslationPatch),
+                "Popup.Show." + nameof(GritGateTerminalKnowledgePopupTranslationPatch)),
+            Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Activate_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent()
+    {
+        const string source = "Ereshkigal delivers insight from the Thin World:\n\nThe location of Bethesda Susa";
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShow(harmony);
+
+            DummyPopupShow.Show(source);
+
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(source));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void Activate_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
+    {
+        const string source = "Ereshkigal delivers insight from the Thin World:\n\nThe location of Bethesda Susa";
+
+        AssertPopupMessage(
+            MessageFrameTranslator.MarkDirectTranslation(source),
+            source);
+
+        Assert.That(
+            DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                nameof(PopupShowTranslationPatch),
+                "Popup.Show." + nameof(GritGateTerminalKnowledgePopupTranslationPatch)),
+            Is.Zero);
+    }
+
+    [Test]
+    public void Activate_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        AssertPopupMessage(string.Empty, string.Empty);
+    }
+
+    private static void AssertPopupMessage(string source, string expected)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShow(harmony);
+            PatchOwner(harmony);
+
+            DummyGritGateTerminalKnowledgeTarget.PopupMessageToShow = source;
+            DummyGritGateTerminalKnowledgeTarget.Activate();
+
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShow(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(
+                typeof(DummyPopupShow),
+                nameof(DummyPopupShow.Show),
+                typeof(string),
+                typeof(string),
+                typeof(string),
+                typeof(bool),
+                typeof(bool),
+                typeof(bool),
+                typeof(bool)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void PatchOwner(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(
+                typeof(DummyGritGateTerminalKnowledgeTarget),
+                nameof(DummyGritGateTerminalKnowledgeTarget.Activate)),
+            prefix: new HarmonyMethod(RequireMethod(
+                typeof(GritGateTerminalKnowledgePopupTranslationPatch),
+                nameof(GritGateTerminalKnowledgePopupTranslationPatch.Prefix))),
+            finalizer: new HarmonyMethod(RequireMethod(
+                typeof(GritGateTerminalKnowledgePopupTranslationPatch),
+                nameof(GritGateTerminalKnowledgePopupTranslationPatch.Finalizer),
+                typeof(Exception))));
+    }
+
+    private static MethodInfo RequireMethod(Type type, string name, params Type[] parameters)
+    {
+        if (parameters.Length == 0)
+        {
+            var methodByName = type.GetMethod(
+                name,
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+            Assert.That(methodByName, Is.Not.Null, $"{type.FullName}.{name} not found");
+            return methodByName!;
+        }
+
+        var method = type.GetMethod(
+            name,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance,
+            binder: null,
+            types: parameters,
+            modifiers: null);
+        Assert.That(method, Is.Not.Null, $"{type.FullName}.{name} not found");
+        return method!;
+    }
+
+    private static string CreateHarmonyId() => $"qudjp.tests.{Guid.NewGuid():N}";
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -441,6 +441,7 @@ public sealed class TargetMethodResolutionTests
     [TestCase(typeof(GameSummaryScreenMenuBarsTranslationPatch), "UpdateMenuBars", "Qud.UI.GameSummaryScreen", "System.Void", new string[0])]
     [TestCase(typeof(GameSummaryScreenShowTranslationPatch), "_ShowGameSummary", "Qud.UI.GameSummaryScreen", "System.Threading.Tasks.Task`1[[System.Boolean]]", new[] { "System.String", "System.String", "System.String", "System.Boolean" })]
     [TestCase(typeof(MainMenuRowTranslationPatch), "setData", "MainMenuRow", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]
+    [TestCase(typeof(GritGateTerminalKnowledgePopupTranslationPatch), "Activate", "XRL.UI.GritGateTerminalScreenKnowledge", "System.Void", new string[0])]
     [TestCase(typeof(PickTargetWindowUpdateTranslationPatch), "Update", "Qud.UI.PickTargetWindow", "System.Void", new string[0])]
     [TestCase(typeof(GivesRepShortDescriptionTranslationPatch), "HandleEvent", "XRL.World.Parts.GivesRep", "System.Boolean", new[] { "XRL.World.GetShortDescriptionEvent" })]
     [TestCase(typeof(MutationsApiTranslationPatch), "BuyRandomMutation", "Qud.API.MutationsAPI", "System.Boolean", new[] { "XRL.World.GameObject", "System.Int32", "System.Boolean", "System.String" })]
@@ -1861,6 +1862,26 @@ public sealed class TargetMethodResolutionTests
         {
             Assert.That(method, Is.Not.Null, "GameObject.RenderForUI(string, bool) not found.");
             Assert.That(method?.ReturnType.FullName, Is.EqualTo("XRL.World.RenderEvent"));
+        });
+    }
+
+    [Test]
+    public void GritGateTerminalKnowledgePopupTargetMethod_ResolvesActivateForConstructorDelegateCallsite()
+    {
+        const string inventoryFamilyId =
+            "XRL.UI/GritGateTerminalScreenKnowledge.cs::XRL.UI.GritGateTerminalScreenKnowledge.GritGateTerminalScreenKnowledge";
+
+        var targetMethod = InvokeTargetMethod(typeof(GritGateTerminalKnowledgePopupTranslationPatch));
+        var methodInfo = targetMethod as MethodInfo;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(inventoryFamilyId, Does.Contain("XRL.UI.GritGateTerminalScreenKnowledge.GritGateTerminalScreenKnowledge"));
+            Assert.That(methodInfo, Is.Not.Null);
+            Assert.That(methodInfo!.DeclaringType?.FullName, Is.EqualTo("XRL.UI.GritGateTerminalScreenKnowledge"));
+            Assert.That(methodInfo.Name, Is.EqualTo("Activate"));
+            Assert.That(NormalizeTypeName(methodInfo.ReturnType.FullName), Is.EqualTo("System.Void"));
+            Assert.That(methodInfo.GetParameters(), Is.Empty);
         });
     }
 #endif

--- a/Mods/QudJP/Assemblies/src/Patches/GritGateTerminalKnowledgePopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GritGateTerminalKnowledgePopupTranslationPatch.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class GritGateTerminalKnowledgePopupTranslationPatch
+{
+    private const string Context = nameof(GritGateTerminalKnowledgePopupTranslationPatch);
+    private const string SourceHeader = "Ereshkigal delivers insight from the Thin World:\n\n";
+    private const string TranslatedHeader = "エレシュキガルは薄界からの洞察を授ける:\n\n";
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = GameTypeResolver.FindType(
+            "XRL.UI.GritGateTerminalScreenKnowledge",
+            "GritGateTerminalScreenKnowledge");
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found.", Context);
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "Activate", Type.EmptyTypes);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.Activate() not found.", Context);
+        }
+
+        return method;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static void ResetForTests()
+    {
+        activeDepth = 0;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        if (!source.StartsWith(SourceHeader, StringComparison.Ordinal))
+        {
+            translated = source;
+            return false;
+        }
+
+        var body = source.Substring(SourceHeader.Length);
+        if (body.Length == 0)
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = TranslatedHeader + body;
+        DynamicTextObservability.RecordTransform(route, family + "." + Context, source, translated);
+        return true;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -31,6 +31,7 @@ internal static class PopupShowSemanticPipeline
         CampfirePreserveTranslationPatch.TryTranslatePopupMessage,
         CookingRuntimeTranslationPatch.TryTranslatePopupMessage,
         StatusScreenPopupTranslationPatch.TryTranslatePopupMessage,
+        GritGateTerminalKnowledgePopupTranslationPatch.TryTranslatePopupMessage,
         TeleprojectorTranslationPatch.TryTranslatePopupMessage,
         CyberneticsMedassistModuleTranslationPatch.TryTranslatePopupMessage,
         LiquidLoaderTranslationPatch.TryTranslatePopupMessage,

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -988,6 +988,50 @@ def _status_screen_popup_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _grit_gate_terminal_knowledge_popup_family() -> tuple[CoveredOwnerFamily, ...]:
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.UI/GritGateTerminalScreenKnowledge.cs::XRL.UI.GritGateTerminalScreenKnowledge.GritGateTerminalScreenKnowledge",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/GritGateTerminalKnowledgePopupTranslationPatch.cs",
+                    (
+                        "GritGateTerminalKnowledgePopupTranslationPatch",
+                        "TryTranslatePopupMessage",
+                        "Ereshkigal delivers insight from the Thin World",
+                        "Activate",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                    ("GritGateTerminalKnowledgePopupTranslationPatch.TryTranslatePopupMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/GritGateTerminalKnowledgePopupTranslationPatchTests.cs",
+                    (
+                        "Activate_TranslatesInsightPopup_WhenOwnerPatched",
+                        "Activate_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent",
+                        "Activate_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+                        "Activate_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                        "nameof(DummyGritGateTerminalKnowledgeTarget.Activate)",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(GritGateTerminalKnowledgePopupTranslationPatch)",
+                        "XRL.UI/GritGateTerminalScreenKnowledge.cs::XRL.UI.GritGateTerminalScreenKnowledge.GritGateTerminalScreenKnowledge",
+                        "XRL.UI.GritGateTerminalScreenKnowledge",
+                        "GritGateTerminalScreenKnowledge",
+                        "Activate",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _campfire_preserve_families() -> tuple[CoveredOwnerFamily, ...]:
     patch = EvidenceFile(
         "Mods/QudJP/Assemblies/src/Patches/CampfirePreserveTranslationPatch.cs",
@@ -3954,6 +3998,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_ability_manager_popup_families(),
     *_cooking_runtime_families(),
     *_status_screen_popup_families(),
+    *_grit_gate_terminal_knowledge_popup_family(),
     *_campfire_preserve_families(),
     *_reality_stabilized_event_families(),
     *_cybernetic_rejection_syndrome_families(),


### PR DESCRIPTION
## Summary
- add an owner-scoped popup translator for the Grit Gate terminal knowledge insight popup
- preserve the dynamic journal/map note body while translating the fixed Ereshkigal header
- register the covered owner family in the static producer closure overlay

## Inventory
- `XRL.UI/GritGateTerminalScreenKnowledge.cs::XRL.UI.GritGateTerminalScreenKnowledge.GritGateTerminalScreenKnowledge`
- line 47 `Popup.Show("Ereshkigal delivers insight from the Thin World:\n\n" + text)`

## Tests
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~GritGateTerminalKnowledgePopupTranslationPatchTests' -v minimal`\n- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.GritGateTerminalKnowledgePopupTargetMethod_ResolvesActivateForConstructorDelegateCallsite|FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature' -v minimal`\n- `just static-producer-check`\n- `git diff --check`\n\n## Queue delta\n- main: 337 families / 940 callsites / 961 text args / 308 source files\n- branch: 336 families / 939 callsites / 960 text args / 307 source files