### PR TITLE
Close PickItem take all owner popup

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyPickItemTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyPickItemTargets.cs
@@ -1,0 +1,14 @@
+using System.Runtime.CompilerServices;
+
+namespace QudJP.Tests.DummyTargets;
+
+internal static class DummyPickItemTakeAllTarget
+{
+    public static string PopupMessageToShow { get; set; } = string.Empty;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static bool TakeAll()
+    {
+        return DummyPopupShow.ShowYesNo(PopupMessageToShow) == 0;
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PickItemTakeAllPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PickItemTakeAllPopupTranslationPatchTests.cs
@@ -1,0 +1,161 @@
+using System.Reflection;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class PickItemTakeAllPopupTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        PickItemTakeAllPopupTranslationPatch.ResetForTests();
+        DummyPopupShow.Reset();
+        DummyPickItemTakeAllTarget.PopupMessageToShow = string.Empty;
+        DynamicTextObservability.ResetForTests();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        PickItemTakeAllPopupTranslationPatch.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+    }
+
+    [TestCase(
+        "Taking this object will put you over your weight limit. Are you sure you want to do it?",
+        "これを取ると重量制限を超えます。本当に実行しますか？")]
+    [TestCase(
+        "Taking these objects will put you over your weight limit. Are you sure you want to do it?",
+        "これらを取ると重量制限を超えます。本当に実行しますか？")]
+    [TestCase(
+        "Taking all these objects will put you over your weight limit. Are you sure you want to do it?",
+        "これらすべてを取ると重量制限を超えます。本当に実行しますか？")]
+    public void TakeAll_TranslatesOverweightConfirmationPopup_WhenOwnerPatched(string source, string expected)
+    {
+        AssertPopupMessage(source, expected);
+
+        Assert.That(
+            DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                nameof(PopupShowTranslationPatch),
+                "Popup.Show." + nameof(PickItemTakeAllPopupTranslationPatch)),
+            Is.EqualTo(1));
+    }
+
+    [Test]
+    public void TakeAll_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent()
+    {
+        const string source = "Taking this object will put you over your weight limit. Are you sure you want to do it?";
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShowYesNo(harmony);
+
+            DummyPopupShow.ShowYesNo(source);
+
+            Assert.That(DummyPopupShow.LastShowYesNoMessage, Is.EqualTo(source));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void TakeAll_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
+    {
+        const string source = "Taking this object will put you over your weight limit. Are you sure you want to do it?";
+
+        AssertPopupMessage(
+            MessageFrameTranslator.MarkDirectTranslation(source),
+            source);
+
+        Assert.That(
+            DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                nameof(PopupShowTranslationPatch),
+                "Popup.Show." + nameof(PickItemTakeAllPopupTranslationPatch)),
+            Is.Zero);
+    }
+
+    [Test]
+    public void TakeAll_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        AssertPopupMessage(string.Empty, string.Empty);
+    }
+
+    private static void AssertPopupMessage(string source, string expected)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShowYesNo(harmony);
+            PatchOwner(harmony);
+
+            DummyPickItemTakeAllTarget.PopupMessageToShow = source;
+            DummyPickItemTakeAllTarget.TakeAll();
+
+            Assert.That(DummyPopupShow.LastShowYesNoMessage, Is.EqualTo(expected));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShowYesNo(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(
+                typeof(DummyPopupShow),
+                nameof(DummyPopupShow.ShowYesNo),
+                typeof(string),
+                typeof(string),
+                typeof(bool),
+                typeof(int)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void PatchOwner(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(
+                typeof(DummyPickItemTakeAllTarget),
+                nameof(DummyPickItemTakeAllTarget.TakeAll)),
+            prefix: new HarmonyMethod(RequireMethod(
+                typeof(PickItemTakeAllPopupTranslationPatch),
+                nameof(PickItemTakeAllPopupTranslationPatch.Prefix))),
+            finalizer: new HarmonyMethod(RequireMethod(
+                typeof(PickItemTakeAllPopupTranslationPatch),
+                nameof(PickItemTakeAllPopupTranslationPatch.Finalizer),
+                typeof(Exception))));
+    }
+
+    private static MethodInfo RequireMethod(Type type, string name, params Type[] parameters)
+    {
+        if (parameters.Length == 0)
+        {
+            var methodByName = type.GetMethod(
+                name,
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+            Assert.That(methodByName, Is.Not.Null, $"{type.FullName}.{name} not found");
+            return methodByName!;
+        }
+
+        var method = type.GetMethod(
+            name,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance,
+            binder: null,
+            types: parameters,
+            modifiers: null);
+        Assert.That(method, Is.Not.Null, $"{type.FullName}.{name} not found");
+        return method!;
+    }
+
+    private static string CreateHarmonyId() => $"qudjp.tests.{Guid.NewGuid():N}";
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -87,6 +87,14 @@ public sealed class TargetMethodResolutionTests
         "System.Boolean",
         "System.Boolean",
     })]
+    [TestCase(typeof(PickItemTakeAllPopupTranslationPatch), "TakeAll", "XRL.UI.PickItem", "System.Boolean", new[]
+    {
+        "XRL.World.GameObject",
+        "XRL.World.GameObject",
+        "XRL.World.Cell",
+        "System.Collections.Generic.IList`1[[XRL.World.GameObject]]",
+        "System.Boolean&",
+    })]
     [TestCase(typeof(InventoryAndEquipmentStatusScreenTranslationPatch), "UpdateViewFromData", "Qud.UI.InventoryAndEquipmentStatusScreen", "System.Void", new string[0])]
     [TestCase(typeof(InventoryAndEquipmentStatusScreenShowRepairPatch), "ShowScreen", "Qud.UI.InventoryAndEquipmentStatusScreen", "XRL.UI.Framework.NavigationContext", new[] { "XRL.World.GameObject", "Qud.UI.StatusScreensScreen" })]
     [TestCase(typeof(InventoryLineTranslationPatch), "setData", "Qud.UI.InventoryLine", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]

--- a/Mods/QudJP/Assemblies/src/Patches/PickItemTakeAllPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PickItemTakeAllPopupTranslationPatch.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class PickItemTakeAllPopupTranslationPatch
+{
+    private const string Context = nameof(PickItemTakeAllPopupTranslationPatch);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = GameTypeResolver.FindType("XRL.UI.PickItem", "PickItem");
+        var gameObjectType = AccessTools.TypeByName("XRL.World.GameObject");
+        var cellType = AccessTools.TypeByName("XRL.World.Cell");
+        if (targetType is null || gameObjectType is null || cellType is null)
+        {
+            Trace.TraceError("QudJP: {0} target types not found.", Context);
+            return null;
+        }
+
+        var itemListType = typeof(IList<>).MakeGenericType(gameObjectType);
+        var method = AccessTools.Method(
+            targetType,
+            "TakeAll",
+            new[] { gameObjectType, gameObjectType, cellType, itemListType, typeof(bool).MakeByRefType() });
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.TakeAll() not found.", Context);
+        }
+
+        return method;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static void ResetForTests()
+    {
+        activeDepth = 0;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        translated = source switch
+        {
+            "Taking this object will put you over your weight limit. Are you sure you want to do it?"
+                => "これを取ると重量制限を超えます。本当に実行しますか？",
+            "Taking these objects will put you over your weight limit. Are you sure you want to do it?"
+                => "これらを取ると重量制限を超えます。本当に実行しますか？",
+            "Taking all these objects will put you over your weight limit. Are you sure you want to do it?"
+                => "これらすべてを取ると重量制限を超えます。本当に実行しますか？",
+            _ => source,
+        };
+
+        if (string.Equals(translated, source, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        DynamicTextObservability.RecordTransform(route, family + "." + Context, source, translated);
+        return true;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -25,6 +25,7 @@ internal static class PopupShowSemanticPipeline
         SunderMindTranslationPatch.TryTranslatePopupMessage,
         KeybindsScreenConflictTranslationPatch.TryTranslatePopupMessage,
         AbilityManagerPopupTranslationPatch.TryTranslatePopupMessage,
+        PickItemTakeAllPopupTranslationPatch.TryTranslatePopupMessage,
         RealityStabilizedEventTranslationPatch.TryTranslatePopupMessage,
         GeomagneticDiscTranslationPatch.TryTranslatePopupMessage,
         CampfireCookAvailabilityTranslationPatch.TryTranslatePopupMessage,

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -776,6 +776,48 @@ def _keybinds_screen_conflict_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _pick_item_take_all_popup_family() -> tuple[CoveredOwnerFamily, ...]:
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.UI/PickItem.cs::XRL.UI.PickItem.TakeAll",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PickItemTakeAllPopupTranslationPatch.cs",
+                    (
+                        "PickItemTakeAllPopupTranslationPatch",
+                        "TryTranslatePopupMessage",
+                        "Taking all these objects will put you over your weight limit",
+                        "TakeAll",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                    ("PickItemTakeAllPopupTranslationPatch.TryTranslatePopupMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/PickItemTakeAllPopupTranslationPatchTests.cs",
+                    (
+                        "TakeAll_TranslatesOverweightConfirmationPopup_WhenOwnerPatched",
+                        "TakeAll_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent",
+                        "TakeAll_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+                        "TakeAll_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                        "nameof(DummyPickItemTakeAllTarget.TakeAll)",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(PickItemTakeAllPopupTranslationPatch)",
+                        '"XRL.UI.PickItem"',
+                        '"TakeAll"',
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _ability_manager_popup_families() -> tuple[CoveredOwnerFamily, ...]:
     pipeline = EvidenceFile(
         "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
@@ -3951,6 +3993,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_sifrah_pure_owner_popup_families(),
     *_sunder_mind_owner_families(),
     *_keybinds_screen_conflict_families(),
+    *_pick_item_take_all_popup_family(),
     *_ability_manager_popup_families(),
     *_cooking_runtime_families(),
     *_status_screen_popup_families(),


### PR DESCRIPTION
## Summary
- add an owner-scoped popup translator for `PickItem.TakeAll` overweight confirmations
- cover the `this object`, `these objects`, and `all these objects` variants routed through `Popup.ShowYesNo`
- register the covered owner family in the static producer closure overlay

## Inventory
- `XRL.UI/PickItem.cs::XRL.UI.PickItem.TakeAll`
- line 811 `Popup.ShowYesNo("Taking " + ... + " will put you over your weight limit. Are you sure you want to do it?")`

## Tests
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~PickItemTakeAllPopupTranslationPatchTests' -v minimal`\n- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature' -v minimal`\n- `just static-producer-check`\n- `git diff --check`\n\n## Queue delta\n- main: 337 families / 940 callsites / 961 text args / 308 source files\n- branch: 336 families / 939 callsites / 960 text args / 307 source files