### PR TITLE
Close TrembleEarthquakes owner message family

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
@@ -1210,6 +1210,11 @@ internal sealed class DummySimpleOwnerQueueTarget
         DummyMessageQueue.AddPlayerMessage(MessageToSend, ColorToSend, Capitalize: false);
     }
 
+    public void Quake()
+    {
+        DummyMessageQueue.AddPlayerMessage(MessageToSend, ColorToSend, Capitalize: false);
+    }
+
     public static string StaticMessageToSend { get; set; } = string.Empty;
 
     public static string? StaticColorToSend { get; set; }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
@@ -3885,6 +3885,8 @@ public sealed class CombatAndLogMessageQueuePatchTests
     [TestCase("Checkpointing enabled")]
     [TestCase("You feel a sense of holiness here.")]
     [TestCase("&CA flash of insight overcomes you!")]
+    [TestCase("The ground shakes violently!")]
+    [TestCase("The ground shakes violently and loose rock falls from the ceiling!")]
     public void FixedOwnerQueue_DoesNotTranslateQueueOnlyTraffic_WhenOwnerAbsent(string source)
     {
         var harmonyId = CreateHarmonyId();
@@ -4003,6 +4005,15 @@ public sealed class CombatAndLogMessageQueuePatchTests
     public void SystemStaticFireEvent_TranslatesFixedQueuedMessages_WhenOwnerPatched(string source, string expected)
     {
         AssertSystemStaticFireEventQueuedMessage(source, expected);
+    }
+
+    [TestCase("The ground shakes violently!", "地面が激しく揺れた！")]
+    [TestCase(
+        "The ground shakes violently and loose rock falls from the ceiling!",
+        "地面が激しく揺れ、天井から岩が崩れ落ちた！")]
+    public void SystemStaticQuake_TranslatesFixedQueuedMessages_WhenOwnerPatched(string source, string expected)
+    {
+        AssertSystemStaticQuakeQueuedMessage(source, expected);
     }
 
     [Test]
@@ -7763,6 +7774,33 @@ public sealed class CombatAndLogMessageQueuePatchTests
             };
 
             _ = target.FireEvent(new DummyEvent());
+
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(expected));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void AssertSystemStaticQuakeQueuedMessage(string message, string expected)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(typeof(DummySimpleOwnerQueueTarget), nameof(DummySimpleOwnerQueueTarget.Quake)),
+                typeof(SystemStaticMessageTranslationPatch));
+
+            var target = new DummySimpleOwnerQueueTarget
+            {
+                MessageToSend = message,
+            };
+
+            target.Quake();
 
             Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(expected));
         }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1135,6 +1135,7 @@ public sealed class TargetMethodResolutionTests
         "XRL.CheckpointingSystem|CheckpointOn|System.Boolean",
         "XRL.HolyPlaceSystem|SetHolyZone|System.Void|XRL.World.Zone|XRL.World.Faction",
         "XRL.World.Parts.Mutation.HeightenedIntelligence|FireEvent|System.Boolean|XRL.World.Event",
+        "XRL.World.Parts.TrembleEarthquakes|Quake|System.Void",
     })]
     [TestCase(typeof(CombatTextSurfaceTranslationPatch), new[]
     {

--- a/Mods/QudJP/Assemblies/src/Patches/SystemStaticMessageTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/SystemStaticMessageTranslationPatch.cs
@@ -30,6 +30,7 @@ public static class SystemStaticMessageTranslationPatch
         AddTarget(targets, "XRL.CheckpointingSystem", "CheckpointOn", Type.EmptyTypes);
         AddTarget(targets, "XRL.HolyPlaceSystem", "SetHolyZone", new[] { zoneType, factionType });
         AddTarget(targets, "XRL.World.Parts.Mutation.HeightenedIntelligence", "FireEvent", new[] { eventType });
+        AddTarget(targets, "XRL.World.Parts.TrembleEarthquakes", "Quake", Type.EmptyTypes);
         return targets;
     }
 
@@ -78,6 +79,8 @@ public static class SystemStaticMessageTranslationPatch
             "Checkpointing enabled" => "チェックポイント機能を有効化した。",
             "You feel a sense of holiness here." => "この場所には神聖さを感じる。",
             "&CA flash of insight overcomes you!" => "&Cひらめきがあなたを満たした！",
+            "The ground shakes violently!" => "地面が激しく揺れた！",
+            "The ground shakes violently and loose rock falls from the ceiling!" => "地面が激しく揺れ、天井から岩が崩れ落ちた！",
             _ => null,
         };
         if (translated is null)

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -3135,6 +3135,37 @@ def _system_static_message_families() -> tuple[CoveredOwnerFamily, ...]:
                 dictionary,
             ),
         ),
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts/TrembleEarthquakes.cs::XRL.World.Parts.TrembleEarthquakes.Quake",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                patch,
+                pipeline,
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+                    (
+                        "SystemStaticQuake_TranslatesFixedQueuedMessages_WhenOwnerPatched",
+                        "FixedOwnerQueue_DoesNotTranslateQueueOnlyTraffic_WhenOwnerAbsent",
+                        "The ground shakes violently!",
+                        "The ground shakes violently and loose rock falls from the ceiling!",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(SystemStaticMessageTranslationPatch)",
+                        "XRL.World.Parts.TrembleEarthquakes|Quake|System.Void",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Localization/Dictionaries/ui-messagelog-world.ja.json",
+                    (
+                        "The ground shakes violently!",
+                        "The ground shakes violently and loose rock falls from the ceiling!",
+                    ),
+                ),
+            ),
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- close the `TrembleEarthquakes.Quake` static producer owner family through `SystemStaticMessageTranslationPatch`
- add owner-scoped L2 evidence for both quake `AddPlayerMessage` literals, including queue-only negative coverage
- register the covered family in `scripts/static_producer_closure.py` with L2, L2G, pipeline, patch, and production dictionary evidence

## Inventory
- `XRL.World.Parts/TrembleEarthquakes.cs::XRL.World.Parts.TrembleEarthquakes.Quake`
  - line 44: `AddPlayerMessage("The ground shakes violently!")`
  - line 47: `AddPlayerMessage("The ground shakes violently and loose rock falls from the ceiling!")`

## Verification
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~CombatAndLogMessageQueuePatchTests.SystemStatic|FullyQualifiedName~CombatAndLogMessageQueuePatchTests.FixedOwnerQueue_DoesNotTranslateQueueOnlyTraffic_WhenOwnerAbsent|FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures' -v minimal`
- `just static-producer-check`
- `git diff --check`

## Queue delta
- main: 337 families / 940 callsites / 961 text args
- branch: 336 families / 938 callsites / 959 text args
- `XRL.World.Parts/TrembleEarthquakes.cs` is no longer present in the branch queue output
