### PR TITLE
Close issue-576 deployable infrastructure popup family

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
@@ -1508,6 +1508,10 @@ internal sealed class DummyDeployableInfrastructureTarget
 {
     public string MessageToSend { get; set; } = string.Empty;
 
+    public string PopupMessageToSend { get; set; } = string.Empty;
+
+    public bool UseShowFail { get; set; }
+
     public string? ColorToSend { get; set; }
 
     public void DeployOne(DummyGameObject actor, DummyCell cell, bool active = true, bool message = false)
@@ -1517,6 +1521,21 @@ internal sealed class DummyDeployableInfrastructureTarget
         _ = active;
         _ = message;
         DummyMessageQueue.AddPlayerMessage(MessageToSend, ColorToSend, Capitalize: false);
+    }
+
+    public bool AttemptDeploy(DummyGameObject actor)
+    {
+        _ = actor;
+        if (UseShowFail)
+        {
+            DummyPopupShow.ShowFail(PopupMessageToSend);
+        }
+        else
+        {
+            DummyPopupShow.Show(PopupMessageToSend);
+        }
+
+        return true;
     }
 }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/DeployableInfrastructurePopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/DeployableInfrastructurePopupTranslationPatchTests.cs
@@ -1,0 +1,202 @@
+using System.Reflection;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+using QudJP.Tests.L1;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class DeployableInfrastructurePopupTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        DynamicTextObservability.ResetForTests();
+        MessageFrameTranslator.ResetForTests();
+        UseRepositoryVerbDictionary();
+        DummyPopupShow.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(null);
+        DynamicTextObservability.ResetForTests();
+        MessageFrameTranslator.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TestCase("You deploy 3フィート分のワイヤー", "あなたは3フィート分のワイヤーを展開した")]
+    [TestCase("You deploy ワイヤー.", "あなたはワイヤーを展開した")]
+    public void AttemptDeploy_TranslatesDeploySuccessPopup_WhenOwnerPatched(string source, string expected)
+    {
+        var target = new DummyDeployableInfrastructureTarget
+        {
+            PopupMessageToSend = source,
+        };
+
+        WithPatchedPopupOwner(target.AttemptDeploy);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+            Assert.That(DeployableInfrastructureHitCount("DoesVerb"), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void AttemptDeploy_TranslatesNoUsefulWayPopup_WhenOwnerPatched()
+    {
+        var target = new DummyDeployableInfrastructureTarget
+        {
+            PopupMessageToSend = "There is no useful way to deploy {{Y|ワイヤー}} there.",
+            UseShowFail = true,
+        };
+
+        WithPatchedPopupOwner(target.AttemptDeploy);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo("ここで{{Y|ワイヤー}}を展開する有用な方法はない。"));
+            Assert.That(DeployableInfrastructureHitCount("NoUsefulWay"), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void AttemptDeploy_LeavesPopupUnchanged_WhenOwnerAbsent()
+    {
+        const string source = "You deploy ワイヤー.";
+        var target = new DummyDeployableInfrastructureTarget
+        {
+            PopupMessageToSend = source,
+        };
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShow(harmony);
+
+            _ = target.AttemptDeploy(new DummyGameObject());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(source));
+                Assert.That(DeployableInfrastructureHitCount("DoesVerb"), Is.Zero);
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void AttemptDeploy_StripsDirectMarkerWithoutRecordingTransform_WhenOwnerPatched()
+    {
+        const string translated = "ワイヤーを展開した。";
+        var target = new DummyDeployableInfrastructureTarget
+        {
+            PopupMessageToSend = MessageFrameTranslator.MarkDirectTranslation(translated),
+        };
+
+        WithPatchedPopupOwner(target.AttemptDeploy);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(translated));
+            Assert.That(DeployableInfrastructureHitCount("DoesVerb"), Is.Zero);
+            Assert.That(DeployableInfrastructureHitCount("NoUsefulWay"), Is.Zero);
+        });
+    }
+
+    [Test]
+    public void AttemptDeploy_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        var target = new DummyDeployableInfrastructureTarget();
+
+        WithPatchedPopupOwner(target.AttemptDeploy);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
+            Assert.That(DeployableInfrastructureHitCount("DoesVerb"), Is.Zero);
+            Assert.That(DeployableInfrastructureHitCount("NoUsefulWay"), Is.Zero);
+        });
+    }
+
+    private static void WithPatchedPopupOwner(Func<DummyGameObject, bool> action)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShow(harmony);
+            PatchOwner(harmony);
+
+            _ = action(new DummyGameObject());
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShow(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.Show)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void PatchOwner(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(
+                typeof(DummyDeployableInfrastructureTarget),
+                nameof(DummyDeployableInfrastructureTarget.AttemptDeploy),
+                typeof(DummyGameObject)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(DeployableInfrastructureTranslationPatch), "Prefix")),
+            finalizer: new HarmonyMethod(RequireMethod(typeof(DeployableInfrastructureTranslationPatch), "Finalizer")));
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameterTypes)
+    {
+        if (parameterTypes.Length == 0)
+        {
+            return type.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
+                   ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+        }
+
+        return AccessTools.Method(type, methodName, parameterTypes)
+               ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private static int DeployableInfrastructureHitCount(string detail)
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show." + nameof(DeployableInfrastructureTranslationPatch) + "." + detail);
+    }
+
+    private static void UseRepositoryVerbDictionary()
+    {
+        var repositoryDictionaryPath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Localization",
+            "MessageFrames",
+            "verbs.ja.json");
+        MessageFrameTranslator.SetDictionaryPathForTests(repositoryDictionaryPath);
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -722,6 +722,7 @@ public sealed class TargetMethodResolutionTests
     })]
     [TestCase(typeof(DeployableInfrastructureTranslationPatch), new[]
     {
+        "XRL.World.GameObject",
         "XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean",
     })]
     [TestCase(typeof(DesalinationPelletTranslationPatch), new[]
@@ -1277,6 +1278,11 @@ public sealed class TargetMethodResolutionTests
         "XRL.World.Parts.LiquidVolume|HandleEvent|System.Boolean|XRL.World.InventoryActionEvent",
         "XRL.World.Parts.LiquidVolume|Pour|System.Boolean|System.Boolean&|XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean|System.Int32|System.Boolean",
         "XRL.World.Parts.LiquidVolume|PerformFill|System.Boolean|XRL.World.GameObject|System.Boolean&|System.Boolean",
+    })]
+    [TestCase(typeof(DeployableInfrastructureTranslationPatch), new[]
+    {
+        "XRL.World.Parts.DeployableInfrastructure|AttemptDeploy|System.Boolean|XRL.World.GameObject",
+        "XRL.World.Parts.DeployableInfrastructure|DeployOne|System.Boolean|XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean",
     })]
     public void OwnerProducerTargetMethods_ResolveExpectedFullSignatures(Type patchType, string[] expectedSignatures)
     {

--- a/Mods/QudJP/Assemblies/src/Patches/DeployableInfrastructureTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/DeployableInfrastructureTranslationPatch.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using HarmonyLib;
 
 namespace QudJP.Patches;
@@ -10,6 +11,12 @@ namespace QudJP.Patches;
 public static class DeployableInfrastructureTranslationPatch
 {
     private const string Context = nameof(DeployableInfrastructureTranslationPatch);
+    private const string DoesVerbDetail = "DoesVerb";
+    private const string NoUsefulWayDetail = "NoUsefulWay";
+
+    private static readonly Regex NoUsefulWayPattern = new(
+        "^There is no useful way to (?<verb>deploy) (?<target>.+?) there\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
     [ThreadStatic]
     private static int activeDepth;
@@ -24,6 +31,16 @@ public static class DeployableInfrastructureTranslationPatch
         {
             Trace.TraceError("QudJP: {0} failed to resolve target types.", Context);
             yield break;
+        }
+
+        var attemptDeploy = AccessTools.Method(targetType, "AttemptDeploy", [gameObjectType]);
+        if (attemptDeploy is not null)
+        {
+            yield return attemptDeploy;
+        }
+        else
+        {
+            Trace.TraceError("QudJP: {0}.AttemptDeploy(GameObject) not found.", Context);
         }
 
         var deployOne = AccessTools.Method(
@@ -83,6 +100,74 @@ public static class DeployableInfrastructureTranslationPatch
         translated = MessageFrameTranslator.MarkDirectTranslation(translated);
         DynamicTextObservability.RecordTransform(Context, "DeployableInfrastructure.DoesVerb", message, translated);
         message = translated;
+        return true;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        translated = source;
+        try
+        {
+            if (activeDepth <= 0 || string.IsNullOrEmpty(source))
+            {
+                return false;
+            }
+
+            if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+            {
+                translated = markedText;
+                return true;
+            }
+
+            if (TryTranslateNoUsefulWayPopup(source, out translated))
+            {
+                DynamicTextObservability.RecordTransform(
+                    route,
+                    family + "." + Context + "." + NoUsefulWayDetail,
+                    source,
+                    translated);
+                return true;
+            }
+
+            if (!DoesVerbRouteTranslator.TryTranslatePlainSentence(source, out translated))
+            {
+                return false;
+            }
+
+            DynamicTextObservability.RecordTransform(
+                route,
+                family + "." + Context + "." + DoesVerbDetail,
+                source,
+                translated);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.TryTranslatePopupMessage failed: {1}", Context, ex);
+            translated = source;
+            return false;
+        }
+    }
+
+    private static bool TryTranslateNoUsefulWayPopup(string source, out string translated)
+    {
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
+        var match = NoUsefulWayPattern.Match(stripped);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        var target = ColorAwareTranslationComposer.RestoreCapture(
+            match.Groups["target"].Value,
+            spans,
+            match.Groups["target"]).Trim();
+        translated = ColorAwareTranslationComposer.RestoreWholeSourceBoundaryWrappersPreservingTranslatedOwnership(
+            $"ここで{target}を展開する有用な方法はない。",
+            spans,
+            stripped.Length,
+            source);
         return true;
     }
 }

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -33,6 +33,7 @@ internal static class PopupShowSemanticPipeline
         StatusScreenPopupTranslationPatch.TryTranslatePopupMessage,
         TeleprojectorTranslationPatch.TryTranslatePopupMessage,
         CyberneticsMedassistModuleTranslationPatch.TryTranslatePopupMessage,
+        DeployableInfrastructureTranslationPatch.TryTranslatePopupMessage,
         LiquidLoaderTranslationPatch.TryTranslatePopupMessage,
         LiquidVolumeTranslationPatch.TryTranslatePopupMessage,
         MutatingTranslationPatch.TryTranslatePopupMessage,

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -2261,6 +2261,49 @@ def _integrated_weapon_hosts_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _deployable_infrastructure_families() -> tuple[CoveredOwnerFamily, ...]:
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts/DeployableInfrastructure.cs::XRL.World.Parts.DeployableInfrastructure.AttemptDeploy",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/DeployableInfrastructureTranslationPatch.cs",
+                    (
+                        "AttemptDeploy",
+                        "TryTranslatePopupMessage",
+                        "TryTranslateNoUsefulWayPopup",
+                        "DoesVerbRouteTranslator.TryTranslatePlainSentence",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                    ("DeployableInfrastructureTranslationPatch.TryTranslatePopupMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/DeployableInfrastructurePopupTranslationPatchTests.cs",
+                    (
+                        "AttemptDeploy_TranslatesDeploySuccessPopup_WhenOwnerPatched",
+                        "AttemptDeploy_TranslatesNoUsefulWayPopup_WhenOwnerPatched",
+                        "AttemptDeploy_LeavesPopupUnchanged_WhenOwnerAbsent",
+                        "AttemptDeploy_StripsDirectMarkerWithoutRecordingTransform_WhenOwnerPatched",
+                        "AttemptDeploy_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                        "nameof(DummyDeployableInfrastructureTarget.AttemptDeploy)",
+                        "UseRepositoryVerbDictionary",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(DeployableInfrastructureTranslationPatch)",
+                        "XRL.World.Parts.DeployableInfrastructure|AttemptDeploy|System.Boolean|XRL.World.GameObject",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _boost_statistic_families() -> tuple[CoveredOwnerFamily, ...]:
     common_evidence = (
         EvidenceFile(
@@ -3980,6 +4023,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_tonic_families(),
     *_xrl_game_families(),
     *_integrated_weapon_hosts_families(),
+    *_deployable_infrastructure_families(),
     *_boost_statistic_families(),
     *_emboldened_families(),
     *_fungal_spore_infection_families(),


### PR DESCRIPTION
## Summary
- extend DeployableInfrastructureTranslationPatch to cover AttemptDeploy popup traffic
- translate deploy success popups via the shipped verb dictionary and the no-useful-way failure popup via an owner helper
- add owner popup tests, target resolution evidence, and static producer closure registration

## Verification
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~DeployableInfrastructurePopupTranslationPatchTests|FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures|FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature' -v minimal\n- just static-producer-check\n\nQueue delta: 337 -> 336 families, 940 -> 937 callsites, 961 -> 958 text args.