### PR TITLE
Close MutationsAPI buy prompt owner family

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/MutationsApiTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/MutationsApiTranslationPatchTests.cs
@@ -132,6 +132,22 @@ public sealed class MutationsApiTranslationPatchTests
     }
 
     [Test]
+    public void TryTranslatePopupMessage_TranslatesDefaultMutationTerm_WhenDictionaryMisses()
+    {
+        WriteDictionary();
+
+        var ok = TryTranslatePopupMessageDuringMutationPurchase(
+            "Are you sure you want to spend 4 mutation points to buy a new mutation?",
+            out var translated);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ok, Is.True);
+            Assert.That(translated, Is.EqualTo("本当に4ポイントを消費して新しい突然変異を購入しますか？"));
+        });
+    }
+
+    [Test]
     public void TryTranslatePopupMessage_ReturnsFalse_ForDirectTranslationMarker()
     {
         var ok = TryTranslatePopupMessageDuringMutationPurchase(

--- a/Mods/QudJP/Assemblies/src/Patches/MutationsApiTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/MutationsApiTranslationPatch.cs
@@ -121,6 +121,13 @@ public static class MutationsApiTranslationPatch
             return translated;
         }
 
+        var strippedTerm = termGroup.Value.Trim();
+        if (string.Equals(strippedTerm, "mutation", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(strippedTerm, "mutations", StringComparison.OrdinalIgnoreCase))
+        {
+            return ColorAwareTranslationComposer.RestoreCapture("突然変異", spans, termGroup).Trim();
+        }
+
         return StringHelpers.TryGetTranslationExactOrLowerAscii(termGroup.Value.Trim(), out translated)
             ? ColorAwareTranslationComposer.RestoreCapture(translated, spans, termGroup).Trim()
             : restored;

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -988,6 +988,49 @@ def _status_screen_popup_families() -> tuple[CoveredOwnerFamily, ...]:
     )
 
 
+def _mutations_api_families() -> tuple[CoveredOwnerFamily, ...]:
+    return (
+        CoveredOwnerFamily(
+            family_id="Qud.API/MutationsAPI.cs::Qud.API.MutationsAPI.BuyRandomMutation",
+            inventory_statuses=("owner_patch_required",),
+            evidence_files=(
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/MutationsApiTranslationPatch.cs",
+                    (
+                        "MutationsApiTranslationPatch",
+                        "BuyPromptPattern",
+                        "mutation points to buy a new",
+                        "突然変異",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs",
+                    ("MutationsApiTranslationPatch.TryTranslatePopupMessage",),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2/MutationsApiTranslationPatchTests.cs",
+                    (
+                        "BuyRandomMutation_TranslatesConfirmationMessage_WhenPatched",
+                        "BuyRandomMutation_PreservesColorTagsInConfirmationMessage_WhenPatched",
+                        "TryTranslatePopupMessage_TranslatesDefaultMutationTerm_WhenDictionaryMisses",
+                        "TryTranslatePopupMessage_ReturnsFalse_ForEmptyInput",
+                        "TryTranslatePopupMessage_ReturnsFalse_ForDirectTranslationMarker",
+                    ),
+                ),
+                EvidenceFile(
+                    "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                    (
+                        "typeof(MutationsApiTranslationPatch)",
+                        "Qud.API.MutationsAPI",
+                        "BuyRandomMutation",
+                        "XRL.World.GameObject",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _campfire_preserve_families() -> tuple[CoveredOwnerFamily, ...]:
     patch = EvidenceFile(
         "Mods/QudJP/Assemblies/src/Patches/CampfirePreserveTranslationPatch.cs",
@@ -3954,6 +3997,7 @@ COVERED_OWNER_FAMILIES: Final = (
     *_ability_manager_popup_families(),
     *_cooking_runtime_families(),
     *_status_screen_popup_families(),
+    *_mutations_api_families(),
     *_campfire_preserve_families(),
     *_reality_stabilized_event_families(),
     *_cybernetic_rejection_syndrome_families(),


### PR DESCRIPTION
## Summary
- close the `Qud.API.MutationsAPI.BuyRandomMutation` static producer owner family through existing `MutationsApiTranslationPatch` coverage
- add a production fallback for the default `mutation` / `mutations` term so the confirmation prompt does not depend on a test-only dictionary leaf
- register the family in `scripts/static_producer_closure.py` with patch, popup handoff, L2, and L2G evidence

## Inventory
- `Qud.API/MutationsAPI.cs::Qud.API.MutationsAPI.BuyRandomMutation`
  - line 111: `Popup.ShowYesNo("Are you sure you want to spend " + Cost + " mutation points to buy a new " + MutationTerm + "?")`

## Verification
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~MutationsApiTranslationPatchTests|FullyQualifiedName~TargetMethodResolutionTests.TargetMethod_ResolvesExpectedSignature' -v minimal`
- `just static-producer-check`
- `git diff --check`

## Queue delta
- main: 337 families / 940 callsites / 961 text args
- branch: 336 families / 939 callsites / 960 text args
- `Qud.API/MutationsAPI.cs` is no longer present in the branch queue output
