### PR TITLE
test: codify issue 699 follow-ups

### DIFF
--- a/docs/glossary.csv
+++ b/docs/glossary.csv
@@ -193,6 +193,7 @@ Nephilim,ネフィリム,,source: ChiliadFactions.jp.xml; world-factions.ja.json
 neutron flux,中性子 フラックス,,source: ui-liquids.ja.json,draft
 Newly Sentient Beings,新知性体,,source: ChiliadFactions.jp.xml; Factions.jp.xml; world-factions.ja.json,draft
 Nima Ruda,ニマ・ルーダ,,source: Conversations.jp.xml,draft
+normality lattice,ノーマリティ格子,ノーマリティ格子,confirmed: runtime spacetime-interdiction term used by RealityStabilized routes,confirmed
 Northern Ark,北方の方舟,,source: Worlds.jp.xml,draft
 Northwise moors,北の湿原,,source: Worlds.jp.xml,draft
 Nuntu,ヌントゥ,,source: Conversations.jp.xml,draft

--- a/scripts/tests/test_ci_workflow_contract.py
+++ b/scripts/tests/test_ci_workflow_contract.py
@@ -125,5 +125,9 @@ def test_ci_message_pattern_route_counts_match_python_contract() -> None:
     workflow = _workflow_text()
     localization_job = _job_block(workflow, "localization", "justfile")
     matches = re.findall(r"--expect-count ([\w-]+)=(\d+)", localization_job)
+    observed: dict[str, int] = {}
+    for route, count in matches:
+        assert route not in observed, f"duplicate --expect-count for route: {route}"
+        observed[route] = int(count)
 
-    assert dict(matches) == {route: str(count) for route, count in _EXPECTED_MESSAGE_ROUTE_COUNTS.items()}
+    assert observed == _EXPECTED_MESSAGE_ROUTE_COUNTS

--- a/scripts/tests/test_ci_workflow_contract.py
+++ b/scripts/tests/test_ci_workflow_contract.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
+
+from scripts.tests.test_validate_pattern_routes import _EXPECTED_MESSAGE_ROUTE_COUNTS
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -115,3 +118,12 @@ def test_ci_installs_just_without_apt_update() -> None:
 
     assert "uses: extractions/setup-just@v3" in workflow
     assert "sudo apt-get update" not in workflow
+
+
+def test_ci_message_pattern_route_counts_match_python_contract() -> None:
+    """CI and repository tests must enforce the same message-pattern route inventory."""
+    workflow = _workflow_text()
+    localization_job = _job_block(workflow, "localization", "justfile")
+    matches = re.findall(r"--expect-count ([\w-]+)=(\d+)", localization_job)
+
+    assert dict(matches) == {route: str(count) for route, count in _EXPECTED_MESSAGE_ROUTE_COUNTS.items()}


### PR DESCRIPTION
## Summary
- add a CI workflow contract test that keeps message-pattern route-count expectations synchronized with the Python route inventory test
- promote `normality lattice` to the glossary as `ノーマリティ格子`

## Verification
- `uv run pytest scripts/tests/test_ci_workflow_contract.py scripts/tests/test_validate_pattern_routes.py scripts/tests/test_check_glossary_consistency.py -q`
- `just localization-check`
- `just python-check`
- `git diff --check`

Follow-up to #700.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI のローカライゼーション関連設定からルート期待値を抽出して実際値と照合するテストを追加。重複ルートがないことを検証し、CI 設定と期待マッピングが完全一致することを確認します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/701)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->