### PR TITLE
Preserve energy cell charge status colors

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/GetDisplayNameProcessPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/GetDisplayNameProcessPatchTests.cs
@@ -611,6 +611,26 @@ public sealed class GetDisplayNameProcessPatchTests
         });
     }
 
+    [TestCase("K", "Drained", "空")]
+    [TestCase("r", "Very Low", "残量ごく少")]
+    [TestCase("R", "Low", "残量少")]
+    [TestCase("W", "Used", "使用済み")]
+    [TestCase("g", "Fresh", "残量多")]
+    [TestCase("G", "Full", "満充電")]
+    public void Postfix_TranslatesColoredChargeStateSuffix_WhenPatched(
+        string color,
+        string state,
+        string expectedState)
+    {
+        RunWithDisplayNameProcessPatch(() =>
+        {
+            var processor = new DummyDisplayNameProcessor();
+            var result = processor.ProcessFor($"{{{{c|ケムセル}}}} {{{{y|({{{{{color}|{state}}}}})}}}}");
+
+            Assert.That(result, Is.EqualTo($"{{{{c|ケムセル}}}} {{{{y|({{{{{color}|{expectedState}}}}})}}}}"));
+        });
+    }
+
     [Test]
     public void Postfix_TranslatesJapaneseEntry_WhenPatched()
     {

--- a/Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs
@@ -47,6 +47,10 @@ internal static class GetDisplayNameRouteTranslator
         new Regex(
             "^(?<modifier>\\{\\{[^|}]+\\|[A-Za-z][A-Za-z\\s\\-']*\\}\\}|\\[\\{\\{[^|}]+\\|[A-Za-z][A-Za-z\\s\\-']*\\}\\}\\])\\s+(?<rest>.+)$",
             RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex ParenthesizedColoredChargeStatusPattern =
+        new Regex(
+            "(?<prefix>\\()(?<status>\\{\\{[^|}]+\\|[^{}]+\\}\\})(?<suffix>\\))",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly Regex PrepositionalStateTemplatePattern =
         new Regex(
             "^(?<template>sitting on|lying on|enclosed in|engulfed by|auto-collecting) (?<target>.+)$",
@@ -107,6 +111,11 @@ internal static class GetDisplayNameRouteTranslator
 
         using var _ = Translator.PushLogContext(context);
 
+        if (TryTranslateParenthesizedColoredChargeStatus(source!, route, out var chargeStatusTranslation))
+        {
+            source = chargeStatusTranslation;
+        }
+
         var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
         if (stripped.Length == 0)
         {
@@ -149,6 +158,38 @@ internal static class GetDisplayNameRouteTranslator
         }
 
         return source!;
+    }
+
+    private static bool TryTranslateParenthesizedColoredChargeStatus(
+        string source,
+        string route,
+        out string translated)
+    {
+        var changed = false;
+        translated = ParenthesizedColoredChargeStatusPattern.Replace(
+            source,
+            match =>
+            {
+                var status = match.Groups["status"].Value;
+                if (!EnergyStorageChargeStatusTranslationPatch.TryTranslateChargeStatus(status, out var translatedStatus))
+                {
+                    return match.Value;
+                }
+
+                changed = true;
+                return match.Groups["prefix"].Value + translatedStatus + match.Groups["suffix"].Value;
+            });
+
+        if (changed)
+        {
+            DynamicTextObservability.RecordTransform(
+                route,
+                "DisplayName.ColoredChargeStatusSuffix",
+                source,
+                translated);
+        }
+
+        return changed;
     }
 
     private static bool TryTranslateDisplayNameRouteText(string source, string route, out string translated)


### PR DESCRIPTION
## Summary
- translate parenthesized colored energy-cell charge status suffixes before generic DisplayName stripping
- preserve the original charge-level color wrappers for all six electrical charge states
- add L2 coverage for chem cell charge status color preservation

## Review
- Separate code-reviewer instance reviewed base c72f1f9f..0c4b1cba and reported no issues / APPROVE.

## Tests
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~GetDisplayNameProcessPatchTests|FullyQualifiedName~EnergyStorageChargeStatusTranslationPatchTests"
- just test-l2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 括弧形式の彩色された充電状態表記の日本語翻訳処理を強化しました。これにより、より正確な状態表示が可能になります

* **テスト**
  * 複数の色パターン（K/R/W/g/G など）に対応した充電状態表記の翻訳機能を検証するテストを新規追加しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/698)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->