### PR TITLE
Close issue-576 mod magnetized popup family

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyFragmentProducerTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyFragmentProducerTargets.cs
@@ -328,6 +328,17 @@ internal sealed class DummyStairsUpProducerTarget
     }
 }
 
+internal sealed class DummyModMagnetizedProducerTarget
+{
+    public string PopupMessageToShow { get; set; } = string.Empty;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public void CheckFloating()
+    {
+        DummyPopupShow.Show(PopupMessageToShow);
+    }
+}
+
 internal sealed class DummyGivesRepProducerTarget
 {
     public string PostfixTextToAppend { get; set; } = string.Empty;

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs
@@ -507,6 +507,7 @@ public sealed class DoesVerbFamilyTests
     [TestCase("The 生物 atomizes and recombines into a 熊.", "生物は原子分解し、熊として再結合した")]
     [TestCase("The 宝石 stops gleaming.", "宝石の輝きが消えた")]
     [TestCase("The 熊 shies away from you.", "熊はあなたから怯えて離れた")]
+    [TestCase("The 装置 falls to the ground; you pick it up.", "装置は地面に落ちた。あなたはそれを拾った。")]
     [TestCase("The 装置 ceases floating near you.", "装置はあなたの近くで浮遊するのをやめた")]
     [TestCase("The 装置 collapses under the pressure of normality and implodes.", "装置は正常性の圧力に耐えきれず崩壊し、内破した")]
     [TestCase("The 金属片 becomes magnetized!", "金属片は磁化された！")]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ModMagnetizedTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ModMagnetizedTranslationPatchTests.cs
@@ -1,0 +1,139 @@
+using System.Reflection;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+using QudJP.Tests.L1;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class ModMagnetizedTranslationPatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        DynamicTextObservability.ResetForTests();
+        MessageFrameTranslator.ResetForTests();
+        UseRepositoryVerbDictionary();
+        DummyPopupShow.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(null);
+        DynamicTextObservability.ResetForTests();
+        MessageFrameTranslator.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TestCase(" to the ground; you pick it up.", "装置は地面に落ちた。あなたはそれを拾った。")]
+    [TestCase(" to the ground.", "装置は地面に倒れた。")]
+    public void CheckFloating_TranslatesDoesVerbPopup_WhenOwnerPatched(string tail, string expected)
+    {
+        var target = new DummyModMagnetizedProducerTarget
+        {
+            PopupMessageToShow = MarkDoesFragment("The 装置 falls") + tail,
+        };
+
+        OwnerPopupRouteTestHarness.WithPatchedPopupOwner(
+            typeof(ModMagnetizedTranslationPatch),
+            RequireOwnerMethod(),
+            target.CheckFloating);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
+            Assert.That(ModMagnetizedHitCount(), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void CheckFloating_LeavesPlainPopupUnchanged_WhenOwnerAbsent()
+    {
+        const string source = "The 装置 falls to the ground.";
+        var target = new DummyModMagnetizedProducerTarget
+        {
+            PopupMessageToShow = source,
+        };
+
+        OwnerPopupRouteTestHarness.WithPatchedPopupOnly(target.CheckFloating);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(source));
+            Assert.That(ModMagnetizedHitCount(), Is.Zero);
+        });
+    }
+
+    [Test]
+    public void CheckFloating_StripsDirectMarkerWithoutRecordingTransform_WhenOwnerPatched()
+    {
+        const string translated = "装置は地面に倒れた。";
+        var target = new DummyModMagnetizedProducerTarget
+        {
+            PopupMessageToShow = MessageFrameTranslator.MarkDirectTranslation(translated),
+        };
+
+        OwnerPopupRouteTestHarness.WithPatchedPopupOwner(
+            typeof(ModMagnetizedTranslationPatch),
+            RequireOwnerMethod(),
+            target.CheckFloating);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(translated));
+            Assert.That(ModMagnetizedHitCount(), Is.Zero);
+        });
+    }
+
+    [Test]
+    public void CheckFloating_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        var target = new DummyModMagnetizedProducerTarget();
+
+        OwnerPopupRouteTestHarness.WithPatchedPopupOwner(
+            typeof(ModMagnetizedTranslationPatch),
+            RequireOwnerMethod(),
+            target.CheckFloating);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(string.Empty));
+            Assert.That(ModMagnetizedHitCount(), Is.Zero);
+        });
+    }
+
+    private static MethodInfo RequireOwnerMethod()
+    {
+        return OwnerPopupRouteTestHarness.RequireMethod(
+            typeof(DummyModMagnetizedProducerTarget),
+            nameof(DummyModMagnetizedProducerTarget.CheckFloating));
+    }
+
+    private static string MarkDoesFragment(string fragment)
+    {
+        return DoesVerbRouteTranslator.MarkDoesFragment(fragment, "fall", "The 装置".Length, null);
+    }
+
+    private static int ModMagnetizedHitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show." + nameof(ModMagnetizedTranslationPatch) + ".DoesVerb");
+    }
+
+    private static void UseRepositoryVerbDictionary()
+    {
+        var repositoryDictionaryPath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Localization",
+            "MessageFrames",
+            "verbs.ja.json");
+        MessageFrameTranslator.SetDictionaryPathForTests(repositoryDictionaryPath);
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -728,6 +728,10 @@ public sealed class TargetMethodResolutionTests
     {
         "XRL.World.InventoryActionEvent",
     })]
+    [TestCase(typeof(ModMagnetizedTranslationPatch), new[]
+    {
+        "",
+    })]
     [TestCase(typeof(EnclosingTranslationPatch), new[]
     {
         "XRL.World.GameObject|XRL.World.IEvent",
@@ -1277,6 +1281,10 @@ public sealed class TargetMethodResolutionTests
         "XRL.World.Parts.LiquidVolume|HandleEvent|System.Boolean|XRL.World.InventoryActionEvent",
         "XRL.World.Parts.LiquidVolume|Pour|System.Boolean|System.Boolean&|XRL.World.GameObject|XRL.World.Cell|System.Boolean|System.Boolean|System.Int32|System.Boolean",
         "XRL.World.Parts.LiquidVolume|PerformFill|System.Boolean|XRL.World.GameObject|System.Boolean&|System.Boolean",
+    })]
+    [TestCase(typeof(ModMagnetizedTranslationPatch), new[]
+    {
+        "XRL.World.Parts.ModMagnetized|CheckFloating|System.Void",
     })]
     public void OwnerProducerTargetMethods_ResolveExpectedFullSignatures(Type patchType, string[] expectedSignatures)
     {

--- a/Mods/QudJP/Assemblies/src/Patches/ModMagnetizedTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/ModMagnetizedTranslationPatch.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class ModMagnetizedTranslationPatch
+{
+    private const string Context = nameof(ModMagnetizedTranslationPatch);
+    private const string DoesVerbDetail = "DoesVerb";
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        var targetType = AccessTools.TypeByName("XRL.World.Parts.ModMagnetized");
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found.", Context);
+            yield break;
+        }
+
+        var checkFloating = AccessTools.Method(targetType, "CheckFloating", Type.EmptyTypes);
+        if (checkFloating is not null)
+        {
+            yield return checkFloating;
+        }
+        else
+        {
+            Trace.TraceError("QudJP: {0}.CheckFloating() not found.", Context);
+        }
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        translated = source;
+        try
+        {
+            if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+            {
+                return false;
+            }
+
+            if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+            {
+                translated = markedText;
+                return true;
+            }
+
+            if (!DoesVerbRouteTranslator.TryTranslateMarkedMessage(source, out translated)
+                && !DoesVerbRouteTranslator.TryTranslatePlainSentence(source, out translated))
+            {
+                return false;
+            }
+
+            DynamicTextObservability.RecordTransform(
+                route,
+                family + "." + Context + "." + DoesVerbDetail,
+                source,
+                translated);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.TryTranslatePopupMessage failed: {1}", Context, ex);
+            translated = source;
+            return false;
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -39,6 +39,7 @@ internal static class PopupShowSemanticPipeline
         LightManipulationTranslationPatch.TryTranslatePopupMessage,
         AsleepOwnerTranslationPatch.TryTranslatePopupMessage,
         EnclosingTranslationPatch.TryTranslatePopupMessage,
+        ModMagnetizedTranslationPatch.TryTranslatePopupMessage,
         StairsDownTranslationPatch.TryTranslatePopupMessage,
         StairsUpTranslationPatch.TryTranslatePopupMessage,
         BeguilingTranslationPatch.TryTranslatePopupMessage,

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -2261,6 +2261,55 @@ def _integrated_weapon_hosts_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _mod_magnetized_families() -> tuple[CoveredOwnerFamily, ...]:
+    return (
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts/ModMagnetized.cs::XRL.World.Parts.ModMagnetized.CheckFloating",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/ModMagnetizedTranslationPatch.cs",
+                    (
+                        "XRL.World.Parts.ModMagnetized",
+                        "CheckFloating",
+                        "TryTranslatePopupMessage",
+                        "DoesVerbRouteTranslator.TryTranslateMarkedMessage",
+                        "DoesVerbRouteTranslator.TryTranslatePlainSentence",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                    ("ModMagnetizedTranslationPatch.TryTranslatePopupMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs",
+                    (
+                        "The 装置 falls to the ground; you pick it up.",
+                        "The 熊 falls to the ground.",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/ModMagnetizedTranslationPatchTests.cs",
+                    (
+                        "CheckFloating_TranslatesDoesVerbPopup_WhenOwnerPatched",
+                        "CheckFloating_LeavesPlainPopupUnchanged_WhenOwnerAbsent",
+                        "CheckFloating_StripsDirectMarkerWithoutRecordingTransform_WhenOwnerPatched",
+                        "CheckFloating_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                        "nameof(DummyModMagnetizedProducerTarget.CheckFloating)",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(ModMagnetizedTranslationPatch)",
+                        "XRL.World.Parts.ModMagnetized|CheckFloating|System.Void",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _boost_statistic_families() -> tuple[CoveredOwnerFamily, ...]:
     common_evidence = (
         EvidenceFile(
@@ -3980,6 +4029,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_tonic_families(),
     *_xrl_game_families(),
     *_integrated_weapon_hosts_families(),
+    *_mod_magnetized_families(),
     *_boost_statistic_families(),
     *_emboldened_families(),
     *_fungal_spore_infection_families(),


### PR DESCRIPTION
## Summary
- add a ModMagnetized.CheckFloating owner popup route for the two fall-to-ground popup shapes
- cover marked Does fragments, owner-absent plain traffic, direct markers, empty popup input, and target resolution
- register the family in static_producer_closure.py

## Verification
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~ModMagnetizedTranslationPatchTests|FullyQualifiedName~DoesVerbFamilyTests.Translate_SingleUseVerbFamily|FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures|FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature' -v minimal\n- just static-producer-check\n\nQueue delta: 337 -> 336 families, 940 -> 938 callsites, 961 -> 959 text args.