### PR TITLE
Fix display stat color tags and dev sync version

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs
@@ -74,6 +74,85 @@ public sealed class GetDisplayNameRouteTranslatorTests
     }
 
     [Test]
+    public void TranslatePreservingColors_PreservesArmorStatSymbolTags_WhenTranslatingNameAndState()
+    {
+        WriteDictionary(("dromad waterskin", "ラクダの水袋"));
+        WriteDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("[empty]", "[空]"));
+
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            "dromad waterskin {{b|\u0004}}0 {{K|\t}}0 [empty]",
+            nameof(GetDisplayNamePatch));
+        var alreadyLocalizedBase = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            "ラクダの水袋 {{b|\u0004}}0 {{K|\t}}0 [empty]",
+            nameof(GetDisplayNamePatch));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.EqualTo("ラクダの水袋 {{b|\u0004}}0 {{K|\t}}0 [空]"));
+            Assert.That(alreadyLocalizedBase, Is.EqualTo("ラクダの水袋 {{b|\u0004}}0 {{K|\t}}0 [空]"));
+        });
+    }
+
+    [Test]
+    public void TranslatePreservingColors_PreservesArmorStatDisplayNameColorOwnership()
+    {
+        WriteDictionary(("dromad waterskin", "ラクダの水袋"));
+        WriteDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("bloody", "{{r|血まみれの}}"),
+            ("[empty]", "[空]"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                GetDisplayNameRouteTranslator.TranslatePreservingColors(
+                    "<color=#44ff88>dromad waterskin {{b|\u0004}}1 {{K|\t}}-2 [empty]</color>",
+                    nameof(GetDisplayNamePatch)),
+                Is.EqualTo("<color=#44ff88>ラクダの水袋 {{b|\u0004}}1 {{K|\t}}-2 [空]</color>"));
+            Assert.That(
+                GetDisplayNameRouteTranslator.TranslatePreservingColors(
+                    "{{C|dromad waterskin}} {{b|\u0004}}-1 {{K|\t}}2",
+                    nameof(GetDisplayNamePatch)),
+                Is.EqualTo("{{C|ラクダの水袋}} {{b|\u0004}}-1 {{K|\t}}2"));
+            Assert.That(
+                GetDisplayNameRouteTranslator.TranslatePreservingColors(
+                    "{{r|bloody}} dromad waterskin {{b|\u0004}}0 {{K|\t}}0 [empty]",
+                    nameof(GetDisplayNamePatch)),
+                Is.EqualTo("{{r|血まみれの}} ラクダの水袋 {{b|\u0004}}0 {{K|\t}}0 [空]"));
+        });
+    }
+
+    [Test]
+    public void TranslatePreservingColors_PreservesCompactWeaponStatSymbolTags_WhenTranslatingName()
+    {
+        WriteDictionary(
+            ("bronze sword", "青銅の剣"),
+            ("throwing axe", "投げ斧"),
+            ("arc cannon", "アークキャノン"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                GetDisplayNameRouteTranslator.TranslatePreservingColors(
+                    "bronze sword {{c|\u001a}}5{{K|/7}} {{r|\u0003}}1d6",
+                    nameof(GetDisplayNamePatch)),
+                Is.EqualTo("青銅の剣 {{c|\u001a}}5{{K|/7}} {{r|\u0003}}1d6"));
+            Assert.That(
+                GetDisplayNameRouteTranslator.TranslatePreservingColors(
+                    "{{C|throwing axe {{c|\u001a}}÷+1 {{r|\u0003}}1d4}}",
+                    nameof(GetDisplayNamePatch)),
+                Is.EqualTo("{{C|投げ斧 {{c|\u001a}}÷+1 {{r|\u0003}}1d4}}"));
+            Assert.That(
+                GetDisplayNameRouteTranslator.TranslatePreservingColors(
+                    "arc cannon {{r|\u0003}}2d6",
+                    nameof(GetDisplayNamePatch)),
+                Is.EqualTo("アークキャノン {{r|\u0003}}2d6"));
+        });
+    }
+
+    [Test]
     public void TranslatePreservingColors_UsesScopedStateTemplateLookup()
     {
         WriteDictionary(

--- a/Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -24,6 +25,12 @@ internal static class GetDisplayNameRouteTranslator
     };
     private static readonly Regex BracketedDisplayNameSuffixPattern =
         new Regex("^(?<base>.+?)\\s+\\[(?<state>.+)\\]$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex ArmorStatsDisplayNameSuffixPattern =
+        new Regex(@"^(?<base>.+?) (?<stats>\x04-?\d+ \t-?\d+)(?: \[(?<state>.+)\])?$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex CompactWeaponStatsDisplayNameSuffixPattern =
+        new Regex(
+            @"^(?<base>.+?) (?<stats>(?:\x1a[^\[\r\n]*(?: \x03[^\[\r\n]+)?|\x03[^\[\r\n]+))(?: \[(?<state>.+)\])?$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly Regex ParenthesizedDisplayNameSuffixPattern =
         new Regex("^(?<base>.+?)\\s+\\((?<state>[A-Za-z][A-Za-z\\s-]*)\\)$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly Regex QuantityDisplayNameSuffixPattern =
@@ -121,6 +128,16 @@ internal static class GetDisplayNameRouteTranslator
         if (TryTranslateLeadingMarkupWrappedModifier(source!, route, out var markupLeadingTranslation))
         {
             return markupLeadingTranslation;
+        }
+
+        if (TryTranslateArmorStatsDisplayNameSuffix(stripped, spans, route, out var armorStatsTranslation))
+        {
+            return armorStatsTranslation;
+        }
+
+        if (TryTranslateCompactWeaponStatsDisplayNameSuffix(stripped, spans, route, out var compactWeaponStatsTranslation))
+        {
+            return compactWeaponStatsTranslation;
         }
 
         if (TryTranslateDisplayNameRouteText(stripped, route, out var translated))
@@ -288,6 +305,83 @@ internal static class GetDisplayNameRouteTranslator
         return true;
     }
 
+    private static bool TryTranslateArmorStatsDisplayNameSuffix(
+        string source,
+        IReadOnlyList<ColorSpan> spans,
+        string route,
+        out string translated)
+    {
+        return TryTranslateStatDisplayNameSuffix(
+            source,
+            spans,
+            route,
+            ArmorStatsDisplayNameSuffixPattern,
+            "DisplayName.ArmorStatsSuffix",
+            out translated);
+    }
+
+    private static bool TryTranslateCompactWeaponStatsDisplayNameSuffix(
+        string source,
+        IReadOnlyList<ColorSpan> spans,
+        string route,
+        out string translated)
+    {
+        return TryTranslateStatDisplayNameSuffix(
+            source,
+            spans,
+            route,
+            CompactWeaponStatsDisplayNameSuffixPattern,
+            "DisplayName.CompactWeaponStatsSuffix",
+            out translated);
+    }
+
+    private static bool TryTranslateStatDisplayNameSuffix(
+        string source,
+        IReadOnlyList<ColorSpan> spans,
+        string route,
+        Regex pattern,
+        string transformName,
+        out string translated)
+    {
+        var match = pattern.Match(source);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        var baseGroup = match.Groups["base"];
+        var baseSource = baseGroup.Value;
+        var translatedBase = RestoreWholeSlice(TranslateDisplayNameFragment(baseSource, route), spans, baseGroup);
+        var stats = RestoreVisibleSlice(match.Groups["stats"], spans);
+        var stateGroup = match.Groups["state"];
+
+        var translatedState = stateGroup.Success
+            ? RestoreWholeSlice(TranslateDisplayNameState(stateGroup.Value, route), spans, stateGroup)
+            : string.Empty;
+
+        if (string.Equals(translatedBase, baseSource, StringComparison.Ordinal)
+            && (!stateGroup.Success || string.Equals(translatedState, stateGroup.Value, StringComparison.Ordinal)))
+        {
+            translated = source;
+            return false;
+        }
+
+        translated = translatedBase + " " + stats;
+        if (stateGroup.Success)
+        {
+            translated += " [" + translatedState + "]";
+        }
+
+        translated = ColorAwareTranslationComposer.RestoreWholeSourceBoundaryWrappersPreservingTranslatedOwnership(
+            translated,
+            spans,
+            source.Length);
+
+        DynamicTextObservability.RecordTransform(route, transformName, source, translated);
+        return true;
+    }
+
     private static bool TryTranslateQuantityDisplayNameSuffix(string source, string route, out string translated)
     {
         var match = QuantityDisplayNameSuffixPattern.Match(source);
@@ -375,7 +469,7 @@ internal static class GetDisplayNameRouteTranslator
         }
 
         var restSource = match.Groups["rest"].Value;
-        var rest = TranslateDisplayNameFragment(restSource, route);
+        var rest = TranslatePreservingColors(restSource, route);
         translated = translatedModifier + (ShouldElideModifierSpace(restSource) ? string.Empty : " ") + rest;
         DynamicTextObservability.RecordTransform(route, "DisplayName.MarkupLeadingModifier", source, translated);
         return true;
@@ -876,6 +970,59 @@ internal static class GetDisplayNameRouteTranslator
         }
 
         return source;
+    }
+
+    private static string RestoreVisibleSlice(Group group, IReadOnlyList<ColorSpan> spans)
+    {
+        var sliceSpans = ColorCodePreserver.SliceSpans(spans, group.Index, group.Length);
+        RemoveUnmatchedTrailingSliceClosers(sliceSpans);
+
+        return ColorAwareTranslationComposer.Restore(
+            group.Value,
+            sliceSpans);
+    }
+
+    private static void RemoveUnmatchedTrailingSliceClosers(List<ColorSpan> spans)
+    {
+        var balance = 0;
+        for (var index = 0; index < spans.Count; index++)
+        {
+            var token = spans[index].Token;
+            if (IsExplicitClosingBoundaryToken(token))
+            {
+                balance--;
+            }
+            else if (ColorCodePreserver.IsOpeningBoundaryToken(token))
+            {
+                balance++;
+            }
+        }
+
+        for (var index = spans.Count - 1; index >= 0 && balance < 0; index--)
+        {
+            if (!IsExplicitClosingBoundaryToken(spans[index].Token))
+            {
+                continue;
+            }
+
+            spans.RemoveAt(index);
+            balance++;
+        }
+    }
+
+    private static bool IsExplicitClosingBoundaryToken(string token)
+    {
+        return string.Equals(token, "}}", StringComparison.Ordinal)
+            || string.Equals(token, "</color>", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string RestoreWholeSlice(string translated, IReadOnlyList<ColorSpan> spans, Group group)
+    {
+        return ColorAwareTranslationComposer.RestoreWholeSliceBoundaryWrappersPreservingTranslatedOwnership(
+            translated,
+            spans,
+            group.Index,
+            group.Length);
     }
 
     private static bool IsStableDisplayNameFragment(string source, string route)

--- a/scripts/sync_mod.py
+++ b/scripts/sync_mod.py
@@ -48,7 +48,7 @@ _MACOS_HELPER_COMMANDS: tuple[Path, ...] = tuple(
 _LOCAL_ONLY_FILES: tuple[Path, ...] = (Path("workshop.json"),)
 _LOCALIZATION_ASSET_SUFFIXES = {".json", ".txt", ".xml"}
 _WINDOWS_DRIVE_PREFIX_LENGTH = 2
-DEFAULT_DEV_VERSION_SUFFIX = "-dev"
+DEFAULT_DEV_VERSION_SUFFIX = ""
 DEFAULT_DEV_TITLE_SUFFIX = " (local dev)"
 
 _MACOS_STABLE_REF_MODS_SUFFIX = (
@@ -513,7 +513,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--dev-version-suffix",
         default=DEFAULT_DEV_VERSION_SUFFIX,
-        help="Version suffix used with --dev. Defaults to -dev.",
+        help=(
+            "Version suffix used with --dev. Defaults to an empty suffix because "
+            "Caves of Qud rejects prerelease strings such as '-dev'."
+        ),
     )
     parser.add_argument(
         "--dev-title-suffix",

--- a/scripts/tests/test_sync_mod.py
+++ b/scripts/tests/test_sync_mod.py
@@ -319,14 +319,15 @@ class TestRunSync:
         assert json.loads((destination / "manifest.json").read_text(encoding="utf-8")) == {
             "Id": "QudJP",
             "Title": f"{SAMPLE_MOD_TITLE}{DEFAULT_DEV_TITLE_SUFFIX}",
-            "Version": f"{SAMPLE_RELEASE_VERSION}{DEFAULT_DEV_VERSION_SUFFIX}",
+            "Version": SAMPLE_RELEASE_VERSION,
         }
 
-    def test_python_fallback_dev_manifest_suffix_is_idempotent(
+    def test_python_fallback_custom_dev_version_suffix_is_idempotent(
         self,
         tmp_path: Path,
     ) -> None:
-        """Dev sync does not duplicate an existing destination-only suffix."""
+        """Dev sync does not duplicate an explicitly configured version suffix."""
+        custom_version_suffix = ".1"
         source = tmp_path / "source"
         destination = tmp_path / "dest"
         source.mkdir()
@@ -334,7 +335,7 @@ class TestRunSync:
             json.dumps(
                 {
                     "Title": f"{SAMPLE_MOD_TITLE}{DEFAULT_DEV_TITLE_SUFFIX}",
-                    "Version": f"{SAMPLE_RELEASE_VERSION}{DEFAULT_DEV_VERSION_SUFFIX}",
+                    "Version": f"{SAMPLE_RELEASE_VERSION}{custom_version_suffix}",
                 },
             ),
             encoding="utf-8",
@@ -344,13 +345,13 @@ class TestRunSync:
             run_sync(
                 source,
                 destination,
-                manifest_version_suffix=DEFAULT_DEV_VERSION_SUFFIX,
+                manifest_version_suffix=custom_version_suffix,
                 manifest_title_suffix=DEFAULT_DEV_TITLE_SUFFIX,
             )
 
         assert json.loads((destination / "manifest.json").read_text(encoding="utf-8")) == {
             "Title": f"{SAMPLE_MOD_TITLE}{DEFAULT_DEV_TITLE_SUFFIX}",
-            "Version": f"{SAMPLE_RELEASE_VERSION}{DEFAULT_DEV_VERSION_SUFFIX}",
+            "Version": f"{SAMPLE_RELEASE_VERSION}{custom_version_suffix}",
         }
 
     def test_python_fallback_requires_title_when_dev_title_suffix_is_set(
@@ -459,7 +460,7 @@ class TestRunSync:
 
         assert json.loads((destination / "manifest.json").read_text(encoding="utf-8")) == {
             "Title": f"{SAMPLE_MOD_TITLE}{DEFAULT_DEV_TITLE_SUFFIX}",
-            "Version": f"{SAMPLE_RELEASE_VERSION}{DEFAULT_DEV_VERSION_SUFFIX}",
+            "Version": SAMPLE_RELEASE_VERSION,
         }
 
     def test_rsync_dry_run_reports_dev_manifest_without_writing(


### PR DESCRIPTION
## Summary
- Preserve color ownership for item display-name AV/DV suffixes and compact weapon stat suffixes while translating item names and optional state text.
- Keep dev sync manifest Version on the release SemVer string by default so Caves of Qud no longer rejects values like 0.2.52-dev as an invalid version string.
- Add regression coverage for stat symbol color tags, whole-wrapper ownership, default dev Version behavior, and explicit custom dev version suffix idempotency.

## Dev Sync Version
- Default dev sync now writes `Version: 0.2.52` for the current release version and only changes `Title` to include `(local dev)`.
- `--dev-version-suffix` remains available for explicit custom suffixes, with idempotency covered by tests.

## Verification
- `git diff --check`
- `uv run pytest scripts/tests/test_sync_mod.py` (40 passed)
- `just python-check`
- `just test-l1` (2214 passed)
- `just test-l2` (1990 passed)
- `just python-test` (1086 passed, 1 skipped)
- `just deploy-dev` (passed; synced manifest Version was `0.2.52`, Title was local dev, DLL hashes matched)

## Polishment
- Independent review: APPROVE, no findings.
- Cleanup path: simplify; implementation code unchanged, sync_mod custom suffix idempotency test strengthened.
- Fresh post-cleanup review: APPROVE, no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 翻訳処理に関連するテストケースを3つ追加

* **Bug Fixes**
  * 翻訳時に色マークアップと統計表示タグを正確に保存

* **Chores**
  * マニフェストバージョン管理ロジックを更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/694)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->