### PR TITLE
Close tinkering build owner popups

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyTinkeringBuildTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyTinkeringBuildTargets.cs
@@ -1,0 +1,25 @@
+using System.Runtime.CompilerServices;
+
+namespace QudJP.Tests.DummyTargets;
+
+internal static class DummyTinkeringBuildTarget
+{
+    public static string PopupMessageToShow { get; set; } = string.Empty;
+
+    public static string PopupMethod { get; set; } = nameof(DummyPopupShow.Show);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static bool PerformUITinkerBuild()
+    {
+        if (string.Equals(PopupMethod, nameof(DummyPopupShow.ShowFail), StringComparison.Ordinal))
+        {
+            DummyPopupShow.ShowFail(PopupMessageToShow);
+        }
+        else
+        {
+            DummyPopupShow.Show(PopupMessageToShow);
+        }
+
+        return true;
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/TinkeringBuildPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/TinkeringBuildPopupTranslationPatchTests.cs
@@ -1,0 +1,169 @@
+using System.Reflection;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class TinkeringBuildPopupTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        TinkeringBuildPopupTranslationPatch.ResetForTests();
+        DummyPopupShow.Reset();
+        DummyTinkeringBuildTarget.PopupMessageToShow = string.Empty;
+        DummyTinkeringBuildTarget.PopupMethod = nameof(DummyPopupShow.Show);
+        DynamicTextObservability.ResetForTests();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        TinkeringBuildPopupTranslationPatch.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+    }
+
+    [Test]
+    public void PerformUITinkerBuild_TranslatesMissingIngredientPopup_WhenOwnerPatched()
+    {
+        DummyTinkeringBuildTarget.PopupMethod = nameof(DummyPopupShow.ShowFail);
+
+        AssertPopupMessage(
+            "You don't have the required ingredient: {{Y|銅線}} or {{C|電池}}!",
+            "必要な材料が足りない: {{Y|銅線}}または{{C|電池}}！");
+
+        Assert.That(TinkeringBuildHitCount(), Is.EqualTo(1));
+    }
+
+    [TestCase("You tinker up {{Y|a freeze grenade}}!", "{{Y|a freeze grenade}}を作った！")]
+    [TestCase("You tinker up two {{Y|freeze grenades}}!", "{{Y|freeze grenades}}を2個作った！")]
+    public void PerformUITinkerBuild_TranslatesSuccessPopups_WhenOwnerPatched(string source, string expected)
+    {
+        AssertPopupMessage(source, expected);
+
+        Assert.That(TinkeringBuildHitCount(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void PerformUITinkerBuild_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent()
+    {
+        const string source = "You tinker up a freeze grenade!";
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShow(harmony);
+
+            DummyPopupShow.Show(source);
+
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(source));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void PerformUITinkerBuild_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
+    {
+        const string source = "You tinker up a freeze grenade!";
+
+        AssertPopupMessage(
+            MessageFrameTranslator.MarkDirectTranslation(source),
+            source);
+
+        Assert.That(TinkeringBuildHitCount(), Is.Zero);
+    }
+
+    [Test]
+    public void PerformUITinkerBuild_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        AssertPopupMessage(string.Empty, string.Empty);
+    }
+
+    private static void AssertPopupMessage(string source, string expected)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShow(harmony);
+            PatchOwner(harmony);
+
+            DummyTinkeringBuildTarget.PopupMessageToShow = source;
+            DummyTinkeringBuildTarget.PerformUITinkerBuild();
+
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShow(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(
+                typeof(DummyPopupShow),
+                nameof(DummyPopupShow.Show),
+                typeof(string),
+                typeof(string),
+                typeof(string),
+                typeof(bool),
+                typeof(bool),
+                typeof(bool),
+                typeof(bool)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void PatchOwner(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(
+                typeof(DummyTinkeringBuildTarget),
+                nameof(DummyTinkeringBuildTarget.PerformUITinkerBuild)),
+            prefix: new HarmonyMethod(RequireMethod(
+                typeof(TinkeringBuildPopupTranslationPatch),
+                nameof(TinkeringBuildPopupTranslationPatch.Prefix))),
+            finalizer: new HarmonyMethod(RequireMethod(
+                typeof(TinkeringBuildPopupTranslationPatch),
+                nameof(TinkeringBuildPopupTranslationPatch.Finalizer),
+                typeof(Exception))));
+    }
+
+    private static MethodInfo RequireMethod(Type type, string name, params Type[] parameters)
+    {
+        if (parameters.Length == 0)
+        {
+            var methodByName = type.GetMethod(
+                name,
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+            Assert.That(methodByName, Is.Not.Null, $"{type.FullName}.{name} not found");
+            return methodByName!;
+        }
+
+        var method = type.GetMethod(
+            name,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance,
+            binder: null,
+            types: parameters,
+            modifiers: null);
+        Assert.That(method, Is.Not.Null, $"{type.FullName}.{name} not found");
+        return method!;
+    }
+
+    private static int TinkeringBuildHitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show." + nameof(TinkeringBuildPopupTranslationPatch));
+    }
+
+    private static string CreateHarmonyId() => $"qudjp.tests.{Guid.NewGuid():N}";
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -57,6 +57,12 @@ public sealed class TargetMethodResolutionTests
     [TestCase(typeof(SaveManagementRowTranslationPatch), "setData", "SaveManagementRow", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]
     [TestCase(typeof(SavesApiReadSaveJsonTranslationPatch), "ReadSaveJson", "Qud.API.SavesAPI", "Qud.API.SaveGameInfo", new[] { "System.String", "System.String" })]
     [TestCase(typeof(TinkeringStatusScreenTranslationPatch), "UpdateViewFromData", "Qud.UI.TinkeringStatusScreen", "System.Void", new string[0])]
+    [TestCase(typeof(TinkeringBuildPopupTranslationPatch), "PerformUITinkerBuild", "XRL.UI.TinkeringScreen", "System.Boolean", new[]
+    {
+        "XRL.World.GameObject",
+        "XRL.World.Tinkering.TinkerData",
+        "XRL.World.IEvent",
+    })]
     [TestCase(typeof(BookLineTranslationPatch), "setData", "Qud.UI.BookLine", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]
     [TestCase(typeof(BookAutoformatCjkWrapPatch), "AutoformatPages", "XRL.UI.BookUI", "System.Collections.Generic.List`1[[XRL.UI.BookPage]]", new[]
     {

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -30,6 +30,7 @@ internal static class PopupShowSemanticPipeline
         CampfireCookAvailabilityTranslationPatch.TryTranslatePopupMessage,
         CampfirePreserveTranslationPatch.TryTranslatePopupMessage,
         CookingRuntimeTranslationPatch.TryTranslatePopupMessage,
+        TinkeringBuildPopupTranslationPatch.TryTranslatePopupMessage,
         StatusScreenPopupTranslationPatch.TryTranslatePopupMessage,
         TeleprojectorTranslationPatch.TryTranslatePopupMessage,
         CyberneticsMedassistModuleTranslationPatch.TryTranslatePopupMessage,

--- a/Mods/QudJP/Assemblies/src/Patches/TinkeringBuildPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/TinkeringBuildPopupTranslationPatch.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class TinkeringBuildPopupTranslationPatch
+{
+    private const string Context = nameof(TinkeringBuildPopupTranslationPatch);
+    private const string MissingIngredientPrefix = "You don't have the required ingredient: ";
+    private const string TinkerUpPrefix = "You tinker up ";
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = GameTypeResolver.FindType("XRL.UI.TinkeringScreen", "TinkeringScreen");
+        var gameObjectType = AccessTools.TypeByName("XRL.World.GameObject");
+        var tinkerDataType = AccessTools.TypeByName("XRL.World.Tinkering.TinkerData");
+        var eventType = AccessTools.TypeByName("XRL.World.IEvent");
+        if (targetType is null || gameObjectType is null || tinkerDataType is null || eventType is null)
+        {
+            Trace.TraceError("QudJP: {0} target types not found.", Context);
+            return null;
+        }
+
+        var method = AccessTools.Method(
+            targetType,
+            "PerformUITinkerBuild",
+            new[] { gameObjectType, tinkerDataType, eventType });
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.PerformUITinkerBuild() not found.", Context);
+        }
+
+        return method;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static void ResetForTests()
+    {
+        activeDepth = 0;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        if (TryTranslateMissingIngredient(source, out translated)
+            || TryTranslateTinkerUp(source, out translated))
+        {
+            DynamicTextObservability.RecordTransform(route, family + "." + Context, source, translated);
+            return true;
+        }
+
+        translated = source;
+        return false;
+    }
+
+    private static bool TryTranslateMissingIngredient(string source, out string translated)
+    {
+        if (!source.StartsWith(MissingIngredientPrefix, StringComparison.Ordinal)
+            || !source.EndsWith("!", StringComparison.Ordinal))
+        {
+            translated = source;
+            return false;
+        }
+
+        var ingredient = source.Substring(
+            MissingIngredientPrefix.Length,
+            source.Length - MissingIngredientPrefix.Length - 1).Replace(" or ", "または");
+        translated = $"必要な材料が足りない: {ingredient}！";
+        return true;
+    }
+
+    private static bool TryTranslateTinkerUp(string source, out string translated)
+    {
+        if (!source.StartsWith(TinkerUpPrefix, StringComparison.Ordinal)
+            || !source.EndsWith("!", StringComparison.Ordinal))
+        {
+            translated = source;
+            return false;
+        }
+
+        var item = source.Substring(TinkerUpPrefix.Length, source.Length - TinkerUpPrefix.Length - 1);
+        if (item.StartsWith("{{", StringComparison.Ordinal))
+        {
+            translated = $"{item}を作った！";
+            return true;
+        }
+
+        var separator = item.IndexOf(' ');
+        if (separator > 0)
+        {
+            var count = item.Substring(0, separator);
+            var rest = item.Substring(separator + 1);
+            if (!IsIndefiniteArticle(count) && !string.IsNullOrWhiteSpace(rest))
+            {
+                translated = $"{rest}を{TranslateCount(count)}個作った！";
+                return true;
+            }
+        }
+
+        translated = $"{item}を作った！";
+        return true;
+    }
+
+    private static bool IsIndefiniteArticle(string value)
+    {
+        return string.Equals(value, "a", StringComparison.Ordinal)
+            || string.Equals(value, "an", StringComparison.Ordinal);
+    }
+
+    private static string TranslateCount(string value)
+    {
+        return value switch
+        {
+            "two" => "2",
+            "three" => "3",
+            "four" => "4",
+            "five" => "5",
+            "six" => "6",
+            "seven" => "7",
+            "eight" => "8",
+            "nine" => "9",
+            "ten" => "10",
+            _ => value,
+        };
+    }
+}

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -988,6 +988,50 @@ def _status_screen_popup_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _tinkering_build_popup_family() -> tuple[CoveredOwnerFamily, ...]:
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.UI/TinkeringScreen.cs::XRL.UI.TinkeringScreen.PerformUITinkerBuild",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/TinkeringBuildPopupTranslationPatch.cs",
+                    (
+                        "TinkeringBuildPopupTranslationPatch",
+                        "TryTranslatePopupMessage",
+                        "You don't have the required ingredient",
+                        "You tinker up",
+                        "PerformUITinkerBuild",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                    ("TinkeringBuildPopupTranslationPatch.TryTranslatePopupMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/TinkeringBuildPopupTranslationPatchTests.cs",
+                    (
+                        "PerformUITinkerBuild_TranslatesMissingIngredientPopup_WhenOwnerPatched",
+                        "PerformUITinkerBuild_TranslatesSuccessPopups_WhenOwnerPatched",
+                        "PerformUITinkerBuild_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent",
+                        "PerformUITinkerBuild_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+                        "PerformUITinkerBuild_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                        "nameof(DummyTinkeringBuildTarget.PerformUITinkerBuild)",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(TinkeringBuildPopupTranslationPatch)",
+                        '"XRL.UI.TinkeringScreen"',
+                        '"PerformUITinkerBuild"',
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _campfire_preserve_families() -> tuple[CoveredOwnerFamily, ...]:
     patch = EvidenceFile(
         "Mods/QudJP/Assemblies/src/Patches/CampfirePreserveTranslationPatch.cs",
@@ -3953,6 +3997,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_keybinds_screen_conflict_families(),
     *_ability_manager_popup_families(),
     *_cooking_runtime_families(),
+    *_tinkering_build_popup_family(),
     *_status_screen_popup_families(),
     *_campfire_preserve_families(),
     *_reality_stabilized_event_families(),


### PR DESCRIPTION
## Summary
- add an owner-scoped popup translator for `TinkeringScreen.PerformUITinkerBuild`
- cover missing ingredient, multi-item success, and single-item success popups
- register the covered owner family in the static producer closure overlay

## Inventory
- `XRL.UI/TinkeringScreen.cs::XRL.UI.TinkeringScreen.PerformUITinkerBuild`
- line 791 `Popup.ShowFail("You don't have the required ingredient: " + text + "!")`\n- line 852 `Popup.Show("You tinker up " + Grammar.Cardinal(part.NumberMade) + " " + Grammar.Pluralize(Object.ShortDisplayName) + "!")`\n- line 856 `Popup.Show("You tinker up " + gameObject2.an() + "!")`\n\n## Tests\n- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TinkeringBuildPopupTranslationPatchTests' -v minimal`\n- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature' -v minimal`\n- `just static-producer-check`\n- `git diff --check`\n\n## Queue delta\n- main: 337 families / 940 callsites / 961 text args / 308 source files\n- branch: 336 families / 937 callsites / 958 text args / 308 source files