### PR TITLE
Optimize CI and local test runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,16 @@ jobs:
         run: >
           dotnet test Mods/QudJP/Assemblies/QudJP.Tests/bin/Release/net10.0/QudJP.Tests.dll
           --filter "TestCategory=${{ matrix.category }}"
+          --logger "trx;LogFileName=qudjp-${{ matrix.category }}.trx"
+          --results-directory TestResults/qudjp-${{ matrix.category }}
+
+      - name: Upload QudJP ${{ matrix.category }} test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qudjp-test-results-${{ matrix.category }}
+          path: TestResults/qudjp-${{ matrix.category }}/*.trx
+          if-no-files-found: ignore
 
   roslyn-tools:
     runs-on: ubuntu-latest

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -161,7 +161,7 @@ public sealed class ColorTagAllowlistCoverageTests
             ["Mods/QudJP/Assemblies/src/Patches/ZoneWindChangeTranslationPatch.cs:114:TryTranslate"] = "Delegates capture and whole-boundary restoration to matched owner-route branches.",
             ["Mods/QudJP/Assemblies/src/Translation/ColorAwareTranslationComposer.cs:30:Strip"] = "Wrapper method exposes the Strip API; callers are checked where they consume the returned spans.",
             ["Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs:77:Translate"] = "Passes stripped text and spans to TranslateStripped, where template application restores colors.",
-            ["Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs:82:Translate"] = "Passes stripped text and spans to TranslateStripped, where template application restores colors.",
+            ["Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs:85:Translate"] = "Passes stripped text and spans to TranslateStripped, where template application restores colors.",
             ["Mods/QudJP/Assemblies/src/UI/FontManager.cs:250:TryWarmPrimaryFontCharactersForUi"] = "UI glyph warmup intentionally strips markup only to add visible characters to the font atlas.",
         };
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -1271,6 +1271,26 @@ public sealed class MessagePatternTranslatorTests
     }
 
     [Test]
+    public void Translate_ReusesLoadedPatternFile_WhenSamePathIsSelectedAgain()
+    {
+        WritePatternDictionary(("^You hear (.+?)[.!]?$", "あなたは{0}を聞いた"));
+        _ = MessagePatternTranslator.Translate("You hear thunder.");
+        Assert.That(MessagePatternTranslator.LoadInvocationCount, Is.EqualTo(1));
+
+        MessagePatternTranslator.SetPatternFileForTests(patternFilePath);
+        var translated = string.Empty;
+        var output = TestTraceHelper.CaptureTrace(() =>
+            translated = MessagePatternTranslator.Translate("You hear rain."));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.EqualTo("あなたはrainを聞いた"));
+            Assert.That(MessagePatternTranslator.LoadInvocationCount, Is.EqualTo(0));
+            Assert.That(output, Does.Not.Contain("loaded 1 pattern(s)"));
+        });
+    }
+
+    [Test]
     public void Translate_RepeatedMissingPatternsRemainMeasurable()
     {
         WritePatternDictionary(("^You equip (.+)[.!]?$", "{0}を装備した"));
@@ -1496,6 +1516,7 @@ public sealed class MessagePatternTranslatorTests
     private void WritePatternFile(string content)
     {
         File.WriteAllText(patternFilePath, content, Utf8WithoutBom);
+        MessagePatternTranslator.InvalidatePatternFileCacheForTests(patternFilePath);
     }
 
     private void WriteMutationsXml(params (string name, string displayName)[] entries)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
@@ -28,6 +28,7 @@ public sealed class CombatAndLogMessageQueuePatchTests
         QuestLifecyclePopupTranslationPatch.ResetForTests();
         MessagePatternTranslator.SetPatternFileForTests(patternFilePath);
         File.WriteAllText(patternFilePath, "{\"patterns\":[]}\n", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        MessagePatternTranslator.InvalidatePatternFileCacheForTests(patternFilePath);
         DummyMessageQueue.Reset();
         DummyPopupShow.Reset();
     }
@@ -4580,47 +4581,52 @@ public sealed class CombatAndLogMessageQueuePatchTests
         }
     }
 
-    [TestCase("You take 1 damage from bleeding.", "あなたは出血で1ダメージを受けた。")]
-    [TestCase("The ワニ hits (x1) for 2 damage with his 噛みつき. [18]", "ワニの噛みつきで2ダメージを受けた。(x1) [18]")]
-    [TestCase("The ワニ critically hits (x1) for 2 damage with his 噛みつき. [18]", "ワニの噛みつきが会心し、2ダメージを受けた。(x1) [18]")]
-    [TestCase("You hit glowfish for 3 damage.", "glowfishに3ダメージを与えた")]
-    [TestCase("You miss with your レンチ! [10 vs 10]", "レンチでの攻撃は外れた。[10 vs 10]")]
-    [TestCase("The タム fails to penetrate your armor [17]!", "タムはあなたの装甲を貫けなかった！ [17]")]
-    [TestCase("Your 鉛スラッグ fails to penetrate the フォームクリートの armor!", "あなたの鉛スラッグはフォームクリートの装甲を貫けなかった！")]
-    [TestCase("The ワニ cannot reach the スナップジョー.", "ワニはスナップジョーに届かない")]
-    [TestCase("Your attack passes through the ワニ!", "あなたの攻撃はワニをすり抜けた！")]
-    [TestCase("One of タムの wounds stops bleeding.", "タムの傷のひとつの出血が止まった。")]
-    [TestCase("The タム's nose begins to bleed.", "タムの鼻から血が流れ始めた")]
-    [TestCase("The タム's brain begins to hemorrhage.", "タムの脳から出血が始まった")]
-    [TestCase("The ウォーターヴァイン農家 misses you with his 鉄の蔓刈り斧! [3 vs 7]", "ウォーターヴァイン農家の鉄の蔓刈り斧は外れた。[3 vs 7]")]
-    [TestCase("Poisonous goo burns your eyes.", "有毒な粘液が目に染みた。")]
-    [TestCase("Putrid ooze splashes into your mouth. You gag at the awful taste.", "腐った軟泥が口に入った。ひどい味に吐き気を催した。")]
-    [TestCase("Brown sludge splashes into your mouth. You wince at the metallic taste.", "茶色い汚泥が口に入った。金属の味に顔をしかめた。")]
-    [TestCase("The liquids stop reacting.", "液体の反応が止まった")]
-    [TestCase("The reacting liquids congeal into a SoupSludge.", "反応した液体が凝固しSoupSludgeになった")]
-    [TestCase("The primordial soup nearby starts reacting with the water.", "nearbyの原初のスープがwaterと反応を始めた")]
-    [TestCase("You receive tinkering bits <{{|AB}}>.", "修理ビット<{{|AB}}>を受け取った。")]
-    [TestCase("You receive 奇妙な小物!", "奇妙な小物を受け取った")]
-    [TestCase("You make some progress disarming 地雷.", "地雷の解除が少し進んだ。")]
-    [TestCase("You reload your クローム・リボルバー with 鉛スラッグ x6.", "クローム・リボルバーに鉛スラッグ x6を装填した")]
-    [TestCase("You toggle {{c|Akimbo}} on.", "{{c|二挺拳銃}}をオンにした。")]
-    [TestCase("You toggle {{c|Akimbo}} off.", "{{c|二挺拳銃}}をオフにした。")]
-    [TestCase("An image of タム disappears.", "タムの映像が消えた。")]
-    [TestCase("The 熊's carapace loosens.", "熊の甲殻が緩んだ")]
-    [TestCase("熊の carapace loosens.", "熊の甲殻が緩んだ")]
-    [TestCase("The zealot mumbles inaudibly, encased in ice.", "氷に閉じ込められた狂信者が、聞き取れないほどに呟いた。")]
-    [TestCase("The infected crust of skin on 熊の left arm loosens and breaks away.", "熊の left armの感染した皮膚の痂皮が緩んで剥がれ落ちた。")]
-    [TestCase("You lose 3 HP.", "あなたは3HPを失った")]
-    [TestCase("You recover 5 HP.", "あなたは5HP回復した")]
-    [TestCase("You take 14 damage from 監視官イラメの freezing effect!", "監視官イラメの凍結効果で14ダメージを受けた！")]
-    [TestCase("You take 6 damage from ドリンクスの pyrokinesis!", "ドリンクスの熱念動で6ダメージを受けた！")]
-    [TestCase("The air here starts to shimmer with heat!", "このあたりの空気が熱で揺らめき始めた！")]
-    [TestCase("The air here ceases shimmering with heat.", "このあたりの空気の熱による揺らめきが収まった。")]
-    [TestCase("You harvest a ヴァインウェハー from the ウォーターヴァイン.", "ウォーターヴァインからヴァインウェハーを収穫した")]
-    [TestCase("カロク begins flying.", "カロクが飛翔し始めた。")]
-    [TestCase("シュウラシュウォレム harvests a スターアップル.", "シュウラシュウォレムはスターアップルを収穫した。")]
-    public void MessagingEmitMessage_TranslatesStableRepositoryFamilies_WhenPatched(string message, string expected)
+    [Test]
+    public void MessagingEmitMessage_TranslatesStableRepositoryFamilies_WhenPatched()
     {
+        var cases = new (string Message, string Expected)[]
+        {
+            ("You take 1 damage from bleeding.", "あなたは出血で1ダメージを受けた。"),
+            ("The ワニ hits (x1) for 2 damage with his 噛みつき. [18]", "ワニの噛みつきで2ダメージを受けた。(x1) [18]"),
+            ("The ワニ critically hits (x1) for 2 damage with his 噛みつき. [18]", "ワニの噛みつきが会心し、2ダメージを受けた。(x1) [18]"),
+            ("You hit glowfish for 3 damage.", "glowfishに3ダメージを与えた"),
+            ("You miss with your レンチ! [10 vs 10]", "レンチでの攻撃は外れた。[10 vs 10]"),
+            ("The タム fails to penetrate your armor [17]!", "タムはあなたの装甲を貫けなかった！ [17]"),
+            ("Your 鉛スラッグ fails to penetrate the フォームクリートの armor!", "あなたの鉛スラッグはフォームクリートの装甲を貫けなかった！"),
+            ("The ワニ cannot reach the スナップジョー.", "ワニはスナップジョーに届かない"),
+            ("Your attack passes through the ワニ!", "あなたの攻撃はワニをすり抜けた！"),
+            ("One of タムの wounds stops bleeding.", "タムの傷のひとつの出血が止まった。"),
+            ("The タム's nose begins to bleed.", "タムの鼻から血が流れ始めた"),
+            ("The タム's brain begins to hemorrhage.", "タムの脳から出血が始まった"),
+            ("The ウォーターヴァイン農家 misses you with his 鉄の蔓刈り斧! [3 vs 7]", "ウォーターヴァイン農家の鉄の蔓刈り斧は外れた。[3 vs 7]"),
+            ("Poisonous goo burns your eyes.", "有毒な粘液が目に染みた。"),
+            ("Putrid ooze splashes into your mouth. You gag at the awful taste.", "腐った軟泥が口に入った。ひどい味に吐き気を催した。"),
+            ("Brown sludge splashes into your mouth. You wince at the metallic taste.", "茶色い汚泥が口に入った。金属の味に顔をしかめた。"),
+            ("The liquids stop reacting.", "液体の反応が止まった"),
+            ("The reacting liquids congeal into a SoupSludge.", "反応した液体が凝固しSoupSludgeになった"),
+            ("The primordial soup nearby starts reacting with the water.", "nearbyの原初のスープがwaterと反応を始めた"),
+            ("You receive tinkering bits <{{|AB}}>.", "修理ビット<{{|AB}}>を受け取った。"),
+            ("You receive 奇妙な小物!", "奇妙な小物を受け取った"),
+            ("You make some progress disarming 地雷.", "地雷の解除が少し進んだ。"),
+            ("You reload your クローム・リボルバー with 鉛スラッグ x6.", "クローム・リボルバーに鉛スラッグ x6を装填した"),
+            ("You toggle {{c|Akimbo}} on.", "{{c|二挺拳銃}}をオンにした。"),
+            ("You toggle {{c|Akimbo}} off.", "{{c|二挺拳銃}}をオフにした。"),
+            ("An image of タム disappears.", "タムの映像が消えた。"),
+            ("The 熊's carapace loosens.", "熊の甲殻が緩んだ"),
+            ("熊の carapace loosens.", "熊の甲殻が緩んだ"),
+            ("The zealot mumbles inaudibly, encased in ice.", "氷に閉じ込められた狂信者が、聞き取れないほどに呟いた。"),
+            ("The infected crust of skin on 熊の left arm loosens and breaks away.", "熊の left armの感染した皮膚の痂皮が緩んで剥がれ落ちた。"),
+            ("You lose 3 HP.", "あなたは3HPを失った"),
+            ("You recover 5 HP.", "あなたは5HP回復した"),
+            ("You take 14 damage from 監視官イラメの freezing effect!", "監視官イラメの凍結効果で14ダメージを受けた！"),
+            ("You take 6 damage from ドリンクスの pyrokinesis!", "ドリンクスの熱念動で6ダメージを受けた！"),
+            ("The air here starts to shimmer with heat!", "このあたりの空気が熱で揺らめき始めた！"),
+            ("The air here ceases shimmering with heat.", "このあたりの空気の熱による揺らめきが収まった。"),
+            ("You harvest a ヴァインウェハー from the ウォーターヴァイン.", "ウォーターヴァインからヴァインウェハーを収穫した"),
+            ("カロク begins flying.", "カロクが飛翔し始めた。"),
+            ("シュウラシュウォレム harvests a スターアップル.", "シュウラシュウォレムはスターアップルを収穫した。"),
+        };
+
         UseRepositoryPatternDictionary();
 
         var harmonyId = CreateHarmonyId();
@@ -4643,10 +4649,17 @@ public sealed class CombatAndLogMessageQueuePatchTests
                     typeof(DummyGameObject)),
                 typeof(GameObjectEmitMessageTranslationPatch));
 
-            DummyMessagingEmitMessageTarget.MessageToSend = message;
-            DummyMessagingEmitMessageTarget.EmitMessage(new DummyGameObject(), "unused", 'W', false, false, false);
+            Assert.Multiple(() =>
+            {
+                foreach (var (message, expected) in cases)
+                {
+                    DummyMessageQueue.Reset();
+                    DummyMessagingEmitMessageTarget.MessageToSend = message;
+                    DummyMessagingEmitMessageTarget.EmitMessage(new DummyGameObject(), "unused", 'W', false, false, false);
 
-            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(expected));
+                    Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(expected), $"source: {message}");
+                }
+            });
         }
         finally
         {
@@ -5213,24 +5226,73 @@ public sealed class CombatAndLogMessageQueuePatchTests
         }
     }
 
-    [TestCase("You miss!", "攻撃は外れた！")]
-    [TestCase("You miss with your bronze dagger! [10 vs 14]", "bronze daggerでの攻撃は外れた。[10 vs 14]")]
-    [TestCase("You miss! [10 vs 14]", "攻撃は外れた！ [10 vs 14]")]
-    [TestCase("Snapjaw Scavenger misses you!", "Snapjaw Scavengerの攻撃は外れた")]
-    [TestCase("Snapjaw Scavenger misses you with its bronze dagger! [10 vs 14]", "Snapjaw Scavengerのbronze daggerは外れた。[10 vs 14]")]
-    [TestCase("Snapjaw Scavenger misses you! [10 vs 14]", "Snapjaw Scavengerの攻撃は外れた！ [10 vs 14]")]
-    [TestCase("Your mental attack does not affect Snapjaw Scavenger.", "あなたの精神攻撃はSnapjaw Scavengerに効かない。")]
-    [TestCase("You fail to deal damage with your attack! [17]", "あなたの攻撃はダメージを与えられなかった！ [17]")]
-    [TestCase("Snapjaw Scavenger fails to deal damage with its attack! [17]", "Snapjaw Scavengerの攻撃はダメージを与えられなかった！ [17]")]
-    [TestCase("You don't penetrate Snapjaw Scavenger's armor.", "Snapjaw Scavengerの装甲を貫けなかった！")]
-    [TestCase("You don't penetrate Snapjaw Scavenger's armor with your bronze dagger. [17]", "bronze daggerではSnapjaw Scavengerの装甲を貫けなかった！ [17]")]
-    [TestCase("You don't penetrate Snapjaw Scavenger's armor. [17]", "Snapjaw Scavengerの装甲を貫けなかった！ [17]")]
-    [TestCase("Snapjaw Scavenger doesn't penetrate your armor.", "Snapjaw Scavengerはあなたの装甲を貫けなかった！")]
-    [TestCase("Snapjaw Scavenger doesn't penetrate your armor with its bronze dagger! [17]", "Snapjaw Scavengerはbronze daggerであなたの装甲を貫けなかった！ [17]")]
-    [TestCase("Snapjaw Scavenger doesn't penetrate your armor! [17]", "Snapjaw Scavengerはあなたの装甲を貫けなかった！ [17]")]
-    public void CombatMeleeAttack_TranslatesInventoriedShapes_WithRepositoryPatterns(string source, string expected)
+    [Test]
+    public void CombatMeleeAttack_TranslatesInventoriedShapes_WithRepositoryPatterns()
     {
-        AssertCombatMeleeAttackQueuedMessageWithRepositoryPatterns(source, expected);
+        var cases = new (string Source, string Expected)[]
+        {
+            ("You miss!", "攻撃は外れた！"),
+            ("You miss with your bronze dagger! [10 vs 14]", "bronze daggerでの攻撃は外れた。[10 vs 14]"),
+            ("You miss! [10 vs 14]", "攻撃は外れた！ [10 vs 14]"),
+            ("Snapjaw Scavenger misses you!", "Snapjaw Scavengerの攻撃は外れた"),
+            ("Snapjaw Scavenger misses you with its bronze dagger! [10 vs 14]", "Snapjaw Scavengerのbronze daggerは外れた。[10 vs 14]"),
+            ("Snapjaw Scavenger misses you! [10 vs 14]", "Snapjaw Scavengerの攻撃は外れた！ [10 vs 14]"),
+            ("Your mental attack does not affect Snapjaw Scavenger.", "あなたの精神攻撃はSnapjaw Scavengerに効かない。"),
+            ("You fail to deal damage with your attack! [17]", "あなたの攻撃はダメージを与えられなかった！ [17]"),
+            ("Snapjaw Scavenger fails to deal damage with its attack! [17]", "Snapjaw Scavengerの攻撃はダメージを与えられなかった！ [17]"),
+            ("You don't penetrate Snapjaw Scavenger's armor.", "Snapjaw Scavengerの装甲を貫けなかった！"),
+            ("You don't penetrate Snapjaw Scavenger's armor with your bronze dagger. [17]", "bronze daggerではSnapjaw Scavengerの装甲を貫けなかった！ [17]"),
+            ("You don't penetrate Snapjaw Scavenger's armor. [17]", "Snapjaw Scavengerの装甲を貫けなかった！ [17]"),
+            ("Snapjaw Scavenger doesn't penetrate your armor.", "Snapjaw Scavengerはあなたの装甲を貫けなかった！"),
+            ("Snapjaw Scavenger doesn't penetrate your armor with its bronze dagger! [17]", "Snapjaw Scavengerはbronze daggerであなたの装甲を貫けなかった！ [17]"),
+            ("Snapjaw Scavenger doesn't penetrate your armor! [17]", "Snapjaw Scavengerはあなたの装甲を貫けなかった！ [17]"),
+        };
+
+        UseRepositoryPatternDictionary();
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(
+                    typeof(DummyCombatMeleeAttackTarget),
+                    nameof(DummyCombatMeleeAttackTarget.MeleeAttackWithWeaponInternal),
+                    typeof(DummyGameObject),
+                    typeof(DummyGameObject),
+                    typeof(DummyGameObject),
+                    typeof(DummyCombatBodyPart),
+                    typeof(string),
+                    typeof(int),
+                    typeof(int),
+                    typeof(int),
+                    typeof(int),
+                    typeof(int),
+                    typeof(bool),
+                    typeof(bool)),
+                typeof(CombatTextSurfaceTranslationPatch));
+
+            var target = new DummyCombatMeleeAttackTarget();
+
+            Assert.Multiple(() =>
+            {
+                foreach (var (source, expected) in cases)
+                {
+                    DummyMessageQueue.Reset();
+                    target.MessageToSend = source;
+
+                    _ = target.MeleeAttackWithWeaponInternal(new DummyGameObject(), new DummyGameObject(), new DummyGameObject(), new DummyCombatBodyPart());
+
+                    Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(expected), $"source: {source}");
+                }
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
     }
 
     [Test]
@@ -8016,6 +8078,7 @@ public sealed class CombatAndLogMessageQueuePatchTests
         builder.AppendLine();
 
         File.WriteAllText(patternFilePath, builder.ToString(), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        MessagePatternTranslator.InvalidatePatternFileCacheForTests(patternFilePath);
     }
 
     private void WriteLeafDictionary(params (string key, string text)[] entries)

--- a/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
@@ -17,6 +17,8 @@ internal static class MessagePatternTranslator
     private static readonly object SyncRoot = new object();
     private static readonly ConcurrentDictionary<string, Regex> RegexCache =
         new ConcurrentDictionary<string, Regex>(StringComparer.Ordinal);
+    private static readonly ConcurrentDictionary<string, CachedPatternFile> PatternFileCache =
+        new ConcurrentDictionary<string, CachedPatternFile>(StringComparer.Ordinal);
     private static readonly Regex JapaneseCharacterPattern =
         new Regex("[\\p{IsHiragana}\\p{IsKatakana}\\p{IsCJKUnifiedIdeographs}]", RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly ConcurrentDictionary<string, int> MissingPatternCounts =
@@ -25,6 +27,7 @@ internal static class MessagePatternTranslator
         new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
 
     private static List<MessagePatternDefinition>? loadedPatterns;
+    private static string? loadedPatternFilePath;
     private static Dictionary<string, string>? leafDictionary;
     private static string? patternFileOverride;
     private static string? leafFileOverride;
@@ -88,17 +91,50 @@ internal static class MessagePatternTranslator
         return TranslateStripped(stripped, spans);
     }
 
+    private sealed class CachedPatternFile
+    {
+        public CachedPatternFile(List<MessagePatternDefinition> patterns, string summary)
+        {
+            Patterns = patterns;
+            Summary = summary;
+        }
+
+        public List<MessagePatternDefinition> Patterns { get; }
+        public string Summary { get; }
+    }
+
     internal static void SetPatternFileForTests(string? filePath)
     {
         lock (SyncRoot)
         {
             patternFileOverride = filePath;
             loadedPatterns = null;
-            RegexCache.Clear();
+            loadedPatternFilePath = null;
             MissingPatternCounts.Clear();
             MissingRouteCounts.Clear();
             patternLoadSummary = "MessagePatternTranslator: pattern load summary unavailable.";
             Interlocked.Exchange(ref loadInvocationCount, 0);
+        }
+    }
+
+    // Required after a test rewrites the contents of a previously selected temp pattern file.
+    internal static void InvalidatePatternFileCacheForTests(string? filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            return;
+        }
+
+        var canonicalPath = GetCanonicalPath(filePath!);
+        lock (SyncRoot)
+        {
+            PatternFileCache.TryRemove(canonicalPath, out _);
+            if (string.Equals(loadedPatternFilePath, canonicalPath, StringComparison.Ordinal))
+            {
+                loadedPatterns = null;
+                loadedPatternFilePath = null;
+                patternLoadSummary = "MessagePatternTranslator: pattern load summary unavailable.";
+            }
         }
     }
 
@@ -255,29 +291,39 @@ internal static class MessagePatternTranslator
 
     private static List<MessagePatternDefinition> GetLoadedPatterns()
     {
+        var patternFilePath = ResolvePatternFilePath();
         var cached = Volatile.Read(ref loadedPatterns);
-        if (cached is not null)
+        if (cached is not null
+            && string.Equals(Volatile.Read(ref loadedPatternFilePath), patternFilePath, StringComparison.Ordinal))
         {
             return cached;
         }
 
         lock (SyncRoot)
         {
-            if (loadedPatterns is null)
+            if (loadedPatterns is null
+                || !string.Equals(loadedPatternFilePath, patternFilePath, StringComparison.Ordinal))
             {
-                loadedPatterns = LoadPatterns();
+                loadedPatterns = LoadPatterns(patternFilePath);
+                loadedPatternFilePath = patternFilePath;
             }
 
             return loadedPatterns;
         }
     }
 
-    private static List<MessagePatternDefinition> LoadPatterns()
+    private static List<MessagePatternDefinition> LoadPatterns(string patternFilePath)
+    {
+        var cached = PatternFileCache.GetOrAdd(patternFilePath, LoadPatternFile);
+        patternLoadSummary = cached.Summary;
+        return cached.Patterns;
+    }
+
+    private static CachedPatternFile LoadPatternFile(string patternFilePath)
     {
         using var timing = RuntimeStartupTiming.Measure("message_pattern.load_patterns");
         Interlocked.Increment(ref loadInvocationCount);
 
-        var patternFilePath = ResolvePatternFilePath();
         if (!File.Exists(patternFilePath))
         {
             throw new FileNotFoundException(
@@ -319,23 +365,28 @@ internal static class MessagePatternTranslator
             definitions.Add(new MessagePatternDefinition(pattern, template));
         }
 
-        patternLoadSummary =
+        var summary =
             $"MessagePatternTranslator: loaded {definitions.Count} pattern(s) from '{patternFilePath}' " +
             $"({seenPatterns.Count} unique, {duplicatePatternCount} duplicate pattern(s) across {duplicatePatternCounts.Count} distinct pattern(s)).";
-        LogObservability($"[QudJP] {patternLoadSummary}");
+        LogObservability($"[QudJP] {summary}");
         LogDuplicatePatternSummary(duplicatePatternCounts);
 
-        return definitions;
+        return new CachedPatternFile(definitions, summary);
     }
 
     private static string ResolvePatternFilePath()
     {
         if (!string.IsNullOrWhiteSpace(patternFileOverride))
         {
-            return Path.GetFullPath(patternFileOverride);
+            return GetCanonicalPath(patternFileOverride!);
         }
 
-        return LocalizationAssetResolver.GetLocalizationPath("Dictionaries/messages.ja.json");
+        return GetCanonicalPath(LocalizationAssetResolver.GetLocalizationPath("Dictionaries/messages.ja.json")!);
+    }
+
+    private static string GetCanonicalPath(string path)
+    {
+        return Path.GetFullPath(path);
     }
 
     private static Regex GetCompiledRegex(string pattern)

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -279,6 +279,14 @@ Producer or queue-gated patches that translate traffic before a generic sink mus
 
 If a route can emit articles, generated names, quantities, or placeholder-like fragments, include those emitted shapes in tests instead of replacing them with dictionary leaves.
 
+For additions to an already-proven route family, keep runtime coverage scalable.
+Prefer static inventory or data-contract coverage for the expanded string set,
+plus one L2 smoke case that proves the existing owner route still hands traffic
+to the shared translator. Do not add one new Harmony patch/unpatch test case for every newly claimed string.
+When many repository-backed examples must exercise
+the same owner route, batch the examples under one patch setup and preserve each
+source/expected pair with case-specific assertion messages.
+
 ## Repo constraints
 
 - Do not commit `Assembly-CSharp.dll` or other game binaries.

--- a/docs/superpowers/plans/2026-05-13-test-runtime-scalability.md
+++ b/docs/superpowers/plans/2026-05-13-test-runtime-scalability.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Build-Once Local C# Test Entrypoint
+## Task 1: Build-Once Local C# Test Entrypoint
 
 **Files:**
 - Modify: `justfile`
@@ -51,7 +51,7 @@ Expected: PASS.
 Run: `/usr/bin/time -p just test-csharp`
 Expected: all C# tests pass. Current measured result after cache and batching work: 4297 passed in `real 32.46`.
 
-### Task 2: CI Test Result Visibility
+## Task 2: CI Test Result Visibility
 
 **Files:**
 - Modify: `.github/workflows/ci.yml`
@@ -89,7 +89,7 @@ Add TRX logger and `actions/upload-artifact@v4` for the C# matrix job.
 Run: `uv run pytest scripts/tests/test_ci_workflow_contract.py -q`
 Expected: PASS.
 
-### Task 3: Python Slow-Test Visibility
+## Task 3: Python Slow-Test Visibility
 
 **Files:**
 - Modify: `pyproject.toml`
@@ -103,7 +103,7 @@ Change pytest `addopts` from `--durations=10` to `--durations=20`.
 Run: `just python-test`
 Expected: PASS and slowest 20 durations printed. Current measured result: 1086 passed, 1 skipped in 37.16 seconds.
 
-### Task 4: Production Message Pattern Load Reuse
+## Task 4: Production Message Pattern Load Reuse
 
 **Files:**
 - Modify: `Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs`
@@ -197,7 +197,7 @@ just test-l2
 
 Actual: PASS. Current measured results: `just test-l1` 2209 passed in `real 36.03`, `just test-l2` 1768 passed in `real 56.80`.
 
-### Task 5: Batch High-Cost L2 Repository-Family Tests
+## Task 5: Batch High-Cost L2 Repository-Family Tests
 
 **Files:**
 - Modify: `Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs`
@@ -221,7 +221,7 @@ Run a focused L2 command against the changed method names if possible, then run 
 
 Actual: PASS with fewer NUnit result rows and lower L2 runtime because repeated patch/unpatch setup has been removed.
 
-### Task 6: Scalable Test-Addition Rules
+## Task 6: Scalable Test-Addition Rules
 
 **Files:**
 - Modify: `docs/test-architecture.md`
@@ -253,7 +253,7 @@ Add L2 scalability guidance to `docs/test-architecture.md` and route-family addi
 Run: `uv run pytest scripts/tests/test_qudjp_dotnet_test_contracts.py::test_route_family_test_guidance_limits_l2_case_growth -q`
 Expected: PASS.
 
-### Task 7: Polishment, Draft PR, and PR Convergence
+## Task 7: Polishment, Draft PR, and PR Convergence
 
 **Files:**
 - Current diff only.

--- a/docs/superpowers/plans/2026-05-13-test-runtime-scalability.md
+++ b/docs/superpowers/plans/2026-05-13-test-runtime-scalability.md
@@ -1,0 +1,286 @@
+# Test Runtime Scalability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce local C# verification time, slow-test growth pressure, and make CI/Python/C# runtime regressions easier to diagnose without deleting test coverage.
+
+**Architecture:** Keep test coverage intact. Remove repeated local build/VSTest startup costs in `justfile`, add CI-visible timing artifacts, cache immutable production message pattern loads by canonical path, batch same-route L2 repository-family examples under one Harmony setup, and document a rule that future owner-family additions should use data/static contracts plus small runtime smoke coverage instead of one Harmony setup per string.
+
+**Tech Stack:** `just`, GitHub Actions, pytest, NUnit, .NET 10, C# static translator helpers.
+
+---
+
+### Task 1: Build-Once Local C# Test Entrypoint
+
+**Files:**
+- Modify: `justfile`
+- Test: `scripts/tests/test_qudjp_dotnet_test_contracts.py`
+
+- [x] **Step 1: Write the failing contract**
+
+```python
+def test_local_csharp_full_suite_builds_test_project_once() -> None:
+    """The local all-C# test entrypoint should avoid per-category build and VSTest startup."""
+    justfile = "\n" + JUSTFILE.read_text(encoding="utf-8")
+    recipe = _recipe_block(justfile, "test-csharp", "python-check")
+    check_recipe = _recipe_block(justfile, "check", "pr-check")
+
+    assert "dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj" in recipe
+    assert recipe.count("dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj") == 1
+    assert recipe.count('dotnet test "$test_dll"') == 1
+    assert "TestCategory=" not in recipe
+
+    assert "test-csharp" in check_recipe
+    assert "test-l1 test-l2 test-l2g" not in check_recipe
+```
+
+- [x] **Step 2: Verify RED**
+
+Run: `uv run pytest scripts/tests/test_qudjp_dotnet_test_contracts.py -q`
+Expected: FAIL because `test-csharp` does not exist, then because it still runs per-category filters.
+
+- [x] **Step 3: Implement the recipe**
+
+Add `test-csharp` to build `QudJP.Tests.csproj` once into an isolated artifacts root, then run `dotnet test "$test_dll"` once. Update `check` to depend on `test-csharp`.
+
+- [x] **Step 4: Verify GREEN and measure**
+
+Run: `uv run pytest scripts/tests/test_qudjp_dotnet_test_contracts.py -q`
+Expected: PASS.
+
+Run: `/usr/bin/time -p just test-csharp`
+Expected: all C# tests pass. Current measured result after cache and batching work: 4297 passed in `real 32.46`.
+
+### Task 2: CI Test Result Visibility
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Test: `scripts/tests/test_ci_workflow_contract.py`
+
+- [x] **Step 1: Write the failing contract**
+
+```python
+def test_ci_qudjp_test_matrix_uploads_category_test_results() -> None:
+    """C# matrix legs should publish per-category TRX results for timing and failure review."""
+    workflow = _workflow_text()
+    job = _job_block(workflow, "qudjp-dotnet-test", "roslyn-tools")
+
+    assert '--logger "trx;LogFileName=qudjp-${{ matrix.category }}.trx"' in job
+    assert "--results-directory TestResults/qudjp-${{ matrix.category }}" in job
+    assert "Upload QudJP ${{ matrix.category }} test results" in job
+    assert "if: always()" in job
+    assert "uses: actions/upload-artifact@v4" in job
+    assert "name: qudjp-test-results-${{ matrix.category }}" in job
+    assert "path: TestResults/qudjp-${{ matrix.category }}/*.trx" in job
+    assert "if-no-files-found: ignore" in job
+```
+
+- [x] **Step 2: Verify RED**
+
+Run: `uv run pytest scripts/tests/test_ci_workflow_contract.py -q`
+Expected: FAIL because TRX logging/artifact upload is absent.
+
+- [x] **Step 3: Implement workflow visibility**
+
+Add TRX logger and `actions/upload-artifact@v4` for the C# matrix job.
+
+- [x] **Step 4: Verify GREEN**
+
+Run: `uv run pytest scripts/tests/test_ci_workflow_contract.py -q`
+Expected: PASS.
+
+### Task 3: Python Slow-Test Visibility
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [x] **Step 1: Expand duration reporting**
+
+Change pytest `addopts` from `--durations=10` to `--durations=20`.
+
+- [x] **Step 2: Verify Python suite**
+
+Run: `just python-test`
+Expected: PASS and slowest 20 durations printed. Current measured result: 1086 passed, 1 skipped in 37.16 seconds.
+
+### Task 4: Production Message Pattern Load Reuse
+
+**Files:**
+- Modify: `Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs`
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs`
+
+- [x] **Step 1: Write failing test for same-file reuse across resets**
+
+Add this test to `MessagePatternTranslatorTests` near `Translate_LoadsPatternFileOnlyOnce_WhenCalledRepeatedly`:
+
+```csharp
+[Test]
+public void Translate_ReusesLoadedPatternFile_WhenSamePathIsSelectedAgain()
+{
+    WritePatternDictionary(("^You hear (.+?)[.!]?$", "あなたは{0}を聞いた"));
+    _ = MessagePatternTranslator.Translate("You hear thunder.");
+
+    MessagePatternTranslator.SetPatternFileForTests(patternFilePath);
+    var translated = string.Empty;
+    var output = TestTraceHelper.CaptureTrace(() =>
+        translated = MessagePatternTranslator.Translate("You hear rain."));
+
+    Assert.Multiple(() =>
+    {
+        Assert.That(translated, Is.EqualTo("あなたはrainを聞いた"));
+        Assert.That(MessagePatternTranslator.LoadInvocationCount, Is.EqualTo(0));
+        Assert.That(output, Does.Not.Contain("loaded 1 pattern(s)"));
+    });
+}
+```
+
+- [x] **Step 2: Verify RED**
+
+Run:
+
+```bash
+QUDJP_DOTNET_ARTIFACTS_ROOT=.artifacts/dotnet-pattern-cache-red2 just test-l1
+```
+
+Actual: FAIL on `Translate_ReusesLoadedPatternFile_WhenSamePathIsSelectedAgain` with `LoadInvocationCount` equal to `1` after the same file path was selected again.
+
+- [x] **Step 3: Implement canonical-path loaded pattern cache**
+
+In `MessagePatternTranslator.cs`, add:
+
+```csharp
+private static readonly ConcurrentDictionary<string, CachedPatternFile> PatternFileCache =
+    new ConcurrentDictionary<string, CachedPatternFile>(StringComparer.Ordinal);
+
+private sealed class CachedPatternFile
+{
+    public CachedPatternFile(List<MessagePatternDefinition> patterns, string summary)
+    {
+        Patterns = patterns;
+        Summary = summary;
+    }
+
+    public List<MessagePatternDefinition> Patterns { get; }
+    public string Summary { get; }
+}
+```
+
+Change `LoadPatterns()` so it resolves the full pattern path, then returns the cached `CachedPatternFile` when present. Only increment `loadInvocationCount`, parse JSON, and build the summary inside the cache factory. Keep `SetPatternFileForTests(...)` clearing active state and observability counters so file override switching still resets active state; do not clear `PatternFileCache` there.
+
+- [x] **Step 4: Add explicit cache invalidation for mutable temp files**
+
+Add an internal test-only method:
+
+```csharp
+internal static void InvalidatePatternFileCacheForTests(string? filePath)
+{
+    if (string.IsNullOrWhiteSpace(filePath))
+    {
+        return;
+    }
+
+    PatternFileCache.TryRemove(Path.GetFullPath(filePath), out _);
+}
+```
+
+Call it from `WritePatternDictionary(...)` in `MessagePatternTranslatorTests` and `CombatAndLogMessageQueuePatchTests` immediately after writing the mutable test dictionary file. This keeps temp-file rewrite tests correct while allowing stable repository dictionaries to be reused.
+
+- [x] **Step 5: Verify GREEN and focused runtime**
+
+Run:
+
+```bash
+uv run pytest scripts/tests/test_qudjp_dotnet_test_contracts.py -q
+just test-l1
+just test-l2
+```
+
+Actual: PASS. Current measured results: `just test-l1` 2209 passed in `real 36.03`, `just test-l2` 1768 passed in `real 56.80`.
+
+### Task 5: Batch High-Cost L2 Repository-Family Tests
+
+**Files:**
+- Modify: `Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs`
+
+- [x] **Step 1: Identify highest-impact same-route parameterized tests**
+
+Use the measured hot spot: `CombatAndLogMessageQueuePatchTests` accounts for most L2 runtime. Start with same Harmony owner/sink tests that currently repeat setup through many `[TestCase]` rows, especially:
+
+```text
+MessagingEmitMessage_TranslatesStableRepositoryFamilies_WhenPatched
+CombatMeleeAttack_TranslatesInventoriedShapes_WithRepositoryPatterns
+```
+
+- [x] **Step 2: Convert source/expected rows into explicit case arrays**
+
+Preserve every source/expected pair. Replace repeated `[TestCase]` execution with a single `[Test]` that creates one Harmony instance, patches once, loops through the case list, and asserts each case with a case-specific message.
+
+- [x] **Step 3: Verify focused L2 behavior**
+
+Run a focused L2 command against the changed method names if possible, then run `just test-l2`.
+
+Actual: PASS with fewer NUnit result rows and lower L2 runtime because repeated patch/unpatch setup has been removed.
+
+### Task 6: Scalable Test-Addition Rules
+
+**Files:**
+- Modify: `docs/test-architecture.md`
+- Modify: `docs/RULES.md`
+- Test: `scripts/tests/test_qudjp_dotnet_test_contracts.py`
+
+- [x] **Step 1: Write failing docs contract**
+
+Add `test_route_family_test_guidance_limits_l2_case_growth` to require:
+
+```python
+assert "batch them under one Harmony patch setup" in test_architecture
+assert "static inventory or data-contract coverage" in test_architecture
+assert "one L2 smoke case" in rules
+assert "Do not add one new Harmony patch/unpatch test case for every newly claimed string" in rules
+```
+
+- [x] **Step 2: Verify RED**
+
+Run: `uv run pytest scripts/tests/test_qudjp_dotnet_test_contracts.py::test_route_family_test_guidance_limits_l2_case_growth -q`
+Expected: FAIL before docs are updated.
+
+- [x] **Step 3: Update docs**
+
+Add L2 scalability guidance to `docs/test-architecture.md` and route-family addition guidance to `docs/RULES.md`.
+
+- [x] **Step 4: Verify GREEN**
+
+Run: `uv run pytest scripts/tests/test_qudjp_dotnet_test_contracts.py::test_route_family_test_guidance_limits_l2_case_growth -q`
+Expected: PASS.
+
+### Task 7: Polishment, Draft PR, and PR Convergence
+
+**Files:**
+- Current diff only.
+
+- [x] **Step 1: Run final deterministic checks**
+
+Run:
+
+```bash
+just test-csharp
+just python-test
+just python-check
+git diff --check
+```
+
+- [x] **Step 2: Independent review**
+
+Dispatch a fresh code reviewer with the full diff and verification evidence. Fix Critical/Important findings, then re-run relevant checks.
+
+- [x] **Step 3: Cleanup pass**
+
+Use the normal `simplify` route unless the reviewer identifies concrete AI-slop signals. Keep cleanup behavior-preserving and scoped to changed files.
+
+- [ ] **Step 4: Create draft PR**
+
+Commit, push `codex/test-runtime-audit`, and open a draft PR summarizing scope, measurements, checks, review verdict, and remaining follow-up work.
+
+- [ ] **Step 5: Converge PR**
+
+Use `post-pr-convergence` after draft PR creation. Watch GitHub Actions, inspect failures or review comments, fix actionable issues, re-run focused checks locally, push updates, and continue until CI is green and no blocking requested changes remain.

--- a/docs/superpowers/plans/2026-05-13-test-runtime-scalability.md
+++ b/docs/superpowers/plans/2026-05-13-test-runtime-scalability.md
@@ -277,10 +277,14 @@ Dispatch a fresh code reviewer with the full diff and verification evidence. Fix
 
 Use the normal `simplify` route unless the reviewer identifies concrete AI-slop signals. Keep cleanup behavior-preserving and scoped to changed files.
 
-- [ ] **Step 4: Create draft PR**
+- [x] **Step 4: Create draft PR**
 
 Commit, push `codex/test-runtime-audit`, and open a draft PR summarizing scope, measurements, checks, review verdict, and remaining follow-up work.
 
-- [ ] **Step 5: Converge PR**
+- [x] **Step 5: Converge PR**
 
 Use `post-pr-convergence` after draft PR creation. Watch GitHub Actions, inspect failures or review comments, fix actionable issues, re-run focused checks locally, push updates, and continue until CI is green and no blocking requested changes remain.
+
+PR `#687` was created and the convergence loop handled GitHub Actions plus
+CodeRabbit feedback. CI is expected to be green after the final documentation
+status update lands.

--- a/docs/superpowers/plans/2026-05-13-test-runtime-scalability.md
+++ b/docs/superpowers/plans/2026-05-13-test-runtime-scalability.md
@@ -285,6 +285,5 @@ Commit, push `codex/test-runtime-audit`, and open a draft PR summarizing scope, 
 
 Use `post-pr-convergence` after draft PR creation. Watch GitHub Actions, inspect failures or review comments, fix actionable issues, re-run focused checks locally, push updates, and continue until CI is green and no blocking requested changes remain.
 
-PR `#687` was created and the convergence loop handled GitHub Actions plus
-CodeRabbit feedback. CI is expected to be green after the final documentation
-status update lands.
+PR `#687` convergence result: GitHub Actions are green and CodeRabbit feedback
+is addressed.

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -91,6 +91,18 @@ L2G で upstream の実メンバー契約や実プロパティ経路そのもの
 - 色コード保持
 - 引数 rewrite / `__result` rewrite の挙動
 
+**スケーラビリティ制約**:
+- 既存の owner route や message-family mechanism に文字列例を追加するだけなら、
+  L2 で文字列ごとに Harmony patch/unpatch を増やさない。route boundary は
+  代表的な smoke case で固定し、網羅性は静的 inventory や data-contract coverage に寄せる。
+- 同じ owner patch、同じ queue/popup sink、同じ辞書 fixture を共有できる
+  repository-family regression は、1 回の Harmony patch setup にまとめて batch 実行する。
+  すべての source/expected pair は残し、失敗時に該当 case が分かる assertion
+  message を付ける。
+- 新規 L2 が必要な場合は、未知入力、空入力、markup、direct marker、
+  owner-absent など route contract の境界を少数の focused case で証明する。
+  既に別層で証明済みの pattern inventory を L2 に複製しない。
+
 **DummyTarget パターン**:
 
 ```csharp

--- a/justfile
+++ b/justfile
@@ -68,6 +68,20 @@ test-l2g:
   test_dll="$artifacts_root/bin/QudJP.Tests/release/QudJP.Tests.dll"
   dotnet test "$test_dll" --filter "TestCategory=L2G"
 
+# Run all local C# test categories from one built test artifact.
+test-csharp:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  mkdir -p "{{dotnet_artifacts_root}}/test-csharp"
+  run_root="$(mktemp -d "{{dotnet_artifacts_root}}/test-csharp/run.XXXXXX")"
+  trap 'rm -rf "$run_root"' EXIT
+  mkdir -p "$run_root/a/b"
+  cp -R Mods/QudJP/Localization "$run_root/Localization"
+  artifacts_root="$run_root/a/b"
+  dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-dependencies --artifacts-path "$artifacts_root"
+  test_dll="$artifacts_root/bin/QudJP.Tests/release/QudJP.Tests.dll"
+  dotnet test "$test_dll"
+
 # Run Python static checks.
 python-check:
   ruff check scripts/
@@ -328,7 +342,7 @@ runtime-evidence-check: test-l1
   uv run pytest scripts/tests/test_triage_integration.py -q -k sample_log_smoke
 
 # Run the broad local verification gate.
-check: build test-l1 test-l2 test-l2g python-check python-test localization-check translation-token-check changelog-link-check markdown-report-check localization-coverage-map-check
+check: build test-csharp python-check python-test localization-check translation-token-check changelog-link-check markdown-report-check localization-coverage-map-check
 
 # Run the CI-like PR gate before pushing broad C#, script, or localization changes.
 pr-check base_ref="origin/main" head_ref="HEAD": ci-dotnet roslyn-build python-check python-test localization-check translation-token-check changelog-link-check localization-coverage-map-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ convention = "google"
 quote-style = "double"
 
 [tool.pytest.ini_options]
-addopts = ["--durations=10"]
+addopts = ["--durations=20"]
 testpaths = ["scripts/tests"]
 markers = [
   "semantic_probe_real: optional real-source smoke tests for RoslynSemanticProbe",

--- a/scripts/tests/test_ci_workflow_contract.py
+++ b/scripts/tests/test_ci_workflow_contract.py
@@ -72,6 +72,21 @@ def test_ci_python_lane_restores_repo_local_node_tools() -> None:
     assert "npm install -g @ast-grep/cli" not in python_job
 
 
+def test_ci_qudjp_test_matrix_uploads_category_test_results() -> None:
+    """C# matrix legs should publish per-category TRX results for timing and failure review."""
+    workflow = _workflow_text()
+    job = _job_block(workflow, "qudjp-dotnet-test", "roslyn-tools")
+
+    assert '--logger "trx;LogFileName=qudjp-${{ matrix.category }}.trx"' in job
+    assert "--results-directory TestResults/qudjp-${{ matrix.category }}" in job
+    assert "Upload QudJP ${{ matrix.category }} test results" in job
+    assert "if: always()" in job
+    assert "uses: actions/upload-artifact@v4" in job
+    assert "name: qudjp-test-results-${{ matrix.category }}" in job
+    assert "path: TestResults/qudjp-${{ matrix.category }}/*.trx" in job
+    assert "if-no-files-found: ignore" in job
+
+
 def test_ci_package_lock_changes_trigger_python_tool_checks() -> None:
     """Node tool dependency changes must exercise the Python/agent tooling lane."""
     workflow = _workflow_text()

--- a/scripts/tests/test_qudjp_dotnet_test_contracts.py
+++ b/scripts/tests/test_qudjp_dotnet_test_contracts.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TEST_ROOT = REPO_ROOT / "Mods" / "QudJP" / "Assemblies" / "QudJP.Tests"
+JUSTFILE = REPO_ROOT / "justfile"
+TEST_ARCHITECTURE_DOC = REPO_ROOT / "docs" / "test-architecture.md"
+RULES_DOC = REPO_ROOT / "docs" / "RULES.md"
 TRANSLATOR_DICTIONARY_CALL = "Translator.SetDictionaryDirectoryForTests("
 
 CLASS_DECLARATION = re.compile(r"\bclass\s+[A-Za-z_][A-Za-z0-9_]*\b")
@@ -88,3 +91,44 @@ def test_translator_dictionary_fixtures_are_non_parallelizable() -> None:
         "test method that uses it:\n"
         + "\n".join(offenders)
     )
+
+
+def _recipe_block(justfile: str, recipe_name: str, next_recipe_name: str | None) -> str:
+    recipe_start = re.compile(rf"\n{re.escape(recipe_name)}(?:\s[^:\n]*)?:")
+    start_match = recipe_start.search(justfile)
+    assert start_match is not None, f"recipe not found: {recipe_name}"
+    start = start_match.start()
+    if next_recipe_name is None:
+        end = len(justfile)
+    else:
+        next_recipe_start = re.compile(rf"\n{re.escape(next_recipe_name)}(?:\s[^:\n]*)?:")
+        end_match = next_recipe_start.search(justfile, start_match.end())
+        assert end_match is not None, f"recipe not found: {next_recipe_name}"
+        end = end_match.start()
+    return justfile[start:end]
+
+
+def test_local_csharp_full_suite_builds_test_project_once() -> None:
+    """The local all-C# test entrypoint should avoid per-category build and VSTest startup."""
+    justfile = "\n" + JUSTFILE.read_text(encoding="utf-8")
+    recipe = _recipe_block(justfile, "test-csharp", "python-check")
+    check_recipe = _recipe_block(justfile, "check", "pr-check")
+
+    assert "dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj" in recipe
+    assert recipe.count("dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj") == 1
+    assert recipe.count('dotnet test "$test_dll"') == 1
+    assert "TestCategory=" not in recipe
+
+    assert "test-csharp" in check_recipe
+    assert "test-l1 test-l2 test-l2g" not in check_recipe
+
+
+def test_route_family_test_guidance_limits_l2_case_growth() -> None:
+    """Route-family additions should not default to one Harmony test per string."""
+    test_architecture = TEST_ARCHITECTURE_DOC.read_text(encoding="utf-8")
+    rules = RULES_DOC.read_text(encoding="utf-8")
+
+    assert "1 回の Harmony patch setup にまとめて batch 実行する" in test_architecture
+    assert "静的 inventory や data-contract coverage" in test_architecture
+    assert "one L2 smoke case" in rules
+    assert "Do not add one new Harmony patch/unpatch test case for every newly claimed string" in rules


### PR DESCRIPTION
## Summary
- add a build-once local `just test-csharp` path and wire broad local `check` through it
- publish per-category C# TRX artifacts from the GitHub Actions matrix and expand pytest slow duration visibility
- cache `MessagePatternTranslator` pattern files by canonical path and batch high-cost same-route L2 repository-family cases under one Harmony setup
- document scalable route-family test guidance and keep the implementation plan with measured results

## Measurements
- Baseline separate local C# recipes: `just test-l1` 37.90s + `just test-l2` 69.66s + `just test-l2g` 15.42s = 122.98s
- Build-once pre-batching: `just test-csharp` 4348 passed in 95.70s
- Final after batching/cache cleanup: `just test-csharp` 4297 passed in 32.46s
- Final `just python-test`: 1086 passed, 1 skipped in 37.16s, with slowest 20 durations printed

## Verification
- `uv run pytest scripts/tests/test_qudjp_dotnet_test_contracts.py scripts/tests/test_ci_workflow_contract.py -q` -> 13 passed
- `/usr/bin/time -p just test-csharp` -> 4297 passed, real 32.46s
- `just python-check` -> passed
- `just python-test` -> 1086 passed, 1 skipped in 37.16s
- `git diff --check` -> passed
- `just lsp-check` -> passed

## Review / cleanup
- Independent review before cleanup: APPROVE
- Cleanup route: `simplify`, scoped to the current diff
- Fresh independent review after cleanup: APPROVE

## Notes
- L2 NUnit result count intentionally drops because 54 source/expected rows are now exercised inside 2 batched tests while preserving per-case assertion messages.
- CI still keeps the existing category matrix; this PR adds timing/failure artifacts rather than changing CI execution topology.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * パターンファイルのプロセス内キャッシュとテスト向け無効化を追加し、キャッシュ再利用を検証する新しい単体テストとCI向け契約テストを追加
  * L2の複数ケースをバッチ化して実行効率を改善しアサーションを強化
  * pytestの遅延レポート数を増加

* **Chores**
  * CIでカテゴリ別のテスト結果（TRX）を生成・アップロードするように変更
  * ローカルC#テスト実行を単一の統合レシピへ切替え

* **Documentation**
  * テストスケーラビリティと運用ガイドラインを追加・拡充

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/687)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->