### PR TITLE
Optimize test validation runtime

### DIFF
--- a/.codex/skills/qudjp-localization-triage/SKILL.md
+++ b/.codex/skills/qudjp-localization-triage/SKILL.md
@@ -77,7 +77,8 @@ Use this skill to turn runtime untranslated text into the smallest correct QudJP
 
 5. Verify using `just` recipes where available.
    - Build: `just build`
-   - C# tests: `just test-l1`, `just test-l2`, `just test-l2g`
+   - C# behavior tests: `just test-l1`, `just test-l2`, `just test-l2g`
+   - Analyzer-inclusive local gates: `just build`, `just check`, or `just pr-check`
    - Localization checks: `just localization-check`, `just translation-token-check`
    - Static coverage map check: `just localization-coverage-map-check`
    - Broad local gate: `just check`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,11 @@ jobs:
 
       - name: Build QudJP.Tests
         if: hashFiles('Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj') != ''
-        run: dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release
+        run: >
+          dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj
+          --configuration Release
+          -p:RunAnalyzers=false
+          -p:RunAnalyzersDuringBuild=false
 
       - name: Upload QudJP test artifact
         if: hashFiles('Mods/QudJP/Assemblies/QudJP.Tests/bin/Release/net10.0/QudJP.Tests.dll') != ''

--- a/Mods/QudJP/Assemblies/AGENTS.md
+++ b/Mods/QudJP/Assemblies/AGENTS.md
@@ -40,9 +40,14 @@ just test-l2
 just test-l2g
 ```
 
-Run `just test-l1`, `just test-l2`, and `just test-l2g` sequentially for local
-verification unless the task explicitly establishes isolated artifacts for a
-parallel run.
+`just test-l1`, `just test-l2`, `just test-l2g`, and `just test-csharp` are
+behavior-test entrypoints. Their test artifact builds intentionally disable
+analyzers for speed. Use `just build`, `just check`, or `just pr-check` when
+analyzer coverage is required.
+
+Use `just test-csharp` for broad local C# behavior coverage. Use category
+recipes for focused layer checks; they use isolated artifacts and can run
+concurrently when the local machine can afford the duplicated setup.
 
 Use deterministic tooling before prompt-only reasoning for route and call-shape
 work:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -114,12 +114,15 @@ just test-l2
 # L2G (ゲーム DLL 必須)
 just test-l2g
 
+# analyzer も含む通常のローカルゲート
+just check
+
 # Python スクリプトの lint とテスト
 just python-check
 just python-test
 ```
 
-全テストがパスすれば環境構築完了です。
+全テストがパスし、`just check` も通れば環境構築完了です。
 
 非 macOS で L2G を走らせる場合は、ビルドと同じ `GameDir` を渡してください。例:
 
@@ -322,8 +325,9 @@ uv run python scripts/sync_mod.py \
 `just lsp-check` は `.sln` / `.csproj` / reference stub / dotnet tool manifest
 の変更時、または editor の診断と `dotnet build` の結果が食い違う時に使います。
 これは language-server が repo の solution を読めることを確認する補助導線であり、
-compiler / analyzer / test の代替ではありません。挙動ゲートは引き続き `just build`
-と `just test-l1` / `just test-l2` / `just test-l2g` です。
+compiler / analyzer / test の代替ではありません。`just test-l1` / `just test-l2` /
+`just test-l2g` は挙動テストのゲートで、analyzer と production build のゲートは
+`just build`、`just check`、または `just pr-check` です。
 
 Codex では repo-local hook (`.codex/hooks.json`) から
 `.codex/hooks/lsp-check-after-tool.sh` を呼びます。Codex 側の matcher は広く、
@@ -446,7 +450,7 @@ PR を出すと GitHub Actions (`.github/workflows/ci.yml`) が変更ファイ�
 
 **全ジョブがパスしないとマージできません。**
 
-ローカルの同一 worktree では `just test-l1` / `just test-l2` / `just test-l2g` を並列実行しないでください。各カテゴリは `obj/` と `bin/` の出力先を共有するため、同時ビルドすると `CS2012` などの DLL file lock で失敗することがあります。CI の matrix 実行は runner が隔離されているため、この制約の対象外です。
+ローカルの同一 worktree でも `just test-l1` / `just test-l2` / `just test-l2g` は run-scoped artifacts を使うため、カテゴリ間の並列実行で `obj/` / `bin/` の file lock は共有しません。ただし各カテゴリが別々に test artifact を build するため、全体確認では `just test-csharp` や `just check` を優先してください。PR 前の最終確認では analyzer を含む `just check` または `just pr-check` を使います。
 
 ---
 

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -136,6 +136,8 @@ just test-l2g
 `QudJP.Tests.csproj` を `--no-dependencies` で build してから生成済み
 `QudJP.Tests.dll` を test します。これにより別 shell から L1/L2/L2G を
 parallel 実行しても、MSBuild/Roslyn の `bin` / `obj` 書き込みが競合しません。
+これらのテスト artifact 用 build では analyzer を無効化します。analyzer
+coverage は `just build` / CI の `Build QudJP` が担います。
 既定の artifacts root は `.artifacts/dotnet` です。
 
 ---

--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@ python := "uv run python"
 decompiled_root := env_var("HOME") + "/dev/coq-decompiled_stable"
 decompiled_annals_root := env_var("HOME") + "/dev/coq-decompiled_stable/XRL.Annals"
 dotnet_artifacts_root := env_var_or_default("QUDJP_DOTNET_ARTIFACTS_ROOT", ".artifacts/dotnet")
+dotnet_test_build_properties := "-p:RunAnalyzers=false -p:RunAnalyzersDuringBuild=false"
 
 default:
   just --list
@@ -36,7 +37,7 @@ test-l1:
   mkdir -p "$run_root/a/b"
   cp -R Mods/QudJP/Localization "$run_root/Localization"
   artifacts_root="$run_root/a/b"
-  dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-dependencies --artifacts-path "$artifacts_root"
+  dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-dependencies --artifacts-path "$artifacts_root" {{dotnet_test_build_properties}}
   test_dll="$artifacts_root/bin/QudJP.Tests/release/QudJP.Tests.dll"
   dotnet test "$test_dll" --filter "TestCategory=L1"
 
@@ -50,7 +51,7 @@ test-l2:
   mkdir -p "$run_root/a/b"
   cp -R Mods/QudJP/Localization "$run_root/Localization"
   artifacts_root="$run_root/a/b"
-  dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-dependencies --artifacts-path "$artifacts_root"
+  dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-dependencies --artifacts-path "$artifacts_root" {{dotnet_test_build_properties}}
   test_dll="$artifacts_root/bin/QudJP.Tests/release/QudJP.Tests.dll"
   dotnet test "$test_dll" --filter "TestCategory=L2"
 
@@ -64,7 +65,7 @@ test-l2g:
   mkdir -p "$run_root/a/b"
   cp -R Mods/QudJP/Localization "$run_root/Localization"
   artifacts_root="$run_root/a/b"
-  dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-dependencies --artifacts-path "$artifacts_root"
+  dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-dependencies --artifacts-path "$artifacts_root" {{dotnet_test_build_properties}}
   test_dll="$artifacts_root/bin/QudJP.Tests/release/QudJP.Tests.dll"
   dotnet test "$test_dll" --filter "TestCategory=L2G"
 
@@ -78,7 +79,7 @@ test-csharp:
   mkdir -p "$run_root/a/b"
   cp -R Mods/QudJP/Localization "$run_root/Localization"
   artifacts_root="$run_root/a/b"
-  dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-dependencies --artifacts-path "$artifacts_root"
+  dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-dependencies --artifacts-path "$artifacts_root" {{dotnet_test_build_properties}}
   test_dll="$artifacts_root/bin/QudJP.Tests/release/QudJP.Tests.dll"
   dotnet test "$test_dll"
 
@@ -426,7 +427,7 @@ ci-dotnet:
   mkdir -p "$run_root/a/b"
   cp -R Mods/QudJP/Localization "$run_root/Localization"
   artifacts_root="$run_root/a/b"
-  dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-dependencies --artifacts-path "$artifacts_root"
+  dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-dependencies --artifacts-path "$artifacts_root" {{dotnet_test_build_properties}}
   dotnet test "$artifacts_root/bin/QudJP.Tests/release/QudJP.Tests.dll"
 
 # Build the Annals Roslyn extractor.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -77,9 +77,11 @@ just sync-mod
 - Roslyn tracked artifact recipes are intentionally named `*-tracked`;
   prefer preview recipes for review and validation unless the task explicitly
   owns the generated artifact.
-- Repo-local Roslyn wrappers and just recipes build into
-  `QUDJP_DOTNET_ARTIFACTS_ROOT` (default: `.artifacts/dotnet`) and execute the
-  produced tool DLL so parallel local runs do not share build outputs.
+- Repo-local Roslyn wrappers build into the shared
+  `QUDJP_DOTNET_ARTIFACTS_ROOT` cache (default: `.artifacts/dotnet`) behind
+  per-tool locks, then execute the produced tool DLL. Just validation recipes
+  that must be parallel-isolated still create run-scoped artifact roots under
+  the same parent.
 - Skill eval execution is orchestrator-owned: render prompts with
   `just render-skill-evals`, run them in fresh Codex subagents from the parent
   session, append results that match `skill-eval-result.schema.json` and

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -89,10 +89,11 @@ just roslyn-test
 just roslyn-check
 ```
 
-These recipes and the Python wrappers build repo-local Roslyn tools into
+These recipes and the Python wrappers build repo-local Roslyn tools under
 `QUDJP_DOTNET_ARTIFACTS_ROOT` (default: `.artifacts/dotnet`) and execute the
-produced DLL. This is the supported path for parallel local test and scanner
-runs.
+produced DLL. Python wrappers reuse the shared incremental build cache behind
+per-tool locks, while validation recipes that need full isolation create
+run-scoped artifact roots under the same parent.
 
 Annals pattern extractor と text construction inventory の入口も `just`
 から呼び出せます。

--- a/scripts/dotnet_tool_runner.py
+++ b/scripts/dotnet_tool_runner.py
@@ -1,4 +1,4 @@
-"""Helpers for running repo-local dotnet tools with run-scoped artifacts."""
+"""Helpers for running repo-local dotnet tools with cached or run-scoped artifacts."""
 # ruff: noqa: S314, S603 -- parses repo-local csproj files and invokes repo-local dotnet tools
 
 from __future__ import annotations
@@ -11,6 +11,7 @@ import tempfile
 import time
 import xml.etree.ElementTree as ET
 from contextlib import contextmanager
+from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
@@ -50,22 +51,40 @@ def run_tool_project(
             artifacts_root=artifacts_root,
             timeout=timeout,
         )
-        dotnet = _dotnet_path()
-        command = [dotnet, str(tool_dll), *args]
-        try:
-            return subprocess.run(
-                command,
-                capture_output=True,
-                text=True,
-                check=False,
+        return _run_tool_dll(tool_dll, args, timeout=timeout)
+
+
+def run_cached_tool_project(
+    project_path: Path,
+    args: list[str],
+    *,
+    timeout: int,
+    configuration: str = "Release",
+) -> subprocess.CompletedProcess[str]:
+    """Build a repo-local tool in the shared artifacts root and execute its DLL."""
+    resolved_project = project_path.resolve()
+    if not resolved_project.is_file():
+        msg = f"dotnet tool project is missing: {resolved_project}"
+        raise DotnetToolError(msg)
+
+    assembly_name = _assembly_name(resolved_project)
+    artifacts_root = _artifacts_root()
+    with _build_lock(artifacts_root, assembly_name):
+        tool_dll = _tool_dll_path(artifacts_root, assembly_name, configuration)
+        if _cached_tool_is_stale(resolved_project, tool_dll):
+            tool_dll = _build_tool_project(
+                resolved_project,
+                configuration=configuration,
+                artifacts_root=artifacts_root,
                 timeout=timeout,
             )
-        except subprocess.TimeoutExpired as exc:
-            details = "\n".join(part for part in (_output_text(exc.stdout), _output_text(exc.stderr)) if part)
-            msg = f"dotnet tool timed out after {timeout}s: {shlex.join(command)}"
-            if details:
-                msg = f"{msg}\n{details}"
-            raise DotnetToolError(msg) from exc
+            stamp_path = _tool_sources_stamp_path(tool_dll)
+            try:
+                _ = stamp_path.write_text(_tool_sources_fingerprint(resolved_project), encoding="utf-8")
+            except OSError as exc:
+                msg = f"failed to write dotnet tool source fingerprint stamp: {stamp_path}: {exc}"
+                raise DotnetToolError(msg) from exc
+    return _run_tool_dll(tool_dll, args, timeout=timeout)
 
 
 def build_tool_project(project_path: Path, *, configuration: str = "Release") -> Path:
@@ -116,11 +135,78 @@ def _build_tool_project(
             msg = f"{msg}\n{details}"
         raise DotnetToolError(msg)
 
-    tool_dll = artifacts_root / "bin" / assembly_name / configuration.lower() / f"{assembly_name}.dll"
+    tool_dll = _tool_dll_path(artifacts_root, assembly_name, configuration)
     if not tool_dll.is_file():
         msg = f"dotnet build succeeded but did not produce expected tool DLL: {tool_dll}"
         raise DotnetToolError(msg)
     return tool_dll
+
+
+def _tool_dll_path(artifacts_root: Path, assembly_name: str, configuration: str) -> Path:
+    return artifacts_root / "bin" / assembly_name / configuration.lower() / f"{assembly_name}.dll"
+
+
+def _cached_tool_is_stale(project_path: Path, tool_dll: Path) -> bool:
+    if not tool_dll.is_file():
+        return True
+
+    stamp_path = _tool_sources_stamp_path(tool_dll)
+    try:
+        cached_fingerprint = stamp_path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return True
+    except OSError as exc:
+        msg = f"failed to read dotnet tool source fingerprint stamp: {stamp_path}: {exc}"
+        raise DotnetToolError(msg) from exc
+    return cached_fingerprint != _tool_sources_fingerprint(project_path)
+
+
+def _tool_sources_stamp_path(tool_dll: Path) -> Path:
+    return tool_dll.with_name(f"{tool_dll.name}.sources.sha256")
+
+
+def _tool_sources_fingerprint(project_path: Path) -> str:
+    digest = sha256()
+    source_root = project_path.parent
+    for path in _tool_source_paths(project_path):
+        digest.update(path.relative_to(source_root).as_posix().encode())
+        digest.update(b"\0")
+        try:
+            digest.update(path.read_bytes())
+        except OSError as exc:
+            msg = f"failed to read dotnet tool source for fingerprint: {path}: {exc}"
+            raise DotnetToolError(msg) from exc
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _tool_source_paths(project_path: Path) -> list[Path]:
+    source_root = project_path.parent
+    source_paths = [
+        path
+        for path in source_root.rglob("*.cs")
+        if not {"bin", "obj"}.intersection(path.relative_to(source_root).parts)
+    ]
+    return [project_path, *sorted(source_paths)]
+
+
+def _run_tool_dll(tool_dll: Path, args: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
+    dotnet = _dotnet_path()
+    command = [dotnet, str(tool_dll), *args]
+    try:
+        return subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        details = "\n".join(part for part in (_output_text(exc.stdout), _output_text(exc.stderr)) if part)
+        msg = f"dotnet tool timed out after {timeout}s: {shlex.join(command)}"
+        if details:
+            msg = f"{msg}\n{details}"
+        raise DotnetToolError(msg) from exc
 
 
 def _run_build_command(

--- a/scripts/extract_annals_patterns.py
+++ b/scripts/extract_annals_patterns.py
@@ -14,7 +14,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.dotnet_tool_runner import DotnetToolError, run_tool_project  # noqa: E402
+from scripts.dotnet_tool_runner import DotnetToolError, run_cached_tool_project  # noqa: E402
 
 PROJECT_PATH = REPO_ROOT / "scripts" / "tools" / "AnnalsPatternExtractor" / "AnnalsPatternExtractor.csproj"
 EXTRACTOR_TIMEOUT_SECONDS = 600
@@ -68,9 +68,9 @@ def main(argv: list[str] | None = None) -> int:
         "--output",
         str(args.output),
     ]
-    print("[extract] building and running AnnalsPatternExtractor via isolated dotnet artifacts")
+    print("[extract] building and running AnnalsPatternExtractor via cached dotnet artifacts")
     try:
-        result = run_tool_project(PROJECT_PATH, tool_args, timeout=EXTRACTOR_TIMEOUT_SECONDS)
+        result = run_cached_tool_project(PROJECT_PATH, tool_args, timeout=EXTRACTOR_TIMEOUT_SECONDS)
     except DotnetToolError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/scripts/roslyn_semantic_probe.py
+++ b/scripts/roslyn_semantic_probe.py
@@ -13,7 +13,7 @@ REPO_ROOT: Final = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.dotnet_tool_runner import DotnetToolError, run_tool_project  # noqa: E402
+from scripts.dotnet_tool_runner import DotnetToolError, run_cached_tool_project  # noqa: E402
 
 DEFAULT_SOURCE_ROOT: Final = Path("~/dev/coq-decompiled_stable").expanduser()
 ROSLYN_PROBE_TIMEOUT_SECONDS: Final = 600
@@ -45,7 +45,7 @@ def run_probe(args: list[str]) -> JsonObject:
 
     output_path = _output_path_from_args(args)
     try:
-        result = run_tool_project(PROJECT_PATH, args, timeout=ROSLYN_PROBE_TIMEOUT_SECONDS)
+        result = run_cached_tool_project(PROJECT_PATH, args, timeout=ROSLYN_PROBE_TIMEOUT_SECONDS)
     except DotnetToolError as exc:
         raise RuntimeError(str(exc)) from exc
 

--- a/scripts/scan_static_producer_inventory.py
+++ b/scripts/scan_static_producer_inventory.py
@@ -15,7 +15,7 @@ REPO_ROOT: Final = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.dotnet_tool_runner import DotnetToolError, run_tool_project  # noqa: E402
+from scripts.dotnet_tool_runner import DotnetToolError, run_cached_tool_project  # noqa: E402
 
 SCHEMA_VERSION: Final = "1.0"
 GAME_VERSION: Final = "1.0.4"
@@ -205,7 +205,7 @@ def _run_roslyn_scanner(source_root: Path, output_path: Path) -> InventoryPayloa
         str(output_path),
     ]
     try:
-        result = run_tool_project(PROJECT_PATH, tool_args, timeout=ROSLYN_SCANNER_TIMEOUT_SECONDS)
+        result = run_cached_tool_project(PROJECT_PATH, tool_args, timeout=ROSLYN_SCANNER_TIMEOUT_SECONDS)
     except DotnetToolError as exc:
         raise RuntimeError(str(exc)) from exc
     if result.returncode != 0:

--- a/scripts/tests/test_ci_workflow_contract.py
+++ b/scripts/tests/test_ci_workflow_contract.py
@@ -20,6 +20,14 @@ def _job_block(workflow: str, job_name: str, next_job_name: str | None) -> str:
     return workflow[start:end]
 
 
+def _step_block(job: str, step_name: str, next_step_name: str | None) -> str:
+    start = job.index(f"\n      - name: {step_name}\n")
+    if next_step_name is None:
+        return job[start:]
+    end = job.index(f"\n      - name: {next_step_name}\n", start + 1)
+    return job[start:end]
+
+
 def test_ci_keeps_required_build_check_as_aggregator() -> None:
     """The branch-protection-facing build job stays stable while work runs in parallel jobs."""
     workflow = _workflow_text()
@@ -40,6 +48,21 @@ def test_ci_splits_qudjp_test_categories_into_matrix() -> None:
     assert '--filter "TestCategory=${{ matrix.category }}"' in workflow
     assert "actions/upload-artifact" in workflow
     assert "actions/download-artifact" in workflow
+
+
+def test_ci_keeps_analyzers_on_production_build_and_skips_them_for_test_artifact() -> None:
+    """The CI test DLL should build cheaply without dropping the production analyzer gate."""
+    workflow = _workflow_text()
+    job = _job_block(workflow, "qudjp-dotnet-build", "qudjp-dotnet-test")
+    production_build = _step_block(job, "Build QudJP", "Build QudJP.Tests")
+    test_artifact_build = _step_block(job, "Build QudJP.Tests", "Upload QudJP test artifact")
+
+    assert "dotnet build Mods/QudJP/Assemblies/QudJP.csproj --configuration Release" in production_build
+    assert "-p:RunAnalyzers" not in production_build
+    assert "-p:RunAnalyzersDuringBuild" not in production_build
+    assert "dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj" in test_artifact_build
+    assert "-p:RunAnalyzers=false" in test_artifact_build
+    assert "-p:RunAnalyzersDuringBuild=false" in test_artifact_build
 
 
 def test_ci_checks_out_repo_for_qudjp_test_matrix() -> None:

--- a/scripts/tests/test_parallel_dotnet_contract.py
+++ b/scripts/tests/test_parallel_dotnet_contract.py
@@ -1,4 +1,5 @@
 """Static contracts for parallel-safe dotnet/Roslyn test execution."""
+# pyright: reportPrivateUsage=false
 
 from __future__ import annotations
 
@@ -37,6 +38,24 @@ def _age_path(path: Path) -> None:
     os.utime(path, (stale_time, stale_time))
 
 
+def _write_probe_project(tmp_path: Path) -> Path:
+    project_path = tmp_path / "Probe.csproj"
+    _ = project_path.write_text(
+        "<Project><PropertyGroup><AssemblyName>Probe</AssemblyName></PropertyGroup></Project>\n",
+        encoding="utf-8",
+    )
+    return project_path
+
+
+def _write_cached_probe_dll(artifacts_root: Path, project_path: Path) -> Path:
+    dll = artifacts_root / "bin" / "Probe" / "release" / "Probe.dll"
+    dll.parent.mkdir(parents=True)
+    _ = dll.write_text("", encoding="utf-8")
+    stamp = dotnet_tool_runner._tool_sources_stamp_path(dll)  # noqa: SLF001
+    _ = stamp.write_text(dotnet_tool_runner._tool_sources_fingerprint(project_path), encoding="utf-8")  # noqa: SLF001
+    return dll
+
+
 def test_category_test_recipes_use_isolated_artifacts_and_test_built_dll() -> None:
     """L1/L2/L2G recipes must be safe to launch from separate shells in parallel."""
     justfile = "\n" + _read_repo_file("justfile")
@@ -50,25 +69,27 @@ def test_category_test_recipes_use_isolated_artifacts_and_test_built_dll() -> No
         assert f"{{{{dotnet_artifacts_root}}}}/{recipe_name}" in block
         assert "--artifacts-path" in block
         assert "--no-dependencies" in block
+        assert "{{dotnet_test_build_properties}}" in block
         assert "QudJP.Tests.dll" in block
         assert "dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj" not in block
         assert f"TestCategory={category}" in block
 
 
 def test_roslyn_tool_wrappers_use_run_scoped_dotnet_runner() -> None:
-    """Python Roslyn wrappers should use the shared run-scoped dotnet helper."""
+    """Python Roslyn wrappers should use the shared cached dotnet helper."""
     for path in (
         "scripts/extract_annals_patterns.py",
         "scripts/roslyn_semantic_probe.py",
         "scripts/scan_static_producer_inventory.py",
     ):
         text = _read_repo_file(path)
-        assert "run_tool_project" in text
+        assert "run_cached_tool_project" in text
 
     helper = _read_repo_file("scripts/dotnet_tool_runner.py")
     assert "--artifacts-path" in helper
     assert "TemporaryDirectory" in helper
     assert "tool-runs" in helper
+    assert "run_cached_tool_project" in helper
     assert "owner.pid" in helper
     assert "_remove_stale_lock" in helper
 
@@ -223,13 +244,226 @@ def test_run_tool_project_applies_timeout_to_build(
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     with pytest.raises(dotnet_tool_runner.DotnetToolError) as exc_info:
-        dotnet_tool_runner.run_tool_project(project_path, [], timeout=3)
+        _ = dotnet_tool_runner.run_tool_project(project_path, [], timeout=3)
 
     message = str(exc_info.value)
     assert "dotnet build timed out after 3s" in message
     assert project_path.as_posix() in message
     assert "partial stdout" in message
     assert "partial stderr" in message
+
+
+def test_run_cached_tool_project_reuses_shared_artifacts_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cached wrapper runs should rebuild incrementally in the shared artifacts root."""
+    project_path = _write_probe_project(tmp_path)
+    artifacts_root = tmp_path / "artifacts"
+    monkeypatch.setattr(dotnet_tool_runner, "_dotnet_path", lambda: "dotnet")
+    monkeypatch.setattr(dotnet_tool_runner, "_artifacts_root", lambda: artifacts_root)
+
+    def fake_run_build_command(
+        command: list[str],
+        *,
+        timeout: float,
+        artifacts_root: Path,
+        assembly_name: str,
+        use_lock: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        assert timeout == 7
+        assert artifacts_root == tmp_path / "artifacts"
+        assert assembly_name == "Probe"
+        assert not use_lock
+        assert (artifacts_root / "locks" / "Probe.lock" / "owner.pid").is_file()
+        assert "--artifacts-path" in command
+        dll = artifacts_root / "bin" / assembly_name / "release" / "Probe.dll"
+        dll.parent.mkdir(parents=True)
+        _ = dll.write_text("", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    def fake_run_tool_dll(
+        tool_dll: Path,
+        args: list[str],
+        *,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        assert tool_dll == artifacts_root / "bin" / "Probe" / "release" / "Probe.dll"
+        assert args == ["--flag"]
+        assert timeout == 7
+        assert not (artifacts_root / "locks" / "Probe.lock" / "owner.pid").exists()
+        return subprocess.CompletedProcess(["dotnet", str(tool_dll), *args], 0, "ok", "")
+
+    monkeypatch.setattr(dotnet_tool_runner, "_run_build_command", fake_run_build_command)
+    monkeypatch.setattr(dotnet_tool_runner, "_run_tool_dll", fake_run_tool_dll)
+
+    result = dotnet_tool_runner.run_cached_tool_project(project_path, ["--flag"], timeout=7)
+
+    assert result.stdout == "ok"
+
+
+def test_run_cached_tool_project_skips_build_when_cached_dll_is_fresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fresh cached tool DLLs should avoid repeated dotnet build startup."""
+    project_path = _write_probe_project(tmp_path)
+    artifacts_root = tmp_path / "artifacts"
+    dll = _write_cached_probe_dll(artifacts_root, project_path)
+    fresh_time = project_path.stat().st_mtime + 10.0
+    os.utime(dll, (fresh_time, fresh_time))
+    monkeypatch.setattr(dotnet_tool_runner, "_dotnet_path", lambda: "dotnet")
+    monkeypatch.setattr(dotnet_tool_runner, "_artifacts_root", lambda: artifacts_root)
+
+    def fail_build(
+        command: list[str],
+        *,
+        timeout: float,
+        artifacts_root: Path,
+        assembly_name: str,
+        use_lock: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        _ = command, timeout, artifacts_root, assembly_name, use_lock
+        pytest.fail("fresh cached tool should not invoke dotnet build")
+
+    def fake_run_tool_dll(
+        tool_dll: Path,
+        args: list[str],
+        *,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        assert tool_dll == dll
+        assert args == ["--cached"]
+        assert timeout == 5
+        return subprocess.CompletedProcess(["dotnet", str(tool_dll), *args], 0, "cached", "")
+
+    monkeypatch.setattr(dotnet_tool_runner, "_run_build_command", fail_build)
+    monkeypatch.setattr(dotnet_tool_runner, "_run_tool_dll", fake_run_tool_dll)
+
+    result = dotnet_tool_runner.run_cached_tool_project(project_path, ["--cached"], timeout=5)
+
+    assert result.stdout == "cached"
+
+
+def test_run_cached_tool_project_rebuilds_when_source_file_is_deleted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cached tool fingerprints should catch SDK-style glob source deletions."""
+    project_path = _write_probe_project(tmp_path)
+    source_path = tmp_path / "Program.cs"
+    artifacts_root = tmp_path / "artifacts"
+    _ = source_path.write_text("public static class Program {}\n", encoding="utf-8")
+    dll = _write_cached_probe_dll(artifacts_root, project_path)
+    source_path.unlink()
+
+    monkeypatch.setattr(dotnet_tool_runner, "_dotnet_path", lambda: "dotnet")
+    monkeypatch.setattr(dotnet_tool_runner, "_artifacts_root", lambda: artifacts_root)
+
+    build_calls = 0
+
+    def fake_run_build_command(
+        command: list[str],
+        *,
+        timeout: float,
+        artifacts_root: Path,
+        assembly_name: str,
+        use_lock: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal build_calls
+        _ = timeout, use_lock
+        build_calls += 1
+        assert command[0] == "dotnet"
+        _ = (artifacts_root / "bin" / assembly_name / "release" / "Probe.dll").write_text("", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    def fake_run_tool_dll(
+        tool_dll: Path,
+        args: list[str],
+        *,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        assert tool_dll == dll
+        assert args == []
+        assert timeout == 5
+        return subprocess.CompletedProcess(["dotnet", str(tool_dll)], 0, "rebuilt", "")
+
+    monkeypatch.setattr(dotnet_tool_runner, "_run_build_command", fake_run_build_command)
+    monkeypatch.setattr(dotnet_tool_runner, "_run_tool_dll", fake_run_tool_dll)
+
+    result = dotnet_tool_runner.run_cached_tool_project(project_path, [], timeout=5)
+
+    assert build_calls == 1
+    assert result.stdout == "rebuilt"
+
+
+def test_run_cached_tool_project_normalizes_stamp_write_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stamp write failures should retain the failing path in a DotnetToolError."""
+    project_path = _write_probe_project(tmp_path)
+    artifacts_root = tmp_path / "artifacts"
+    broken_stamp = tmp_path / "missing-parent" / "Probe.dll.sources.sha256"
+    monkeypatch.setattr(dotnet_tool_runner, "_dotnet_path", lambda: "dotnet")
+    monkeypatch.setattr(dotnet_tool_runner, "_artifacts_root", lambda: artifacts_root)
+
+    def broken_stamp_path(_tool_dll: Path) -> Path:
+        return broken_stamp
+
+    monkeypatch.setattr(dotnet_tool_runner, "_tool_sources_stamp_path", broken_stamp_path)
+
+    def fake_run_build_command(
+        command: list[str],
+        *,
+        timeout: float,
+        artifacts_root: Path,
+        assembly_name: str,
+        use_lock: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        _ = timeout, use_lock
+        assert command[0] == "dotnet"
+        dll = artifacts_root / "bin" / assembly_name / "release" / "Probe.dll"
+        dll.parent.mkdir(parents=True)
+        _ = dll.write_text("", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(dotnet_tool_runner, "_run_build_command", fake_run_build_command)
+
+    with pytest.raises(dotnet_tool_runner.DotnetToolError) as exc_info:
+        _ = dotnet_tool_runner.run_cached_tool_project(project_path, [], timeout=5)
+
+    assert broken_stamp.as_posix() in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, OSError)
+
+
+def test_cached_tool_stale_check_normalizes_stamp_read_errors(tmp_path: Path) -> None:
+    """Unreadable stamp paths should report the failing stamp path consistently."""
+    project_path = _write_probe_project(tmp_path)
+    artifacts_root = tmp_path / "artifacts"
+    dll = _write_cached_probe_dll(artifacts_root, project_path)
+    stamp = dotnet_tool_runner._tool_sources_stamp_path(dll)  # noqa: SLF001
+    stamp.unlink()
+    stamp.mkdir()
+
+    with pytest.raises(dotnet_tool_runner.DotnetToolError) as exc_info:
+        _ = dotnet_tool_runner._cached_tool_is_stale(project_path, dll)  # noqa: SLF001
+
+    assert stamp.as_posix() in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, OSError)
+
+
+def test_tool_sources_fingerprint_normalizes_source_read_errors(tmp_path: Path) -> None:
+    """Unreadable source inputs should report the failing source path consistently."""
+    project_path = _write_probe_project(tmp_path)
+    broken_source = tmp_path / "Broken.cs"
+    broken_source.mkdir()
+
+    with pytest.raises(dotnet_tool_runner.DotnetToolError) as exc_info:
+        _ = dotnet_tool_runner._tool_sources_fingerprint(project_path)  # noqa: SLF001
+
+    assert broken_source.as_posix() in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, OSError)
 
 
 def test_parallel_dotnet_policy_is_documented() -> None:

--- a/scripts/tests/test_qudjp_dotnet_test_contracts.py
+++ b/scripts/tests/test_qudjp_dotnet_test_contracts.py
@@ -114,8 +114,10 @@ def test_local_csharp_full_suite_builds_test_project_once() -> None:
     recipe = _recipe_block(justfile, "test-csharp", "python-check")
     check_recipe = _recipe_block(justfile, "check", "pr-check")
 
+    assert 'dotnet_test_build_properties := "-p:RunAnalyzers=false -p:RunAnalyzersDuringBuild=false"' in justfile
     assert "dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj" in recipe
     assert recipe.count("dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj") == 1
+    assert "{{dotnet_test_build_properties}}" in recipe
     assert recipe.count('dotnet test "$test_dll"') == 1
     assert "TestCategory=" not in recipe
 

--- a/scripts/tests/test_roslyn_extractor_smoke.py
+++ b/scripts/tests/test_roslyn_extractor_smoke.py
@@ -11,6 +11,8 @@ from typing import cast
 
 import pytest
 
+from scripts.dotnet_tool_runner import build_tool_project
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 ANNALS_PROJECT_PATH = _REPO_ROOT / "scripts" / "tools" / "AnnalsPatternExtractor" / "AnnalsPatternExtractor.csproj"
 STATIC_PRODUCER_PROJECT_PATH = (
@@ -22,6 +24,14 @@ STATIC_PRODUCER_PROJECT_PATH = (
 )
 SEMANTIC_PROBE_PROJECT_PATH = _REPO_ROOT / "scripts" / "tools" / "RoslynSemanticProbe" / "RoslynSemanticProbe.csproj"
 FIXTURES = Path(__file__).resolve().parent / "fixtures" / "annals"
+
+
+@pytest.fixture(scope="session")
+def annals_tool_dll() -> Path:
+    """Build the Annals extractor once for smoke execution."""
+    if not shutil.which("dotnet"):
+        pytest.skip("dotnet SDK not available")
+    return build_tool_project(ANNALS_PROJECT_PATH)
 
 
 @pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
@@ -67,7 +77,7 @@ def test_semantic_probe_csproj_builds_in_release() -> None:
 
 
 @pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
-def test_threeplus_arm_chain_does_not_collide_with_sibling_if(tmp_path: Path) -> None:
+def test_threeplus_arm_chain_does_not_collide_with_sibling_if(tmp_path: Path, annals_tool_dll: Path) -> None:
     """3+-arm else-if chains must produce arm-distinct ids that don't collide with sibling ifs.
 
     Regression guard for issue-430 follow-up (ChallengeSultan): when a 3-arm chain drives a
@@ -85,10 +95,7 @@ def test_threeplus_arm_chain_does_not_collide_with_sibling_if(tmp_path: Path) ->
     result = subprocess.run(
         [
             "dotnet",
-            "run",
-            "--project",
-            str(ANNALS_PROJECT_PATH),
-            "--",
+            str(annals_tool_dll),
             "--source-root",
             str(FIXTURES),
             "--include",
@@ -125,7 +132,7 @@ def test_threeplus_arm_chain_does_not_collide_with_sibling_if(tmp_path: Path) ->
 
 
 @pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
-def test_flatten_concat_partial_rollback(tmp_path: Path) -> None:
+def test_flatten_concat_partial_rollback(tmp_path: Path, annals_tool_dll: Path) -> None:
     """FlattenConcat must roll back stale pieces when a sub-expression fails.
 
     Regression guard for A1 (Devin finding): when a local variable's initializer
@@ -143,10 +150,7 @@ def test_flatten_concat_partial_rollback(tmp_path: Path) -> None:
     result = subprocess.run(
         [
             "dotnet",
-            "run",
-            "--project",
-            str(ANNALS_PROJECT_PATH),
-            "--",
+            str(annals_tool_dll),
             "--source-root",
             str(FIXTURES),
             "--include",

--- a/scripts/tests/test_roslyn_text_construction_inventory.py
+++ b/scripts/tests/test_roslyn_text_construction_inventory.py
@@ -1,5 +1,5 @@
 """Smoke tests for the Roslyn text construction inventory tool."""
-# ruff: noqa: S603,S607 -- tests invoke dotnet (PATH-resolved) to drive the repo-local tool
+# ruff: noqa: S603 -- tests invoke dotnet to drive the repo-local tool
 
 from __future__ import annotations
 
@@ -11,12 +11,25 @@ from typing import Any
 
 import pytest
 
+from scripts.dotnet_tool_runner import build_tool_project
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 PROJECT_PATH = _REPO_ROOT / "scripts" / "tools" / "TextConstructionInventory" / "TextConstructionInventory.csproj"
 
 
+@pytest.fixture(scope="session")
+def inventory_tool_dll() -> Path:
+    """Build the inventory tool once and reuse its DLL for smoke tests."""
+    if not shutil.which("dotnet"):
+        pytest.skip("dotnet SDK not available")
+    return build_tool_project(PROJECT_PATH)
+
+
 @pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
-def test_roslyn_inventory_emits_raw_free_deterministic_family_summary(tmp_path: Path) -> None:  # noqa: PLR0915
+def test_roslyn_inventory_emits_raw_free_deterministic_family_summary(  # noqa: PLR0915
+    tmp_path: Path,
+    inventory_tool_dll: Path,
+) -> None:
     """The Roslyn tool records construction shapes and surfaces without source text."""
     source_root = tmp_path / "source"
     source_root.mkdir()
@@ -76,8 +89,8 @@ public static class MessageQueue
     output_b = tmp_path / "inventory-b.json"
     summary_output = tmp_path / "inventory-summary.md"
 
-    _run_tool(source_root, output_a, summary_output=summary_output)
-    _run_tool(source_root, output_b)
+    _run_tool(inventory_tool_dll, source_root, output_a, summary_output=summary_output)
+    _run_tool(inventory_tool_dll, source_root, output_b)
 
     assert output_a.read_text(encoding="utf-8") == output_b.read_text(encoding="utf-8")
     payload = json.loads(output_a.read_text(encoding="utf-8"))
@@ -148,26 +161,15 @@ public static class MessageQueue
 
 
 @pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
-def test_roslyn_inventory_csproj_builds_in_release() -> None:
-    """The Roslyn inventory tool must build cleanly so it does not rot."""
-    result = subprocess.run(
-        ["dotnet", "build", str(PROJECT_PATH), "--configuration", "Release"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert result.returncode == 0, (
-        f"dotnet build failed (exit {result.returncode}).\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+def test_roslyn_inventory_csproj_builds_in_release(inventory_tool_dll: Path) -> None:
+    """The shared Release-build fixture must produce the Roslyn inventory DLL."""
+    assert inventory_tool_dll.is_file()
 
 
-def _run_tool(source_root: Path, output: Path, *, summary_output: Path | None = None) -> None:
+def _run_tool(tool_dll: Path, source_root: Path, output: Path, *, summary_output: Path | None = None) -> None:
     command = [
         "dotnet",
-        "run",
-        "--project",
-        str(PROJECT_PATH),
-        "--",
+        str(tool_dll),
         "--source-root",
         str(source_root),
         "--output",

--- a/scripts/tests/test_scan_static_producer_inventory.py
+++ b/scripts/tests/test_scan_static_producer_inventory.py
@@ -103,14 +103,14 @@ def test_write_inventory_reports_roslyn_scanner_timeout(
     _ = project_path.write_text("<Project />\n", encoding="utf-8")
     monkeypatch.setattr(scanner, "PROJECT_PATH", project_path)
 
-    def fake_run_tool_project(project: Path, args: list[str], *, timeout: int) -> object:
+    def fake_run_cached_tool_project(project: Path, args: list[str], *, timeout: int) -> object:
         assert project == project_path
         assert "--source-root" in args
         assert timeout == scanner.ROSLYN_SCANNER_TIMEOUT_SECONDS
         message = f"dotnet tool timed out after {timeout}s: dotnet scanner.dll\npartial stdout\npartial stderr"
         raise DotnetToolError(message)
 
-    monkeypatch.setattr(scanner, "run_tool_project", fake_run_tool_project)
+    monkeypatch.setattr(scanner, "run_cached_tool_project", fake_run_cached_tool_project)
 
     with pytest.raises(RuntimeError) as exc_info:
         write_inventory(source_root, tmp_path / "inventory.json")


### PR DESCRIPTION
## Summary

- Disable analyzers only for QudJP test artifact builds in local/CI test recipes while keeping analyzer coverage on the production `QudJP.csproj` build.
- Reuse cached repo-local Roslyn tool DLLs from Python wrappers, with per-tool build locks and source fingerprints so deleted/renamed sources invalidate the cache.
- Reuse prebuilt Roslyn tool DLLs inside Python smoke tests instead of paying repeated `dotnet run --project` startup/build cost.
- Update docs and repo-local skill guidance so `test-*` recipes are documented as behavior-test entrypoints and `build`/`check`/`pr-check` remain the analyzer-inclusive gates.

## Runtime Measurements

Measured on latest `origin/main` (`e140e5f2`) vs this branch (`713edb4b`) with fresh local `.artifacts`/`.venv` for each measured command. The follow-up CodeRabbit fixes are error-path/test-contract/docstring changes and do not affect the measured hot paths.

| Command | Before | After | Improvement |
|---|---:|---:|---:|
| `just test-l1` | 25.46s | 12.84s | 49.6% faster, 1.98x |
| `just test-l2` | 55.40s | 45.45s | 18.0% faster, 1.22x |
| `just python-test` | 53.07s | 31.74s | 40.2% faster, 1.67x |

## Review / Cleanup

- ai-slop-cleaner pass: kept scope to the test-runtime optimization diff; removed duplicate Probe project/cache setup in contract tests; fixed the independent review findings around cached tool lock lifetime and source deletion invalidation.
- Independent review: `codex review --uncommitted` initially requested changes for cached tool lock lifetime and stale DLL invalidation; after fixes, the second review found no discrete correctness, security, or maintainability issues.
- CodeRabbit follow-up: normalized cached stamp/source I/O errors as `DotnetToolError`, tightened the CI analyzer contract test so production/test artifact build assertions are scoped to the correct steps, and clarified the shared Release-build fixture docstring.
- polishment simplify pass: behavior-preserving cleanup only; no production behavior changes beyond the intended test/runtime optimization.

## Verification

- `just build`
- `just roslyn-python-check`
- `uv run pytest scripts/tests/test_parallel_dotnet_contract.py scripts/tests/test_qudjp_dotnet_test_contracts.py scripts/tests/test_ci_workflow_contract.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_roslyn_extractor_smoke.py scripts/tests/test_roslyn_text_construction_inventory.py -q` -> 67 passed, 1 skipped after CodeRabbit follow-up
- `uv run pytest scripts/tests/test_roslyn_text_construction_inventory.py -q` -> 2 passed after docstring follow-up
- `/usr/bin/time -p just test-l1` -> 2235 passed, 12.84s real
- `/usr/bin/time -p just test-l2` -> 3553 passed, 45.45s real
- `/usr/bin/time -p just python-test` -> 1147 passed, 1 skipped, 31.74s real
- `git diff --check`
- `just --summary`
- `just markdown-report-check`
- `just python-check`
- `GameDir=/tmp/qudjp-no-game-dir just pr-check` -> passed; C# suite 5778 passed, Python 1147 passed / 1 skipped, localization/token/report gates passed

Notes:

- The `GameDir=/tmp/qudjp-no-game-dir` override matches the CI no-game-DLL condition instead of this machine's local Caves of Qud DLL. The local game DLL path has unrelated signature drift for L2G-style checks, so this avoids making local runtime install state part of the PR gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * テスト向けビルドでアナライザーを無効化し、テストアーティファクト生成時のビルド性能を改善

* **ドキュメント**
  * ローカル検証手順、貢献ガイド、テストアーキテクチャ、実行レシピ、スクリプトREADMEを整理・明確化（テストゲートや並列実行の注意を含む）

* **チューン**
  * 共有アーティファクトの再利用経路を導入し、ローカル並列実行時のビルド効率と隔離を向上

* **テスト**
  * キャッシュ挙動・CIビルド契約・タイムアウト/エラー処理を検証するテストを追加・強化

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/716?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->