### PR TITLE
Close conversation take item owner popups

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyConversationTakeItemTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyConversationTakeItemTargets.cs
@@ -1,0 +1,25 @@
+using System.Runtime.CompilerServices;
+
+namespace QudJP.Tests.DummyTargets;
+
+internal static class DummyConversationTakeItemTarget
+{
+    public static string PopupMessageToShow { get; set; } = string.Empty;
+
+    public static string PopupMethod { get; set; } = nameof(DummyPopupShow.Show);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static bool Execute()
+    {
+        if (string.Equals(PopupMethod, nameof(DummyPopupShow.ShowFail), StringComparison.Ordinal))
+        {
+            DummyPopupShow.ShowFail(PopupMessageToShow);
+        }
+        else
+        {
+            DummyPopupShow.Show(PopupMessageToShow);
+        }
+
+        return true;
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ConversationTakeItemPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ConversationTakeItemPopupTranslationPatchTests.cs
@@ -1,0 +1,170 @@
+using System.Reflection;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class ConversationTakeItemPopupTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        ConversationTakeItemPopupTranslationPatch.ResetForTests();
+        DummyPopupShow.Reset();
+        DummyConversationTakeItemTarget.PopupMessageToShow = string.Empty;
+        DummyConversationTakeItemTarget.PopupMethod = nameof(DummyPopupShow.Show);
+        DynamicTextObservability.ResetForTests();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        ConversationTakeItemPopupTranslationPatch.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+    }
+
+    [Test]
+    public void Execute_TranslatesCannotGivePopup_WhenOwnerPatched()
+    {
+        DummyConversationTakeItemTarget.PopupMethod = nameof(DummyPopupShow.ShowFail);
+
+        AssertPopupMessage(
+            "You cannot give {{Y|奇妙な小物}}!",
+            "{{Y|奇妙な小物}}を渡せない！");
+
+        Assert.That(TakeItemHitCount(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Execute_TranslatesTakeSuccessPopup_WhenOwnerPatched()
+    {
+        AssertPopupMessage(
+            "Q Girl takes {{Y|奇妙な小物}}.",
+            "Q Girlは{{Y|奇妙な小物}}を受け取った。");
+
+        Assert.That(TakeItemHitCount(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Execute_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent()
+    {
+        const string source = "Q Girl takes {{Y|奇妙な小物}}.";
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShow(harmony);
+
+            DummyPopupShow.Show(source);
+
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(source));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void Execute_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
+    {
+        const string source = "Q Girl takes {{Y|奇妙な小物}}.";
+
+        AssertPopupMessage(
+            MessageFrameTranslator.MarkDirectTranslation(source),
+            source);
+
+        Assert.That(TakeItemHitCount(), Is.Zero);
+    }
+
+    [Test]
+    public void Execute_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        AssertPopupMessage(string.Empty, string.Empty);
+    }
+
+    private static void AssertPopupMessage(string source, string expected)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShow(harmony);
+            PatchOwner(harmony);
+
+            DummyConversationTakeItemTarget.PopupMessageToShow = source;
+            DummyConversationTakeItemTarget.Execute();
+
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShow(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(
+                typeof(DummyPopupShow),
+                nameof(DummyPopupShow.Show),
+                typeof(string),
+                typeof(string),
+                typeof(string),
+                typeof(bool),
+                typeof(bool),
+                typeof(bool),
+                typeof(bool)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void PatchOwner(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(
+                typeof(DummyConversationTakeItemTarget),
+                nameof(DummyConversationTakeItemTarget.Execute)),
+            prefix: new HarmonyMethod(RequireMethod(
+                typeof(ConversationTakeItemPopupTranslationPatch),
+                nameof(ConversationTakeItemPopupTranslationPatch.Prefix))),
+            finalizer: new HarmonyMethod(RequireMethod(
+                typeof(ConversationTakeItemPopupTranslationPatch),
+                nameof(ConversationTakeItemPopupTranslationPatch.Finalizer),
+                typeof(Exception))));
+    }
+
+    private static MethodInfo RequireMethod(Type type, string name, params Type[] parameters)
+    {
+        if (parameters.Length == 0)
+        {
+            var methodByName = type.GetMethod(
+                name,
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+            Assert.That(methodByName, Is.Not.Null, $"{type.FullName}.{name} not found");
+            return methodByName!;
+        }
+
+        var method = type.GetMethod(
+            name,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance,
+            binder: null,
+            types: parameters,
+            modifiers: null);
+        Assert.That(method, Is.Not.Null, $"{type.FullName}.{name} not found");
+        return method!;
+    }
+
+    private static int TakeItemHitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show." + nameof(ConversationTakeItemPopupTranslationPatch));
+    }
+
+    private static string CreateHarmonyId() => $"qudjp.tests.{Guid.NewGuid():N}";
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -452,6 +452,7 @@ public sealed class TargetMethodResolutionTests
         "System.Boolean",
         "System.Boolean",
     })]
+    [TestCase(typeof(ConversationTakeItemPopupTranslationPatch), "Execute", "XRL.World.Conversations.Parts.TakeItem", "System.Boolean", new string[0])]
 #endif
 #if HAS_TMP
     [TestCase(typeof(TextMeshProUguiFontPatch), "OnEnable", "TMPro.TextMeshProUGUI", "System.Void", new string[0])]

--- a/Mods/QudJP/Assemblies/src/Patches/ConversationTakeItemPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/ConversationTakeItemPopupTranslationPatch.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class ConversationTakeItemPopupTranslationPatch
+{
+    private const string Context = nameof(ConversationTakeItemPopupTranslationPatch);
+    private const string CannotGivePrefix = "You cannot give ";
+    private const string TakeVerb = " takes ";
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = AccessTools.TypeByName("XRL.World.Conversations.Parts.TakeItem");
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found.", Context);
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "Execute", Type.EmptyTypes);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.Execute() not found.", Context);
+        }
+
+        return method;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static void ResetForTests()
+    {
+        activeDepth = 0;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        if (TryTranslateCannotGive(source, out translated)
+            || TryTranslateTakeSuccess(source, out translated))
+        {
+            DynamicTextObservability.RecordTransform(route, family + "." + Context, source, translated);
+            return true;
+        }
+
+        translated = source;
+        return false;
+    }
+
+    private static bool TryTranslateCannotGive(string source, out string translated)
+    {
+        if (!source.StartsWith(CannotGivePrefix, StringComparison.Ordinal)
+            || !source.EndsWith("!", StringComparison.Ordinal))
+        {
+            translated = source;
+            return false;
+        }
+
+        var item = source.Substring(CannotGivePrefix.Length, source.Length - CannotGivePrefix.Length - 1);
+        translated = $"{item}を渡せない！";
+        return true;
+    }
+
+    private static bool TryTranslateTakeSuccess(string source, out string translated)
+    {
+        if (!source.EndsWith(".", StringComparison.Ordinal))
+        {
+            translated = source;
+            return false;
+        }
+
+        var separator = source.IndexOf(TakeVerb, StringComparison.Ordinal);
+        if (separator <= 0)
+        {
+            translated = source;
+            return false;
+        }
+
+        var actor = source.Substring(0, separator);
+        var itemStart = separator + TakeVerb.Length;
+        var item = source.Substring(itemStart, source.Length - itemStart - 1);
+        if (string.IsNullOrWhiteSpace(actor) || string.IsNullOrWhiteSpace(item))
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = $"{actor}は{item}を受け取った。";
+        return true;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -18,6 +18,7 @@ internal static class PopupShowSemanticPipeline
         RealityStabilizedInterdictTranslationPatch.TryTranslatePopupMessage,
         HackingSifrahResultTranslationPatch.TryTranslatePopupMessage,
         QuestLifecyclePopupTranslationPatch.TryTranslatePopupMessage,
+        ConversationTakeItemPopupTranslationPatch.TryTranslatePopupMessage,
         BodyTranslationPatch.TryTranslatePopupMessage,
         SifrahTokenItemPopupTranslationPatch.TryTranslatePopupMessage,
         SifrahPureOwnerPopupTranslationPatch.TryTranslatePopupMessage,

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -321,6 +321,50 @@ def _quest_lifecycle_popup_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _conversation_take_item_popup_family() -> tuple[CoveredOwnerFamily, ...]:
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.World.Conversations.Parts/TakeItem.cs::XRL.World.Conversations.Parts.TakeItem.Execute",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/ConversationTakeItemPopupTranslationPatch.cs",
+                    (
+                        "ConversationTakeItemPopupTranslationPatch",
+                        "TryTranslatePopupMessage",
+                        "You cannot give",
+                        " takes ",
+                        "Execute",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                    ("ConversationTakeItemPopupTranslationPatch.TryTranslatePopupMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/ConversationTakeItemPopupTranslationPatchTests.cs",
+                    (
+                        "Execute_TranslatesCannotGivePopup_WhenOwnerPatched",
+                        "Execute_TranslatesTakeSuccessPopup_WhenOwnerPatched",
+                        "Execute_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent",
+                        "Execute_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+                        "Execute_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                        "nameof(DummyConversationTakeItemTarget.Execute)",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(ConversationTakeItemPopupTranslationPatch)",
+                        '"XRL.World.Conversations.Parts.TakeItem"',
+                        '"Execute"',
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _flight_families() -> tuple[CoveredOwnerFamily, ...]:
     target_signatures = (
         (
@@ -3945,6 +3989,7 @@ COVERED_OWNER_FAMILIES: Final = (
     ),
     *_hacking_sifrah_result_families(),
     *_quest_lifecycle_popup_families(),
+    *_conversation_take_item_popup_family(),
     *_flight_families(),
     *_body_families(),
     *_item_modding_sifrah_result_families(),


### PR DESCRIPTION
## Summary
- add an owner-scoped popup translator for `XRL.World.Conversations.Parts.TakeItem.Execute`
- cover both `You cannot give ...!` failure callsites and the conversation recipient `takes ...` success popup
- register the covered owner family in the static producer closure overlay

## Inventory
- `XRL.World.Conversations.Parts/TakeItem.cs::XRL.World.Conversations.Parts.TakeItem.Execute`
- lines 136 and 144 `Popup.ShowFail("You cannot give " + gameObject3.t() + "!")`
- line 148 `Popup.Show(gameObject2.Does("take", ...) + " " + gameObject3.t(...) + ".")`

## Tests
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~ConversationTakeItemPopupTranslationPatchTests' -v minimal`\n- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature' -v minimal`\n- `just static-producer-check`\n- `git diff --check`\n\n## Queue delta\n- main: 337 families / 940 callsites / 961 text args / 308 source files\n- branch: 336 families / 937 callsites / 958 text args / 307 source files