### PR TITLE
Close issue-576 powered floating popup family

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyFragmentProducerTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyFragmentProducerTargets.cs
@@ -328,6 +328,17 @@ internal sealed class DummyStairsUpProducerTarget
     }
 }
 
+internal sealed class DummyPoweredFloatingProducerTarget
+{
+    public string PopupMessageToShow { get; set; } = string.Empty;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public void CheckFloating()
+    {
+        DummyPopupShow.Show(PopupMessageToShow);
+    }
+}
+
 internal sealed class DummyGivesRepProducerTarget
 {
     public string PostfixTextToAppend { get; set; } = string.Empty;

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs
@@ -508,6 +508,7 @@ public sealed class DoesVerbFamilyTests
     [TestCase("The 宝石 stops gleaming.", "宝石の輝きが消えた")]
     [TestCase("The 熊 shies away from you.", "熊はあなたから怯えて離れた")]
     [TestCase("The 装置 ceases floating near you.", "装置はあなたの近くで浮遊するのをやめた")]
+    [TestCase("The 装置 falls to the ground; you scoop it up.", "装置は地面に落ちた。あなたはそれをすくい上げた。")]
     [TestCase("The 装置 collapses under the pressure of normality and implodes.", "装置は正常性の圧力に耐えきれず崩壊し、内破した")]
     [TestCase("The 金属片 becomes magnetized!", "金属片は磁化された！")]
     [TestCase("The 熊 vomits everywhere!", "熊はあたりに嘔吐した！")]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PoweredFloatingTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PoweredFloatingTranslationPatchTests.cs
@@ -1,0 +1,148 @@
+using System.Reflection;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+using QudJP.Tests.L1;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class PoweredFloatingTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        DynamicTextObservability.ResetForTests();
+        MessageFrameTranslator.ResetForTests();
+        UseRepositoryVerbDictionary();
+        DummyPopupShow.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(null);
+        DynamicTextObservability.ResetForTests();
+        MessageFrameTranslator.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TestCase("cease", " floating near you.", "装置はあなたの近くで浮遊するのをやめた")]
+    [TestCase("fall", " to the ground; you scoop it up.", "装置は地面に落ちた。あなたはそれをすくい上げた。")]
+    [TestCase("fall", " to the ground.", "装置は地面に倒れた。")]
+    public void CheckFloating_TranslatesDoesVerbPopup_WhenOwnerPatched(
+        string verb,
+        string tail,
+        string expected)
+    {
+        var target = new DummyPoweredFloatingProducerTarget
+        {
+            PopupMessageToShow = MarkDoesFragment("The 装置 " + BuildVerbForm(verb), verb) + tail,
+        };
+
+        OwnerPopupRouteTestHarness.WithPatchedPopupOwner(
+            typeof(PoweredFloatingTranslationPatch),
+            RequireOwnerMethod(),
+            target.CheckFloating);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+            Assert.That(PoweredFloatingHitCount(), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void CheckFloating_LeavesPlainPopupUnchanged_WhenOwnerAbsent()
+    {
+        const string source = "The 装置 falls to the ground.";
+        var target = new DummyPoweredFloatingProducerTarget
+        {
+            PopupMessageToShow = source,
+        };
+
+        OwnerPopupRouteTestHarness.WithPatchedPopupOnly(target.CheckFloating);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(source));
+            Assert.That(PoweredFloatingHitCount(), Is.Zero);
+        });
+    }
+
+    [Test]
+    public void CheckFloating_StripsDirectMarkerWithoutRecordingTransform_WhenOwnerPatched()
+    {
+        const string translated = "装置は地面に倒れた。";
+        var target = new DummyPoweredFloatingProducerTarget
+        {
+            PopupMessageToShow = MessageFrameTranslator.MarkDirectTranslation(translated),
+        };
+
+        OwnerPopupRouteTestHarness.WithPatchedPopupOwner(
+            typeof(PoweredFloatingTranslationPatch),
+            RequireOwnerMethod(),
+            target.CheckFloating);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(translated));
+            Assert.That(PoweredFloatingHitCount(), Is.Zero);
+        });
+    }
+
+    [Test]
+    public void CheckFloating_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        var target = new DummyPoweredFloatingProducerTarget();
+
+        OwnerPopupRouteTestHarness.WithPatchedPopupOwner(
+            typeof(PoweredFloatingTranslationPatch),
+            RequireOwnerMethod(),
+            target.CheckFloating);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
+            Assert.That(PoweredFloatingHitCount(), Is.Zero);
+        });
+    }
+
+    private static MethodInfo RequireOwnerMethod()
+    {
+        return OwnerPopupRouteTestHarness.RequireMethod(
+            typeof(DummyPoweredFloatingProducerTarget),
+            nameof(DummyPoweredFloatingProducerTarget.CheckFloating));
+    }
+
+    private static string MarkDoesFragment(string fragment, string verb)
+    {
+        return DoesVerbRouteTranslator.MarkDoesFragment(fragment, verb, "The 装置".Length, null);
+    }
+
+    private static string BuildVerbForm(string verb)
+    {
+        return string.Equals(verb, "cease", StringComparison.Ordinal) ? "ceases" : "falls";
+    }
+
+    private static int PoweredFloatingHitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show." + nameof(PoweredFloatingTranslationPatch) + ".DoesVerb");
+    }
+
+    private static void UseRepositoryVerbDictionary()
+    {
+        var repositoryDictionaryPath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Localization",
+            "MessageFrames",
+            "verbs.ja.json");
+        MessageFrameTranslator.SetDictionaryPathForTests(repositoryDictionaryPath);
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -728,6 +728,10 @@ public sealed class TargetMethodResolutionTests
     {
         "XRL.World.InventoryActionEvent",
     })]
+    [TestCase(typeof(PoweredFloatingTranslationPatch), new[]
+    {
+        "XRL.World.Parts.PoweredFloating|CheckFloating|System.Void",
+    })]
     [TestCase(typeof(EnclosingTranslationPatch), new[]
     {
         "XRL.World.GameObject|XRL.World.IEvent",

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -46,6 +46,7 @@ internal static class PopupShowSemanticPipeline
         CarapaceTranslationPatch.TryTranslatePopupMessage,
         NephalPropertiesTranslationPatch.TryTranslatePopupMessage,
         IntegratedWeaponHostsTranslationPatch.TryTranslatePopupMessage,
+        PoweredFloatingTranslationPatch.TryTranslatePopupMessage,
         FungalSporeInfectionTranslationPatch.TryTranslatePopupMessage,
     ];
 

--- a/Mods/QudJP/Assemblies/src/Patches/PoweredFloatingTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PoweredFloatingTranslationPatch.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class PoweredFloatingTranslationPatch
+{
+    private const string Context = nameof(PoweredFloatingTranslationPatch);
+    private const string DoesVerbDetail = "DoesVerb";
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        var targetType = AccessTools.TypeByName("XRL.World.Parts.PoweredFloating");
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found.", Context);
+            yield break;
+        }
+
+        var checkFloating = AccessTools.Method(targetType, "CheckFloating", Type.EmptyTypes);
+        if (checkFloating is not null)
+        {
+            yield return checkFloating;
+        }
+        else
+        {
+            Trace.TraceError("QudJP: {0}.CheckFloating() not found.", Context);
+        }
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        translated = source;
+        try
+        {
+            if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+            {
+                return false;
+            }
+
+            if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+            {
+                translated = markedText;
+                return true;
+            }
+
+            if (!DoesVerbRouteTranslator.TryTranslateMarkedMessage(source, out translated)
+                && !DoesVerbRouteTranslator.TryTranslatePlainSentence(source, out translated))
+            {
+                return false;
+            }
+
+            DynamicTextObservability.RecordTransform(
+                route,
+                family + "." + Context + "." + DoesVerbDetail,
+                source,
+                translated);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.TryTranslatePopupMessage failed: {1}", Context, ex);
+            translated = source;
+            return false;
+        }
+    }
+}

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -2261,6 +2261,56 @@ def _integrated_weapon_hosts_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _powered_floating_families() -> tuple[CoveredOwnerFamily, ...]:
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts/PoweredFloating.cs::XRL.World.Parts.PoweredFloating.CheckFloating",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PoweredFloatingTranslationPatch.cs",
+                    (
+                        "XRL.World.Parts.PoweredFloating",
+                        "CheckFloating",
+                        "TryTranslatePopupMessage",
+                        "DoesVerbRouteTranslator.TryTranslateMarkedMessage",
+                        "DoesVerbRouteTranslator.TryTranslatePlainSentence",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                    ("PoweredFloatingTranslationPatch.TryTranslatePopupMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs",
+                    (
+                        "The 装置 ceases floating near you.",
+                        "The 装置 falls to the ground; you scoop it up.",
+                        "The 熊 falls to the ground.",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/PoweredFloatingTranslationPatchTests.cs",
+                    (
+                        "CheckFloating_TranslatesDoesVerbPopup_WhenOwnerPatched",
+                        "CheckFloating_LeavesPlainPopupUnchanged_WhenOwnerAbsent",
+                        "CheckFloating_StripsDirectMarkerWithoutRecordingTransform_WhenOwnerPatched",
+                        "CheckFloating_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                        "nameof(DummyPoweredFloatingProducerTarget.CheckFloating)",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(PoweredFloatingTranslationPatch)",
+                        "XRL.World.Parts.PoweredFloating|CheckFloating|System.Void",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _boost_statistic_families() -> tuple[CoveredOwnerFamily, ...]:
     common_evidence = (
         EvidenceFile(
@@ -3980,6 +4030,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_tonic_families(),
     *_xrl_game_families(),
     *_integrated_weapon_hosts_families(),
+    *_powered_floating_families(),
     *_boost_statistic_families(),
     *_emboldened_families(),
     *_fungal_spore_infection_families(),


### PR DESCRIPTION
## Summary
- add a PoweredFloating.CheckFloating owner popup route for the three DoesVerb popup shapes
- cover marked Does fragments, owner-absent plain traffic, direct markers, empty popup input, and target resolution
- register the family in static_producer_closure.py

## Verification
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~PoweredFloatingTranslationPatchTests|FullyQualifiedName~DoesVerbFamilyTests.Translate_SingleUseVerbFamily' -v minimal\n- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature|FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures' -v minimal\n- just static-producer-check\n\nQueue delta: 337 -> 336 families, 940 -> 937 callsites, 961 -> 958 text args.