### PR TITLE
Close spore infection owner message families

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
@@ -1322,6 +1322,24 @@ internal sealed class DummyFungalSporeInfectionTarget
     public bool FireEvent(DummyGameEvent e)
     {
         _ = e;
+        return EmitQueuedMessage("fungal");
+    }
+
+    public bool PaxFireEvent(DummyGameEvent e)
+    {
+        _ = e;
+        return EmitQueuedMessage("pax");
+    }
+
+    public bool PuffFireEvent(DummyGameEvent e)
+    {
+        _ = e;
+        return EmitQueuedMessage("puff");
+    }
+
+    private bool EmitQueuedMessage(string producer)
+    {
+        _ = producer;
         DummyMessageQueue.AddPlayerMessage(MessageToSend, ColorToSend, Capitalize: false);
         return true;
     }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
@@ -3564,6 +3564,34 @@ public sealed class CombatAndLogMessageQueuePatchTests
         AssertFungalSporeInfectionQueuedMessage("Your skin itches.", "肌がむずむずする。");
     }
 
+    [TestCase(
+        nameof(DummyFungalSporeInfectionTarget.PaxFireEvent),
+        "Your left arm spews a cloud of spores.",
+        "あなたのleft armから胞子の雲が噴き出した。")]
+    [TestCase(
+        nameof(DummyFungalSporeInfectionTarget.PaxFireEvent),
+        "Your left hands spew a cloud of spores.",
+        "あなたのleft handsから胞子の雲が噴き出した。")]
+    [TestCase(
+        nameof(DummyFungalSporeInfectionTarget.PaxFireEvent),
+        "snapjaw's right hand spews a cloud of spores.",
+        "snapjaw's right handから胞子の雲が噴き出した。")]
+    [TestCase(
+        nameof(DummyFungalSporeInfectionTarget.PuffFireEvent),
+        "&yYour left arm spews a cloud of spores.",
+        "&yあなたのleft armから胞子の雲が噴き出した。")]
+    [TestCase(
+        nameof(DummyFungalSporeInfectionTarget.PuffFireEvent),
+        "snapjaw's&y right hand spews a cloud of spores.",
+        "snapjaw's&y right handから胞子の雲が噴き出した。")]
+    public void FungalSporeInfectionFireEvent_TranslatesSporeCloudQueuedMessages_WhenOwnerPatched(
+        string methodName,
+        string source,
+        string expected)
+    {
+        AssertFungalSporeInfectionQueuedMessage(methodName, source, expected);
+    }
+
     [Test]
     public void FungalSporeInfectionFireEvent_DoesNotTranslateQueueOnlyTraffic_WhenOwnerAbsent()
     {
@@ -3574,8 +3602,10 @@ public sealed class CombatAndLogMessageQueuePatchTests
             PatchQueue(harmony);
 
             DummyMessageQueue.AddPlayerMessage("Your skin itches.", Capitalize: false);
+            DummyMessageQueue.AddPlayerMessage("Your left arm spews a cloud of spores.", Capitalize: false);
+            DummyMessageQueue.AddPlayerMessage("&yYour left arm spews a cloud of spores.", Capitalize: false);
 
-            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("Your skin itches."));
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("&yYour left arm spews a cloud of spores."));
         }
         finally
         {
@@ -3589,6 +3619,14 @@ public sealed class CombatAndLogMessageQueuePatchTests
         AssertFungalSporeInfectionQueuedMessage(
             MessageFrameTranslator.MarkDirectTranslation("Your skin itches."),
             "Your skin itches.");
+        AssertFungalSporeInfectionQueuedMessage(
+            nameof(DummyFungalSporeInfectionTarget.PaxFireEvent),
+            MessageFrameTranslator.MarkDirectTranslation("Your left arm spews a cloud of spores."),
+            "Your left arm spews a cloud of spores.");
+        AssertFungalSporeInfectionQueuedMessage(
+            nameof(DummyFungalSporeInfectionTarget.PuffFireEvent),
+            MessageFrameTranslator.MarkDirectTranslation("&yYour left arm spews a cloud of spores."),
+            "&yYour left arm spews a cloud of spores.");
     }
 
     [Test]
@@ -7345,6 +7383,11 @@ public sealed class CombatAndLogMessageQueuePatchTests
 
     private static void AssertFungalSporeInfectionQueuedMessage(string message, string expected)
     {
+        AssertFungalSporeInfectionQueuedMessage(nameof(DummyFungalSporeInfectionTarget.FireEvent), message, expected);
+    }
+
+    private static void AssertFungalSporeInfectionQueuedMessage(string methodName, string message, string expected)
+    {
         var harmonyId = CreateHarmonyId();
         var harmony = new Harmony(harmonyId);
         try
@@ -7352,7 +7395,7 @@ public sealed class CombatAndLogMessageQueuePatchTests
             PatchQueue(harmony);
             PatchOwner(
                 harmony,
-                RequireMethod(typeof(DummyFungalSporeInfectionTarget), nameof(DummyFungalSporeInfectionTarget.FireEvent), typeof(DummyGameEvent)),
+                RequireMethod(typeof(DummyFungalSporeInfectionTarget), methodName, typeof(DummyGameEvent)),
                 typeof(FungalSporeInfectionTranslationPatch));
 
             var target = new DummyFungalSporeInfectionTarget
@@ -7360,7 +7403,18 @@ public sealed class CombatAndLogMessageQueuePatchTests
                 MessageToSend = message,
             };
 
-            _ = target.FireEvent(new DummyGameEvent { ID = "EndTurn" });
+            if (string.Equals(methodName, nameof(DummyFungalSporeInfectionTarget.PaxFireEvent), StringComparison.Ordinal))
+            {
+                _ = target.PaxFireEvent(new DummyGameEvent { ID = "BeforeApplyDamage" });
+            }
+            else if (string.Equals(methodName, nameof(DummyFungalSporeInfectionTarget.PuffFireEvent), StringComparison.Ordinal))
+            {
+                _ = target.PuffFireEvent(new DummyGameEvent { ID = "BeforeApplyDamage" });
+            }
+            else
+            {
+                _ = target.FireEvent(new DummyGameEvent { ID = "EndTurn" });
+            }
 
             Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(expected));
         }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1069,6 +1069,8 @@ public sealed class TargetMethodResolutionTests
     {
         "XRL.World.Effects.FungalSporeInfection|ApplyFungalInfection|System.Boolean|XRL.World.GameObject|System.String|XRL.World.Anatomy.BodyPart",
         "XRL.World.Effects.FungalSporeInfection|FireEvent|System.Boolean|XRL.World.Event",
+        "XRL.World.Parts.PaxInfection|FireEvent|System.Boolean|XRL.World.Event",
+        "XRL.World.Parts.PuffInfection|FireEvent|System.Boolean|XRL.World.Event",
     })]
     [TestCase(typeof(HealingTranslationPatch), new[]
     {

--- a/Mods/QudJP/Assemblies/src/Patches/FungalSporeInfectionTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/FungalSporeInfectionTranslationPatch.cs
@@ -16,6 +16,14 @@ public static class FungalSporeInfectionTranslationPatch
         "^You've contracted (?<infection>.+?) on your (?<part>.+?)\\.$",
         RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
+    private static readonly Regex YourSporeCloudPattern = new(
+        "^Your (?<part>.+?) spews? a cloud of spores\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex VisibleSubjectSporeCloudPattern = new(
+        "^(?<subject>.+?) (?<part>.+?) spews? a cloud of spores\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
     [ThreadStatic]
     private static int activeDepth;
 
@@ -24,6 +32,8 @@ public static class FungalSporeInfectionTranslationPatch
     {
         var targets = new List<MethodBase>();
         var targetType = AccessTools.TypeByName("XRL.World.Effects.FungalSporeInfection");
+        var paxType = AccessTools.TypeByName("XRL.World.Parts.PaxInfection");
+        var puffType = AccessTools.TypeByName("XRL.World.Parts.PuffInfection");
         var gameObjectType = AccessTools.TypeByName("XRL.World.GameObject");
         var bodyPartType = AccessTools.TypeByName("XRL.World.Anatomy.BodyPart");
         var eventType = AccessTools.TypeByName("XRL.World.Event");
@@ -45,6 +55,8 @@ public static class FungalSporeInfectionTranslationPatch
         if (eventType is not null)
         {
             AddTarget(targets, targetType, "FireEvent", new[] { eventType });
+            AddTargetByTypeName(targets, paxType, "XRL.World.Parts.PaxInfection", "FireEvent", new[] { eventType });
+            AddTargetByTypeName(targets, puffType, "XRL.World.Parts.PuffInfection", "FireEvent", new[] { eventType });
         }
         else
         {
@@ -159,6 +171,22 @@ public static class FungalSporeInfectionTranslationPatch
         Trace.TraceError("QudJP: {0}.{1}.{2} target not found.", Context, targetType.FullName, methodName);
     }
 
+    private static void AddTargetByTypeName(
+        List<MethodBase> targets,
+        Type? targetType,
+        string typeName,
+        string methodName,
+        Type[] parameters)
+    {
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found: {1}.", Context, typeName);
+            return;
+        }
+
+        AddTarget(targets, targetType, methodName, parameters);
+    }
+
     private static bool TryTranslateQueuedCore(string source, out string translated)
     {
         if (string.Equals(source, "Your skin itches.", StringComparison.Ordinal))
@@ -167,8 +195,63 @@ public static class FungalSporeInfectionTranslationPatch
             return true;
         }
 
+        if (TryTranslateSporeCloud(source, out translated))
+        {
+            return true;
+        }
+
         translated = source;
         return false;
+    }
+
+    private static bool TryTranslateSporeCloud(string source, out string translated)
+    {
+        if (TryTranslateSporeCloudPattern(
+            YourSporeCloudPattern,
+            source,
+            (match, spans) => $"あなたの{Restore(match, spans, "part")}から胞子の雲が噴き出した。",
+            out translated))
+        {
+            return true;
+        }
+
+        return TryTranslateSporeCloudPattern(
+            VisibleSubjectSporeCloudPattern,
+            source,
+            (match, spans) => $"{JoinSubjectAndPart(Restore(match, spans, "subject"), Restore(match, spans, "part"))}から胞子の雲が噴き出した。",
+            out translated);
+    }
+
+    private static string JoinSubjectAndPart(string subject, string part)
+    {
+        if (part.Length >= 2 && part[0] == '&' && char.IsLetter(part[1]))
+        {
+            return subject + part.Substring(0, 2) + " " + part.Substring(2);
+        }
+
+        return subject + " " + part;
+    }
+
+    private static bool TryTranslateSporeCloudPattern(
+        Regex pattern,
+        string source,
+        Func<Match, IReadOnlyList<ColorSpan>, string> translate,
+        out string translated)
+    {
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
+        var match = pattern.Match(stripped);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = ColorAwareTranslationComposer.RestoreWholeSourceBoundaryWrappersPreservingTranslatedOwnership(
+            translate(match, spans),
+            spans,
+            stripped.Length,
+            source);
+        return true;
     }
 
     private static bool TryTranslatePopupCore(string source, out string translated)

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -2434,6 +2434,76 @@ def _fungal_spore_infection_families() -> tuple[CoveredOwnerFamily, ...]:
                 ),
             ),
         ),
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts/PaxInfection.cs::XRL.World.Parts.PaxInfection.FireEvent",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/FungalSporeInfectionTranslationPatch.cs",
+                    (
+                        "XRL.World.Parts.PaxInfection",
+                        "YourSporeCloudPattern",
+                        "VisibleSubjectSporeCloudPattern",
+                        "TryTranslateSporeCloud",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs",
+                    ("FungalSporeInfectionTranslationPatch.TryTranslateQueuedMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+                    (
+                        "FungalSporeInfectionFireEvent_TranslatesSporeCloudQueuedMessages_WhenOwnerPatched",
+                        "nameof(DummyFungalSporeInfectionTarget.PaxFireEvent)",
+                        "FungalSporeInfectionFireEvent_DoesNotTranslateQueueOnlyTraffic_WhenOwnerAbsent",
+                        "FungalSporeInfectionFireEvent_DoesNotRetranslateDirectMarkedQueuedMessage_WhenOwnerPatched",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(FungalSporeInfectionTranslationPatch)",
+                        "XRL.World.Parts.PaxInfection|FireEvent|System.Boolean|XRL.World.Event",
+                    ),
+                ),
+            ),
+        ),
+        CoveredOwnerFamily(
+            family_id="XRL.World.Parts/PuffInfection.cs::XRL.World.Parts.PuffInfection.FireEvent",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/FungalSporeInfectionTranslationPatch.cs",
+                    (
+                        "XRL.World.Parts.PuffInfection",
+                        "YourSporeCloudPattern",
+                        "VisibleSubjectSporeCloudPattern",
+                        "JoinSubjectAndPart",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs",
+                    ("FungalSporeInfectionTranslationPatch.TryTranslateQueuedMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+                    (
+                        "FungalSporeInfectionFireEvent_TranslatesSporeCloudQueuedMessages_WhenOwnerPatched",
+                        "nameof(DummyFungalSporeInfectionTarget.PuffFireEvent)",
+                        "FungalSporeInfectionFireEvent_DoesNotTranslateQueueOnlyTraffic_WhenOwnerAbsent",
+                        "snapjaw's&y right handから胞子の雲が噴き出した。",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(FungalSporeInfectionTranslationPatch)",
+                        "XRL.World.Parts.PuffInfection|FireEvent|System.Boolean|XRL.World.Event",
+                    ),
+                ),
+            ),
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- close the `PaxInfection.FireEvent` and `PuffInfection.FireEvent` static producer owner families through `FungalSporeInfectionTranslationPatch`
- add owner-scoped L2 coverage for player and visible-subject spore cloud message shapes, including Puff `&y` markup preservation
- register both covered families in `scripts/static_producer_closure.py` with patch, queue pipeline, L2, and L2G evidence

## Inventory
- `XRL.World.Parts/PaxInfection.cs::XRL.World.Parts.PaxInfection.FireEvent`
  - line 136: `AddPlayerMessage("Your " + bodyPart.GetOrdinalName() + " " + (bodyPart.Plural ? "spew" : "spews") + " a cloud of spores.")`
  - line 141: `AddPlayerMessage(Grammar.MakePossessive(equipped2.The + equipped2.ShortDisplayName) + " " + bodyPart2.GetOrdinalName() + " " + (bodyPart2.Plural ? "spew" : "spews") + " a cloud of spores.")`
- `XRL.World.Parts/PuffInfection.cs::XRL.World.Parts.PuffInfection.FireEvent`
  - line 113: `AddPlayerMessage("&yYour " + bodyPart.GetOrdinalName() + " " + (bodyPart.Plural ? "spew" : "spews") + " a cloud of spores.")`
  - line 118: `AddPlayerMessage(Grammar.MakePossessive(equipped.The + equipped.ShortDisplayName) + "&y " + bodyPart2.GetOrdinalName() + " " + (bodyPart2.Plural ? "spew" : "spews") + " a cloud of spores.")`

`PaxInfection.ActivatePaxInfection` also has an adjacent `XDidY(... "spew", "a cloud of spores" ...)` path, but it is not part of this inventory batch and is not claimed here.

## Verification
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~CombatAndLogMessageQueuePatchTests.FungalSporeInfectionFireEvent|FullyQualifiedName~TargetMethodResolutionTests.OwnerProducerTargetMethods_ResolveExpectedFullSignatures' -v minimal`
- `just static-producer-check`
- `git diff --check`

## Queue delta
- main: 337 families / 940 callsites / 961 text args
- branch: 335 families / 936 callsites / 957 text args
- `XRL.World.Parts/PaxInfection.cs` and `XRL.World.Parts/PuffInfection.cs` are no longer present in the branch queue output
