### PR TITLE
Record workshop v0.2.52 release evidence

### DIFF
--- a/docs/reports/2026-05-13-workshop-v0.2.52.md
+++ b/docs/reports/2026-05-13-workshop-v0.2.52.md
@@ -3,11 +3,11 @@
 ## Identity
 
 - Version: `0.2.52`
-- Git commit: pending release commit
-- Git tag: `v0.2.52` (pending explicit tag confirmation)
-- Previous release tag/range: `v0.2.51..HEAD`
+- Git commit: `f4d911519e24`
+- Git tag: `v0.2.52`
+- Previous release tag/range: `v0.2.51..v0.2.52`
 - Version source: `Mods/QudJP/manifest.json`
-- GitHub Release URL: pending tag workflow
+- GitHub Release URL: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.52
 - Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
 - Steam app ID: `333640`
 - Published file ID: `3718988020`
@@ -15,16 +15,20 @@
 ## Changenote
 
 ```text
-v0.2.52 / <release-commit-short-hash>
+v0.2.52 / f4d911519e24
 
 更新内容:
-- macOS Apple Silicon 環境で Harmony 2.4.2 の native ARM64 回避策を試すための上級者向け補助スクリプトと復元スクリプトを追加しました。
+- macOS Apple Silicon 環境向けに、起動や復元を補助する上級者向けスクリプトを追加しました。
 
 翻訳追加・改善:
 - 戦闘スキル、火災鎮圧、ゴーレム選択、ロケーション検索、変異の自己対象確認、古いセーブデータの継続確認、Water Ritual、Trade UI などの自動生成ポップアップ・メッセージに日本語訳を追加しました。
 - 取引、充電状態、料理、ステータス画面、キャンプ保存、アビリティ管理画面の一部ポップアップ訳を修正しました。
 - 攻撃が対象の装甲を貫通しなかったときの戦闘ログ表示について、ロール値が表示されない経路でも日本語化されるようにしました。
-- ミサイル武器 UI の射撃・リロード表示を日本語化する際、Unity のレイアウト更新例外が起きることがある問題を修正しました。
+- アイテム名を日本語化したときに、AV/DV や武器性能の記号色が失われる場合がある問題を修正しました。
+- ミサイル武器 UI の射撃・リロード表示を日本語化する際、表示更新の例外が起きることがある問題を修正しました。
+
+修正:
+- ローカル確認用の dev 同期で、ゲーム側が無効なバージョン文字列として扱う Version が生成されないようにしました。
 
 既知の問題:
 - 一部の自動生成テキスト、チュートリアル、キャラクター生成画面には未翻訳または不自然な訳が残る場合があります。
@@ -33,10 +37,10 @@ v0.2.52 / <release-commit-short-hash>
 
 ## Artifacts
 
-- Release ZIP: pending `dist/release-assets/v0.2.52/QudJP-v0.2.52.zip`
-- Release ZIP SHA256: pending
-- GitHub Release asset: `QudJP-v0.2.52.zip` (pending)
-- GitHub Release asset SHA256: pending
+- Release ZIP: `dist/release-assets/v0.2.52/QudJP-v0.2.52.zip`
+- Release ZIP SHA256: `3656259b898a1279166f550550d1ebd73f9ec37ade26b7829862bd317dc8c2cf`
+- GitHub Release asset: `QudJP-v0.2.52.zip`
+- GitHub Release asset SHA256: `3656259b898a1279166f550550d1ebd73f9ec37ade26b7829862bd317dc8c2cf`
 - Workshop content folder: `dist/workshop/QudJP/`
 - Workshop VDF: `dist/workshop/workshop_item.vdf`
 
@@ -50,31 +54,31 @@ v0.2.52 / <release-commit-short-hash>
 - [x] `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~UITextSkinTranslationPatchTests.MissileWeaponAreaPostfix_TranslatesPlayerUiFireAndReloadHotkeyLabels_FromOwnerDictionary" --no-restore`
 - [x] `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~UITextSkinTranslationPatchTests|FullyQualifiedName~TargetMethodResolutionTests" --no-restore`
 - [x] `just test-l2 && just test-l2g`
-- [ ] `Mods/QudJP/manifest.json` version, `v0.2.52` tag, release ZIP name, changenote first line, and report version match
-- [ ] `git rev-list -n1 v0.2.52` matches `git rev-parse HEAD`
-- [ ] `git merge-base --is-ancestor "$(git rev-list -n1 v0.2.52)" origin/main`
-- [ ] Draft GitHub Release created by tag workflow
+- [x] `Mods/QudJP/manifest.json` version, `v0.2.52` tag, release ZIP name, changenote first line, and report version match
+- [x] `git rev-list -n1 v0.2.52` matched the release commit `f4d911519e24`
+- [x] `git merge-base --is-ancestor "$(git rev-list -n1 v0.2.52)" origin/main`
+- [x] Draft GitHub Release created by tag workflow
 - [x] Workshop changenote compared with the previous release to remove already-shipped bullets
-- [ ] Workshop changenote rewritten in player-facing terms and checked by `workshop-upload-preflight`
-- [ ] `just download-release-zip 0.2.52`
-- [ ] `just workshop-preflight 0.2.52`
-- [ ] `just release-zip-check dist/release-assets/v0.2.52/QudJP-v0.2.52.zip`
-- [ ] `just build-workshop-upload dist/release-assets/v0.2.52/QudJP-v0.2.52.zip /tmp/qudjp-workshop-changenote.txt`
-- [ ] `just workshop-upload-preflight dist/release-assets/v0.2.52/QudJP-v0.2.52.zip 0.2.52`
+- [x] Workshop changenote rewritten in player-facing terms and checked by `workshop-upload-preflight`
+- [x] `just download-release-zip 0.2.52`
+- [ ] `just workshop-preflight 0.2.52` failed before upload because `release-zip-check` had a stale allowlist for the Apple Silicon helper scripts; fixed by PR #696 after upload.
+- [x] `just release-zip-check dist/release-assets/v0.2.52/QudJP-v0.2.52.zip`
+- [x] `just build-workshop-upload dist/release-assets/v0.2.52/QudJP-v0.2.52.zip /tmp/qudjp-workshop-changenote.txt`
+- [x] `just workshop-upload-preflight dist/release-assets/v0.2.52/QudJP-v0.2.52.zip 0.2.52`
 
 ## Upload
 
 - steamcmd command: `/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +workshop_build_item <repo-root>/dist/workshop/workshop_item.vdf +quit`
-- Upload completed at: pending explicit upload confirmation
-- Steam output summary: pending
-- GitHub Release published at: pending
+- Upload completed at: 2026-05-14 08:22 JST
+- Steam output summary: `Preparing update... Preparing content... Uploading content... Uploading preview image... Committing update...Success.`
+- GitHub Release published at: 2026-05-14 08:23 JST
 
 ## Post-Publish Smoke
 
 - [ ] Workshop page title, description, preview image, visibility, file size, and changenote checked
 - [ ] Subscribe/resubscribe checked
-- [ ] `steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit`
-- [ ] `just workshop-download-check 0.2.52 dist/release-assets/v0.2.52/QudJP-v0.2.52.zip`
+- [x] `steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit`
+- [x] `just workshop-download-check 0.2.52 dist/release-assets/v0.2.52/QudJP-v0.2.52.zip`
 - [ ] Mod Manager lists QudJP with expected version and preview
 - [ ] Options screen renders Japanese text and CJK glyphs
 - [ ] One short conversation renders Japanese text and CJK glyphs
@@ -83,6 +87,6 @@ v0.2.52 / <release-commit-short-hash>
 
 ## Decision
 
-- Result: PENDING - waiting for release commit, explicit tag confirmation, tag workflow artifact, and explicit Workshop upload confirmation.
-- Notes: Prepared release identity, changelog entry, player-facing Workshop changenote draft, and release evidence report from `v0.2.51..HEAD`. `just check` passed before commit/tag. Fresh local `Player.log` after syncing `0.2.52` showed QudJP startup/load success and zero untranslated triage rows, but also two `ArgumentOutOfRangeException` entries in `Qud.UI.MissileWeaponArea.Update -> XRL.UI.UITextSkin.Apply`. Root cause: the game writes `MissileWeaponArea` hotkey labels by assigning `UITextSkin.text` in `AfterRender` and lets `Update()` call `Apply()`, while QudJP re-entered `UITextSkin.SetText()` from the `AfterRender` postfix and could trigger Unity layout rebuild at the wrong time. Fix: `MissileWeaponAreaTranslationPatch` now updates the `text` field directly for this owner route and defers `Apply()` to the game's normal update path. Fill the changenote short hash after the release prep commit is created.
+- Result: GO - Steam Workshop upload completed, public Workshop download matched the release ZIP DLL, and GitHub Release `v0.2.52` was published.
+- Notes: Prepared release identity, changelog entry, player-facing Workshop changenote draft, and release evidence report from `v0.2.51..v0.2.52`. `just check` passed before commit/tag. Fresh local `Player.log` after syncing `0.2.52` showed QudJP startup/load success and zero untranslated triage rows, but also two `ArgumentOutOfRangeException` entries in `Qud.UI.MissileWeaponArea.Update -> XRL.UI.UITextSkin.Apply`. Root cause: the game writes `MissileWeaponArea` hotkey labels by assigning `UITextSkin.text` in `AfterRender` and lets `Update()` call `Apply()`, while QudJP re-entered `UITextSkin.SetText()` from the `AfterRender` postfix and could trigger Unity layout rebuild at the wrong time. Fix: `MissileWeaponAreaTranslationPatch` now updates the `text` field directly for this owner route and defers `Apply()` to the game's normal update path. After upload, `just workshop-download-check 0.2.52 dist/release-assets/v0.2.52/QudJP-v0.2.52.zip` verified downloaded `manifest.json` version `0.2.52` and DLL SHA256 `5c0f6fdddcabaa68a81e3fac317cef76886440beb0eb038f2566b10ae068b55d`.
 - Rollback tag, if needed: `v0.2.51`


### PR DESCRIPTION
## Summary
- Record the completed v0.2.52 Steam Workshop upload.
- Capture the published GitHub Release URL, release ZIP SHA256, Steam upload result, and Workshop download verification.
- Update the changenote evidence to match the player-facing text used for the upload.

## Verification
- `git diff --check`
- `just markdown-report-check origin/main HEAD`
- Already completed before this evidence update: `just workshop-upload-preflight dist/release-assets/v0.2.52/QudJP-v0.2.52.zip 0.2.52`
- Already completed after upload: `just workshop-download-check 0.2.52 dist/release-assets/v0.2.52/QudJP-v0.2.52.zip`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * Workshop v0.2.52のリリースレポートが配布物とリリース検証の詳細で更新されました。
  * 翻訳の追加と修正が完了しました。

* **バグ修正**
  * UI テキストパッチング関連の問題が解決されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/697)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->