### PR TITLE
build: align Harmony fallback with 2.4.2

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.csproj
+++ b/Mods/QudJP/Assemblies/QudJP.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="!Exists('$(ManagedDir)/0Harmony.dll')">
-    <PackageReference Include="Lib.Harmony" Version="2.2.2" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="Lib.Harmony" Version="2.4.2" PrivateAssets="all" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/release-notes/unreleased/harmony-fallback-242.md
+++ b/docs/release-notes/unreleased/harmony-fallback-242.md
@@ -1,0 +1,1 @@
+- Align the build-time `Lib.Harmony` fallback package with the documented Harmony 2.4.2 native Apple Silicon workaround.

--- a/docs/release-notes/unreleased/harmony-fallback-242.md
+++ b/docs/release-notes/unreleased/harmony-fallback-242.md
@@ -1,1 +1,3 @@
+### Changed
+
 - Align the build-time `Lib.Harmony` fallback package with the documented Harmony 2.4.2 native Apple Silicon workaround.


### PR DESCRIPTION
## Summary
- Align the QudJP build-time `Lib.Harmony` fallback package with Harmony 2.4.2.
- Add a release-note fragment for the fallback version alignment.

## Why
When `Managed/0Harmony.dll` is available, QudJP builds against the game DLL. When it is absent, the project falls back to the NuGet `Lib.Harmony` compile-time reference. That fallback was still pinned to 2.2.2 even though the test harness and documented native Apple Silicon workaround use 2.4.2.

## Verification
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj --configuration Release`
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj --configuration Release -p:GameDir=/tmp/qudjp-missing-game-dir`
- `uv run pytest scripts/tests/test_harmony_native_scripts.py -q`
- `just release-note-check origin/main HEAD`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * Apple Silicon 向けのビルド挙動に関する説明を追記しました（ネイティブ対応のフォールバックに関する注意）。

* **改善**
  * 基盤ライブラリのバージョン相当を更新し、Apple Silicon 環境での互換性と安定性を向上しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->