### PR TITLE
Fix release ZIP check for Harmony helpers

### DIFF
--- a/justfile
+++ b/justfile
@@ -171,6 +171,8 @@ release-zip-check release_zip="":
       "QudJP/NOTICE.md",
       "QudJP/Bootstrap.cs",
       "QudJP/Launch CavesOfQud (Rosetta).command",
+      "QudJP/Install Native Apple Silicon Harmony.command",
+      "QudJP/Restore Game Harmony.command",
       "QudJP/Assemblies/QudJP.dll",
   }
   required_prefixes = {


### PR DESCRIPTION
## Summary
- Include the opt-in Apple Silicon Harmony helper scripts in the release ZIP spot-check allowlist.
- This aligns `just release-zip-check` with `scripts/build_release.py`, `scripts/build_workshop_upload.py`, and `docs/release.md`.

## Verification
- `git diff --check`
- `just release-zip-check dist/QudJP-v0.2.52.zip`

## Release note
- This fixes the local Workshop preflight gate for v0.2.52 staging; the generated release ZIP already includes these helper files intentionally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **品質改善**
  * Apple Silicon ネイティブ対応のインストールスクリプト検証が強化されました。これにより、リリースパッケージの完全性と品質保証が向上します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/696)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->