### PR TITLE
[codex] Prepare workshop v0.2.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.2.52] - 2026-05-13
+
+### Added
+
+- macOS Apple Silicon 環境で Harmony 2.4.2 の native ARM64 回避策を試すための上級者向け補助スクリプトと、QudJP が保持したバックアップからゲーム DLL を戻す復元スクリプトを追加しました。
+
+### Fixed
+
+- 戦闘スキル、火災鎮圧、ゴーレム選択、ロケーション検索、変異の自己対象確認、古いセーブデータの継続確認、Water Ritual、Trade UI などの自動生成ポップアップ・メッセージに日本語訳を追加しました。
+- 追加の静的生成テキストについて、実行時の文脈に応じた日本語訳が使われる経路を拡充しました。
+- 取引、充電状態、料理、ステータス画面、キャンプ保存、アビリティ管理画面の一部ポップアップ訳を修正しました。
+- 攻撃が対象の装甲を貫通しなかったときの戦闘ログ表示について、ロール値が表示されない経路でも日本語化されるようにしました。
+- ミサイル武器 UI の射撃・リロード表示を日本語化する際、Unity のレイアウト更新例外が起きることがある問題を修正しました。
+
+---
+
 ## [0.2.51] - 2026-05-10
 
 ### Changed
@@ -286,7 +302,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.2.51...HEAD
+[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.2.52...HEAD
+[0.2.52]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.52
 [0.2.51]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.51
 [0.2.50]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.50
 [0.2.46]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.46

--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyUITextSkin.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyUITextSkin.cs
@@ -6,12 +6,15 @@ internal sealed class DummyUITextSkin
 
     public string? text;
 
+    public int SetTextCallCount { get; private set; }
+
     public int ApplyCallCount { get; private set; }
 
     public DummyActiveObject gameObject = new DummyActiveObject();
 
     public void SetText(string text)
     {
+        SetTextCallCount++;
         Text = text;
         this.text = text;
     }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/UITextSkinTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/UITextSkinTranslationPatchTests.cs
@@ -506,10 +506,21 @@ public sealed class UITextSkinTranslationPatchTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(fire.Text, Is.EqualTo("{{W|[F]}} 射撃"));
-            Assert.That(reload.Text, Is.EqualTo("{{W|[R]}} リロード"));
+            Assert.That(fire.text, Is.EqualTo("{{W|[F]}} 射撃"));
+            Assert.That(reload.text, Is.EqualTo("{{W|[R]}} リロード"));
+            Assert.That(fire.SetTextCallCount, Is.EqualTo(1));
+            Assert.That(reload.SetTextCallCount, Is.EqualTo(1));
             Assert.That(fire.ApplyCallCount, Is.EqualTo(0));
             Assert.That(reload.ApplyCallCount, Is.EqualTo(0));
+        });
+
+        fire.Apply();
+        reload.Apply();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fire.Text, Is.EqualTo("{{W|[F]}} 射撃"));
+            Assert.That(reload.Text, Is.EqualTo("{{W|[R]}} リロード"));
         });
     }
 

--- a/Mods/QudJP/Assemblies/src/Patches/MissileWeaponAreaTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/MissileWeaponAreaTranslationPatch.cs
@@ -76,6 +76,6 @@ public static class MissileWeaponAreaTranslationPatch
         }
 
         DynamicTextObservability.RecordTransform(Context, "MissileWeaponArea.HotkeyLabel", source, translated);
-        _ = UITextSkinReflectionAccessor.SetCurrentText(uiTextSkin, translated, Context);
+        _ = UITextSkinReflectionAccessor.SetCurrentTextField(uiTextSkin, translated);
     }
 }

--- a/Mods/QudJP/Assemblies/src/Patches/UITextSkinReflectionAccessor.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/UITextSkinReflectionAccessor.cs
@@ -73,4 +73,21 @@ internal static class UITextSkinReflectionAccessor
 
         return false;
     }
+
+    internal static bool SetCurrentTextField(object? uiTextSkin, string translated)
+    {
+        if (uiTextSkin is null)
+        {
+            return false;
+        }
+
+        var textField = AccessTools.Field(uiTextSkin.GetType(), "text");
+        if (textField?.FieldType != typeof(string))
+        {
+            return false;
+        }
+
+        textField.SetValue(uiTextSkin, translated);
+        return true;
+    }
 }

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.2.51",
+  "Version": "0.2.52",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/release-notes/unreleased/harmony-native-helper-scripts.md
+++ b/docs/release-notes/unreleased/harmony-native-helper-scripts.md
@@ -1,3 +1,0 @@
-### Added
-
-- Added opt-in macOS helper scripts for advanced Apple Silicon users who want to try the Harmony 2.4.2 native ARM64 workaround, plus a restore helper to put the game DLL back from QudJP's backup.

--- a/docs/release-notes/unreleased/issue-576-combat-skill-owner.md
+++ b/docs/release-notes/unreleased/issue-576-combat-skill-owner.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Registered audited combat skill owner-message translations for static producer coverage.

--- a/docs/release-notes/unreleased/issue-576-fire-suppression-discharge.md
+++ b/docs/release-notes/unreleased/issue-576-fire-suppression-discharge.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Added owner-routed Japanese translations for fire suppression discharge messages.

--- a/docs/release-notes/unreleased/issue-576-game-summary-tombstone-popups.md
+++ b/docs/release-notes/unreleased/issue-576-game-summary-tombstone-popups.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Added owner-route closure for game-summary tombstone save result popups.

--- a/docs/release-notes/unreleased/issue-576-golem-selection-popups.md
+++ b/docs/release-notes/unreleased/issue-576-golem-selection-popups.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Added owner-routed Japanese translations for Golem quest selection failure popups.

--- a/docs/release-notes/unreleased/issue-576-location-finder-popups.md
+++ b/docs/release-notes/unreleased/issue-576-location-finder-popups.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Added owner-route closure for location finder discovery and travel popups.

--- a/docs/release-notes/unreleased/issue-576-mutation-self-target.md
+++ b/docs/release-notes/unreleased/issue-576-mutation-self-target.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Added owner-routed Japanese translations for mutation self-target confirmation popups.

--- a/docs/release-notes/unreleased/issue-576-mutations-api-owner.md
+++ b/docs/release-notes/unreleased/issue-576-mutations-api-owner.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Added owner-route closure evidence for buying random mutations from the mutations API.

--- a/docs/release-notes/unreleased/issue-576-old-save-owner-popups.md
+++ b/docs/release-notes/unreleased/issue-576-old-save-owner-popups.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Added owner-route closure evidence for old-save continue menu popups.

--- a/docs/release-notes/unreleased/issue-576-static-producer-coverage.md
+++ b/docs/release-notes/unreleased/issue-576-static-producer-coverage.md
@@ -1,4 +1,0 @@
-### Fixed
-
-- Add Japanese owner-route translations for additional generated popup and message text from static producer coverage.
-- Correct trade, charge status, cooking, status screen, campfire preserve, and ability manager popup translations.

--- a/docs/release-notes/unreleased/issue-576-tradeui-remainder.md
+++ b/docs/release-notes/unreleased/issue-576-tradeui-remainder.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Translated additional TradeUI owner-routed vendor, identify, and recharge popups.

--- a/docs/release-notes/unreleased/issue-576-tradeui-vendor-popups.md
+++ b/docs/release-notes/unreleased/issue-576-tradeui-vendor-popups.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Translated TradeUI vendor repair/drop failure popups through the owner-routed popup pipeline.

--- a/docs/release-notes/unreleased/issue-576-water-ritual-owner.md
+++ b/docs/release-notes/unreleased/issue-576-water-ritual-owner.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Added owner-routed Japanese translations for Water Ritual begin, skill point, and tinkering recipe popups.

--- a/docs/release-notes/unreleased/issue-635-combat-text-surface.md
+++ b/docs/release-notes/unreleased/issue-635-combat-text-surface.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Added coverage for combat log messages where an attack fails to penetrate a target's armor without a displayed roll value.

--- a/docs/reports/2026-05-13-workshop-v0.2.52.md
+++ b/docs/reports/2026-05-13-workshop-v0.2.52.md
@@ -1,0 +1,88 @@
+# Workshop Release v0.2.52
+
+## Identity
+
+- Version: `0.2.52`
+- Git commit: pending release commit
+- Git tag: `v0.2.52` (pending explicit tag confirmation)
+- Previous release tag/range: `v0.2.51..HEAD`
+- Version source: `Mods/QudJP/manifest.json`
+- GitHub Release URL: pending tag workflow
+- Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
+- Steam app ID: `333640`
+- Published file ID: `3718988020`
+
+## Changenote
+
+```text
+v0.2.52 / <release-commit-short-hash>
+
+更新内容:
+- macOS Apple Silicon 環境で Harmony 2.4.2 の native ARM64 回避策を試すための上級者向け補助スクリプトと復元スクリプトを追加しました。
+
+翻訳追加・改善:
+- 戦闘スキル、火災鎮圧、ゴーレム選択、ロケーション検索、変異の自己対象確認、古いセーブデータの継続確認、Water Ritual、Trade UI などの自動生成ポップアップ・メッセージに日本語訳を追加しました。
+- 取引、充電状態、料理、ステータス画面、キャンプ保存、アビリティ管理画面の一部ポップアップ訳を修正しました。
+- 攻撃が対象の装甲を貫通しなかったときの戦闘ログ表示について、ロール値が表示されない経路でも日本語化されるようにしました。
+- ミサイル武器 UI の射撃・リロード表示を日本語化する際、Unity のレイアウト更新例外が起きることがある問題を修正しました。
+
+既知の問題:
+- 一部の自動生成テキスト、チュートリアル、キャラクター生成画面には未翻訳または不自然な訳が残る場合があります。
+- ゲーム本体のアップデートにより、一部表示やパッチが壊れる可能性があります。
+```
+
+## Artifacts
+
+- Release ZIP: pending `dist/release-assets/v0.2.52/QudJP-v0.2.52.zip`
+- Release ZIP SHA256: pending
+- GitHub Release asset: `QudJP-v0.2.52.zip` (pending)
+- GitHub Release asset SHA256: pending
+- Workshop content folder: `dist/workshop/QudJP/`
+- Workshop VDF: `dist/workshop/workshop_item.vdf`
+
+## Preflight
+
+- [x] `git status --short --branch`
+- [x] Release range established from previous tag, release report, changelog/GitHub release, or explicit user range
+- [x] `just check`
+- [x] Fresh local `Player.log` checked after syncing `0.2.52` for regression evidence
+- [x] `MissileWeaponArea.Update -> UITextSkin.Apply` exception root cause investigated and fixed
+- [x] `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~UITextSkinTranslationPatchTests.MissileWeaponAreaPostfix_TranslatesPlayerUiFireAndReloadHotkeyLabels_FromOwnerDictionary" --no-restore`
+- [x] `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~UITextSkinTranslationPatchTests|FullyQualifiedName~TargetMethodResolutionTests" --no-restore`
+- [x] `just test-l2 && just test-l2g`
+- [ ] `Mods/QudJP/manifest.json` version, `v0.2.52` tag, release ZIP name, changenote first line, and report version match
+- [ ] `git rev-list -n1 v0.2.52` matches `git rev-parse HEAD`
+- [ ] `git merge-base --is-ancestor "$(git rev-list -n1 v0.2.52)" origin/main`
+- [ ] Draft GitHub Release created by tag workflow
+- [x] Workshop changenote compared with the previous release to remove already-shipped bullets
+- [ ] Workshop changenote rewritten in player-facing terms and checked by `workshop-upload-preflight`
+- [ ] `just download-release-zip 0.2.52`
+- [ ] `just workshop-preflight 0.2.52`
+- [ ] `just release-zip-check dist/release-assets/v0.2.52/QudJP-v0.2.52.zip`
+- [ ] `just build-workshop-upload dist/release-assets/v0.2.52/QudJP-v0.2.52.zip /tmp/qudjp-workshop-changenote.txt`
+- [ ] `just workshop-upload-preflight dist/release-assets/v0.2.52/QudJP-v0.2.52.zip 0.2.52`
+
+## Upload
+
+- steamcmd command: `/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +workshop_build_item <repo-root>/dist/workshop/workshop_item.vdf +quit`
+- Upload completed at: pending explicit upload confirmation
+- Steam output summary: pending
+- GitHub Release published at: pending
+
+## Post-Publish Smoke
+
+- [ ] Workshop page title, description, preview image, visibility, file size, and changenote checked
+- [ ] Subscribe/resubscribe checked
+- [ ] `steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit`
+- [ ] `just workshop-download-check 0.2.52 dist/release-assets/v0.2.52/QudJP-v0.2.52.zip`
+- [ ] Mod Manager lists QudJP with expected version and preview
+- [ ] Options screen renders Japanese text and CJK glyphs
+- [ ] One short conversation renders Japanese text and CJK glyphs
+- [ ] Fresh Player.log checked for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`
+- [ ] Non-QudJP platform SDK noise, if present, recorded in notes and not conflated with QudJP blockers
+
+## Decision
+
+- Result: PENDING - waiting for release commit, explicit tag confirmation, tag workflow artifact, and explicit Workshop upload confirmation.
+- Notes: Prepared release identity, changelog entry, player-facing Workshop changenote draft, and release evidence report from `v0.2.51..HEAD`. `just check` passed before commit/tag. Fresh local `Player.log` after syncing `0.2.52` showed QudJP startup/load success and zero untranslated triage rows, but also two `ArgumentOutOfRangeException` entries in `Qud.UI.MissileWeaponArea.Update -> XRL.UI.UITextSkin.Apply`. Root cause: the game writes `MissileWeaponArea` hotkey labels by assigning `UITextSkin.text` in `AfterRender` and lets `Update()` call `Apply()`, while QudJP re-entered `UITextSkin.SetText()` from the `AfterRender` postfix and could trigger Unity layout rebuild at the wrong time. Fix: `MissileWeaponAreaTranslationPatch` now updates the `text` field directly for this owner route and defers `Apply()` to the game's normal update path. Fill the changenote short hash after the release prep commit is created.
+- Rollback tag, if needed: `v0.2.51`


### PR DESCRIPTION
## Summary

- Prepare the QudJP Workshop v0.2.52 release metadata by bumping `Mods/QudJP/manifest.json` and folding unreleased fragments into `CHANGELOG.md`.
- Add the local Workshop preparation report for 2026-05-13.
- Fix the missile weapon fire/reload hotkey translation route so it updates the `UITextSkin.text` field without calling `SetText()` immediately during `MissileWeaponArea.AfterRender`.

## Root cause

The fresh `Player.log` showed `ArgumentOutOfRangeException` from `Qud.UI.MissileWeaponArea.Update -> XRL.UI.UITextSkin.Apply -> TMPro.TMP_Text.set_text -> UnityEngine.UI.LayoutRebuilder.MarkLayoutForRebuild`.

`MissileWeaponArea.AfterRender` writes the fire/reload hotkey text directly, then the game later applies it from `Update()`. QudJP was translating that route through `UITextSkin.SetText()`, which calls `Apply()` immediately. That eager apply can force a TMP layout rebuild at the wrong point in the `AfterRender` path. This PR changes that specific route to update only the backing `text` field and let the game's normal `Update()` call apply the value.

## Validation

- `git diff --cached --check`
- `just changelog-link-check`
- `just test-l2 && just test-l2g`
  - L2: 1990 passed, 0 failed
  - L2G: 328 passed, 0 failed
- `just deploy-mod`
  - Built `QudJP.dll` successfully and synced it to the local Caves of Qud stable reference install.
  - Synced manifest version checked as `0.2.52`.
  - Synced DLL SHA-256 matched the workspace DLL.

## Runtime follow-up

Before publishing the Workshop item, run the game once more with this synced build and re-check `Player.log` for the `MissileWeaponArea.Update` `ArgumentOutOfRangeException`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v0.2.52 リリースノート

* **新機能**
  * macOS Apple Siliconの最適化スクリプトを追加
  * DLL復元機能を追加

* **バグ修正**
  * 日本語ローカライズを複数のポップアップとメッセージに拡張
  * 戦闘ログの表示を改善
  * UIのホットキーラベル翻訳を修正
  * Unityレイアウト例外を修正

* **ドキュメント**
  * CHANGELOGをv0.2.52にアップデート

<!-- end of auto-generated comment: release notes by coderabbit.ai -->