### PR TITLE
Close absorbable psyche owner popups

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyAbsorbablePsycheTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyAbsorbablePsycheTargets.cs
@@ -1,0 +1,25 @@
+using System.Runtime.CompilerServices;
+
+namespace QudJP.Tests.DummyTargets;
+
+internal static class DummyAbsorbablePsycheTarget
+{
+    public static string PopupMessageToShow { get; set; } = string.Empty;
+
+    public static string PopupMethod { get; set; } = nameof(DummyPopupShow.Show);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static bool HandleEvent()
+    {
+        if (string.Equals(PopupMethod, nameof(DummyPopupShow.ShowYesNo), StringComparison.Ordinal))
+        {
+            DummyPopupShow.ShowYesNo(PopupMessageToShow);
+        }
+        else
+        {
+            DummyPopupShow.Show(PopupMessageToShow);
+        }
+
+        return true;
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbsorbablePsychePopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/AbsorbablePsychePopupTranslationPatchTests.cs
@@ -1,0 +1,199 @@
+using System.Reflection;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class AbsorbablePsychePopupTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        AbsorbablePsychePopupTranslationPatch.ResetForTests();
+        DummyPopupShow.Reset();
+        DummyAbsorbablePsycheTarget.PopupMessageToShow = string.Empty;
+        DummyAbsorbablePsycheTarget.PopupMethod = nameof(DummyPopupShow.Show);
+        DynamicTextObservability.ResetForTests();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        AbsorbablePsychePopupTranslationPatch.ResetForTests();
+        DynamicTextObservability.ResetForTests();
+    }
+
+    [Test]
+    public void HandleEvent_TranslatesConfirmationPopup_WhenOwnerPatched()
+    {
+        DummyAbsorbablePsycheTarget.PopupMethod = nameof(DummyPopupShow.ShowYesNo);
+
+        AssertPopupMessage(
+            "At the moment of victory, your swelling ego curves the psychic aether and causes the psyche of {{Y|Esper Hunter}} to collide with your own. As the weaker of the two, its binding energy is exceeded and it explodes. Would you like to encode its psionic bits on the holographic boundary of your own psyche?\n\n(+1 Ego permanently)",
+            "勝利の瞬間、膨張する自我が精神のエーテルをゆがませ、{{Y|Esper Hunter}}の精神をあなた自身の精神に衝突させる。弱い方であるその精神は束縛エネルギーを超えて爆発する。そのサイオニック片をあなた自身の精神を囲むホログラフィック境界に刻みつけますか？\n\n（恒久的に自我 +1）");
+
+        Assert.That(AbsorbablePsycheHitCount(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void HandleEvent_TranslatesEncodePopup_WhenOwnerPatched()
+    {
+        AssertPopupMessage(
+            "You encode the psyche of Esper Hunter and gain +{{C|1}} {{Y|Ego}}!",
+            "Esper Hunterの精神を刻みつけ、自我が+{{C|1}}上昇した！");
+
+        Assert.That(AbsorbablePsycheHitCount(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void HandleEvent_TranslatesRadiatePopup_WhenOwnerPatched()
+    {
+        AssertPopupMessage(
+            "You pause as the psyche of Esper Hunter radiates into nothingness.",
+            "Esper Hunterの精神が無へと放射されていくのを見届ける。");
+
+        Assert.That(AbsorbablePsycheHitCount(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void HandleEvent_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent()
+    {
+        const string source = "You encode the psyche of Esper Hunter and gain +{{C|1}} {{Y|Ego}}!";
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShow(harmony);
+
+            DummyPopupShow.Show(source);
+
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(source));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void HandleEvent_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
+    {
+        const string source = "You encode the psyche of Esper Hunter and gain +{{C|1}} {{Y|Ego}}!";
+
+        AssertPopupMessage(
+            MessageFrameTranslator.MarkDirectTranslation(source),
+            source);
+
+        Assert.That(AbsorbablePsycheHitCount(), Is.Zero);
+    }
+
+    [Test]
+    public void HandleEvent_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        AssertPopupMessage(string.Empty, string.Empty);
+    }
+
+    private static void AssertPopupMessage(string source, string expected)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShow(harmony);
+            PatchPopupShowYesNo(harmony);
+            PatchOwner(harmony);
+
+            DummyAbsorbablePsycheTarget.PopupMessageToShow = source;
+            DummyAbsorbablePsycheTarget.HandleEvent();
+
+            if (string.Equals(DummyAbsorbablePsycheTarget.PopupMethod, nameof(DummyPopupShow.ShowYesNo), StringComparison.Ordinal))
+            {
+                Assert.That(DummyPopupShow.LastShowYesNoMessage, Is.EqualTo(expected));
+            }
+            else
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+            }
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShow(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(
+                typeof(DummyPopupShow),
+                nameof(DummyPopupShow.Show),
+                typeof(string),
+                typeof(string),
+                typeof(string),
+                typeof(bool),
+                typeof(bool),
+                typeof(bool),
+                typeof(bool)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void PatchPopupShowYesNo(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(
+                typeof(DummyPopupShow),
+                nameof(DummyPopupShow.ShowYesNo),
+                typeof(string),
+                typeof(string),
+                typeof(bool),
+                typeof(int)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void PatchOwner(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyAbsorbablePsycheTarget), nameof(DummyAbsorbablePsycheTarget.HandleEvent)),
+            prefix: new HarmonyMethod(RequireMethod(
+                typeof(AbsorbablePsychePopupTranslationPatch),
+                nameof(AbsorbablePsychePopupTranslationPatch.Prefix))),
+            finalizer: new HarmonyMethod(RequireMethod(
+                typeof(AbsorbablePsychePopupTranslationPatch),
+                nameof(AbsorbablePsychePopupTranslationPatch.Finalizer),
+                typeof(Exception))));
+    }
+
+    private static MethodInfo RequireMethod(Type type, string name, params Type[] parameters)
+    {
+        if (parameters.Length == 0)
+        {
+            var methodByName = type.GetMethod(
+                name,
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+            Assert.That(methodByName, Is.Not.Null, $"{type.FullName}.{name} not found");
+            return methodByName!;
+        }
+
+        var method = type.GetMethod(
+            name,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance,
+            binder: null,
+            types: parameters,
+            modifiers: null);
+        Assert.That(method, Is.Not.Null, $"{type.FullName}.{name} not found");
+        return method!;
+    }
+
+    private static int AbsorbablePsycheHitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show." + nameof(AbsorbablePsychePopupTranslationPatch));
+    }
+
+    private static string CreateHarmonyId() => $"qudjp.tests.{Guid.NewGuid():N}";
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -435,6 +435,7 @@ public sealed class TargetMethodResolutionTests
     [TestCase(typeof(ZoneManagerSetActiveZoneMapNotesTranslationPatch), "SetActiveZone", "XRL.World.ZoneManager", "XRL.World.Zone", new[] { "XRL.World.Zone" })]
     [TestCase(typeof(ZoneManagerGenerateZoneTranslationPatch), "GenerateZone", "XRL.World.ZoneManager", "System.Void", new[] { "System.String" })]
     [TestCase(typeof(BedTranslationPatch), "AttemptSleep", "XRL.World.Parts.Bed", "System.Void", new[] { "XRL.World.GameObject", "System.Boolean&", "System.Boolean&", "System.Boolean&" })]
+    [TestCase(typeof(AbsorbablePsychePopupTranslationPatch), "HandleEvent", "XRL.World.Parts.AbsorbablePsyche", "System.Boolean", new[] { "XRL.World.BeforeDeathRemovalEvent" })]
     [TestCase(typeof(ChairTranslationPatch), "SitDown", "XRL.World.Parts.Chair", "System.Boolean", new[] { "XRL.World.GameObject", "XRL.World.IEvent" })]
     [TestCase(typeof(StairsDownTranslationPatch), "HandleEvent", "XRL.World.Parts.StairsDown", "System.Boolean", new[] { "XRL.World.InventoryActionEvent" })]
     [TestCase(typeof(StairsUpTranslationPatch), "HandleEvent", "XRL.World.Parts.StairsUp", "System.Boolean", new[] { "XRL.World.InventoryActionEvent" })]

--- a/Mods/QudJP/Assemblies/src/Patches/AbsorbablePsychePopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/AbsorbablePsychePopupTranslationPatch.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class AbsorbablePsychePopupTranslationPatch
+{
+    private const string Context = nameof(AbsorbablePsychePopupTranslationPatch);
+    private const string ConfirmationPrefix =
+        "At the moment of victory, your swelling ego curves the psychic aether and causes the psyche of ";
+    private const string ConfirmationSuffix =
+        " to collide with your own. As the weaker of the two, its binding energy is exceeded and it explodes. Would you like to encode its psionic bits on the holographic boundary of your own psyche?\n\n(+1 Ego permanently)";
+    private const string EncodePrefix = "You encode the psyche of ";
+    private const string EncodeSuffix = " and gain +{{C|1}} {{Y|Ego}}!";
+    private const string RadiatePrefix = "You pause as the psyche of ";
+    private const string RadiateSuffix = " radiates into nothingness.";
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = AccessTools.TypeByName("XRL.World.Parts.AbsorbablePsyche");
+        var eventType = AccessTools.TypeByName("XRL.World.BeforeDeathRemovalEvent");
+        if (targetType is null || eventType is null)
+        {
+            Trace.TraceError("QudJP: {0} target types not found.", Context);
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "HandleEvent", new[] { eventType });
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.HandleEvent(BeforeDeathRemovalEvent) not found.", Context);
+        }
+
+        return method;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static void ResetForTests()
+    {
+        activeDepth = 0;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        if (TryTranslateConfirmation(source, out translated)
+            || TryTranslateEncode(source, out translated)
+            || TryTranslateRadiate(source, out translated))
+        {
+            DynamicTextObservability.RecordTransform(route, family + "." + Context, source, translated);
+            return true;
+        }
+
+        translated = source;
+        return false;
+    }
+
+    private static bool TryTranslateConfirmation(string source, out string translated)
+    {
+        if (!TryCaptureBetween(source, ConfirmationPrefix, ConfirmationSuffix, out var name))
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = "勝利の瞬間、膨張する自我が精神のエーテルをゆがませ、"
+            + name
+            + "の精神をあなた自身の精神に衝突させる。弱い方であるその精神は束縛エネルギーを超えて爆発する。"
+            + "そのサイオニック片をあなた自身の精神を囲むホログラフィック境界に刻みつけますか？\n\n"
+            + "（恒久的に自我 +1）";
+        return true;
+    }
+
+    private static bool TryTranslateEncode(string source, out string translated)
+    {
+        if (!TryCaptureBetween(source, EncodePrefix, EncodeSuffix, out var name))
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = name + "の精神を刻みつけ、自我が+{{C|1}}上昇した！";
+        return true;
+    }
+
+    private static bool TryTranslateRadiate(string source, out string translated)
+    {
+        if (!TryCaptureBetween(source, RadiatePrefix, RadiateSuffix, out var name))
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = name + "の精神が無へと放射されていくのを見届ける。";
+        return true;
+    }
+
+    private static bool TryCaptureBetween(string source, string prefix, string suffix, out string capture)
+    {
+        if (!source.StartsWith(prefix, StringComparison.Ordinal)
+            || !source.EndsWith(suffix, StringComparison.Ordinal))
+        {
+            capture = string.Empty;
+            return false;
+        }
+
+        capture = source.Substring(prefix.Length, source.Length - prefix.Length - suffix.Length);
+        return capture.Length > 0;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -41,6 +41,7 @@ internal static class PopupShowSemanticPipeline
         EnclosingTranslationPatch.TryTranslatePopupMessage,
         StairsDownTranslationPatch.TryTranslatePopupMessage,
         StairsUpTranslationPatch.TryTranslatePopupMessage,
+        AbsorbablePsychePopupTranslationPatch.TryTranslatePopupMessage,
         BeguilingTranslationPatch.TryTranslatePopupMessage,
         AscensionCableTranslationPatch.TryTranslatePopupMessage,
         CarapaceTranslationPatch.TryTranslatePopupMessage,

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -458,6 +458,52 @@ def _body_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _absorbable_psyche_popup_family() -> tuple[CoveredOwnerFamily, ...]:
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts/AbsorbablePsyche.cs::XRL.World.Parts.AbsorbablePsyche.HandleEvent",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/AbsorbablePsychePopupTranslationPatch.cs",
+                    (
+                        "AbsorbablePsychePopupTranslationPatch",
+                        "TryTranslatePopupMessage",
+                        "At the moment of victory",
+                        "You encode the psyche of",
+                        "You pause as the psyche of",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                    ("AbsorbablePsychePopupTranslationPatch.TryTranslatePopupMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/AbsorbablePsychePopupTranslationPatchTests.cs",
+                    (
+                        "HandleEvent_TranslatesConfirmationPopup_WhenOwnerPatched",
+                        "HandleEvent_TranslatesEncodePopup_WhenOwnerPatched",
+                        "HandleEvent_TranslatesRadiatePopup_WhenOwnerPatched",
+                        "HandleEvent_DoesNotTranslatePopupOnlyTraffic_WhenOwnerAbsent",
+                        "HandleEvent_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+                        "HandleEvent_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                        "nameof(DummyAbsorbablePsycheTarget.HandleEvent)",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(AbsorbablePsychePopupTranslationPatch)",
+                        '"XRL.World.Parts.AbsorbablePsyche"',
+                        '"HandleEvent"',
+                        '"XRL.World.BeforeDeathRemovalEvent"',
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _item_modding_sifrah_result_families() -> tuple[CoveredOwnerFamily, ...]:
     target_signatures = (
         ("ResultFailure", "XRL.World.ItemModdingSifrah|ResultFailure|System.Void|XRL.World.GameObject"),
@@ -3947,6 +3993,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_quest_lifecycle_popup_families(),
     *_flight_families(),
     *_body_families(),
+    *_absorbable_psyche_popup_family(),
     *_item_modding_sifrah_result_families(),
     *_sifrah_pure_owner_popup_families(),
     *_sunder_mind_owner_families(),


### PR DESCRIPTION
## Summary
- add an owner-scoped popup translator for `AbsorbablePsyche.HandleEvent(BeforeDeathRemovalEvent)`
- cover the psyche absorption confirmation, encode success, and radiate decline popups
- register the covered owner family in the static producer closure overlay

## Inventory
- `XRL.World.Parts/AbsorbablePsyche.cs::XRL.World.Parts.AbsorbablePsyche.HandleEvent`
- line 68 `Popup.ShowYesNo(...)` absorption confirmation
- line 71 `Popup.Show("You encode the psyche of ...")`
- line 77 `Popup.Show("You pause as the psyche of ...")`

## Tests
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~AbsorbablePsychePopupTranslationPatchTests' -v minimal`\n- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature' -v minimal`\n- `just static-producer-check`\n- `git diff --check`\n\n## Queue delta\n- main: 337 families / 940 callsites / 961 text args / 308 source files\n- branch: 336 families / 937 callsites / 958 text args / 307 source files