### PR TITLE
fix: close static producer issue 699 queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
           --expect-count popup=12
           --expect-count journal=0
           --expect-count leaf=0
-          --expect-count emit-message=308
+          --expect-count emit-message=314
           --expect-count does-verb=0
           --expect-count message-log=1
           --expect-count description=4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
           --expect-count popup=12
           --expect-count journal=0
           --expect-count leaf=0
-          --expect-count emit-message=303
+          --expect-count emit-message=308
           --expect-count does-verb=0
           --expect-count message-log=1
           --expect-count description=4

--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
@@ -670,6 +670,12 @@ internal sealed class DummyRealityStabilizedEventTarget
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public void FailedToContestPopup()
+    {
+        DummyPopupShow.Show(PopupMessageToSend);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public void ShortCircuitDevice(bool usePopup)
     {
         if (usePopup)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs
@@ -370,6 +370,7 @@ public sealed class DoesVerbFamilyTests
     // --- Say Family ---
 
     [TestCase("The 熊 says, '挨拶'.", "熊は「挨拶」と言った")]
+    [TestCase("The 熊 says, '{{|挨拶}}'.", "熊は「挨拶」と言った{{|}}")]
     // Color-wrapped
     [TestCase("{{g|The 熊 says, '挨拶'.}}", "{{g|熊は「挨拶」と言った}}")]
     public void Translate_SayFamily(string input, string expected)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -343,6 +343,16 @@ public sealed class MessagePatternTranslatorTests
     [TestCase("熊の carapace loosens.", "熊の甲殻が緩んだ")]
     [TestCase("The zealot mumbles inaudibly, encased in ice.", "氷に閉じ込められた狂信者が、聞き取れないほどに呟いた。")]
     [TestCase("The infected crust of skin on 熊の left arm loosens and breaks away.", "熊の left armの感染した皮膚の痂皮が緩んで剥がれ落ちた。")]
+    [TestCase("Exodus launch in 7...", "エクソダス発射まで7…")]
+    [TestCase("Something hits タム (x2) with a 鉛スラッグ for 6 damage!", "何かが鉛スラッグでタムに6ダメージを与えた！ (x2)")]
+    [TestCase("The タレット hits you with a 鉛スラッグ, but your mental attack has no effect.", "タレットの鉛スラッグが命中したが、精神攻撃は効果がない")]
+    [TestCase("The タレット hits タム with a 鉛スラッグ, but their mental attack has no effect.", "タレットは鉛スラッグでタムに命中させたが、精神攻撃は効果がない")]
+    [TestCase("The タレット hits タム (x2) with a 鉛スラッグ!", "タレットは鉛スラッグでタムに命中した (x2)")]
+    [TestCase("鉛スラッグ hits you to the east! (x2)", "鉛スラッグがあなたにto the east命中！ (x2)")]
+    [TestCase("鉛スラッグ hits you to the east, but your mental attack has no effect.", "鉛スラッグがあなたに命中した to the east, but your mental attack has no effect。")]
+    [TestCase("鉛スラッグ hits タム to the east, but your mental attack has no effect.", "鉛スラッグがタムに命中した to the east, but your mental attack has no effect。")]
+    [TestCase("鉛スラッグ hits you (x2) to the east!", "鉛スラッグがあなたにto the east命中！ (x2)")]
+    [TestCase("鉛スラッグ hits タム (x2) to the east!", "鉛スラッグがタムにto the east命中！ (x2)")]
     public void Translate_RepositoryDictionary_AppliesEmitMessageSweepPatterns(string source, string expected)
     {
         UseRepositoryPatternDictionary();

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -349,10 +349,15 @@ public sealed class MessagePatternTranslatorTests
     [TestCase("The タレット hits タム with a 鉛スラッグ, but their mental attack has no effect.", "タレットは鉛スラッグでタムに命中させたが、精神攻撃は効果がない")]
     [TestCase("The タレット hits タム (x2) with a 鉛スラッグ!", "タレットは鉛スラッグでタムに命中した (x2)")]
     [TestCase("鉛スラッグ hits you to the east! (x2)", "鉛スラッグがあなたにto the east命中！ (x2)")]
+    [TestCase("鉛スラッグ critically hits you to the east! (x2)", "鉛スラッグが会心であなたにto the east命中！ (x2)")]
     [TestCase("鉛スラッグ hits you to the east, but your mental attack has no effect.", "鉛スラッグがあなたに命中した to the east, but your mental attack has no effect。")]
+    [TestCase("鉛スラッグ critically hits you to the east.", "鉛スラッグが会心であなたに命中した to the east。")]
     [TestCase("鉛スラッグ hits タム to the east, but your mental attack has no effect.", "鉛スラッグがタムに命中した to the east, but your mental attack has no effect。")]
+    [TestCase("鉛スラッグ critically hits タム to the east.", "鉛スラッグが会心でタムに命中した to the east。")]
     [TestCase("鉛スラッグ hits you (x2) to the east!", "鉛スラッグがあなたにto the east命中！ (x2)")]
+    [TestCase("鉛スラッグ critically hits you (x2) to the east!", "鉛スラッグが会心であなたにto the east命中！ (x2)")]
     [TestCase("鉛スラッグ hits タム (x2) to the east!", "鉛スラッグがタムにto the east命中！ (x2)")]
+    [TestCase("鉛スラッグ critically hits タム (x2) to the east!", "鉛スラッグが会心でタムにto the east命中！ (x2)")]
     public void Translate_RepositoryDictionary_AppliesEmitMessageSweepPatterns(string source, string expected)
     {
         UseRepositoryPatternDictionary();

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
@@ -2134,10 +2134,10 @@ public sealed class CombatAndLogMessageQueuePatchTests
 
     [TestCase(
         "You try to push through the normality lattice, but it snaps back into place.",
-        "あなたは通常性格子を押し通ろうとしたが、それは跳ね返って元に戻った。")]
+        "あなたはノーマリティ格子を押し通ろうとしたが、それは跳ね返って元に戻った。")]
     [TestCase(
         "You try to push through the normality lattice, but it snaps back into place. You wince in pain.",
-        "あなたは通常性格子を押し通ろうとしたが、それは跳ね返って元に戻った。あなたは痛みに顔をしかめた。")]
+        "あなたはノーマリティ格子を押し通ろうとしたが、それは跳ね返って元に戻った。あなたは痛みに顔をしかめた。")]
     [TestCase(
         "You push against the normality lattice, but nothing happens.",
         "You push against the normality lattice, but nothing happens.")]
@@ -2147,7 +2147,7 @@ public sealed class CombatAndLogMessageQueuePatchTests
         "You try to push through the normality lattice, but it snaps back into place.")]
     [TestCase(
         "{{R|You try to push through the normality lattice, but it snaps back into place.}}",
-        "{{R|あなたは通常性格子を押し通ろうとしたが、それは跳ね返って元に戻った。}}")]
+        "{{R|あなたはノーマリティ格子を押し通ろうとしたが、それは跳ね返って元に戻った。}}")]
     public void RealityStabilizedEvent_TranslatesFailedContestSelfPopup_WhenOwnerPatched(
         string source,
         string expected)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
@@ -130,6 +130,9 @@ public sealed class CombatAndLogMessageQueuePatchTests
     }
 
     [TestCase(
+        "OUCH! You collide with a chrome pyramid.",
+        "痛っ！chrome pyramidに衝突した。")]
+    [TestCase(
         "The way is blocked by an chrome pyramid.",
         "chrome pyramidに道を塞がれている。")]
     [TestCase(
@@ -2124,8 +2127,25 @@ public sealed class CombatAndLogMessageQueuePatchTests
     public void RealityStabilizedEvent_TranslatesShortCircuitPopup_WhenOwnerPatched()
     {
         AssertRealityStabilizedEventPopup(
+            nameof(DummyRealityStabilizedEventTarget.ShortCircuitDevice),
             "{{G|phase cannon}} emits a shower of sparks!",
             "{{G|phase cannon}}が火花の雨を放った！");
+    }
+
+    [TestCase(
+        "You try to push through the normality lattice, but it snaps back into place.",
+        "あなたは通常性格子を押し通ろうとしたが、それは跳ね返って元に戻った。")]
+    [TestCase(
+        "You try to push through the normality lattice, but it snaps back into place. You wince in pain.",
+        "あなたは通常性格子を押し通ろうとしたが、それは跳ね返って元に戻った。あなたは痛みに顔をしかめた。")]
+    public void RealityStabilizedEvent_TranslatesFailedContestSelfPopup_WhenOwnerPatched(
+        string source,
+        string expected)
+    {
+        AssertRealityStabilizedEventPopup(
+            nameof(DummyRealityStabilizedEventTarget.FailedToContestPopup),
+            source,
+            expected);
     }
 
     [TestCase("You feel a psychic whiff as glowfish pushes past resistance in the structure of spacetime.")]
@@ -2187,6 +2207,7 @@ public sealed class CombatAndLogMessageQueuePatchTests
     public void RealityStabilizedEvent_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
     {
         AssertRealityStabilizedEventPopup(
+            nameof(DummyRealityStabilizedEventTarget.ShortCircuitDevice),
             MessageFrameTranslator.MarkDirectTranslation("phase cannon emits a shower of sparks!"),
             "phase cannon emits a shower of sparks!");
     }
@@ -2195,7 +2216,7 @@ public sealed class CombatAndLogMessageQueuePatchTests
     public void RealityStabilizedEvent_LeavesEmptyMessagesUnchanged_WhenOwnerPatched()
     {
         AssertRealityStabilizedEventQueuedMessage(nameof(DummyRealityStabilizedEventTarget.TryContest), string.Empty, string.Empty);
-        AssertRealityStabilizedEventPopup(string.Empty, string.Empty);
+        AssertRealityStabilizedEventPopup(nameof(DummyRealityStabilizedEventTarget.ShortCircuitDevice), string.Empty, string.Empty);
     }
 
     [TestCase(
@@ -7581,24 +7602,37 @@ public sealed class CombatAndLogMessageQueuePatchTests
         }
     }
 
-    private static void AssertRealityStabilizedEventPopup(string message, string expected)
+    private static void AssertRealityStabilizedEventPopup(string methodName, string message, string expected)
     {
         var harmonyId = CreateHarmonyId();
         var harmony = new Harmony(harmonyId);
         try
         {
             PatchPopupShow(harmony);
-            PatchOwner(
-                harmony,
-                RequireMethod(typeof(DummyRealityStabilizedEventTarget), nameof(DummyRealityStabilizedEventTarget.ShortCircuitDevice), typeof(bool)),
-                typeof(RealityStabilizedEventTranslationPatch));
+            MethodInfo original = methodName switch
+            {
+                nameof(DummyRealityStabilizedEventTarget.ShortCircuitDevice) =>
+                    RequireMethod(typeof(DummyRealityStabilizedEventTarget), methodName, typeof(bool)),
+                nameof(DummyRealityStabilizedEventTarget.FailedToContestPopup) =>
+                    RequireMethod(typeof(DummyRealityStabilizedEventTarget), methodName),
+                _ => throw new ArgumentOutOfRangeException(nameof(methodName), methodName, null),
+            };
+            PatchOwner(harmony, original, typeof(RealityStabilizedEventTranslationPatch));
 
             var target = new DummyRealityStabilizedEventTarget
             {
                 PopupMessageToSend = message,
             };
 
-            target.ShortCircuitDevice(usePopup: true);
+            switch (methodName)
+            {
+                case nameof(DummyRealityStabilizedEventTarget.ShortCircuitDevice):
+                    target.ShortCircuitDevice(usePopup: true);
+                    break;
+                case nameof(DummyRealityStabilizedEventTarget.FailedToContestPopup):
+                    target.FailedToContestPopup();
+                    break;
+            }
 
             Assert.That(DummyPopupShow.LastShowMessage, Is.EqualTo(expected));
         }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
@@ -2138,6 +2138,16 @@ public sealed class CombatAndLogMessageQueuePatchTests
     [TestCase(
         "You try to push through the normality lattice, but it snaps back into place. You wince in pain.",
         "あなたは通常性格子を押し通ろうとしたが、それは跳ね返って元に戻った。あなたは痛みに顔をしかめた。")]
+    [TestCase(
+        "You push against the normality lattice, but nothing happens.",
+        "You push against the normality lattice, but nothing happens.")]
+    [TestCase("", "")]
+    [TestCase(
+        "\x01You try to push through the normality lattice, but it snaps back into place.",
+        "You try to push through the normality lattice, but it snaps back into place.")]
+    [TestCase(
+        "{{R|You try to push through the normality lattice, but it snaps back into place.}}",
+        "{{R|あなたは通常性格子を押し通ろうとしたが、それは跳ね返って元に戻った。}}")]
     public void RealityStabilizedEvent_TranslatesFailedContestSelfPopup_WhenOwnerPatched(
         string source,
         string expected)

--- a/Mods/QudJP/Assemblies/src/Patches/RealityStabilizedEventTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/RealityStabilizedEventTranslationPatch.cs
@@ -145,20 +145,30 @@ public static class RealityStabilizedEventTranslationPatch
 
     private static bool TryTranslateNormalityLatticePopup(string source, out string translated)
     {
-        if (string.Equals(source, NormalityLatticePopup, StringComparison.Ordinal))
+        var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
+        string? result = null;
+
+        if (string.Equals(stripped, NormalityLatticePopup, StringComparison.Ordinal))
         {
-            translated = NormalityLatticeTranslation;
-            return true;
+            result = NormalityLatticeTranslation;
+        }
+        else if (string.Equals(stripped, NormalityLatticePopup + NormalityLatticeWinceSuffix, StringComparison.Ordinal))
+        {
+            result = NormalityLatticeTranslation + NormalityLatticeWinceTranslation;
         }
 
-        if (string.Equals(source, NormalityLatticePopup + NormalityLatticeWinceSuffix, StringComparison.Ordinal))
+        if (result is null)
         {
-            translated = NormalityLatticeTranslation + NormalityLatticeWinceTranslation;
-            return true;
+            translated = source;
+            return false;
         }
 
-        translated = source;
-        return false;
+        translated = ColorAwareTranslationComposer.RestoreWholeSourceBoundaryWrappersPreservingTranslatedOwnership(
+            result,
+            spans,
+            stripped.Length,
+            source);
+        return true;
     }
 
     private static void AddTarget(List<MethodBase> targets, Type targetType, string methodName, Type[] parameters)

--- a/Mods/QudJP/Assemblies/src/Patches/RealityStabilizedEventTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/RealityStabilizedEventTranslationPatch.cs
@@ -32,6 +32,16 @@ public static class RealityStabilizedEventTranslationPatch
         "^(?<device>.+?) emits? a shower of sparks!$",
         RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
+    private const string NormalityLatticePopup =
+        "You try to push through the normality lattice, but it snaps back into place.";
+
+    private const string NormalityLatticeWinceSuffix = " You wince in pain.";
+
+    private const string NormalityLatticeTranslation =
+        "あなたは通常性格子を押し通ろうとしたが、それは跳ね返って元に戻った。";
+
+    private const string NormalityLatticeWinceTranslation = "あなたは痛みに顔をしかめた。";
+
     [ThreadStatic]
     private static int activeDepth;
 
@@ -118,6 +128,12 @@ public static class RealityStabilizedEventTranslationPatch
             return true;
         }
 
+        if (TryTranslateNormalityLatticePopup(source, out translated))
+        {
+            DynamicTextObservability.RecordTransform(route, family + "." + Context, source, translated);
+            return true;
+        }
+
         if (!TryTranslatePattern(EmitSparksPattern, source, device => $"{device}が火花の雨を放った！", out translated))
         {
             return false;
@@ -125,6 +141,24 @@ public static class RealityStabilizedEventTranslationPatch
 
         DynamicTextObservability.RecordTransform(route, family + "." + Context, source, translated);
         return true;
+    }
+
+    private static bool TryTranslateNormalityLatticePopup(string source, out string translated)
+    {
+        if (string.Equals(source, NormalityLatticePopup, StringComparison.Ordinal))
+        {
+            translated = NormalityLatticeTranslation;
+            return true;
+        }
+
+        if (string.Equals(source, NormalityLatticePopup + NormalityLatticeWinceSuffix, StringComparison.Ordinal))
+        {
+            translated = NormalityLatticeTranslation + NormalityLatticeWinceTranslation;
+            return true;
+        }
+
+        translated = source;
+        return false;
     }
 
     private static void AddTarget(List<MethodBase> targets, Type targetType, string methodName, Type[] parameters)

--- a/Mods/QudJP/Assemblies/src/Patches/RealityStabilizedEventTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/RealityStabilizedEventTranslationPatch.cs
@@ -38,7 +38,7 @@ public static class RealityStabilizedEventTranslationPatch
     private const string NormalityLatticeWinceSuffix = " You wince in pain.";
 
     private const string NormalityLatticeTranslation =
-        "あなたは通常性格子を押し通ろうとしたが、それは跳ね返って元に戻った。";
+        "あなたはノーマリティ格子を押し通ろうとしたが、それは跳ね返って元に戻った。";
 
     private const string NormalityLatticeWinceTranslation = "あなたは痛みに顔をしかめた。";
 

--- a/Mods/QudJP/Localization/Dictionaries/messages.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/messages.ja.json
@@ -1604,6 +1604,11 @@
       "route": "emit-message"
     },
     {
+      "pattern": "^Exodus launch in (\\d+)\\.\\.\\.$",
+      "template": "エクソダス発射まで{0}…",
+      "route": "emit-message"
+    },
+    {
       "pattern": "^The protective force of the cherubim prevents (?:the |a |an )?(.+?) from taking anything from the reliquary[.!]?$",
       "template": "ケルビムの守護の力が{0}を聖遺物櫃から何かを取ることを阻んでいる",
       "route": "emit-message"
@@ -1826,6 +1831,26 @@
     {
       "pattern": "^(.+?) hits (.+?) (.+?)[!.] \\(x(\\d+)\\)$",
       "template": "{0}が{1}に{2}命中！ (x{3})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(.+?) (?:critically )?hits you \\(x(\\d+)\\) (.+?)!$",
+      "template": "{0}があなたに{2}命中！ (x{1})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(.+?) (?:critically )?hits (.+?) \\(x(\\d+)\\) (.+?)!$",
+      "template": "{0}が{1}に{3}命中！ (x{2})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(.+?) (?:critically )?hits you(.*)\\.$",
+      "template": "{0}があなたに命中した{1}。",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(.+?) (?:critically )?hits (.+?) (to the .+?)\\.$",
+      "template": "{0}が{1}に命中した {2}。",
       "route": "emit-message"
     },
     {

--- a/Mods/QudJP/Localization/Dictionaries/messages.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/messages.ja.json
@@ -1824,8 +1824,18 @@
       "route": "emit-message"
     },
     {
+      "pattern": "^(.+?) critically hits you (.+?)[!.] \\(x(\\d+)\\)$",
+      "template": "{0}が会心であなたに{1}命中！ (x{2})",
+      "route": "emit-message"
+    },
+    {
       "pattern": "^(.+?) hits you (.+?)[!.] \\(x(\\d+)\\)$",
       "template": "{0}があなたに{1}命中！ (x{2})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(.+?) critically hits (.+?) (.+?)[!.] \\(x(\\d+)\\)$",
+      "template": "{0}が会心で{1}に{2}命中！ (x{3})",
       "route": "emit-message"
     },
     {
@@ -1834,22 +1844,42 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) (?:critically )?hits you \\(x(\\d+)\\) (.+?)!$",
+      "pattern": "^(.+?) critically hits you \\(x(\\d+)\\) (.+?)!$",
+      "template": "{0}が会心であなたに{2}命中！ (x{1})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(.+?) hits you \\(x(\\d+)\\) (.+?)!$",
       "template": "{0}があなたに{2}命中！ (x{1})",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) (?:critically )?hits (.+?) \\(x(\\d+)\\) (.+?)!$",
+      "pattern": "^(.+?) critically hits (.+?) \\(x(\\d+)\\) (.+?)!$",
+      "template": "{0}が会心で{1}に{3}命中！ (x{2})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(.+?) hits (.+?) \\(x(\\d+)\\) (.+?)!$",
       "template": "{0}が{1}に{3}命中！ (x{2})",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) (?:critically )?hits you(.*)\\.$",
+      "pattern": "^(.+?) critically hits you(.*)\\.$",
+      "template": "{0}が会心であなたに命中した{1}。",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(.+?) hits you(.*)\\.$",
       "template": "{0}があなたに命中した{1}。",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) (?:critically )?hits (.+?) (to the .+?)\\.$",
+      "pattern": "^(.+?) critically hits (.+?) (to the .+?)\\.$",
+      "template": "{0}が会心で{1}に命中した {2}。",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(.+?) hits (.+?) (to the .+?)\\.$",
       "template": "{0}が{1}に命中した {2}。",
       "route": "emit-message"
     },

--- a/Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json
@@ -2671,6 +2671,76 @@
             "key": "{{r|Your mind is stranded here.}}",
             "context": "XRL.UI.Popup.Show.Message",
             "text": "{{r|心がここに取り残されている。}}"
+        },
+        {
+            "key": "That code is invalid.",
+            "context": "XRL.UI.Popup.Show.Message",
+            "text": "そのコードは無効だ。"
+        },
+        {
+            "key": "Your new pet is ready to love.",
+            "context": "XRL.UI.Popup.Show.Message",
+            "text": "新しいペットが愛情を待っている。"
+        },
+        {
+            "key": "You have no activated abilities.",
+            "context": "XRL.UI.Popup.Show.Message",
+            "text": "発動できるアビリティがない。"
+        },
+        {
+            "key": "{{R|Error}}",
+            "context": "XRL.UI.Popup.Show.Message",
+            "text": "{{R|エラー}}"
+        },
+        {
+            "key": "Mouse input is disabled but you clicked on the screen several times. Would you like to enable mouse input?",
+            "context": "XRL.UI.Popup.Show.Message",
+            "text": "マウス入力は無効だが、画面が何度かクリックされた。マウス入力を有効にするか？"
+        },
+        {
+            "key": "There is no valid last character to use.",
+            "context": "XRL.UI.Popup.Show.Message",
+            "text": "使用できる最後のキャラクターがない。"
+        },
+        {
+            "key": " {{W|C}} - Copy seed  {{W|ESC}} - Exit ",
+            "context": "XRL.UI.Popup.Show.Message",
+            "text": " {{W|C}} - シードをコピー  {{W|ESC}} - 終了 "
+        },
+        {
+            "key": "Choose color",
+            "context": "XRL.UI.Popup.Show.Message",
+            "text": "色を選択"
+        },
+        {
+            "key": "What color do you want to draw with?",
+            "context": "XRL.UI.Popup.Show.Message",
+            "text": "何色で描くか？"
+        },
+        {
+            "key": "Choose a primary color.",
+            "context": "XRL.UI.Popup.Show.Message",
+            "text": "主色を選択。"
+        },
+        {
+            "key": "Choose a secondary color.",
+            "context": "XRL.UI.Popup.Show.Message",
+            "text": "副色を選択。"
+        },
+        {
+            "key": "Choose a color for your maker's mark.",
+            "context": "XRL.UI.Popup.Show.Message",
+            "text": "製作者の印の色を選択。"
+        },
+        {
+            "key": "That name is already in use.",
+            "context": "XRL.UI.Popup.Show.Message",
+            "text": "その名前は既に使われている。"
+        },
+        {
+            "key": "There was a fatal exception attempting to save your game. Caves of Qud attempted to recover your prior save. You probably want to close the game and reload your most recent save. It'd be helpful to send the save and logs to support@freeholdgames.com",
+            "context": "XRL.UI.Popup.Show.Message",
+            "text": "ゲーム保存中に致命的な例外が発生した。Caves of Qud は以前のセーブの復元を試みた。ゲームを終了して直近のセーブを読み込み直すのがよいだろう。セーブデータとログを support@freeholdgames.com に送ると助かる。"
         }
     ]
 }

--- a/Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json
@@ -2420,7 +2420,7 @@
         {
             "key": "You try to push through the normality lattice, but it snaps back into place.",
             "context": "XRL.UI.Popup.Show.Message",
-            "text": "正常性格子を押し通ろうとするが、すぐに元の位置へ戻る。"
+            "text": "ノーマリティ格子を押し通ろうとするが、すぐに元の位置へ戻る。"
         },
         {
             "key": "You'll be able to explore the world freely after the tutorial.\n\nFor now, let's visit Joppa.",

--- a/docs/release-notes/unreleased/issue-699-static-producer-popup-leaves.md
+++ b/docs/release-notes/unreleased/issue-699-static-producer-popup-leaves.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Added Japanese text for several fixed popup messages, including code redemption, color selection, mouse input, and save-error prompts.
+- Added message-pattern coverage for Exodus countdown and additional missile hit-output variants.

--- a/docs/reports/2026-05-15-issue-576-static-producer-runtime-deferrals.md
+++ b/docs/reports/2026-05-15-issue-576-static-producer-runtime-deferrals.md
@@ -1,0 +1,271 @@
+# 2026-05-15 issue-576 static producer runtime deferrals
+
+This report records static-producer rows that remain visible in
+`docs/static-producer-inventory.json` as `runtime_required`, but are not
+actionable owner-route implementation work without runtime evidence or a
+dedicated generator owner. The closure overlay keeps them explicit through
+`DEFERRED_RUNTIME_CALLSITES` and removes them from `just
+static-producer-owner-queue` so the queue reflects static owner work.
+
+## Campfire cooking runtime deferrals
+
+`XRL.World.Parts.Campfire.CookPresetMeal`, `CookFromIngredients`, and
+`CookFromRecipe` mix fixed popup leaves, already-covered owner-generated popup
+frames, and runtime cooking text.
+
+Deferred runtime callsites:
+
+- `CookPresetMeal`: line `738`,
+  `HistoricStringExpander.ExpandString("<spice.cooking.ate.!random>")`
+- `CookFromIngredients`: lines `1012`, `1039`, and `1068`, `DescribeMeal(list3)`
+- `CookFromIngredients`: lines `1017`, `1023`, `1044`, `1050`, `1075`, and
+  `1082`, `HistoricStringExpander.ExpandString("<spice.cooking.ate.!random>")`
+- `CookFromRecipe`: lines `1221` and `1228`,
+  `HistoricStringExpander.ExpandString("<spice.cooking.ate.!random>")`
+
+Static decision: `DescribeMeal` depends on selected runtime ingredients and
+cooking template expansion. The `HistoricStringExpander` calls depend on
+runtime HistorySpice selection. These rows should stay outside owner-action
+closure until a scoped cooking/HistorySpice owner route is implemented.
+
+## XRLCore PlayerTurn runtime deferrals
+
+`XRL.Core.XRLCore.PlayerTurn` already has covered owner callsites for the HP
+warning, invalid inventory object, invalid wait count, autoattack/flee/reach
+path popups, nearby-hostile message, and terse/verbose message toggles.
+
+Deferred runtime callsites:
+
+- line `945`, `text4`
+- line `1057`, generated game-mode, turn, and world-seed popup block plus copy
+  footer state
+- line `1335`, `currentCell8.ParentZone.SpecialUpMessage()`
+- line `1780`, `text5 ?? ("You need to reload! (" + ControlManager...)`
+
+Static decision: final text depends on runtime ability/use failure state, game
+state, zone-supplied movement text, or active control binding descriptions.
+
+## Inventory FireEvent runtime deferrals
+
+`XRL.World.Parts.Inventory.FireEvent` already has covered owner callsites for
+the graveyard-zone queued recovery line and container ownership popup.
+
+Deferred runtime callsites:
+
+- lines `1657`, `1726`, and `1745`, `FailureMessage2`
+- line `1974`, `text3`
+- lines `2036`, `2046`, `2089`, `2100`, and `2147`, `FailureMessage3`
+
+Static decision: these messages are supplied by runtime inventory action and
+equipment procedure branches. They need route-specific runtime evidence or a
+separate failure-message owner before implementation.
+
+## Physics and ConversationScript runtime deferrals
+
+`XRL.World.Parts.Physics.HandleEvent` already has covered owner callsites for
+object-entering-cell messages and inventory-action popups. `ProcessTargetedMove`
+already has covered owner callsite coverage for the attack-confirm popup.
+
+Owner-covered Physics callsites:
+
+- `HandleEvent` line `2582`, `OUCH! You collide with ...`, is handled by
+  `PhysicsObjectEnteringCellTranslationPatch` through the repository message
+  pattern for collision text.
+- `HandleEvent` lines `2593` and `2598` are handled by the same owner route for
+  world-map traversal and blocked-way messages.
+- `ProcessTargetedMove` line `3938` is handled by
+  `SingleCallsiteOwnerPopupTranslationPatch` for the attack-confirm popup.
+
+Deferred Physics runtime callsites:
+
+- `HandleEvent` line `2589`, `ParentObject.GetTag("OverlandBlockMessage")`
+- `HandleEvent` line `2847`, `GetDebugInternalsEvent.GetFor(ParentObject)`
+- `ProcessTargetedMove` line `3912`,
+  `TargetCell.GetFirstObjectWithPropertyOrTag("NoTeleport").GetPropertyOrTag("NoTeleport")`
+
+`XRL.World.Parts.ConversationScript` already has covered owner callsites for
+the generated physical and mental conversation popups.
+
+Deferred ConversationScript runtime callsites:
+
+- `IsPhysicalConversationPossible` lines `273` and `323`, runtime `Message` /
+  `FailureMessage`
+- `IsMentalConversationPossible` lines `363` and `381`, runtime `Message` /
+  `FailureMessage`
+
+Static decision: these shapes are supplied by runtime object tags, debug
+internals, target-cell properties, conversation event messages, or failure
+message variables. They are not fixed popup leaves and should not be counted as
+owner-action work until runtime evidence identifies a concrete owner route.
+
+## Next owner queue runtime deferrals
+
+After the high-volume mixed families above were split, the next queue leaders
+were small mixed families whose remaining owner-action rows were also
+runtime-only or pseudo-runtime rows.
+
+`XRL.World.Parts.Crayons.HandleEvent`:
+
+- line `63`, `Popup.ShowColorPicker("What color do you want to draw with?", 0,
+  null, 60, ..., "", includeNone: false)`.
+- Static decision: the visible title is an exact `ui-popup.ja.json` leaf. The
+  callsite is classified as `runtime_required` because Roslyn records the
+  `null` intro and empty spacing text formal arguments; those are not visible
+  owner-action work.
+
+`XRL.World.Parts.Chat.PerformChat`:
+
+- lines `182`, `191`, and `206`, direct `Says` payload pass-through from star
+  and bracket-authored chat text.
+- Static decision: the generated speech-frame rows are covered separately by
+  DoesVerb route evidence. The direct payload rows are runtime-authored object
+  data and need data-source/runtime proof before translation.
+
+`XRL.World.Parts.ITeleporter.AttemptTeleport`:
+
+- line `297`, `customTeleportFailure`.
+- Static decision: this text is supplied by the active teleporter implementation
+  at runtime. The fixed and generated owner popups plus queued activation line
+  are already covered by `ITeleporterTranslationPatch`.
+
+`XRL.World.Parts.MissileWeapon.FireEvent`:
+
+- lines `2472` and `2490`, `Message` / `Message2` returned by ammo/load events.
+- Static decision: these are runtime event failure messages. The fixed/generic
+  shot-wild and pass-by rows are handled through existing message leaves and
+  message patterns.
+
+`XRL.World.Parts.Garbage.AttemptRifle`:
+
+- line `148`, `text2`, the trash-divining journal note message.
+- Static decision: the prefix frame is generated from actor/object/direction,
+  then concatenated with `randomUnrevealedNote.Text`. The actor rifling rows
+  and player rifling result patterns are covered separately; the journal-note
+  body remains runtime data.
+
+## Small mixed-family runtime deferrals
+
+The next queue pass found additional small mixed families where owner-generated
+rows are already covered, fixed leaves are already in dictionaries, and only
+runtime/pseudo-runtime rows kept the source file in the owner queue.
+
+`XRL.World.Parts.TattooGun.AttemptTattoo`:
+
+- line `177`, primary color `Popup.ShowColorPicker`.
+- Static decision: the visible primary-color title is an exact popup leaf. The
+  owner-generated tattoo success lines remain covered by
+  `TattooGunTranslationPatch`; the color-picker null/empty optional arguments
+  are not owner-action work.
+
+`XRL.UI.Popup.AskStringAsync`:
+
+- line `1395`, `ShowColorPickerAsync("Choose color", ..., StripFormatting(result))`.
+- Static decision: the visible title is an exact popup leaf. The preview content
+  is runtime user input and should not be treated as a static owner queue item.
+
+`XRL.World.Tinkering.TinkeringHelpers.CheckMakersMark`:
+
+- line `99`, `ShowColorPicker("Choose a color for your maker's mark.", ..., text)`.
+- Static decision: the visible title is an exact popup leaf. The maker-mark
+  preview value is runtime-selected.
+
+`XRL.UI.TradeUI.ShowTradeScreen`:
+
+- line `1087`, `stringBuilder.ToString()`.
+- Static decision: haggle text is assembled from runtime trade offer state.
+  Existing trade-owner popups are covered separately.
+
+`XRL.World.Parts.LiquidVolume.HandleEvent`:
+
+- lines `3192`, `3227`, and `3538`, liquid interaction string builders.
+- Static decision: ownership and fixed queue/popup fragments are covered by
+  existing LiquidVolume owner routes; these rows are runtime detail builders.
+
+`XRL.World.Parts.RandomAltarBaetyl.BaetylWantsSacrifice`:
+
+- lines `759` and `805`, sacrifice/reward string builders.
+- Static decision: fixed and generated reward popups are covered separately;
+  these rows depend on runtime sacrifice/reward details.
+
+`XRL.World.Parts.Stomach.FireEvent`:
+
+- line `538`, runtime `stringBuilder`.
+- Static decision: fixed moisture-loss messages are covered separately; this row
+  is runtime drinking/eating detail text.
+
+`XRL.SifrahGame.UseInsight`:
+
+- line `856`, runtime `stringBuilder.ToString()`.
+- Static decision: option-elimination text depends on the current Sifrah option
+  state. The fixed no-op insight leaves are dictionary-covered.
+
+## Final small mixed-family runtime deferrals
+
+The remaining owner queue pass reduced to small mixed families where all
+`owner_patch_required` rows were already covered by owner-route tests and the
+only actionable residue was scanner `runtime_required` text. These rows are
+registered as callsite-level runtime deferrals rather than full-family owner
+closure.
+
+- `XRL.UI.AbilityManager.Show` line `483`: ability `NotUsableDescription`
+  supplied by the selected runtime `ActivatedAbilityEntry`.
+- `XRL.UI.OptionsUI.Show` line `546`: restart prompt assembled from runtime
+  option display text.
+- `WaterRitualRandomMutation.HandleEvent` line `98`: conversation-authored
+  reward text expanded with runtime speaker and mutation data.
+- `ShadeOil_Tonic.FireEvent` line `196`: phasing prompt assembled from runtime
+  body-part and source-object context.
+- `Rifle_SuppressiveFire.FireEvent` line `64` and
+  `Rifle_WoundingFire.FireEvent` line `60`: reload popup text supplied by
+  runtime ammo events or current control binding text.
+- `FixitSpray.HandleEvent` line `90`: fallback popup supplied by runtime
+  inventory-action message data.
+- `IZoneLandmark.WishCurrent` line `139`: landmark wish output built from
+  runtime zone/location landmark data.
+- `TerrainTravel.HandleEvent` lines `120` and `124`: encounter prompts supplied
+  by runtime encounter definitions.
+- `ZoneManager.SetActiveZone` lines `1889` and `1912`: zone display names and
+  journal-note entry text are runtime/source-data payloads. Line `1885` remains
+  owner-covered separately because it adds the generated time suffix frame.
+- `MetricsManager.LogException` line `563`: exception popup body is runtime
+  diagnostic text; the `{{R|Error}}` title is a fixed popup leaf.
+- `Scores.Show` line `265`: high-score details are saved scoreboard detail
+  text.
+- `StatusScreen.Show` line `460`: psychic glimmer description generated from
+  the runtime glimmer value.
+- `WaterRitualBuySecret.RevealEntry` line `64`: gossip text combines
+  HistorySpice lead-in and runtime journal observation text.
+- `Snapjaw_Howl.FireEvent` line `146`: affected-object list assembled from
+  runtime nearby objects.
+- `ActivatedAbilityEntry.TrySendCommandEventOnPlayer` line `555`: ability
+  failure text returned by runtime command handling.
+- `DestroyOnUnequip.HandleEvent` line `33`: part-authored message
+  variable-replaced against the runtime object.
+- `Examiner.ResultCriticalFailure` line `951`: critical failure text selected
+  from runtime examination/object state.
+- `Fetches.HandleEvent` line `35`: configured sniff message variable-replaced
+  against the runtime object.
+- `MagnetizedApplicator.HandleEvent` line `66`: callback popup supplied by
+  runtime event message data.
+- `Mutations.WishMutation` line `976`: wish/debug failure text composed from
+  runtime wish arguments.
+- `NephalProperties.HandleEvent` line `161`: configured phase message
+  variable-replaced with runtime actor/object data.
+- `NeutronFluxContainment.HandleEvent` line `99`: warning body built from
+  runtime containment state.
+- `StairsDown.CheckPullDown` line `443`: pull-down message supplied by
+  part/runtime data.
+- `ThiefBot.FireEvent` line `69`: steal message assembled from runtime
+  actor/target/item data.
+- `Tonic.HandleEvent` line `212`: tonic action popup supplied by part/runtime
+  message data.
+- `GameObjectFactory.HandleBlueprintXML` line `1761`: wish/debug output dumps
+  runtime blueprint XML.
+- `PopulationManager.WishGenerate` line `1015`: wish/debug generation report
+  assembled from runtime generated-object counts/results.
+- `XRLGame.LoadGame` line `1916`: load-game failure popup displays runtime
+  save/mod/exception context.
+
+One near miss was not deferred: `RealityStabilized.FailedToContest` line `477`
+is a local fixed string-builder shape, not runtime payload. It is covered by
+`RealityStabilizedEventTranslationPatch` with focused popup tests instead.

--- a/docs/reports/2026-05-15-issue-699-static-producer-message-candidates.md
+++ b/docs/reports/2026-05-15-issue-699-static-producer-message-candidates.md
@@ -1,0 +1,117 @@
+# 2026-05-15 issue 699 static producer message-candidate policy pass
+
+## Scope
+
+This report resolves the `messages_candidate` side of the static producer
+inventory after the issue-576 owner-patch closure work. It uses
+`docs/static-producer-inventory.json` plus the current
+`scripts/static_producer_closure.py` coverage overlay. Covered owner families
+and covered mixed-family owner callsites are excluded before policy grouping.
+
+This is not an owner-route patch batch. `AddPlayerMessage` remains
+sink-observed and is not a fixed-leaf destination shortcut.
+
+## Export command
+
+```bash
+uv run python scripts/static_producer_closure.py \
+  --queue message-candidates \
+  --format json \
+  --limit 0
+```
+
+The text summary form is:
+
+```bash
+uv run python scripts/static_producer_closure.py \
+  --queue message-candidates \
+  --limit 0
+```
+
+## Current decision summary
+
+After adding the accepted popup leaves in this batch, the remaining
+`messages_candidate` text arguments group as follows:
+
+| Decision | Text args | Destination | Policy result |
+| --- | ---: | --- | --- |
+| `existing_dictionary_coverage` | 542 | existing popup/message dictionaries | Already covered by exact dictionary keys; no new import work. |
+| `existing_message_pattern_coverage` | 144 | existing message patterns | Already covered by current `messages.ja.json` patterns and L1/L2 tests. |
+| `existing_does_verb_route_coverage` | 5 | existing DoesVerb route | Already covered by `verbs.ja.json` frame routing and DoesVerb tests. |
+| `existing_owner_route_coverage` | 2 | existing owner route | Already covered by current owner patches and L2 tests. |
+| `reject_pseudo_leaf` | 5 | none | Empty popup arguments; pseudo-leaf noise. |
+
+Surface split:
+
+| Surface | Text args |
+| --- | ---: |
+| `Popup.Show*` | 536 |
+| `EmitMessage` | 162 |
+
+## Accepted popup leaves
+
+These were fixed `Popup.Show*` literals with no exact dictionary coverage, so
+they were added to `Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json`.
+Concrete mutation range leaves such as `That is out of range! (8 squares)` were
+kept out of the exact-leaf additions because the existing parameterized
+out-of-range popup entries already cover them.
+
+| Source | Key |
+| --- | --- |
+| `CodeRedemptionManager.cs` | `That code is invalid.` |
+| `CodeRedemptionManager.cs` | `Your new pet is ready to love.` |
+| `Qud.UI/AbilityManagerScreen.cs` | `You have no activated abilities.` |
+| `MetricsManager.cs` | <code>{{R&#124;Error}}</code> |
+| `Qud.UI/MouseBlocker.cs` | `Mouse input is disabled but you clicked on the screen several times. Would you like to enable mouse input?` |
+| `XRL.CharacterBuilds.Qud/QudChartypeModule.cs` | `There is no valid last character to use.` |
+| `XRL.Core/XRLCore.cs` | <code> {{W&#124;C}} - Copy seed  {{W&#124;ESC}} - Exit </code> |
+| `XRL.UI/Popup.cs` | `Choose color` |
+| `XRL.World.Parts/Crayons.cs` | `What color do you want to draw with?` |
+| `XRL.World.Parts/TattooGun.cs` | `Choose a primary color.` |
+| `XRL.World.Parts/TattooGun.cs` | `Choose a secondary color.` |
+| `XRL.World.Tinkering/TinkeringHelpers.cs` | `Choose a color for your maker's mark.` |
+| `XRL.World/Gender.cs` | `That name is already in use.` |
+| `XRL/XRLGame.cs` | `There was a fatal exception attempting to save your game. Caves of Qud attempted to recover your prior save. You probably want to close the game and reload your most recent save. It'd be helpful to send the save and logs to support@freeholdgames.com` |
+
+## Rejected and deferred groups
+
+- The five empty popup arguments are pseudo-leaf rows from color/prompt helper
+  calls. They are intentionally not dictionary entries.
+- 144 generated `EmitMessage` rows are now classified as existing message-pattern
+  coverage because current `messages.ja.json` patterns and tests already prove
+  the emitted shapes. The covered groups are LiquidProteanGunk, LiquidWarmStatic
+  glitch and wish-effect messages, Bleeding stop messages, FungalCureQueasy, IrisdualCallow,
+  Luminous, Nosebleed, Carapace loosen messages, CherubimLock, Combat reach/pass-through
+  messages, CyberneticsButcherableCybernetic butcher/rip messages,
+  CyberneticsHolographicVisage, DecoyHologramEmitter image messages, Door open/close messages,
+  ForceBubble, ChevronWall/HexCrystal, CursedCellSocket, FungalInfection skin
+  messages, Garbage rifle-through messages, GeomagneticDisc, Harvestable,
+  HelpingHands, Joppa/SixDay zealot speech, MagazineAmmoLoader reload/no ammo
+  messages, Mutations chimeric growth, RocketSkates, SoupSludge,
+  Tinkering_Mine disarm results, VehicleMeleeInfiltration, SpaceTimeVortex,
+  and the MissileWeapon vital-area, penetration, suppressive/flattening fire,
+  wound/disorient, wild-shot, pass-by, hit-output, direction, critical, and
+  outcome-fragment messages. `ShevaStarshipControl.CheckTimer` is covered by the
+  new `Exodus launch in N...` pattern.
+- Five generated `EmitMessage` rows are classified as existing DoesVerb route
+  coverage: `Campfire.Extinguish`, `FungalInfection.FireEvent` line 77, and
+  `MagazineAmmoLoader.HandleEvent` line 361, plus the two `Chat.PerformChat`
+  speech-frame rows. For `Chat`, the dynamic speech payload is preserved while
+  only the generated `says, '{{|...}}'.` frame is counted as covered.
+- Two generated `EmitMessage` rows are classified as existing owner-route
+  coverage: `DesalinationPellet.HandleEvent` and
+  `DeployableInfrastructure.DeployOne`.
+- No `messages_candidate` text arguments remain deferred in this policy export.
+- `EmitMessage` static literals with exact dictionary coverage are counted as
+  existing coverage, not new additions.
+
+## Verification targets
+
+This batch should pass:
+
+```bash
+just static-producer-check
+just localization-check
+just translation-token-check
+just release-note-check origin/main HEAD
+```

--- a/justfile
+++ b/justfile
@@ -102,7 +102,7 @@ python-test-filter pattern:
 localization-check:
   {{python}} scripts/check_encoding.py Mods/QudJP/Localization scripts
   {{python}} scripts/check_glossary_consistency.py Mods/QudJP/Localization
-  {{python}} scripts/validate_pattern_routes.py Mods/QudJP/Localization/Dictionaries/messages.ja.json --expect-count message-frame=41 --expect-count popup=12 --expect-count journal=0 --expect-count leaf=0 --expect-count emit-message=303 --expect-count does-verb=0 --expect-count message-log=1 --expect-count description=4 --expect-count effect-cripple=1 --expect-count needs-harmony-patch=37 --expect-count unclassified=6
+  {{python}} scripts/validate_pattern_routes.py Mods/QudJP/Localization/Dictionaries/messages.ja.json --expect-count message-frame=41 --expect-count popup=12 --expect-count journal=0 --expect-count leaf=0 --expect-count emit-message=308 --expect-count does-verb=0 --expect-count message-log=1 --expect-count description=4 --expect-count effect-cripple=1 --expect-count needs-harmony-patch=37 --expect-count unclassified=6
   {{python}} scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
 
 # Check placeholder and markup-token parity in JSON localization assets.

--- a/justfile
+++ b/justfile
@@ -102,7 +102,7 @@ python-test-filter pattern:
 localization-check:
   {{python}} scripts/check_encoding.py Mods/QudJP/Localization scripts
   {{python}} scripts/check_glossary_consistency.py Mods/QudJP/Localization
-  {{python}} scripts/validate_pattern_routes.py Mods/QudJP/Localization/Dictionaries/messages.ja.json --expect-count message-frame=41 --expect-count popup=12 --expect-count journal=0 --expect-count leaf=0 --expect-count emit-message=308 --expect-count does-verb=0 --expect-count message-log=1 --expect-count description=4 --expect-count effect-cripple=1 --expect-count needs-harmony-patch=37 --expect-count unclassified=6
+  {{python}} scripts/validate_pattern_routes.py Mods/QudJP/Localization/Dictionaries/messages.ja.json --expect-count message-frame=41 --expect-count popup=12 --expect-count journal=0 --expect-count leaf=0 --expect-count emit-message=314 --expect-count does-verb=0 --expect-count message-log=1 --expect-count description=4 --expect-count effect-cripple=1 --expect-count needs-harmony-patch=37 --expect-count unclassified=6
   {{python}} scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
 
 # Check placeholder and markup-token parity in JSON localization assets.

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -17,6 +17,8 @@ DEFAULT_INVENTORY_PATH: Final = REPO_ROOT / "docs" / "static-producer-inventory.
 COVERED_BY_OWNER_PATCH: Final = "covered_by_owner_patch"
 OWNER_ACTION_STATUSES: Final = frozenset({"owner_patch_required", "needs_family_review"})
 OWNER_ACTION_CALLSITE_STATUSES: Final = frozenset({"owner_patch_required", "runtime_required", "needs_family_review"})
+MESSAGE_CANDIDATE_STATUS: Final = "messages_candidate"
+DICTIONARY_RELATIVE_ROOT: Final = Path("Mods/QudJP/Localization/Dictionaries")
 HACKING_SIFRAH_RESULT_SIGNATURE_SUFFIX: Final = (
     "System.Void|XRL.World.GameObject|XRL.World.GameObject|XRL.World.HackingSifrah"
 )
@@ -42,6 +44,17 @@ COMBAT_MELEE_ATTACK_SIGNATURE_PARTS: Final = (
 )
 COMBAT_MELEE_ATTACK_FULL_SIGNATURE: Final = "|".join(COMBAT_MELEE_ATTACK_SIGNATURE_PARTS)
 OutputFormat = Literal["text", "json"]
+OutputQueue = Literal["owner", "message-candidates"]
+MessageCandidateDecision = Literal[
+    "existing_dictionary_coverage",
+    "existing_message_pattern_coverage",
+    "existing_does_verb_route_coverage",
+    "existing_owner_route_coverage",
+    "fixed_popup_leaf_addition_candidate",
+    "reject_pseudo_leaf",
+    "defer_emit_message_pattern",
+    "defer_generated_or_runtime",
+]
 
 
 class OwnerActionQueueEntry(TypedDict):
@@ -72,6 +85,27 @@ class SourceFileQueueEntry(TypedDict):
     families: list[OwnerActionQueueEntry]
 
 
+class MessageCandidatePolicyEntry(TypedDict):
+    """Policy review row for one remaining messages_candidate text argument."""
+
+    source_file: str
+    producer_family_id: str
+    type_name: str
+    member_name: str
+    member_start_line: int
+    line: int
+    target_surface: str
+    argument_role: str
+    formal_index: int
+    expression: str
+    expression_kind: str
+    literal_text: str | None
+    decision: MessageCandidateDecision
+    destination: str
+    reason: str
+    coverage_locations: list[str]
+
+
 @dataclass(frozen=True)
 class EvidenceFile:
     """A source or test file that must contain evidence for a covered family."""
@@ -96,6 +130,37 @@ class CoveredOwnerCallsites:
     family_id: str
     lines: tuple[int, ...]
     inventory_statuses: tuple[str, ...]
+    evidence_files: tuple[EvidenceFile, ...]
+
+
+@dataclass(frozen=True)
+class DeferredRuntimeCallsites:
+    """Runtime-dependent callsites that should not remain in the owner-action queue."""
+
+    family_id: str
+    lines: tuple[int, ...]
+    reason: str
+    evidence_files: tuple[EvidenceFile, ...]
+
+
+@dataclass(frozen=True)
+class CoveredMessagePatternCallsites:
+    """Inventory message-candidate callsites covered by current message patterns and tests."""
+
+    family_id: str
+    lines: tuple[int, ...]
+    evidence_files: tuple[EvidenceFile, ...]
+
+
+@dataclass(frozen=True)
+class CoveredMessageCandidateRouteCallsites:
+    """Inventory message-candidate callsites covered by non-pattern translation routes."""
+
+    family_id: str
+    lines: tuple[int, ...]
+    decision: MessageCandidateDecision
+    destination: str
+    reason: str
     evidence_files: tuple[EvidenceFile, ...]
 
 
@@ -3004,7 +3069,7 @@ def _physics_handle_event_object_entering_cell_callsites() -> tuple[CoveredOwner
     return (
         CoveredOwnerCallsites(
             family_id="XRL.World.Parts/Physics.cs::XRL.World.Parts.Physics.HandleEvent",
-            lines=(2593, 2598),
+            lines=(2582, 2593, 2598),
             inventory_statuses=("needs_family_review",),
             evidence_files=(
                 EvidenceFile(
@@ -3027,6 +3092,7 @@ def _physics_handle_event_object_entering_cell_callsites() -> tuple[CoveredOwner
                         "PhysicsObjectEnteringCell_DoesNotTranslateQueueOnlyTraffic_WhenOwnerAbsent",
                         "PhysicsObjectEnteringCell_DoesNotRetranslateDirectMarkedQueuedMessage_WhenOwnerPatched",
                         "PhysicsObjectEnteringCell_LeavesEmptyQueuedMessageUnchanged_WhenOwnerPatched",
+                        "OUCH! You collide with a chrome pyramid.",
                         "The way is blocked by an chrome pyramid.",
                         "too difficult to traverse via the world map",
                     ),
@@ -3042,6 +3108,7 @@ def _physics_handle_event_object_entering_cell_callsites() -> tuple[CoveredOwner
                 EvidenceFile(
                     "Mods/QudJP/Localization/Dictionaries/messages.ja.json",
                     (
+                        "OUCH! You collide with",
                         "The way is blocked by",
                         "too difficult to traverse via the world map",
                     ),
@@ -11990,6 +12057,365 @@ def _xrl_core_player_turn_owner_callsites() -> tuple[CoveredOwnerCallsites, ...]
     )
 
 
+def _issue_576_runtime_deferred_callsites() -> tuple[DeferredRuntimeCallsites, ...]:
+    """Runtime-only leftovers split out of large mixed static-producer families."""
+    report = EvidenceFile(
+        "docs/reports/2026-05-15-issue-576-static-producer-runtime-deferrals.md",
+        (
+            "Campfire cooking runtime deferrals",
+            "XRLCore PlayerTurn runtime deferrals",
+            "Inventory FireEvent runtime deferrals",
+            "Physics and ConversationScript runtime deferrals",
+            "Next owner queue runtime deferrals",
+            "Small mixed-family runtime deferrals",
+            "Final small mixed-family runtime deferrals",
+        ),
+    )
+    tests = EvidenceFile(
+        "scripts/tests/test_static_producer_closure.py",
+        (
+            "test_deferred_runtime_callsite_registry_has_unique_line_keys",
+            "test_large_mixed_families_drop_out_of_owner_action_queue_after_runtime_deferral",
+        ),
+    )
+
+    return (
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/Campfire.cs::XRL.World.Parts.Campfire.CookPresetMeal",
+            lines=(738,),
+            reason="HistorySpice cooking ate text is generated at runtime.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/Campfire.cs::XRL.World.Parts.Campfire.CookFromIngredients",
+            lines=(1012, 1017, 1023, 1039, 1044, 1050, 1068, 1075, 1082),
+            reason="DescribeMeal and HistorySpice cooking ate text depend on runtime ingredient and spice expansion.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/Campfire.cs::XRL.World.Parts.Campfire.CookFromRecipe",
+            lines=(1221, 1228),
+            reason="HistorySpice cooking ate text is generated at runtime.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.Core/XRLCore.cs::XRL.Core.XRLCore.PlayerTurn",
+            lines=(945, 1057, 1335, 1780),
+            reason="PlayerTurn popup text depends on runtime ability, game state, zone, or control binding values.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/Inventory.cs::XRL.World.Parts.Inventory.FireEvent",
+            lines=(1657, 1726, 1745, 1974, 2036, 2046, 2089, 2100, 2147),
+            reason="Inventory failure-message variables are supplied by runtime event/procedure branches.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/Physics.cs::XRL.World.Parts.Physics.HandleEvent",
+            lines=(2589, 2847),
+            reason="Physics block/debug messages are supplied by runtime object tags, properties, or debug internals.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/Physics.cs::XRL.World.Parts.Physics.ProcessTargetedMove",
+            lines=(3912,),
+            reason="NoTeleport failure popup is supplied by a runtime target-cell object property or tag.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id=(
+                "XRL.World.Parts/ConversationScript.cs::"
+                "XRL.World.Parts.ConversationScript.IsPhysicalConversationPossible"
+            ),
+            lines=(273, 323),
+            reason="Conversation physical failure text is supplied by runtime event failure-message variables.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id=(
+                "XRL.World.Parts/ConversationScript.cs::"
+                "XRL.World.Parts.ConversationScript.IsMentalConversationPossible"
+            ),
+            lines=(363, 381),
+            reason="Conversation mental failure text is supplied by runtime event failure-message variables.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/Crayons.cs::XRL.World.Parts.Crayons.HandleEvent",
+            lines=(63,),
+            reason=(
+                "ShowColorPicker visible title is a covered fixed leaf; null intro and empty spacing text "
+                "are pseudo-runtime arguments."
+            ),
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/Chat.cs::XRL.World.Parts.Chat.PerformChat",
+            lines=(182, 191, 206),
+            reason=(
+                "Chat payload text is read from the runtime Says property and may be authored bracket/star "
+                "pass-through text."
+            ),
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/ITeleporter.cs::XRL.World.Parts.ITeleporter.AttemptTeleport",
+            lines=(297,),
+            reason="Custom teleport failure text is supplied by the active teleporter implementation at runtime.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/MissileWeapon.cs::XRL.World.Parts.MissileWeapon.FireEvent",
+            lines=(2472, 2490),
+            reason="Missile load-ammo failure text is supplied by runtime ammo/load events.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/Garbage.cs::XRL.World.Parts.Garbage.AttemptRifle",
+            lines=(148,),
+            reason="Trash-divining journal-note text is composed from runtime note selection and note body text.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/TattooGun.cs::XRL.World.Parts.TattooGun.AttemptTattoo",
+            lines=(177,),
+            reason=(
+                "ShowColorPicker visible primary-color title is a covered fixed leaf; null intro and spacing "
+                "are pseudo-runtime arguments."
+            ),
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.UI/Popup.cs::XRL.UI.Popup.AskStringAsync",
+            lines=(1395,),
+            reason="AskStringAsync color picker uses a covered fixed title plus runtime input preview content.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Tinkering/TinkeringHelpers.cs::XRL.World.Tinkering.TinkeringHelpers.CheckMakersMark",
+            lines=(99,),
+            reason="Maker's mark color picker uses a covered fixed title plus runtime maker-mark preview content.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.UI/TradeUI.cs::XRL.UI.TradeUI.ShowTradeScreen",
+            lines=(1087,),
+            reason="Haggle popup text is assembled from runtime trade-offer state.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/LiquidVolume.cs::XRL.World.Parts.LiquidVolume.HandleEvent",
+            lines=(3192, 3227, 3538),
+            reason="Liquid interaction detail text is assembled in runtime string builders.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/RandomAltarBaetyl.cs::XRL.World.Parts.RandomAltarBaetyl.BaetylWantsSacrifice",
+            lines=(759, 805),
+            reason="Baetyl sacrifice and reward detail text is assembled in runtime string builders.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/Stomach.cs::XRL.World.Parts.Stomach.FireEvent",
+            lines=(538,),
+            reason="Drinking/eating outcome detail text is assembled in a runtime string builder.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL/SifrahGame.cs::XRL.SifrahGame.UseInsight",
+            lines=(856,),
+            reason="Insight option-elimination popup text is assembled from runtime Sifrah option state.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.UI/AbilityManager.cs::XRL.UI.AbilityManager.Show",
+            lines=(483,),
+            reason="Ability not-usable popup text is supplied by the runtime ActivatedAbilityEntry.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.UI/OptionsUI.cs::XRL.UI.OptionsUI.Show",
+            lines=(546,),
+            reason="Restart-required option prompt is assembled from runtime option display text.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id=(
+                "XRL.World.Conversations.Parts/WaterRitualRandomMutation.cs::"
+                "XRL.World.Conversations.Parts.WaterRitualRandomMutation.HandleEvent"
+            ),
+            lines=(98,),
+            reason=(
+                "Water ritual mutation reward text is authored per conversation part and filled with "
+                "runtime speaker/mutation data."
+            ),
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Effects/ShadeOil_Tonic.cs::XRL.World.Effects.ShadeOil_Tonic.FireEvent",
+            lines=(196,),
+            reason="Shade-oil phasing prompt is assembled from runtime phase context and source object names.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts.Skill/Rifle_SuppressiveFire.cs::XRL.World.Parts.Skill.Rifle_SuppressiveFire.FireEvent",
+            lines=(64,),
+            reason="Suppressive-fire reload popup is supplied by runtime ammo events or current control binding text.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts.Skill/Rifle_WoundingFire.cs::XRL.World.Parts.Skill.Rifle_WoundingFire.FireEvent",
+            lines=(60,),
+            reason="Wounding-fire reload popup is supplied by runtime ammo events or current control binding text.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/FixitSpray.cs::XRL.World.Parts.FixitSpray.HandleEvent",
+            lines=(90,),
+            reason="Fix-it spray fallback popup is supplied by runtime inventory-action message data.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/IZoneLandmark.cs::XRL.World.Parts.IZoneLandmark.WishCurrent",
+            lines=(139,),
+            reason="Landmark wish output is built from runtime zone/location landmark data.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/TerrainTravel.cs::XRL.World.Parts.TerrainTravel.HandleEvent",
+            lines=(120, 124),
+            reason="Terrain encounter prompts are supplied by runtime encounter definitions.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World/ZoneManager.cs::XRL.World.ZoneManager.SetActiveZone",
+            lines=(1889, 1912),
+            reason="Active-zone display messages are composed from runtime zone names and entry messages.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="MetricsManager.cs::MetricsManager.LogException",
+            lines=(563,),
+            reason="Exception popup body is assembled from runtime exception and metric context.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.Core/Scores.cs::XRL.Core.Scores.Show",
+            lines=(265,),
+            reason="High-score details popup displays runtime score detail text.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.UI/StatusScreen.cs::XRL.UI.StatusScreen.Show",
+            lines=(460,),
+            reason="Psychic glimmer popup text is generated from runtime glimmer value.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id=(
+                "XRL.World.Conversations.Parts/WaterRitualBuySecret.cs::"
+                "XRL.World.Conversations.Parts.WaterRitualBuySecret.RevealEntry"
+            ),
+            lines=(64,),
+            reason="Water ritual secret text is supplied by the runtime journal entry.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts.Skill/Snapjaw_Howl.cs::XRL.World.Parts.Skill.Snapjaw_Howl.FireEvent",
+            lines=(146,),
+            reason="Snapjaw howl effect list is assembled from runtime nearby objects.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id=(
+                "XRL.World.Parts/ActivatedAbilityEntry.cs::"
+                "XRL.World.Parts.ActivatedAbilityEntry.TrySendCommandEventOnPlayer"
+            ),
+            lines=(555,),
+            reason="Activated ability failure message is returned by the runtime command event.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/DestroyOnUnequip.cs::XRL.World.Parts.DestroyOnUnequip.HandleEvent",
+            lines=(33,),
+            reason="Destroy-on-unequip popup is supplied by part data and variable-replaced at runtime.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/Examiner.cs::XRL.World.Parts.Examiner.ResultCriticalFailure",
+            lines=(951,),
+            reason="Critical examination failure popup is selected from runtime examination state.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/Fetches.cs::XRL.World.Parts.Fetches.HandleEvent",
+            lines=(35,),
+            reason="Fetch sniff message is part-authored text variable-replaced against the runtime object.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/MagnetizedApplicator.cs::XRL.World.Parts.MagnetizedApplicator.HandleEvent",
+            lines=(66,),
+            reason="Magnetized applicator callback popup is supplied by runtime event message data.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/Mutations.cs::XRL.World.Parts.Mutations.WishMutation",
+            lines=(976,),
+            reason="Wish mutation failure popup is composed from runtime wish arguments.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/NephalProperties.cs::XRL.World.Parts.NephalProperties.HandleEvent",
+            lines=(161,),
+            reason="Nephal phase message is part-authored text variable-replaced with runtime actor/object data.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/NeutronFluxContainment.cs::XRL.World.Parts.NeutronFluxContainment.HandleEvent",
+            lines=(99,),
+            reason="Neutron flux warning popup is built from runtime containment state.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/StairsDown.cs::XRL.World.Parts.StairsDown.CheckPullDown",
+            lines=(443,),
+            reason="Pull-down message is supplied by part/runtime data.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/ThiefBot.cs::XRL.World.Parts.ThiefBot.FireEvent",
+            lines=(69,),
+            reason="Thief-bot steal message is assembled from runtime target/item data.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World.Parts/Tonic.cs::XRL.World.Parts.Tonic.HandleEvent",
+            lines=(212,),
+            reason="Tonic action popup is supplied by part/runtime message data.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL.World/GameObjectFactory.cs::XRL.World.GameObjectFactory.HandleBlueprintXML",
+            lines=(1761,),
+            reason="Blueprint XML popup displays runtime blueprint XML content.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL/PopulationManager.cs::XRL.PopulationManager.WishGenerate",
+            lines=(1015,),
+            reason="Population wish generation output is assembled from runtime generated objects.",
+            evidence_files=(report, tests),
+        ),
+        DeferredRuntimeCallsites(
+            family_id="XRL/XRLGame.cs::XRL.XRLGame.LoadGame",
+            lines=(1916,),
+            reason="Load-game failure popup displays runtime exception/failure message text.",
+            evidence_files=(report, tests),
+        ),
+    )
+
+
 COVERED_OWNER_FAMILIES: Final = (
     CoveredOwnerFamily(
         family_id="XRL.World.Parts/LiquidVolume.cs::XRL.World.Parts.LiquidVolume.Pour",
@@ -14406,12 +14832,12 @@ COVERED_OWNER_CALLSITES: Final = (
             ),
         ),
     ),
-    CoveredOwnerCallsites(
-        family_id=(
-            "XRL.World.Effects/RealityStabilized.cs::"
-            "XRL.World.Effects.RealityStabilized.FailedToContest"
-        ),
-        lines=(489, 493),
+        CoveredOwnerCallsites(
+            family_id=(
+                "XRL.World.Effects/RealityStabilized.cs::"
+                "XRL.World.Effects.RealityStabilized.FailedToContest"
+            ),
+        lines=(477, 489, 493),
         inventory_statuses=("needs_family_review",),
         evidence_files=(
             EvidenceFile(
@@ -14419,10 +14845,16 @@ COVERED_OWNER_CALLSITES: Final = (
                 (
                     "RealityStabilizedEventTranslationPatch",
                     "FailedToContest",
+                    "NormalityLatticePopup",
                     "PsychicThudPattern",
                     "WincePattern",
                     "TryTranslateQueuedMessage",
+                    "TryTranslatePopupMessage",
                 ),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/PopupShowSemanticPipeline.cs",
+                ("RealityStabilizedEventTranslationPatch.TryTranslatePopupMessage",),
             ),
             EvidenceFile(
                 "Mods/QudJP/Assemblies/src/Patches/MessageQueueSemanticPipeline.cs",
@@ -14431,10 +14863,12 @@ COVERED_OWNER_CALLSITES: Final = (
             EvidenceFile(
                 "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
                 (
+                    "RealityStabilizedEvent_TranslatesFailedContestSelfPopup_WhenOwnerPatched",
                     "RealityStabilizedEvent_TranslatesQueuedMessages_WhenOwnerPatched",
                     "RealityStabilizedEvent_DoesNotTranslateQueueOnlyTraffic_WhenOwnerAbsent",
                     "RealityStabilizedEvent_DoesNotRetranslateDirectMarkedQueuedMessage_WhenOwnerPatched",
                     "RealityStabilizedEvent_LeavesEmptyMessagesUnchanged_WhenOwnerPatched",
+                    "You try to push through the normality lattice, but it snaps back into place.",
                     "nameof(DummyRealityStabilizedEventTarget.FailedToContest)",
                     "You feel a psychic thud as {{G|glowfish}} pushes against",
                     "someone pushes against the structure of spacetime and fails to break through.",
@@ -17163,6 +17597,497 @@ COVERED_OWNER_CALLSITE_KEYS: Final = frozenset(
     for covered in COVERED_OWNER_CALLSITES
     for line in covered.lines
 )
+DEFERRED_RUNTIME_CALLSITES: Final = _issue_576_runtime_deferred_callsites()
+DEFERRED_RUNTIME_CALLSITE_KEYS: Final = frozenset(
+    (deferred.family_id, line)
+    for deferred in DEFERRED_RUNTIME_CALLSITES
+    for line in deferred.lines
+)
+CYBERNETICS_BUTCHER_PATTERN_FILE: Final = "XRL.World.Parts/CyberneticsButcherableCybernetic.cs::"
+CYBERNETICS_BUTCHER_PATTERN_MEMBER: Final = "XRL.World.Parts.CyberneticsButcherableCybernetic.AttemptButcher"
+CYBERNETICS_BUTCHER_PATTERN_FAMILY_ID: Final = (
+    f"{CYBERNETICS_BUTCHER_PATTERN_FILE}{CYBERNETICS_BUTCHER_PATTERN_MEMBER}"
+)
+HOLOGRAPHIC_VISAGE_PATTERN_FILE: Final = "XRL.World.Parts/CyberneticsHolographicVisage.cs::"
+HOLOGRAPHIC_VISAGE_PATTERN_MEMBER: Final = "XRL.World.Parts.CyberneticsHolographicVisage.SelectVisage"
+HOLOGRAPHIC_VISAGE_PATTERN_FAMILY_ID: Final = (
+    f"{HOLOGRAPHIC_VISAGE_PATTERN_FILE}{HOLOGRAPHIC_VISAGE_PATTERN_MEMBER}"
+)
+TINKERING_MINE_EXCEPTIONAL_SUCCESS_PATTERN_FILE: Final = "XRL.World.Parts/Tinkering_Mine.cs::"
+TINKERING_MINE_EXCEPTIONAL_SUCCESS_PATTERN_MEMBER: Final = (
+    "XRL.World.Parts.Tinkering_Mine.DisarmingResultExceptionalSuccess"
+)
+TINKERING_MINE_EXCEPTIONAL_SUCCESS_PATTERN_FAMILY_ID: Final = (
+    f"{TINKERING_MINE_EXCEPTIONAL_SUCCESS_PATTERN_FILE}{TINKERING_MINE_EXCEPTIONAL_SUCCESS_PATTERN_MEMBER}"
+)
+VEHICLE_MELEE_INFILTRATION_PATTERN_FILE: Final = "XRL.World.Parts/VehicleMeleeInfiltration.cs::"
+VEHICLE_MELEE_INFILTRATION_PATTERN_MEMBER: Final = "XRL.World.Parts.VehicleMeleeInfiltration.HandleEvent"
+VEHICLE_MELEE_INFILTRATION_PATTERN_FAMILY_ID: Final = (
+    f"{VEHICLE_MELEE_INFILTRATION_PATTERN_FILE}{VEHICLE_MELEE_INFILTRATION_PATTERN_MEMBER}"
+)
+MESSAGE_PATTERN_COVERED_CALLSITES: Final = (
+    CoveredMessagePatternCallsites(
+        "XRL.Liquids/LiquidProteanGunk.cs::XRL.Liquids.LiquidProteanGunk.ProcessTurns",
+        (208, 219),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.Liquids/LiquidWarmStatic.cs::XRL.Liquids.LiquidWarmStatic.GlitchLiquidComponents",
+        (417, 421),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.Liquids/LiquidWarmStatic.cs::XRL.Liquids.LiquidWarmStatic.WishWarmEffect",
+        (827,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.Liquids/LiquidWarmStatic.cs::XRL.Liquids.LiquidWarmStatic.WishWarmEffectSpec",
+        (844, 849),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Effects/Bleeding.cs::XRL.World.Effects.Bleeding.StopMessage",
+        (333,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Effects/FungalCureQueasy.cs::XRL.World.Effects.FungalCureQueasy.Apply",
+        (48,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Effects/IrisdualCallow.cs::XRL.World.Effects.IrisdualCallow.Apply",
+        (139,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Effects/IrisdualCallow.cs::XRL.World.Effects.IrisdualCallow.Remove",
+        (146,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Effects/Luminous.cs::XRL.World.Effects.Luminous.Remove",
+        (53,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Effects/Nosebleed.cs::XRL.World.Effects.Nosebleed.StartMessage",
+        (93, 97, 102, 106),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Effects/Nosebleed.cs::XRL.World.Effects.Nosebleed.StopMessage",
+        (120, 124, 129, 133),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts.Mutation/Carapace.cs::XRL.World.Parts.Mutation.Carapace.Loosen",
+        (221, 230),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts.Mutation/ForceBubble.cs::XRL.World.Parts.Mutation.ForceBubble.CreateBubble",
+        (210,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts.Mutation/ErosTeleportation.cs::XRL.World.Parts.Mutation.ErosTeleportation.Cast",
+        (139,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/ChevronWall.cs::XRL.World.Parts.ChevronWall.HandleEvent",
+        (54, 58),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/CherubimLock.cs::XRL.World.Parts.CherubimLock.FireEvent",
+        (105,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/Combat.cs::XRL.World.Parts.Combat.PerformMeleeAttack",
+        (690, 695),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/CursedCellSocket.cs::XRL.World.Parts.CursedCellSocket.HandleEvent",
+        (68,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        CYBERNETICS_BUTCHER_PATTERN_FAMILY_ID,
+        (161, 165, 178, 182),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        HOLOGRAPHIC_VISAGE_PATTERN_FAMILY_ID,
+        (150,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/DecoyHologramEmitter.cs::XRL.World.Parts.DecoyHologramEmitter.PlaceHologram",
+        (329,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/DecoyHologramEmitter.cs::XRL.World.Parts.DecoyHologramEmitter.DestroyHolograms",
+        (438, 450),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/Door.cs::XRL.World.Parts.Door.AttemptOpen",
+        (388, 396, 404, 432, 446, 461, 475, 510),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/Door.cs::XRL.World.Parts.Door.AttemptClose",
+        (630, 642, 657, 692),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/FungalInfection.cs::XRL.World.Parts.FungalInfection.FireEvent",
+        (81,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/FungalInfection.cs::XRL.World.Parts.FungalInfection.Cure",
+        (121,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/EquipStatBoost.cs::XRL.World.Parts.EquipStatBoost.ExamineFailure",
+        (364,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/Garbage.cs::XRL.World.Parts.Garbage.AttemptRifle",
+        (168, 179, 192),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/GeomagneticDisc.cs::XRL.World.Parts.GeomagneticDisc.FireEvent",
+        (202,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/Harvestable.cs::XRL.World.Parts.Harvestable.AttemptHarvest",
+        (316, 320, 324, 331, 335, 339),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/HelpingHands.cs::XRL.World.Parts.HelpingHands.ExamineFailure",
+        (114,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/HexCrystal.cs::XRL.World.Parts.HexCrystal.HandleEvent",
+        (54, 58),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/JoppaZealot.cs::XRL.World.Parts.JoppaZealot.ZealotDeclaim",
+        (118,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/MagazineAmmoLoader.cs::XRL.World.Parts.MagazineAmmoLoader.HandleEvent",
+        (353,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/MagazineAmmoLoader.cs::XRL.World.Parts.MagazineAmmoLoader.Load",
+        (613,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/MissileWeapon.cs::XRL.World.Parts.MissileWeapon.MissileHit",
+        (
+            1678,
+            1682,
+            1783,
+            1787,
+            1794,
+            1798,
+            1836,
+            1840,
+            1849,
+            1853,
+            1866,
+            1870,
+            1878,
+            1882,
+            2018,
+            2022,
+            2027,
+            2039,
+            2043,
+            2048,
+            2053,
+            2057,
+            2069,
+            2073,
+            2078,
+            2082,
+            2089,
+            2093,
+            2098,
+            2102,
+            2113,
+            2117,
+            2122,
+            2126,
+            2133,
+            2137,
+            2142,
+            2146,
+            2166,
+            2170,
+            2175,
+            2185,
+            2189,
+            2194,
+            2199,
+            2203,
+            2214,
+            2218,
+            2223,
+            2227,
+            2234,
+            2238,
+            2243,
+            2247,
+            2258,
+            2262,
+            2267,
+            2271,
+            2278,
+            2282,
+            2287,
+            2291,
+        ),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/MissileWeapon.cs::XRL.World.Parts.MissileWeapon.FireEvent",
+        (2590, 3476),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/Mutations.cs::XRL.World.Parts.Mutations.AddChimericBodyPart",
+        (562,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/RocketSkates.cs::XRL.World.Parts.RocketSkates.HandleEvent",
+        (103,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/SixDayZealot.cs::XRL.World.Parts.SixDayZealot.ZealotDeclaim",
+        (60,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/SoupSludge.cs::XRL.World.Parts.SoupSludge.CatalyzeMessage",
+        (155, 159),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/SpaceTimeVortex.cs::XRL.World.Parts.SpaceTimeVortex.ApplyVortex",
+        (386,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/Tinkering_Mine.cs::XRL.World.Parts.Tinkering_Mine.DisarmingResultSuccess",
+        (820,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        TINKERING_MINE_EXCEPTIONAL_SUCCESS_PATTERN_FAMILY_ID,
+        (834,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/Tinkering_Mine.cs::XRL.World.Parts.Tinkering_Mine.DisarmingResultPartialSuccess",
+        (843,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        VEHICLE_MELEE_INFILTRATION_PATTERN_FAMILY_ID,
+        (103,),
+        (),
+    ),
+    CoveredMessagePatternCallsites(
+        "XRL.World.Parts/ShevaStarshipControl.cs::XRL.World.Parts.ShevaStarshipControl.CheckTimer",
+        (142,),
+        (),
+    ),
+)
+MESSAGE_PATTERN_COVERED_CALLSITE_KEYS: Final = frozenset(
+    (covered.family_id, line)
+    for covered in MESSAGE_PATTERN_COVERED_CALLSITES
+    for line in covered.lines
+)
+MESSAGE_CANDIDATE_ROUTE_COVERED_CALLSITES: Final = (
+    CoveredMessageCandidateRouteCallsites(
+        "XRL.World.Parts.Mutation/AcidSlimeGlands.cs::XRL.World.Parts.Mutation.AcidSlimeGlands.FireEvent",
+        (81,),
+        "existing_dictionary_coverage",
+        "existing popup dictionary leaf",
+        "static popup leaf is covered by the parameterized out-of-range popup dictionary leaf",
+        (
+            EvidenceFile(
+                "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+                ("That is out of range! ({0} squares)",),
+            ),
+        ),
+    ),
+    CoveredMessageCandidateRouteCallsites(
+        "XRL.World.Parts.Mutation/Burgeoning.cs::XRL.World.Parts.Mutation.Burgeoning.Burgeon",
+        (205,),
+        "existing_dictionary_coverage",
+        "existing popup dictionary leaf",
+        "static popup leaf is covered by the parameterized out-of-range popup dictionary leaf",
+        (
+            EvidenceFile(
+                "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+                ("That is out of range! ({0} squares)",),
+            ),
+        ),
+    ),
+    CoveredMessageCandidateRouteCallsites(
+        "XRL.World.Parts.Mutation/FrostWebs.cs::XRL.World.Parts.Mutation.FrostWebs.FireEvent",
+        (113,),
+        "existing_dictionary_coverage",
+        "existing popup dictionary leaf",
+        "static popup leaf is covered by the parameterized out-of-range popup dictionary leaf",
+        (
+            EvidenceFile(
+                "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+                ("That is out of range! ({0} squares)",),
+            ),
+        ),
+    ),
+    CoveredMessageCandidateRouteCallsites(
+        "XRL.World.Parts.Mutation/SlogGlands.cs::XRL.World.Parts.Mutation.SlogGlands.FireEvent",
+        (148,),
+        "existing_dictionary_coverage",
+        "existing popup dictionary leaf",
+        "static popup leaf is covered by the parameterized out-of-range popup dictionary leaf",
+        (
+            EvidenceFile(
+                "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+                ("That is out of range! ({0} squares)",),
+            ),
+        ),
+    ),
+    CoveredMessageCandidateRouteCallsites(
+        "XRL.World.Parts.Mutation/SpacetimeVortex.cs::XRL.World.Parts.Mutation.SpacetimeVortex.FireEvent",
+        (117,),
+        "existing_dictionary_coverage",
+        "existing popup dictionary leaf",
+        "static popup leaf is covered by the parameterized target out-of-range popup dictionary leaf",
+        (
+            EvidenceFile(
+                "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+                ("That target is out of range! ({0} squares)",),
+            ),
+        ),
+    ),
+    CoveredMessageCandidateRouteCallsites(
+        "XRL.World.Parts/Campfire.cs::XRL.World.Parts.Campfire.Extinguish",
+        (1936,),
+        "existing_does_verb_route_coverage",
+        "existing DoesVerb route",
+        "current verbs.ja.json frames and DoesVerb tests cover this generated sentence",
+        (
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs",
+                ("The 炎 is extinguished by the 水.",),
+            ),
+        ),
+    ),
+    CoveredMessageCandidateRouteCallsites(
+        "XRL.World.Parts/Chat.cs::XRL.World.Parts.Chat.PerformChat",
+        (195, 210),
+        "existing_does_verb_route_coverage",
+        "existing DoesVerb route",
+        "current verbs.ja.json frames and DoesVerb tests cover the generated speech frame",
+        (
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs",
+                ("The 熊 says, '{{|挨拶}}'.",),
+            ),
+        ),
+    ),
+    CoveredMessageCandidateRouteCallsites(
+        "XRL.World.Parts/FungalInfection.cs::XRL.World.Parts.FungalInfection.FireEvent",
+        (77,),
+        "existing_does_verb_route_coverage",
+        "existing DoesVerb route",
+        "current verbs.ja.json frames and DoesVerb tests cover this generated sentence",
+        (
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs",
+                ("The 装置 is immune to conventional treatments.",),
+            ),
+        ),
+    ),
+    CoveredMessageCandidateRouteCallsites(
+        "XRL.World.Parts/MagazineAmmoLoader.cs::XRL.World.Parts.MagazineAmmoLoader.HandleEvent",
+        (361,),
+        "existing_does_verb_route_coverage",
+        "existing DoesVerb route",
+        "current verbs.ja.json frames and DoesVerb tests cover this generated sentence",
+        (
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs",
+                ("The 武器 is already fully loaded.",),
+            ),
+        ),
+    ),
+    CoveredMessageCandidateRouteCallsites(
+        "XRL.World.Parts/DesalinationPellet.cs::XRL.World.Parts.DesalinationPellet.HandleEvent",
+        (85,),
+        "existing_owner_route_coverage",
+        "existing owner route",
+        "current owner patch and fragment translator cover this generated composite message",
+        (
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/DesalinationPelletTranslationPatch.cs",
+                ("XRL.World.Parts.DesalinationPellet", "HandleEvent"),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/WorldPartsProducerTranslationPatchTests.cs",
+                ("DesalinationPelletPatch_TranslatesCompositePopupPrefix_WhenPatched",),
+            ),
+        ),
+    ),
+    CoveredMessageCandidateRouteCallsites(
+        "XRL.World.Parts/DeployableInfrastructure.cs::XRL.World.Parts.DeployableInfrastructure.DeployOne",
+        (334,),
+        "existing_owner_route_coverage",
+        "existing owner route",
+        "current owner patch and queue semantic pipeline cover this generated DoesVerb message",
+        (
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/src/Patches/DeployableInfrastructureTranslationPatch.cs",
+                ("XRL.World.Parts.DeployableInfrastructure", "DeployOne"),
+            ),
+            EvidenceFile(
+                "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+                ("DeployableInfrastructurePatch_TranslatesDeployMessage_WhenPatched",),
+            ),
+        ),
+    ),
+)
+MESSAGE_CANDIDATE_ROUTE_COVERED_CALLSITE_DETAILS: Final = {
+    (covered.family_id, line): covered
+    for covered in MESSAGE_CANDIDATE_ROUTE_COVERED_CALLSITES
+    for line in covered.lines
+}
 
 
 def load_inventory(path: Path) -> InventoryPayload:
@@ -17178,6 +18103,11 @@ def covered_family_ids() -> frozenset[str]:
 def covered_callsite_keys() -> frozenset[tuple[str, int]]:
     """Return mixed-family callsites that current tests close as owner-patch covered."""
     return COVERED_OWNER_CALLSITE_KEYS
+
+
+def deferred_runtime_callsite_keys() -> frozenset[tuple[str, int]]:
+    """Return runtime-required callsites that are explicitly outside static owner-action work."""
+    return DEFERRED_RUNTIME_CALLSITE_KEYS
 
 
 def family_closure_status(family: FamilyPayload) -> str:
@@ -17224,6 +18154,126 @@ def owner_action_queue_by_file(inventory: InventoryPayload) -> list[SourceFileQu
             entry["source_file"],
         ),
     )
+
+
+def message_candidate_policy_entries(
+    inventory: InventoryPayload,
+    repo_root: Path = REPO_ROOT,
+) -> list[MessageCandidatePolicyEntry]:
+    """Return remaining messages_candidate text arguments with policy routing."""
+    dictionary_locations = _dictionary_key_locations(repo_root / DICTIONARY_RELATIVE_ROOT, repo_root)
+    entries: list[MessageCandidatePolicyEntry] = []
+    covered_families = covered_family_ids()
+    covered_callsites = covered_callsite_keys()
+    for callsite in inventory["callsites"]:
+        if callsite["producer_family_id"] in covered_families:
+            continue
+        if (callsite["producer_family_id"], callsite["line"]) in covered_callsites:
+            continue
+
+        for text_argument in callsite["text_arguments"]:
+            if text_argument["closure_status"] != MESSAGE_CANDIDATE_STATUS:
+                continue
+
+            callsite_key = (callsite["producer_family_id"], callsite["line"])
+            literal_text = _literal_expression_value(text_argument["expression"])
+            if callsite_key in MESSAGE_PATTERN_COVERED_CALLSITE_KEYS:
+                decision: MessageCandidateDecision = "existing_message_pattern_coverage"
+                destination = "existing message pattern"
+                reason = "current messages.ja.json patterns and tests cover this generated EmitMessage shape"
+            elif route_coverage := MESSAGE_CANDIDATE_ROUTE_COVERED_CALLSITE_DETAILS.get(callsite_key):
+                decision = route_coverage.decision
+                destination = route_coverage.destination
+                reason = route_coverage.reason
+            else:
+                decision, destination, reason = _message_candidate_policy(
+                    target_surface=callsite["target_surface"],
+                    expression_kind=text_argument["expression_kind"],
+                    literal_text=literal_text,
+                    dictionary_locations=dictionary_locations,
+                )
+            entries.append(
+                {
+                    "source_file": callsite["file"],
+                    "producer_family_id": callsite["producer_family_id"],
+                    "type_name": callsite["type_name"],
+                    "member_name": callsite["member_name"],
+                    "member_start_line": callsite["member_start_line"],
+                    "line": callsite["line"],
+                    "target_surface": callsite["target_surface"],
+                    "argument_role": text_argument["role"],
+                    "formal_index": text_argument["formal_index"],
+                    "expression": text_argument["expression"],
+                    "expression_kind": text_argument["expression_kind"],
+                    "literal_text": literal_text,
+                    "decision": decision,
+                    "destination": destination,
+                    "reason": reason,
+                    "coverage_locations": sorted(dictionary_locations.get(literal_text or "", ())),
+                }
+            )
+
+    return sorted(
+        entries,
+        key=lambda entry: (
+            entry["decision"],
+            entry["destination"],
+            entry["source_file"],
+            entry["line"],
+            entry["formal_index"],
+        ),
+    )
+
+
+def format_message_candidate_policy_queue(
+    inventory: InventoryPayload,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> str:
+    """Format remaining messages_candidate policy groups for review."""
+    entries = message_candidate_policy_entries(inventory, repo_root)
+    decision_counts = _message_candidate_counter(entries, "decision")
+    destination_counts = _message_candidate_counter(entries, "destination")
+    source_files = {entry["source_file"] for entry in entries}
+    lines = [
+        "".join(
+            (
+                "message candidate policy queue: ",
+                f"{len(entries)} text arguments across {len(source_files)} source files; ",
+                f"decisions={_format_counter(decision_counts)}; ",
+                f"destinations={_format_counter(destination_counts)}",
+            )
+        )
+    ]
+
+    grouped: dict[str, list[MessageCandidatePolicyEntry]] = {}
+    for entry in entries:
+        grouped.setdefault(entry["decision"], []).append(entry)
+
+    for decision in sorted(grouped):
+        decision_entries = grouped[decision]
+        destinations = _message_candidate_counter(decision_entries, "destination")
+        surfaces = _message_candidate_counter(decision_entries, "target_surface")
+        lines.append(
+            "".join(
+                (
+                    f"- {decision}: {len(decision_entries)} text args; ",
+                    f"destinations={_format_counter(destinations)}; ",
+                    f"surfaces={_format_counter(surfaces)}",
+                )
+            )
+        )
+        lines.extend(
+            "".join(
+                (
+                    f"  - {entry['source_file']}:{entry['line']} ",
+                    f"{entry['target_surface']} {entry['expression']}",
+                )
+            )
+            for entry in decision_entries[:5]
+        )
+
+    return "\n".join(lines)
 
 
 def format_owner_action_queue(
@@ -17308,8 +18358,99 @@ def validate_covered_owner_families(
         errors.extend(_validate_evidence_files(covered.family_id, covered.evidence_files, repo_root))
 
     errors.extend(_validate_covered_owner_callsites(inventory, families, repo_root))
+    errors.extend(_validate_deferred_runtime_callsites(inventory, families, repo_root))
+    errors.extend(_validate_message_pattern_covered_callsites(inventory, repo_root))
+    errors.extend(_validate_message_candidate_route_covered_callsites(inventory, repo_root))
 
     return errors
+
+
+def _dictionary_key_locations(dictionary_root: Path, repo_root: Path = REPO_ROOT) -> dict[str, set[str]]:
+    locations: dict[str, set[str]] = {}
+    for path in sorted(dictionary_root.glob("*.ja.json")):
+        payload = cast("dict[str, object]", json.loads(path.read_text(encoding="utf-8")))
+        raw_entries = payload.get("entries", ())
+        if not isinstance(raw_entries, list):
+            continue
+        entries = cast("list[object]", raw_entries)
+        for raw_entry in entries:
+            if not isinstance(raw_entry, dict):
+                continue
+            entry = cast("dict[str, object]", raw_entry)
+            key = entry.get("key")
+            if isinstance(key, str):
+                locations.setdefault(key, set()).add(str(path.relative_to(repo_root)))
+    return locations
+
+
+def _literal_expression_value(expression: str) -> str | None:
+    if not (expression.startswith('"') and expression.endswith('"')):
+        return None
+
+    try:
+        value = cast("object", json.loads(expression))
+    except json.JSONDecodeError:
+        return None
+
+    return value if isinstance(value, str) else None
+
+
+def _message_candidate_policy(
+    *,
+    target_surface: str,
+    expression_kind: str,
+    literal_text: str | None,
+    dictionary_locations: dict[str, set[str]],
+) -> tuple[MessageCandidateDecision, str, str]:
+    if literal_text is not None and literal_text.strip() == "":
+        return (
+            "reject_pseudo_leaf",
+            "none",
+            "empty or whitespace-only popup text is pseudo-leaf noise, not a player-facing dictionary leaf",
+        )
+
+    if target_surface == "EmitMessage":
+        if expression_kind == "static_literal" and literal_text in dictionary_locations:
+            return (
+                "existing_dictionary_coverage",
+                "existing message dictionary leaf",
+                "static EmitMessage leaf already has exact dictionary coverage",
+            )
+        return (
+            "defer_emit_message_pattern",
+            "message-pattern route review",
+            "EmitMessage text is message-route traffic and must be reviewed as a message pattern or owner route",
+        )
+
+    if target_surface == "Popup.Show*" and expression_kind == "static_literal":
+        if literal_text in dictionary_locations:
+            return (
+                "existing_dictionary_coverage",
+                "existing popup dictionary leaf",
+                "static popup leaf already has exact dictionary coverage",
+            )
+        return (
+            "fixed_popup_leaf_addition_candidate",
+            "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+            "static popup leaf has no exact dictionary coverage and is eligible for narrow popup dictionary review",
+        )
+
+    return (
+        "defer_generated_or_runtime",
+        "owner/runtime route review",
+        "non-static or non-popup candidate needs route-specific review before dictionary promotion",
+    )
+
+
+def _message_candidate_counter(
+    entries: list[MessageCandidatePolicyEntry],
+    key: Literal["decision", "destination", "target_surface"],
+) -> dict[str, int]:
+    counter: dict[str, int] = {}
+    for entry in entries:
+        value = entry[key]
+        counter[value] = counter.get(value, 0) + 1
+    return counter
 
 
 def _validate_covered_owner_callsites(
@@ -17346,6 +18487,135 @@ def _validate_covered_owner_callsites(
     return errors
 
 
+def _validate_deferred_runtime_callsites(
+    inventory: InventoryPayload,
+    families: dict[str, FamilyPayload],
+    repo_root: Path,
+) -> list[str]:
+    errors: list[str] = []
+    callsites_by_family: dict[str, list[CallsitePayload]] = {}
+    for callsite in inventory["callsites"]:
+        callsites_by_family.setdefault(callsite["producer_family_id"], []).append(callsite)
+
+    seen_callsite_keys: set[tuple[str, int]] = set()
+    for deferred in DEFERRED_RUNTIME_CALLSITES:
+        family = families.get(deferred.family_id)
+        if family is None:
+            errors.append(f"deferred runtime family missing from inventory: {deferred.family_id}")
+            continue
+
+        errors.extend(
+            _validate_deferred_runtime_callsite_lines(
+                deferred,
+                callsites_by_family.get(deferred.family_id, []),
+                seen_callsite_keys,
+            )
+        )
+        errors.extend(_validate_evidence_files(deferred.family_id, deferred.evidence_files, repo_root))
+
+    return errors
+
+
+def _validate_deferred_runtime_callsite_lines(
+    deferred: DeferredRuntimeCallsites,
+    family_callsites: list[CallsitePayload],
+    seen_callsite_keys: set[tuple[str, int]],
+) -> list[str]:
+    errors: list[str] = []
+    indexed_callsites = {callsite["line"]: callsite for callsite in family_callsites}
+    for line in deferred.lines:
+        key = (deferred.family_id, line)
+        if key in seen_callsite_keys:
+            errors.append(f"duplicate deferred runtime callsite: {deferred.family_id}:{line}")
+            continue
+
+        seen_callsite_keys.add(key)
+        callsite = indexed_callsites.get(line)
+        if callsite is None:
+            errors.append(f"deferred runtime callsite missing from inventory: {deferred.family_id}:{line}")
+            continue
+
+        if callsite["closure_status"] != "runtime_required":
+            errors.append(
+                f"{deferred.family_id}:{line}: expected runtime_required callsite, got {callsite['closure_status']}"
+            )
+
+    return errors
+
+
+def _validate_message_pattern_covered_callsites(
+    inventory: InventoryPayload,
+    repo_root: Path,
+) -> list[str]:
+    errors: list[str] = []
+    callsites_by_family: dict[str, list[CallsitePayload]] = {}
+    for callsite in inventory["callsites"]:
+        callsites_by_family.setdefault(callsite["producer_family_id"], []).append(callsite)
+
+    seen_callsite_keys: set[tuple[str, int]] = set()
+    for covered in MESSAGE_PATTERN_COVERED_CALLSITES:
+        errors.extend(
+            _validate_message_pattern_callsite_lines(
+                covered,
+                callsites_by_family.get(covered.family_id, []),
+                seen_callsite_keys,
+            )
+        )
+        errors.extend(_validate_evidence_files(covered.family_id, covered.evidence_files, repo_root))
+
+    return errors
+
+
+def _validate_message_candidate_route_covered_callsites(
+    inventory: InventoryPayload,
+    repo_root: Path,
+) -> list[str]:
+    errors: list[str] = []
+    callsites_by_family: dict[str, list[CallsitePayload]] = {}
+    for callsite in inventory["callsites"]:
+        callsites_by_family.setdefault(callsite["producer_family_id"], []).append(callsite)
+
+    seen_callsite_keys: set[tuple[str, int]] = set()
+    for covered in MESSAGE_CANDIDATE_ROUTE_COVERED_CALLSITES:
+        errors.extend(
+            _validate_message_pattern_callsite_lines(
+                covered,
+                callsites_by_family.get(covered.family_id, []),
+                seen_callsite_keys,
+            )
+        )
+        errors.extend(_validate_evidence_files(covered.family_id, covered.evidence_files, repo_root))
+
+    return errors
+
+
+def _validate_message_pattern_callsite_lines(
+    covered: CoveredMessagePatternCallsites | CoveredMessageCandidateRouteCallsites,
+    family_callsites: list[CallsitePayload],
+    seen_callsite_keys: set[tuple[str, int]],
+) -> list[str]:
+    errors: list[str] = []
+    indexed_callsites = {callsite["line"]: callsite for callsite in family_callsites}
+    for line in covered.lines:
+        key = (covered.family_id, line)
+        if key in seen_callsite_keys:
+            errors.append(f"duplicate message-pattern covered callsite: {covered.family_id}:{line}")
+            continue
+
+        seen_callsite_keys.add(key)
+        callsite = indexed_callsites.get(line)
+        if callsite is None:
+            errors.append(f"message-pattern covered callsite missing from inventory: {covered.family_id}:{line}")
+            continue
+
+        if callsite["closure_status"] != MESSAGE_CANDIDATE_STATUS:
+            errors.append(
+                f"{covered.family_id}:{line}: expected messages_candidate callsite, got {callsite['closure_status']}"
+            )
+
+    return errors
+
+
 def _validate_covered_owner_callsite_lines(
     covered: CoveredOwnerCallsites,
     family_callsites: list[CallsitePayload],
@@ -17365,9 +18635,14 @@ def _validate_covered_owner_callsite_lines(
             errors.append(f"covered callsite missing from inventory: {covered.family_id}:{line}")
             continue
 
-        if callsite["closure_status"] != "owner_patch_required":
+        if callsite["closure_status"] not in {"owner_patch_required", "runtime_required"}:
             errors.append(
-                f"{covered.family_id}:{line}: expected owner_patch_required callsite, got {callsite['closure_status']}"
+                "".join(
+                    (
+                        f"{covered.family_id}:{line}: expected owner_patch_required/runtime_required callsite, ",
+                        f"got {callsite['closure_status']}",
+                    )
+                )
             )
 
     return errors
@@ -17397,13 +18672,15 @@ def _validate_evidence_files(
 
 def main(argv: list[str] | None = None) -> int:
     """Print or serialize the current static-producer owner action queue."""
-    parser = ArgumentParser(description="Summarize static producer owner-route work by decompiled C# file.")
+    parser = ArgumentParser(description="Summarize static producer owner-route and message-candidate policy work.")
     _ = parser.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY_PATH)
+    _ = parser.add_argument("--queue", choices=("owner", "message-candidates"), default="owner")
     _ = parser.add_argument("--format", choices=("text", "json"), default="text")
     _ = parser.add_argument("--limit", type=int, default=30, help="maximum source files for text output; 0 means all")
     args = parser.parse_args(argv)
 
     inventory_path = cast("Path", args.inventory)
+    queue = cast("OutputQueue", args.queue)
     output_format = cast("OutputFormat", args.format)
     limit_arg = cast("int", args.limit)
     limit = None if limit_arg == 0 else limit_arg
@@ -17413,6 +18690,25 @@ def main(argv: list[str] | None = None) -> int:
     if evidence_errors:
         _ = sys.stderr.write("\n".join(evidence_errors) + "\n")
         return 1
+
+    if queue == "message-candidates":
+        entries = message_candidate_policy_entries(inventory)
+        if output_format == "json":
+            payload = {
+                "schema_version": "1.0",
+                "inventory": str(inventory_path),
+                "source_file_count": len({entry["source_file"] for entry in entries}),
+                "text_argument_count": len(entries),
+                "decision_counts": _message_candidate_counter(entries, "decision"),
+                "destination_counts": _message_candidate_counter(entries, "destination"),
+                "surface_counts": _message_candidate_counter(entries, "target_surface"),
+                "entries": entries,
+            }
+            _ = sys.stdout.write(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+            return 0
+
+        _ = sys.stdout.write(format_message_candidate_policy_queue(inventory) + "\n")
+        return 0
 
     if output_format == "json":
         source_entries = owner_action_queue_by_file(inventory)
@@ -17475,13 +18771,20 @@ def _remaining_family_callsite_records(inventory: InventoryPayload, family: Fami
     if family["producer_family_id"] in covered_family_ids():
         return []
 
+    deferred_runtime_keys = deferred_runtime_callsite_keys()
+
     if not _family_has_partial_callsite_coverage(family["producer_family_id"]):
-        return _family_callsite_records(inventory, family)
+        return [
+            call
+            for call in _family_callsite_records(inventory, family)
+            if (call["producer_family_id"], call["line"]) not in deferred_runtime_keys
+        ]
 
     return [
         call
         for call in _family_callsite_records(inventory, family)
         if (call["producer_family_id"], call["line"]) not in covered_callsite_keys()
+        and (call["producer_family_id"], call["line"]) not in deferred_runtime_keys
     ]
 
 
@@ -17489,9 +18792,6 @@ def _family_has_owner_action_remaining(inventory: InventoryPayload, family: Fami
     status = family_closure_status(family)
     if status not in OWNER_ACTION_STATUSES:
         return False
-
-    if not _family_has_partial_callsite_coverage(family["producer_family_id"]):
-        return True
 
     return any(
         call["closure_status"] in OWNER_ACTION_CALLSITE_STATUSES

--- a/scripts/tests/test_static_producer_closure.py
+++ b/scripts/tests/test_static_producer_closure.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
+from collections import Counter
 from pathlib import Path
 
 from scripts.static_producer_closure import (
     COVERED_BY_OWNER_PATCH,
     COVERED_OWNER_CALLSITES,
     COVERED_OWNER_FAMILIES,
+    DEFERRED_RUNTIME_CALLSITES,
     covered_callsite_keys,
     covered_family_ids,
+    deferred_runtime_callsite_keys,
     family_closure_status,
+    format_message_candidate_policy_queue,
     format_owner_action_queue,
     load_inventory,
+    message_candidate_policy_entries,
     owner_action_queue,
     owner_action_queue_by_file,
     validate_covered_owner_families,
@@ -37,6 +42,26 @@ def test_covered_owner_callsite_registry_has_unique_line_keys() -> None:
 
     assert len(expected_keys) == len(set(expected_keys))
     assert covered_callsite_keys() == frozenset(expected_keys)
+
+
+def test_deferred_runtime_callsite_registry_has_unique_line_keys() -> None:
+    """Runtime-required deferrals must be unique and visible."""
+    expected_keys = [
+        (deferred.family_id, line)
+        for deferred in DEFERRED_RUNTIME_CALLSITES
+        for line in deferred.lines
+    ]
+
+    assert len(expected_keys) == len(set(expected_keys))
+    assert deferred_runtime_callsite_keys() == frozenset(expected_keys)
+
+
+def test_owner_covered_runtime_callsite_can_close_local_dataflow_shape() -> None:
+    """A scanner runtime row can be owner-covered when static local dataflow and tests prove the shape."""
+    family_id = "XRL.World.Parts/Physics.cs::XRL.World.Parts.Physics.HandleEvent"
+
+    assert (family_id, 2582) in covered_callsite_keys()
+    assert (family_id, 2582) not in deferred_runtime_callsite_keys()
 
 
 def test_covered_owner_families_have_current_source_and_test_evidence() -> None:
@@ -151,10 +176,9 @@ def test_trade_ui_vendor_owner_callsites_are_split_from_fixed_fallbacks() -> Non
     inventory = load_inventory(TRACKED_INVENTORY)
     raw_families = {family["producer_family_id"]: family for family in inventory["families"]}
     queued_family_ids = {family["producer_family_id"] for family in owner_action_queue(inventory)}
-    source_entries = owner_action_queue_by_file(inventory)
-    trade_ui_entry = next(entry for entry in source_entries if entry["source_file"] == "XRL.UI/TradeUI.cs")
     examine_id = "XRL.UI/TradeUI.cs::XRL.UI.TradeUI.DoVendorExamine"
     recharge_id = "XRL.UI/TradeUI.cs::XRL.UI.TradeUI.DoVendorRecharge"
+    show_trade_id = "XRL.UI/TradeUI.cs::XRL.UI.TradeUI.ShowTradeScreen"
 
     assert raw_families[examine_id]["family_closure_status"] == "needs_family_review"
     assert raw_families[recharge_id]["family_closure_status"] == "needs_family_review"
@@ -164,7 +188,8 @@ def test_trade_ui_vendor_owner_callsites_are_split_from_fixed_fallbacks() -> Non
     assert recharge_id not in covered_family_ids()
     assert examine_id not in queued_family_ids
     assert recharge_id not in queued_family_ids
-    assert [family["member_name"] for family in trade_ui_entry["families"]] == ["ShowTradeScreen"]
+    assert show_trade_id not in queued_family_ids
+    assert not any(entry["source_file"] == "XRL.UI/TradeUI.cs" for entry in owner_action_queue_by_file(inventory))
 
 
 def test_journal_screen_popup_owner_callsites_are_split_from_fixed_fallbacks() -> None:
@@ -187,7 +212,7 @@ def test_journal_screen_popup_owner_callsites_are_split_from_fixed_fallbacks() -
 
 
 def test_conversation_script_popup_owner_callsites_are_split_from_fixed_and_runtime_fallbacks() -> None:
-    """ConversationScript popup owner callsites must close without claiming fixed or runtime popups."""
+    """ConversationScript popup owner callsites close while runtime popups are deferred."""
     inventory = load_inventory(TRACKED_INVENTORY)
     raw_families = {family["producer_family_id"]: family for family in inventory["families"]}
     queued_family_ids = {family["producer_family_id"] for family in owner_action_queue(inventory)}
@@ -201,16 +226,11 @@ def test_conversation_script_popup_owner_callsites_are_split_from_fixed_and_runt
         assert raw_families[family_id]["family_closure_status"] == "needs_family_review"
         assert family_closure_status(raw_families[family_id]) == "needs_family_review"
         assert family_id not in covered_family_ids()
-        assert family_id in queued_family_ids
+        assert family_id not in queued_family_ids
 
-    conversation_entry = next(
-        entry for entry in source_entries if entry["source_file"] == "XRL.World.Parts/ConversationScript.cs"
-    )
-    assert conversation_entry["callsite_count"] == 6
-    assert [family["member_name"] for family in conversation_entry["families"]] == [
-        "IsPhysicalConversationPossible",
-        "IsMentalConversationPossible",
-    ]
+    assert "XRL.World.Parts/ConversationScript.cs" not in {
+        entry["source_file"] for entry in source_entries
+    }
 
 
 def test_terrain_travel_owner_callsites_are_split_from_runtime_and_fixed_popups() -> None:
@@ -229,13 +249,17 @@ def test_terrain_travel_owner_callsites_are_split_from_runtime_and_fixed_popups(
         assert family_closure_status(raw_families[family_id]) == "needs_family_review"
         assert family_id not in covered_family_ids()
 
-    assert "XRL.World.Parts/TerrainTravel.cs::XRL.World.Parts.TerrainTravel.HandleEvent" in queued_family_ids
-    assert "XRL.World.Parts/TerrainTravel.cs::XRL.World.Parts.TerrainTravel.HandleLeavingCell" not in queued_family_ids
-    terrain_entry = next(
-        entry for entry in source_entries if entry["source_file"] == "XRL.World.Parts/TerrainTravel.cs"
+    assert ("XRL.World.Parts/TerrainTravel.cs::XRL.World.Parts.TerrainTravel.HandleEvent", 120) in (
+        deferred_runtime_callsite_keys()
     )
-    assert terrain_entry["callsite_count"] == 2
-    assert [family["member_name"] for family in terrain_entry["families"]] == ["HandleEvent"]
+    assert ("XRL.World.Parts/TerrainTravel.cs::XRL.World.Parts.TerrainTravel.HandleEvent", 124) in (
+        deferred_runtime_callsite_keys()
+    )
+    assert "XRL.World.Parts/TerrainTravel.cs::XRL.World.Parts.TerrainTravel.HandleEvent" not in queued_family_ids
+    assert "XRL.World.Parts/TerrainTravel.cs::XRL.World.Parts.TerrainTravel.HandleLeavingCell" not in queued_family_ids
+    assert "XRL.World.Parts/TerrainTravel.cs" not in {
+        entry["source_file"] for entry in source_entries
+    }
 
 
 def test_precognition_owner_queue_callsites_are_split_from_fixed_popups() -> None:
@@ -318,7 +342,7 @@ def test_single_fixed_queue_owner_callsites_are_split_from_mixed_siblings() -> N
         },
         "XRL.World.Parts/ThiefBot.cs::XRL.World.Parts.ThiefBot.FireEvent": {
             "closed_lines": {45, 76},
-            "queued": True,
+            "queued": False,
         },
     }
 
@@ -341,7 +365,7 @@ def test_single_mixed_owner_callsites_are_split_from_fixed_and_runtime_siblings(
     split_families = {
         "XRL.World.Parts/StairsDown.cs::XRL.World.Parts.StairsDown.CheckPullDown": {
             "closed_lines": {372, 439},
-            "queued": True,
+            "queued": False,
         },
         (
             "XRL.World.ZoneParts/ScriptCallToArms.cs::"
@@ -383,7 +407,6 @@ def test_zone_manager_owner_callsites_are_split_from_runtime_and_fixed_popup_sha
     raw_families = {family["producer_family_id"]: family for family in inventory["families"]}
     queued_family_ids = {family["producer_family_id"] for family in owner_action_queue(inventory)}
     callsite_keys = covered_callsite_keys()
-    source_entries = owner_action_queue_by_file(inventory)
     set_active_zone_family_id = "XRL.World/ZoneManager.cs::XRL.World.ZoneManager.SetActiveZone"
     generate_zone_family_id = "XRL.World/ZoneManager.cs::XRL.World.ZoneManager.GenerateZone"
 
@@ -392,26 +415,13 @@ def test_zone_manager_owner_callsites_are_split_from_runtime_and_fixed_popup_sha
         assert family_closure_status(raw_families[family_id]) == "needs_family_review"
         assert family_id not in covered_family_ids()
 
-    assert set_active_zone_family_id in queued_family_ids
+    assert (set_active_zone_family_id, 1889) in deferred_runtime_callsite_keys()
+    assert (set_active_zone_family_id, 1912) in deferred_runtime_callsite_keys()
+    assert set_active_zone_family_id not in queued_family_ids
     assert generate_zone_family_id not in queued_family_ids
     assert {
         line for covered_family, line in callsite_keys if covered_family == generate_zone_family_id
     } == {3286, 3570}
-
-    zone_manager_entry = next(
-        entry for entry in source_entries if entry["source_file"] == "XRL.World/ZoneManager.cs"
-    )
-    assert zone_manager_entry["callsite_count"] == 2
-    assert [family["member_name"] for family in zone_manager_entry["families"]] == ["SetActiveZone"]
-    assert [
-        family["representative_lines"] for family in zone_manager_entry["families"]
-    ] == [[1889, 1912]]
-    assert [
-        family["closure_status_counts"] for family in zone_manager_entry["families"]
-    ] == [{"runtime_required": 2}]
-    assert [family["surface_counts"] for family in zone_manager_entry["families"]] == [
-        {"AddPlayerMessage": 2},
-    ]
 
 
 def test_additional_single_callsite_owner_popup_families_are_closed_by_owner_patch() -> None:
@@ -498,9 +508,7 @@ def test_xrlcore_old_save_popup_callsite_is_split_from_fixed_save_management_pop
     assert (family_id, 3962) in covered_callsite_keys()
     assert family_id not in queued_family_ids
 
-    xrlcore_entry = next(entry for entry in source_entries if entry["source_file"] == "XRL.Core/XRLCore.cs")
-    assert "SaveManagement" not in [family["member_name"] for family in xrlcore_entry["families"]]
-    assert "PlayerTurn" in [family["member_name"] for family in xrlcore_entry["families"]]
+    assert "XRL.Core/XRLCore.cs" not in {entry["source_file"] for entry in source_entries}
 
 
 def test_sifrah_token_item_owner_callsites_are_split_from_fixed_kind_message() -> None:
@@ -616,7 +624,6 @@ def test_water_ritual_random_mutation_incompatible_popup_is_split_from_fixed_and
     inventory = load_inventory(TRACKED_INVENTORY)
     raw_families = {family["producer_family_id"]: family for family in inventory["families"]}
     queued_family_ids = {family["producer_family_id"] for family in owner_action_queue(inventory)}
-    source_entries = owner_action_queue_by_file(inventory)
     family_id = (
         "XRL.World.Conversations.Parts/WaterRitualRandomMutation.cs::"
         "XRL.World.Conversations.Parts.WaterRitualRandomMutation.HandleEvent"
@@ -626,23 +633,13 @@ def test_water_ritual_random_mutation_incompatible_popup_is_split_from_fixed_and
         for callsite in inventory["callsites"]
         if callsite["producer_family_id"] == family_id
     ]
-    queued_family = next(
-        family
-        for source_entry in source_entries
-        for family in source_entry["families"]
-        if family["producer_family_id"] == family_id
-    )
 
     assert raw_families[family_id]["family_closure_status"] == "needs_family_review"
     assert family_closure_status(raw_families[family_id]) == "needs_family_review"
     assert family_id not in covered_family_ids()
     assert (family_id, 92) in covered_callsite_keys()
-    assert family_id in queued_family_ids
-    assert queued_family["representative_lines"] == [88, 98]
-    assert queued_family["closure_status_counts"] == {
-        "messages_candidate": 1,
-        "runtime_required": 1,
-    }
+    assert (family_id, 98) in deferred_runtime_callsite_keys()
+    assert family_id not in queued_family_ids
     assert {
         (callsite["line"], callsite["closure_status"])
         for callsite in family_callsites
@@ -937,7 +934,8 @@ def test_neutron_flux_containment_popups_are_split_from_runtime_warning() -> Non
     assert (family_id, 63) in covered_callsite_keys()
     assert (family_id, 91) in covered_callsite_keys()
     assert (family_id, 99) not in covered_callsite_keys()
-    assert family_id in queued_family_ids
+    assert (family_id, 99) in deferred_runtime_callsite_keys()
+    assert family_id not in queued_family_ids
     assert {
         (callsite["line"], callsite["target_surface"], callsite["closure_status"])
         for callsite in family_callsites
@@ -976,45 +974,94 @@ def test_polygel_handle_event_popups_are_split_from_fixed_popup() -> None:
     }
 
 
-def test_uncovered_high_volume_owner_family_remains_in_owner_action_queue() -> None:
-    """Uncovered high-volume owner families must stay actionable."""
+def test_message_candidate_policy_entries_group_remaining_static_and_pattern_rows() -> None:
+    """Message-candidate policy export must split existing leaves, rejects, and pattern deferrals."""
+    inventory = load_inventory(TRACKED_INVENTORY)
+    entries = message_candidate_policy_entries(inventory, REPO_ROOT)
+    decision_counts = Counter(entry["decision"] for entry in entries)
+    choose_color_entry = next(entry for entry in entries if entry["literal_text"] == "Choose color")
+    empty_entry = next(
+        entry
+        for entry in entries
+        if entry["source_file"] == "XRL.UI/Popup.cs" and entry["literal_text"] == ""
+    )
+    chat_template_entry = next(
+        entry
+        for entry in entries
+        if entry["producer_family_id"] == "XRL.World.Parts/Chat.cs::XRL.World.Parts.Chat.PerformChat"
+    )
+
+    assert len(entries) == 698
+    assert decision_counts == {
+        "existing_dictionary_coverage": 542,
+        "existing_message_pattern_coverage": 144,
+        "existing_does_verb_route_coverage": 5,
+        "existing_owner_route_coverage": 2,
+        "reject_pseudo_leaf": 5,
+    }
+    assert choose_color_entry["decision"] == "existing_dictionary_coverage"
+    assert choose_color_entry["coverage_locations"] == [
+        "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json"
+    ]
+    assert empty_entry["decision"] == "reject_pseudo_leaf"
+    assert chat_template_entry["decision"] == "existing_does_verb_route_coverage"
+
+
+def test_message_candidate_policy_text_summary_reports_group_counts() -> None:
+    """Message-candidate text output must be useful as a policy handoff summary."""
+    inventory = load_inventory(TRACKED_INVENTORY)
+
+    summary = format_message_candidate_policy_queue(inventory, repo_root=REPO_ROOT)
+
+    assert "message candidate policy queue: 698 text arguments" in summary
+    assert "existing_dictionary_coverage:542" in summary
+    assert "existing_message_pattern_coverage:144" in summary
+    assert "existing_does_verb_route_coverage:5" in summary
+    assert "existing_owner_route_coverage:2" in summary
+    assert "reject_pseudo_leaf:5" in summary
+
+
+def test_large_mixed_families_drop_out_of_owner_action_queue_after_runtime_deferral() -> None:
+    """Large mixed families should leave the owner queue after owner and runtime rows are split."""
     inventory = load_inventory(TRACKED_INVENTORY)
     queued_family_ids = {family["producer_family_id"] for family in owner_action_queue(inventory)}
 
-    assert "XRL.World.Parts/Campfire.cs::XRL.World.Parts.Campfire.CookFromIngredients" in queued_family_ids
+    assert {
+        "XRL.World.Parts/Campfire.cs::XRL.World.Parts.Campfire.CookPresetMeal",
+        "XRL.World.Parts/Campfire.cs::XRL.World.Parts.Campfire.CookFromIngredients",
+        "XRL.World.Parts/Campfire.cs::XRL.World.Parts.Campfire.CookFromRecipe",
+        "XRL.Core/XRLCore.cs::XRL.Core.XRLCore.PlayerTurn",
+        "XRL.World.Parts/Inventory.cs::XRL.World.Parts.Inventory.FireEvent",
+        "XRL.World.Parts/Physics.cs::XRL.World.Parts.Physics.HandleEvent",
+        "XRL.World.Parts/Physics.cs::XRL.World.Parts.Physics.ProcessTargetedMove",
+        (
+            "XRL.World.Parts/ConversationScript.cs::"
+            "XRL.World.Parts.ConversationScript.IsPhysicalConversationPossible"
+        ),
+        (
+            "XRL.World.Parts/ConversationScript.cs::"
+            "XRL.World.Parts.ConversationScript.IsMentalConversationPossible"
+        ),
+        "XRL.World.Parts/Crayons.cs::XRL.World.Parts.Crayons.HandleEvent",
+        "XRL.World.Parts/Chat.cs::XRL.World.Parts.Chat.PerformChat",
+        "XRL.World.Parts/ITeleporter.cs::XRL.World.Parts.ITeleporter.AttemptTeleport",
+        "XRL.World.Parts/MissileWeapon.cs::XRL.World.Parts.MissileWeapon.FireEvent",
+        "XRL.World.Parts/Garbage.cs::XRL.World.Parts.Garbage.AttemptRifle",
+    }.isdisjoint(queued_family_ids)
 
 
 def test_owner_action_queue_groups_actionable_work_by_source_file() -> None:
-    """Static producer work queue must expose class-file starting points."""
+    """All static producer owner-route work must be closed or explicitly deferred."""
     inventory = load_inventory(TRACKED_INVENTORY)
     source_entries = owner_action_queue_by_file(inventory)
-    campfire_entry = next(entry for entry in source_entries if entry["source_file"] == "XRL.World.Parts/Campfire.cs")
 
-    assert source_entries == sorted(
-        source_entries,
-        key=lambda entry: (
-            -entry["family_count"],
-            -entry["text_argument_count"],
-            -entry["callsite_count"],
-            entry["source_file"],
-        ),
-    )
-    assert campfire_entry["family_count"] > 0
-    assert campfire_entry["text_argument_count"] > 0
-    assert any(
-        family["producer_family_id"]
-        == "XRL.World.Parts/Campfire.cs::XRL.World.Parts.Campfire.CookFromIngredients"
-        for family in campfire_entry["families"]
-    )
+    assert source_entries == []
 
 
 def test_owner_action_queue_text_summary_names_source_files_and_methods() -> None:
-    """Text output must be useful as an agent handoff queue."""
+    """Text output must report a zero-sized owner queue when no owner action remains."""
     inventory = load_inventory(TRACKED_INVENTORY)
 
     summary = format_owner_action_queue(inventory, limit=5)
 
-    assert "owner action queue:" in summary
-    assert ".cs:" in summary
-    assert "surfaces=" in summary
-    assert "line " in summary
+    assert summary == "owner action queue: 0 families, 0 callsites, 0 text arguments across 0 source files"

--- a/scripts/tests/test_validate_pattern_routes.py
+++ b/scripts/tests/test_validate_pattern_routes.py
@@ -12,7 +12,7 @@ _EXPECTED_MESSAGE_ROUTE_COUNTS = {
     "popup": 12,
     "journal": 0,
     "leaf": 0,
-    "emit-message": 303,
+    "emit-message": 308,
     "does-verb": 0,
     "message-log": 1,
     "description": 4,

--- a/scripts/tests/test_validate_pattern_routes.py
+++ b/scripts/tests/test_validate_pattern_routes.py
@@ -12,7 +12,7 @@ _EXPECTED_MESSAGE_ROUTE_COUNTS = {
     "popup": 12,
     "journal": 0,
     "leaf": 0,
-    "emit-message": 308,
+    "emit-message": 314,
     "does-verb": 0,
     "message-log": 1,
     "description": 4,


### PR DESCRIPTION
## Summary

- Closes the remaining static producer owner action queue for issue 699.
- Adds message-candidate policy coverage for fixed popup leaves, existing message patterns, DoesVerb frames, owner routes, and pseudo-leaf rejects.
- Registers runtime-only mixed-family callsites as explicit deferred runtime callsites so the owner queue reports only actionable owner-route work.
- Adds focused RealityStabilized popup coverage for the normality lattice local builder and new message patterns for Exodus countdown / missile hit-output variants.

Closes #699

## Results

- Owner action queue: `0 families, 0 callsites, 0 text arguments across 0 source files`
- Message candidate policy queue: `698 text arguments`, all classified as existing coverage or pseudo-leaf rejects

## Cleanup and Review

- Ran `ai-slop-cleaner`; removed line-length noqa noise and then fixed the regression-risk review finding in the hit-output fallback regex.
- Ran `polishment` review flow.
- Independent review verdicts:
  - Initial pre-PR review: `APPROVE`
  - Simplify regression-risk pass found a blocker in a broad hit fallback regex; fixed before PR.
  - Final independent re-review: `APPROVE`

## Verification

- `just test-l1` — 2226 passed
- `just test-l2` — 3399 passed
- `just static-producer-check` — 61 passed, ruff passed, basedpyright passed
- `just localization-check` — passed with existing `Tzedech Welcome` empty-text warning
- `just translation-token-check` — passed
- `just release-note-check origin/main HEAD` — passed
- `git diff --check` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * UIポップアップ日本語訳を拡張（各種プロンプト、保存エラー、色選択などを追加）
  * テキスト出力の翻訳パターンを拡張（Exodusカウントダウン、命中/会心表現など）
  * テスト用のポップアップ表示パスを追加し、特定通知がポップアップ経由でも表示可能に

* **テスト**
  * 多数の翻訳ケースと検証テストを追加・更新（ポップアップ挙動、メッセージ候補の分類を検証）

* **その他**
  * ローカル検証タスクの期待件数を更新し、メッセージ候補検出・分類の検証処理を強化

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/700)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->