### PR TITLE
Close old save continue menu owner families

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
@@ -585,6 +585,28 @@ internal sealed class DummyKeybindsScreenConflictTarget
     }
 }
 
+internal sealed class DummyOldSaveContinueMenuTarget
+{
+    public string PopupMessageToSend { get; set; } = string.Empty;
+
+    public Task<object?> MainMenuContinueMenu()
+    {
+        return ShowOldSavePopup(nameof(MainMenuContinueMenu));
+    }
+
+    public Task<object?> SaveManagementContinueMenu()
+    {
+        return ShowOldSavePopup(nameof(SaveManagementContinueMenu));
+    }
+
+    private async Task<object?> ShowOldSavePopup(string route)
+    {
+        _ = route;
+        await DummyPopupShow.ShowAsync(PopupMessageToSend).ConfigureAwait(false);
+        return null;
+    }
+}
+
 internal sealed class DummyRealityStabilizedEventTarget
 {
     public string MessageToSend { get; set; } = string.Empty;

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
@@ -137,6 +137,10 @@ internal static class ColorRouteCatalog
     internal static readonly SortedDictionary<string, GenericPopupProducerRouteAllowance> GenericPopupProducerRouteAllowlist =
         new SortedDictionary<string, GenericPopupProducerRouteAllowance>(StringComparer.Ordinal)
         {
+            ["Mods/QudJP/Assemblies/src/Patches/OldSaveContinueMenuTranslationPatch.cs|PopupTranslationPatch.TranslatePopupTextForProducerRoute("] =
+                new(
+                    1,
+                    "Old-save ContinueMenu owner scope runs before the generic Popup.Show fallback; this call only handles the fixed old-save popup template."),
             ["Mods/QudJP/Assemblies/src/Patches/PopupAskNumberTranslationPatch.cs|PopupTranslationPatch.TranslatePopupTextForProducerRoute("] =
                 new(
                     1,
@@ -234,6 +238,7 @@ internal static class ColorRouteCatalog
             ["Mods/QudJP/Assemblies/src/Patches/MessageLogProducerTranslationHelpers.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 5,
             ["Mods/QudJP/Assemblies/src/Patches/MessageLogProducerTranslationHelpers.cs|MessagePatternTranslator.Translate("] = 4,
             ["Mods/QudJP/Assemblies/src/Patches/OptionsLocalizationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
+            ["Mods/QudJP/Assemblies/src/Patches/OldSaveContinueMenuTranslationPatch.cs|PopupTranslationPatch.TranslatePopupTextForProducerRoute("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/PopupAskNumberTranslationPatch.cs|PopupTranslationPatch.TranslatePopupTextForProducerRoute("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/PopupAskStringTranslationPatch.cs|PopupTranslationPatch.TranslatePopupTextForProducerRoute("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/PopupGetPopupOptionTranslationPatch.cs|PopupTranslationPatch.TranslatePopupMenuItemTextForProducerRoute("] = 1,

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/OldSaveContinueMenuTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/OldSaveContinueMenuTranslationPatchTests.cs
@@ -1,0 +1,164 @@
+using System.Reflection;
+using HarmonyLib;
+using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class OldSaveContinueMenuTranslationPatchTests
+{
+    private const string OldSaveSource =
+        "That save file looks like it's from an older save format revision (2.0.3). Sorry!\n\nYou can probably change to a previous branch in your game client and get it to load if you want to finish it off.";
+
+    private const string OldSaveExpected =
+        "このセーブデータは古いフォーマット（2.0.3）のようです。\nゲームクライアントで以前のブランチに切り替えれば読み込める可能性があります。";
+
+    [SetUp]
+    public void SetUp()
+    {
+        LocalizationAssetResolver.SetLocalizationRootForTests(GetLocalizationRoot());
+        Translator.ResetForTests();
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+        DummyPopupShow.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(null);
+        Translator.ResetForTests();
+        LocalizationAssetResolver.SetLocalizationRootForTests(null);
+        DynamicTextObservability.ResetForTests();
+        SinkObservation.ResetForTests();
+    }
+
+    [TestCase(nameof(DummyOldSaveContinueMenuTarget.MainMenuContinueMenu))]
+    [TestCase(nameof(DummyOldSaveContinueMenuTarget.SaveManagementContinueMenu))]
+    public void Patch_TranslatesOldSavePopup_WhenOwnerPatched(string methodName)
+    {
+        AssertOldSavePopup(methodName, OldSaveSource, OldSaveExpected, expectedOwnerRouteHits: 1);
+    }
+
+    [Test]
+    public void TryTranslatePopupMessage_DoesNotClaimOldSavePopup_WhenOwnerAbsent()
+    {
+        var ok = OldSaveContinueMenuTranslationPatch.TryTranslatePopupMessage(
+            OldSaveSource,
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show",
+            out var translated);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ok, Is.False);
+            Assert.That(translated, Is.EqualTo(OldSaveSource));
+            Assert.That(OwnerRouteHitCount(), Is.Zero);
+        });
+    }
+
+    [Test]
+    public void Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
+    {
+        AssertOldSavePopup(
+            nameof(DummyOldSaveContinueMenuTarget.MainMenuContinueMenu),
+            MessageFrameTranslator.MarkDirectTranslation(OldSaveSource),
+            OldSaveSource,
+            expectedOwnerRouteHits: 0);
+    }
+
+    [Test]
+    public void Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched()
+    {
+        AssertOldSavePopup(
+            nameof(DummyOldSaveContinueMenuTarget.MainMenuContinueMenu),
+            string.Empty,
+            string.Empty,
+            expectedOwnerRouteHits: 0);
+    }
+
+    private static void AssertOldSavePopup(
+        string methodName,
+        string source,
+        string expected,
+        int expectedOwnerRouteHits)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPopupShowAsync(harmony);
+            PatchOwner(harmony, RequireOwnerMethod(methodName));
+
+            var target = new DummyOldSaveContinueMenuTarget
+            {
+                PopupMessageToSend = source,
+            };
+
+            _ = RequireOwnerMethod(methodName).Invoke(target, Array.Empty<object>());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupShow.LastShowAsyncMessage, Is.EqualTo(expected));
+                Assert.That(OwnerRouteHitCount(), Is.EqualTo(expectedOwnerRouteHits));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void PatchPopupShowAsync(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupShow), nameof(DummyPopupShow.ShowAsync)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void PatchOwner(Harmony harmony, MethodInfo original)
+    {
+        harmony.Patch(
+            original: original,
+            prefix: new HarmonyMethod(RequireMethod(typeof(OldSaveContinueMenuTranslationPatch), nameof(OldSaveContinueMenuTranslationPatch.Prefix))),
+            finalizer: new HarmonyMethod(RequireMethod(typeof(OldSaveContinueMenuTranslationPatch), nameof(OldSaveContinueMenuTranslationPatch.Finalizer), typeof(Exception))));
+    }
+
+    private static MethodInfo RequireOwnerMethod(string methodName)
+    {
+        return RequireMethod(typeof(DummyOldSaveContinueMenuTarget), methodName);
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameterTypes)
+    {
+        if (parameterTypes.Length == 0)
+        {
+            return type.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
+                   ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+        }
+
+        return AccessTools.Method(type, methodName, parameterTypes)
+               ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private static int OwnerRouteHitCount()
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupShowTranslationPatch),
+            "Popup.Show." + nameof(OldSaveContinueMenuTranslationPatch));
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+
+    private static string GetLocalizationRoot()
+    {
+        return Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "../../../../../Localization"));
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1070,6 +1070,11 @@ public sealed class TargetMethodResolutionTests
         "XRL.World.Effects.FungalSporeInfection|ApplyFungalInfection|System.Boolean|XRL.World.GameObject|System.String|XRL.World.Anatomy.BodyPart",
         "XRL.World.Effects.FungalSporeInfection|FireEvent|System.Boolean|XRL.World.Event",
     })]
+    [TestCase(typeof(OldSaveContinueMenuTranslationPatch), new[]
+    {
+        "Qud.UI.MainMenu|ContinueMenu|System.Threading.Tasks.Task`1[[XRL.XRLGame]]",
+        "Qud.UI.SaveManagement|ContinueMenu|System.Threading.Tasks.Task`1[[XRL.XRLGame]]",
+    })]
     [TestCase(typeof(HealingTranslationPatch), new[]
     {
         "XRL.World.Effects.Healing|HandleEvent|System.Boolean|XRL.World.UseEnergyEvent",

--- a/Mods/QudJP/Assemblies/src/Patches/OldSaveContinueMenuTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/OldSaveContinueMenuTranslationPatch.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class OldSaveContinueMenuTranslationPatch
+{
+    private const string Context = nameof(OldSaveContinueMenuTranslationPatch);
+
+    [ThreadStatic]
+    private static int activeDepth;
+
+    [HarmonyTargetMethods]
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        var targets = new List<MethodBase>();
+        AddTarget(targets, "Qud.UI.MainMenu", "ContinueMenu");
+        AddTarget(targets, "Qud.UI.SaveManagement", "ContinueMenu");
+        return targets;
+    }
+
+    public static void Prefix()
+    {
+        try
+        {
+            OwnerTranslationScope.Enter(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+
+    public static Exception? Finalizer(Exception? __exception)
+    {
+        try
+        {
+            OwnerTranslationScope.Exit(ref activeDepth);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Finalizer failed: {1}", Context, ex);
+        }
+
+        return __exception;
+    }
+
+    internal static bool TryTranslatePopupMessage(string source, string route, string family, out string translated)
+    {
+        if (!OwnerTranslationScope.IsActive(activeDepth) || string.IsNullOrEmpty(source))
+        {
+            translated = source;
+            return false;
+        }
+
+        if (MessageFrameTranslator.TryStripDirectTranslationMarker(source, out var markedText))
+        {
+            translated = markedText;
+            return true;
+        }
+
+        translated = PopupTranslationPatch.TranslatePopupTextForProducerRoute(source, Context);
+        if (string.Equals(translated, source, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        DynamicTextObservability.RecordTransform(route, family + "." + Context, source, translated);
+        return true;
+    }
+
+    private static void AddTarget(List<MethodBase> targets, string typeName, string methodName)
+    {
+        var targetType = AccessTools.TypeByName(typeName);
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type not found: {1}.", Context, typeName);
+            return;
+        }
+
+        var method = AccessTools.Method(targetType, methodName, Type.EmptyTypes);
+        if (method is not null)
+        {
+            targets.Add(method);
+            return;
+        }
+
+        Trace.TraceError("QudJP: {0}.{1}.{2} target not found.", Context, typeName, methodName);
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs
@@ -33,6 +33,7 @@ internal static class PopupShowSemanticPipeline
         StatusScreenPopupTranslationPatch.TryTranslatePopupMessage,
         TeleprojectorTranslationPatch.TryTranslatePopupMessage,
         CyberneticsMedassistModuleTranslationPatch.TryTranslatePopupMessage,
+        OldSaveContinueMenuTranslationPatch.TryTranslatePopupMessage,
         LiquidLoaderTranslationPatch.TryTranslatePopupMessage,
         LiquidVolumeTranslationPatch.TryTranslatePopupMessage,
         MutatingTranslationPatch.TryTranslatePopupMessage,

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -4941,6 +4941,84 @@ COVERED_OWNER_FAMILIES: Final = (
             ),
         ),
     ),
+    CoveredOwnerFamily(
+        family_id="Qud.UI/MainMenu.cs::Qud.UI.MainMenu.ContinueMenu",
+        inventory_statuses=("owner_patch_required",),
+        evidence_files=(
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/OldSaveContinueMenuTranslationPatch.cs",
+                ("TryTranslatePopupMessage", "Qud.UI.MainMenu", "Qud.UI.SaveManagement"),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                ("OldSaveContinueMenuTranslationPatch.TryTranslatePopupMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+                (
+                    "That save file looks like it's from an older save format revision ({0}). Sorry!",
+                    "このセーブデータは古いフォーマット",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/OldSaveContinueMenuTranslationPatchTests.cs",
+                (
+                    "Patch_TranslatesOldSavePopup_WhenOwnerPatched",
+                    "TryTranslatePopupMessage_DoesNotClaimOldSavePopup_WhenOwnerAbsent",
+                    "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+                    "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                    "nameof(DummyOldSaveContinueMenuTarget.MainMenuContinueMenu)",
+                    "nameof(DummyOldSaveContinueMenuTarget.SaveManagementContinueMenu)",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                (
+                    "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
+                    "Qud.UI.MainMenu|ContinueMenu|System.Threading.Tasks.Task`1[[XRL.XRLGame]]",
+                ),
+            ),
+        ),
+    ),
+    CoveredOwnerFamily(
+        family_id="Qud.UI/SaveManagement.cs::Qud.UI.SaveManagement.ContinueMenu",
+        inventory_statuses=("owner_patch_required",),
+        evidence_files=(
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/OldSaveContinueMenuTranslationPatch.cs",
+                ("TryTranslatePopupMessage", "Qud.UI.MainMenu", "Qud.UI.SaveManagement"),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                ("OldSaveContinueMenuTranslationPatch.TryTranslatePopupMessage",),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+                (
+                    "That save file looks like it's from an older save format revision ({0}). Sorry!",
+                    "このセーブデータは古いフォーマット",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/OldSaveContinueMenuTranslationPatchTests.cs",
+                (
+                    "Patch_TranslatesOldSavePopup_WhenOwnerPatched",
+                    "TryTranslatePopupMessage_DoesNotClaimOldSavePopup_WhenOwnerAbsent",
+                    "Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched",
+                    "Patch_LeavesEmptyPopupUnchanged_WhenOwnerPatched",
+                    "nameof(DummyOldSaveContinueMenuTarget.MainMenuContinueMenu)",
+                    "nameof(DummyOldSaveContinueMenuTarget.SaveManagementContinueMenu)",
+                ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+                (
+                    "OwnerProducerTargetMethods_ResolveExpectedFullSignatures",
+                    "Qud.UI.SaveManagement|ContinueMenu|System.Threading.Tasks.Task`1[[XRL.XRLGame]]",
+                ),
+            ),
+        ),
+    ),
     *_examiner_result_popup_families(),
 )
 COVERED_OWNER_FAMILY_IDS: Final = frozenset(family.family_id for family in COVERED_OWNER_FAMILIES)


### PR DESCRIPTION
## Summary
- add an owner-scoped popup translator for MainMenu/SaveManagement old-save ContinueMenu prompts
- add L2 ShowAsync owner-route evidence, direct-marker, empty, and owner-absent tests
- register the two fully covered owner families in static producer closure evidence

## Verification
- Red: OldSaveContinueMenuTranslationPatchTests failed before pipeline registration because owner-route hit count stayed 0
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~OldSaveContinueMenuTranslationPatchTests' --no-restore --logger 'console;verbosity=normal'
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter 'FullyQualifiedName~OwnerProducerTargetMethods_ResolveExpectedFullSignatures' --no-restore --logger 'console;verbosity=normal'
- just static-producer-check
- git diff --check

Queue delta: main 337 families / 940 callsites / 961 text args -> branch 335 families / 938 callsites / 959 text args.