### PR TITLE
Fix article handling in generated text routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,7 @@ jobs:
           --expect-count popup=14
           --expect-count journal=1
           --expect-count leaf=0
-          --expect-count emit-message=336
+          --expect-count emit-message=342
           --expect-count does-verb=0
           --expect-count message-log=1
           --expect-count description=10

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs
@@ -450,10 +450,10 @@ public sealed class DoesVerbFamilyTests
     // --- Cleave Family ---
 
     [TestCase("The 戦士 cleaves through your 盾.", "戦士はあなたの盾を両断した")]
-    [TestCase("The 戦士 cleaves through the 熊's 腕.", "戦士は熊's 腕を両断した")]
+    [TestCase("The 戦士 cleaves through the 熊's 腕.", "戦士は熊の腕を両断した")]
     // Color-wrapped
     [TestCase("{{R|The 戦士 cleaves through your 盾.}}", "{{R|戦士はあなたの盾を両断した}}")]
-    [TestCase("{{g|The 戦士 cleaves through the 熊's 腕.}}", "{{g|戦士は熊's 腕を両断した}}")]
+    [TestCase("{{g|The 戦士 cleaves through the 熊's 腕.}}", "{{g|戦士は熊の腕を両断した}}")]
     public void Translate_CleaveFamily(string input, string expected)
     {
         AssertTranslated(input, expected);
@@ -578,6 +578,7 @@ public sealed class DoesVerbFamilyTests
 
     [TestCase("You critically hit the 熊 (x3) with a 短弓 for 15 damage!", "短弓で熊に会心の一撃、15ダメージを与えた！ (x3)")]
     [TestCase("You hit the 熊 (x2) with an 矢 for 8 damage!", "矢で熊に8ダメージを与えた！ (x2)")]
+    [TestCase("You hit the 熊 for 5 damage.", "熊に5ダメージを与えた")]
     [TestCase("You hit the 熊 with a 矢 for 5 damage.", "矢で熊に5ダメージを与えた")]
     [TestCase("You critically hit the 熊 (x3) with a 短弓!", "短弓で熊に会心の一撃！ (x3)")]
     [TestCase("You hit the 熊 (x2) with a 矢!", "矢で熊に命中した (x2)")]
@@ -595,8 +596,8 @@ public sealed class DoesVerbFamilyTests
 
     [TestCase("Something hits the 熊 with an 矢 for 5 damage.", "何かが矢で熊に5ダメージを与えた")]
     [TestCase("Something hits the 熊 with an 矢.", "何かが矢で熊に命中した")]
-    [TestCase("You hit something to the north!", "to the northの方角の何かに命中した")]
-    [TestCase("The 熊 hits something to the south.", "熊はto the southの方角の何かに命中させた")]
+    [TestCase("You hit something to the north!", "北側の方角の何かに命中した")]
+    [TestCase("The 熊 hits something to the south.", "熊は南側の方角の何かに命中させた")]
     // Color-wrapped
     [TestCase("{{r|Something hits the 熊 with an 矢 for 5 damage.}}", "{{r|何かが矢で熊に5ダメージを与えた}}")]
     public void Translate_MissileHitSomethingFamily(string input, string expected)
@@ -699,10 +700,10 @@ public sealed class DoesVerbFamilyTests
 
     // --- Pass By Family ---
 
-    [TestCase("The 矢 whizzes past to the north.", "矢がto the northのそばを通り過ぎた")]
-    [TestCase("The 矢 flies past to the south.", "矢がto the southのそばを通り過ぎた")]
+    [TestCase("The 矢 whizzes past to the north.", "矢が北側のそばを通り過ぎた")]
+    [TestCase("The 矢 flies past to the south.", "矢が南側のそばを通り過ぎた")]
     // Color-wrapped
-    [TestCase("{{r|The 矢 whizzes past to the north.}}", "{{r|矢がto the northのそばを通り過ぎた}}")]
+    [TestCase("{{r|The 矢 whizzes past to the north.}}", "{{r|矢が北側のそばを通り過ぎた}}")]
     public void Translate_PassByFamily(string input, string expected)
     {
         AssertTranslated(input, expected);
@@ -772,16 +773,16 @@ public sealed class DoesVerbFamilyTests
 
     // --- Nosebleed Family ---
 
-    [TestCase("Your nose begins bleeding more heavily.", "あなたの鼻からさらに激しくbleedingが始まった")]
-    [TestCase("Your nose begins bleeding.", "あなたの鼻からbleedingが始まった")]
-    [TestCase("Your nose stops bleeding quite so heavily.", "あなたの鼻からのbleedingが少し治まった")]
-    [TestCase("Your nose stops bleeding.", "あなたの鼻からのbleedingが止まった")]
-    [TestCase("The 熊's nose begins bleeding.", "熊の鼻からbleedingが始まった")]
-    [TestCase("The 熊's nose stops bleeding.", "熊の鼻からのbleedingが止まった")]
-    [TestCase("The 熊's noses begin bleeding more heavily.", "熊の鼻からさらに激しくbleedingが始まった")]
-    [TestCase("The 熊's noses stop bleeding quite so heavily.", "熊の鼻からのbleedingが少し治まった")]
+    [TestCase("Your nose begins bleeding more heavily.", "あなたの鼻からさらに激しく出血が始まった")]
+    [TestCase("Your nose begins leaking.", "あなたの鼻から液漏れが始まった")]
+    [TestCase("Your nose stops oozing quite so heavily.", "あなたの鼻からの滲出が少し治まった")]
+    [TestCase("Your nose stops fluxing.", "あなたの鼻からのフラックス漏れが止まった")]
+    [TestCase("The 熊's nose begins bleeding.", "熊の鼻から出血が始まった")]
+    [TestCase("The 熊's nose stops leaking.", "熊の鼻からの液漏れが止まった")]
+    [TestCase("The 熊's noses begin oozing more heavily.", "熊の鼻からさらに激しく滲出が始まった")]
+    [TestCase("The 熊's noses stop fluxing quite so heavily.", "熊の鼻からのフラックス漏れが少し治まった")]
     // Color-wrapped
-    [TestCase("{{r|Your nose begins bleeding.}}", "{{r|あなたの鼻からbleedingが始まった}}")]
+    [TestCase("{{r|Your nose begins bleeding.}}", "{{r|あなたの鼻から出血が始まった}}")]
     public void Translate_NosebleedFamily(string input, string expected)
     {
         AssertTranslated(input, expected);
@@ -872,7 +873,7 @@ public sealed class DoesVerbFamilyTests
 
     [TestCase("The reacting liquids congeal into a スラッジ.", "反応した液体が凝固しスラッジになった")]
     [TestCase("The liquids stop reacting.", "液体の反応が止まった")]
-    [TestCase("The primordial soup to the east starts reacting with the 酸.", "to the eastの原初のスープが酸と反応を始めた")]
+    [TestCase("The primordial soup to the east starts reacting with the 酸.", "東側の原初のスープが酸と反応を始めた")]
     // Color-wrapped
     [TestCase("{{g|The reacting liquids congeal into a スラッジ.}}", "{{g|反応した液体が凝固しスラッジになった}}")]
     public void Translate_LiquidReactionFamily(string input, string expected)
@@ -944,10 +945,10 @@ public sealed class DoesVerbFamilyTests
 
     // --- Flailing/Battering Family ---
 
-    [TestCase("Suddenly the 武器 starts flailing around and battering you!", "突然武器が暴れ出し、youを殴りつけた！")]
-    [TestCase("Two tubular sections of the 武器 flail around and batter you!", "武器の2本の管状の部分が暴れ、youを殴りつけた！")]
+    [TestCase("Suddenly the 武器 starts flailing around and battering you!", "突然武器が暴れ出し、あなたを殴りつけた！")]
+    [TestCase("Two tubular sections of the 武器 flail around and batter you!", "武器の2本の管状の部分が暴れ、あなたを殴りつけた！")]
     // Color-wrapped
-    [TestCase("{{r|Two tubular sections of the 武器 flail around and batter you!}}", "{{r|武器の2本の管状の部分が暴れ、youを殴りつけた！}}")]
+    [TestCase("{{r|Two tubular sections of the 武器 flail around and batter you!}}", "{{r|武器の2本の管状の部分が暴れ、あなたを殴りつけた！}}")]
     public void Translate_FlailingBatteringFamily(string input, string expected)
     {
         AssertTranslated(input, expected);
@@ -1077,8 +1078,8 @@ public sealed class DoesVerbFamilyTests
 
     // --- Holographic Visage Family ---
 
-    [TestCase("In a glissade of light, the 熊's visage morphs into an image pleasing to the Barathrumites.", "光が滑るように走り、熊の顔貌はthe Barathrumitesに好ましい姿へと変化した")]
-    [TestCase("{{g|In a glissade of light, the 熊's visage morphs into an image pleasing to the Barathrumites.}}", "{{g|光が滑るように走り、熊の顔貌はthe Barathrumitesに好ましい姿へと変化した}}")]
+    [TestCase("In a glissade of light, the 熊's visage morphs into an image pleasing to the Barathrumites.", "光が滑るように走り、熊の顔貌はバラサラム派（技師団）に好ましい姿へと変化した")]
+    [TestCase("{{g|In a glissade of light, the 熊's visage morphs into an image pleasing to the Barathrumites.}}", "{{g|光が滑るように走り、熊の顔貌はバラサラム派（技師団）に好ましい姿へと変化した}}")]
     public void Translate_HolographicVisageFamily(string input, string expected)
     {
         AssertTranslated(input, expected);

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs
@@ -596,8 +596,8 @@ public sealed class DoesVerbFamilyTests
 
     [TestCase("Something hits the 熊 with an 矢 for 5 damage.", "何かが矢で熊に5ダメージを与えた")]
     [TestCase("Something hits the 熊 with an 矢.", "何かが矢で熊に命中した")]
-    [TestCase("You hit something to the north!", "北側の方角の何かに命中した")]
-    [TestCase("The 熊 hits something to the south.", "熊は南側の方角の何かに命中させた")]
+    [TestCase("You hit something to the north!", "北側の何かに命中した")]
+    [TestCase("The 熊 hits something to the south.", "熊は南側の何かに命中させた")]
     // Color-wrapped
     [TestCase("{{r|Something hits the 熊 with an 矢 for 5 damage.}}", "{{r|何かが矢で熊に5ダメージを与えた}}")]
     public void Translate_MissileHitSomethingFamily(string input, string expected)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessageFrameTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessageFrameTranslatorTests.cs
@@ -771,8 +771,11 @@ public sealed class MessageFrameTranslatorTests
             {
                 ("begin", "{0}", "{t0}が始まった"),
                 ("begin", "{0} from another wound", "別の傷から{t0}が始まった"),
-                ("begin", "acting like {0} {1}", "{t1}のふりをし始めた"),
-                ("stop", "{0}", "{t0}が止まった")
+                ("begin", "acting like {0} {1}", "{t0} {t1}のふりをし始めた"),
+                ("begin", "acting like {0} {1} from another wound", "{t0} {t1}のふりをし始めた（別の傷から）"),
+                ("stop", "{0}", "{t0}が止まった"),
+                ("stop", "acting like {0} {1}", "{t0} {t1}のふりをやめた"),
+                ("stop", "acting like {0} {1} so much", "{t0} {t1}のふりをするのをやめた")
             });
 
         Assert.Multiple(() =>
@@ -788,14 +791,39 @@ public sealed class MessageFrameTranslatorTests
             Assert.That(oozing, Is.EqualTo("粘液は別の傷から滲出が始まった！"));
 
             Assert.That(
-                MessageFrameTranslator.TryTranslateXDidY("幻影", "begin", "acting like it is fluxing", null, out var holographic),
+                MessageFrameTranslator.TryTranslateXDidY("幻影", "begin", "acting like chrome hoverer", null, out var holographic),
                 Is.True);
-            Assert.That(holographic, Is.EqualTo("幻影はフラックス漏れのふりをし始めた。"));
+            Assert.That(holographic, Is.EqualTo("幻影はchrome hovererのふりをし始めた。"));
+
+            Assert.That(
+                MessageFrameTranslator.TryTranslateXDidY(
+                    "幻影",
+                    "begin",
+                    "acting like chrome hoverer from another wound",
+                    null,
+                    out var holographicWound),
+                Is.True);
+            Assert.That(holographicWound, Is.EqualTo("幻影はchrome hovererのふりをし始めた（別の傷から）。"));
 
             Assert.That(
                 MessageFrameTranslator.TryTranslateXDidY("機械", "stop", "leaking", ".", out var stopped),
                 Is.True);
             Assert.That(stopped, Is.EqualTo("機械は液漏れが止まった。"));
+
+            Assert.That(
+                MessageFrameTranslator.TryTranslateXDidY("幻影", "stop", "acting like chrome hoverer", ".", out var stoppedActing),
+                Is.True);
+            Assert.That(stoppedActing, Is.EqualTo("幻影はchrome hovererのふりをやめた。"));
+
+            Assert.That(
+                MessageFrameTranslator.TryTranslateXDidY(
+                    "幻影",
+                    "stop",
+                    "acting like chrome hoverer so much",
+                    ".",
+                    out var stoppedActingSoMuch),
+                Is.True);
+            Assert.That(stoppedActingSoMuch, Is.EqualTo("幻影はchrome hovererのふりをするのをやめた。"));
         });
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessageFrameTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessageFrameTranslatorTests.cs
@@ -428,14 +428,15 @@ public sealed class MessageFrameTranslatorTests
     [Test]
     public void TryTranslateXDidY_Tier3_BreakFreeFrom()
     {
-        WriteDictionary(tier3: new[] { ("break", "free from {0}", "{0}から抜け出した") });
+        WriteExactDictionary(("hook", "鉤"));
+        WriteDictionary(tier3: new[] { ("break", "free from {0}", "{t0}から抜け出した") });
 
         var ok = MessageFrameTranslator.TryTranslateXDidY("戦士", "break", "free from the hook", "!", out var sentence);
 
         Assert.Multiple(() =>
         {
             Assert.That(ok, Is.True);
-            Assert.That(sentence, Is.EqualTo("戦士はthe hookから抜け出した！"));
+            Assert.That(sentence, Is.EqualTo("戦士は鉤から抜け出した！"));
         });
     }
 
@@ -456,70 +457,75 @@ public sealed class MessageFrameTranslatorTests
     [Test]
     public void TryTranslateXDidY_Tier3_AssumeFormOf()
     {
-        WriteDictionary(tier3: new[] { ("assume", "the form of {0}", "{0}の姿をとった") });
+        WriteExactDictionary(("bear", "熊"));
+        WriteDictionary(tier3: new[] { ("assume", "the form of {0}", "{t0}の姿をとった") });
 
         var ok = MessageFrameTranslator.TryTranslateXDidY("変異者", "assume", "the form of a bear", ".", out var sentence);
 
         Assert.Multiple(() =>
         {
             Assert.That(ok, Is.True);
-            Assert.That(sentence, Is.EqualTo("変異者はa bearの姿をとった。"));
+            Assert.That(sentence, Is.EqualTo("変異者は熊の姿をとった。"));
         });
     }
 
     [Test]
     public void TryTranslateXDidY_Tier3_AreKnockedDirection()
     {
-        WriteDictionary(tier3: new[] { ("are", "knocked {0}", "{0}に吹き飛ばされた") });
+        WriteExactDictionary(("to the north", "北側"));
+        WriteDictionary(tier3: new[] { ("are", "knocked {0}", "{t0}に吹き飛ばされた") });
 
         var ok = MessageFrameTranslator.TryTranslateXDidY("ゴブリン", "are", "knocked to the north", ".", out var sentence);
 
         Assert.Multiple(() =>
         {
             Assert.That(ok, Is.True);
-            Assert.That(sentence, Is.EqualTo("ゴブリンはto the northに吹き飛ばされた。"));
+            Assert.That(sentence, Is.EqualTo("ゴブリンは北側に吹き飛ばされた。"));
         });
     }
 
     [Test]
     public void TryTranslateXDidY_Tier3_AreNoLonger()
     {
-        WriteDictionary(tier3: new[] { ("are", "no longer {0}", "{0}状態ではなくなった") });
+        WriteExactDictionary(("rooted", "根付いた"));
+        WriteDictionary(tier3: new[] { ("are", "no longer {0}", "{t0}状態ではなくなった") });
 
         var ok = MessageFrameTranslator.TryTranslateXDidY("あなた", "are", "no longer rooted", ".", out var sentence);
 
         Assert.Multiple(() =>
         {
             Assert.That(ok, Is.True);
-            Assert.That(sentence, Is.EqualTo("あなたはrooted状態ではなくなった。"));
+            Assert.That(sentence, Is.EqualTo("あなたは根付いた状態ではなくなった。"));
         });
     }
 
     [Test]
     public void TryTranslateXDidY_Tier3_SwitchStance()
     {
-        WriteDictionary(tier3: new[] { ("switch", "to {0} stance", "{0}の構えに切り替えた") });
+        WriteExactDictionary(("aggressive", "攻撃的"));
+        WriteDictionary(tier3: new[] { ("switch", "to {0} stance", "{t0}の構えに切り替えた") });
 
         var ok = MessageFrameTranslator.TryTranslateXDidY("剣士", "switch", "to aggressive stance", ".", out var sentence);
 
         Assert.Multiple(() =>
         {
             Assert.That(ok, Is.True);
-            Assert.That(sentence, Is.EqualTo("剣士はaggressiveの構えに切り替えた。"));
+            Assert.That(sentence, Is.EqualTo("剣士は攻撃的の構えに切り替えた。"));
         });
     }
 
     [Test]
     public void TryTranslateXDidY_Tier3_TeleportAway()
     {
-        WriteDictionary(tier3: new[] { ("teleport", "{0} away", "{0}をテレポートさせた") });
+        WriteExactDictionary(("bear", "熊"));
+        WriteDictionary(tier3: new[] { ("teleport", "{0} away", "{t0}をテレポートさせた") });
 
         var ok = MessageFrameTranslator.TryTranslateXDidY("念動力者", "teleport", "the bear away", ".", out var sentence);
 
         Assert.Multiple(() =>
         {
             Assert.That(ok, Is.True);
-            Assert.That(sentence, Is.EqualTo("念動力者はthe bearをテレポートさせた。"));
+            Assert.That(sentence, Is.EqualTo("念動力者は熊をテレポートさせた。"));
         });
     }
 
@@ -576,14 +582,15 @@ public sealed class MessageFrameTranslatorTests
     [Test]
     public void TryTranslateXDidY_Tier3_ArePromoted()
     {
-        WriteDictionary(tier3: new[] { ("are", "promoted to the {0} of {1}", "{1}の{0}に昇進した") });
+        WriteExactDictionary(("Champion", "チャンピオン"), ("Barathrumites", "バラサラム派"));
+        WriteDictionary(tier3: new[] { ("are", "promoted to the {0} of {1}", "{t1}の{t0}に昇進した") });
 
         var ok = MessageFrameTranslator.TryTranslateXDidY("あなた", "are", "promoted to the Champion of the Barathrumites", ".", out var sentence);
 
         Assert.Multiple(() =>
         {
             Assert.That(ok, Is.True);
-            Assert.That(sentence, Is.EqualTo("あなたはthe BarathrumitesのChampionに昇進した。"));
+            Assert.That(sentence, Is.EqualTo("あなたはバラサラム派のチャンピオンに昇進した。"));
         });
     }
 
@@ -698,8 +705,9 @@ public sealed class MessageFrameTranslatorTests
     [Test]
     public void TryTranslateXDidY_Tier3_StareAtMultipleTargets()
     {
+        WriteExactDictionary(("yeti", "イエティ"), ("baboon", "ヒヒ"));
         WriteDictionary(tier3: new[] {
-            ("stare", "at {0} menacingly", "{0}を睨みつけた")
+            ("stare", "at {0} menacingly", "{t0}を睨みつけた")
         });
 
         var ok = MessageFrameTranslator.TryTranslateXDidY("熊", "stare", "at the yeti and the baboon menacingly", ".", out var sentence);
@@ -707,7 +715,7 @@ public sealed class MessageFrameTranslatorTests
         Assert.Multiple(() =>
         {
             Assert.That(ok, Is.True);
-            Assert.That(sentence, Is.EqualTo("熊はthe yeti and the baboonを睨みつけた。"));
+            Assert.That(sentence, Is.EqualTo("熊はイエティとヒヒを睨みつけた。"));
         });
     }
 
@@ -752,6 +760,42 @@ public sealed class MessageFrameTranslatorTests
         {
             Assert.That(ok, Is.True);
             Assert.That(sentence, Is.EqualTo("あなたは別の傷から出血し始めた！"));
+        });
+    }
+
+    [Test]
+    public void TryTranslateXDidY_Tier3_TranslatesCirculatoryLossTerms()
+    {
+        WriteDictionary(
+            tier3: new[]
+            {
+                ("begin", "{0}", "{t0}が始まった"),
+                ("begin", "{0} from another wound", "別の傷から{t0}が始まった"),
+                ("begin", "acting like {0} {1}", "{t1}のふりをし始めた"),
+                ("stop", "{0}", "{t0}が止まった")
+            });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                MessageFrameTranslator.TryTranslateXDidY("光葉", "begin", "leaking", "!", out var leaking),
+                Is.True);
+            Assert.That(leaking, Is.EqualTo("光葉は液漏れが始まった！"));
+
+            Assert.That(
+                MessageFrameTranslator.TryTranslateXDidY("粘液", "begin", "oozing from another wound", "!", out var oozing),
+                Is.True);
+            Assert.That(oozing, Is.EqualTo("粘液は別の傷から滲出が始まった！"));
+
+            Assert.That(
+                MessageFrameTranslator.TryTranslateXDidY("幻影", "begin", "acting like it is fluxing", null, out var holographic),
+                Is.True);
+            Assert.That(holographic, Is.EqualTo("幻影はフラックス漏れのふりをし始めた。"));
+
+            Assert.That(
+                MessageFrameTranslator.TryTranslateXDidY("機械", "stop", "leaking", ".", out var stopped),
+                Is.True);
+            Assert.That(stopped, Is.EqualTo("機械は液漏れが止まった。"));
         });
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessageLogProducerTranslationHelpersTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessageLogProducerTranslationHelpersTests.cs
@@ -315,7 +315,7 @@ public sealed class MessageLogProducerTranslationHelpersTests
     [Test]
     public void PreparePassByMessage_MarksTranslatedMessage()
     {
-        WritePatternDictionary(("^You pass by (.+?)[.!]?$", "{0}のそばを通り過ぎた。"));
+        WritePatternDictionary(("^You pass by (?:a |an |the )?(.+?)[.!]?$", "{0}のそばを通り過ぎた。"));
 
         var result = MessageLogProducerTranslationHelpers.PreparePassByMessage(
             "You pass by ウォーターヴァイン.",
@@ -324,10 +324,23 @@ public sealed class MessageLogProducerTranslationHelpersTests
         Assert.That(result, Is.EqualTo("\u0001ウォーターヴァインのそばを通り過ぎた。"));
     }
 
+    [TestCase("You pass by an 編みかご.", "\u0001編みかごのそばを通り過ぎた。")]
+    [TestCase("You pass by the ウォーターヴァイン.", "\u0001ウォーターヴァインのそばを通り過ぎた。")]
+    public void PreparePassByMessage_StripsLeadingEnglishArticle(string source, string expected)
+    {
+        WritePatternDictionary(("^You pass by (?:a |an |the )?(.+?)[.!]?$", "{0}のそばを通り過ぎた。"));
+
+        var result = MessageLogProducerTranslationHelpers.PreparePassByMessage(
+            source,
+            "PhysicsEnterCellPassByTranslationPatch");
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
     [Test]
     public void PreparePassByMessage_PreservesColorTags()
     {
-        WritePatternDictionary(("^You pass by (.+?)[.!]?$", "{0}のそばを通り過ぎた。"));
+        WritePatternDictionary(("^You pass by (?:a |an |the )?(.+?)[.!]?$", "{0}のそばを通り過ぎた。"));
 
         var result = MessageLogProducerTranslationHelpers.PreparePassByMessage(
             "You pass by <color=#ff0>ウォーターヴァイン</color>.",

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -559,12 +559,11 @@ public sealed class MessagePatternTranslatorTests
     [Test]
     public void Translate_AppliesNpcHitsSomethingPatternWithExclamation()
     {
-        WriteExactDictionary(("Turret", "タレット"));
-        WritePatternDictionary(("^(.+?) hits something (.+?)[.!]?$", "{t0}の射撃が{t1}の何かに命中した。"));
+        UseRepositoryPatternDictionary();
 
-        var translated = MessagePatternTranslator.Translate("Turret hits something to the east!");
+        var translated = MessagePatternTranslator.Translate("タレット hits something to the east!");
 
-        Assert.That(translated, Is.EqualTo("タレットの射撃が東側の何かに命中した。"));
+        Assert.That(translated, Is.EqualTo("タレットは東側の何かに命中させた"));
     }
 
     [Test]
@@ -953,7 +952,7 @@ public sealed class MessagePatternTranslatorTests
     [Test]
     public void Translate_AppliesYellPattern()
     {
-        WritePatternDictionary(("^(?:The |the |[Aa]n? )?(.+?) yells, '(.+)'$", "{t0}は「{1}」と叫んだ。"));
+        UseRepositoryPatternDictionary();
 
         var translated = MessagePatternTranslator.Translate("The ウォーターヴァイン農家のメカニマス教徒改宗者 yells, 'Is it a dybbuk that possesses the robot? It should be sacred and still.'");
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -115,7 +115,7 @@ public sealed class MessagePatternTranslatorTests
 
         var translated = MessagePatternTranslator.Translate(source);
 
-        Assert.That(translated, Is.EqualTo(expected));
+        Assert.That(translated, Is.EqualTo(expected), source);
     }
 
 
@@ -724,6 +724,24 @@ public sealed class MessagePatternTranslatorTests
         Assert.That(translated, Is.EqualTo("あなたは出血で1ダメージを受けた。"));
     }
 
+    [TestCase("The {{B|濡れた}}光葉 begins leaking.", "{{B|濡れた}}光葉は液漏れし始めた。")]
+    [TestCase("an 樹液まみれの濡れた光葉 begins oozing from another wound.", "樹液まみれの濡れた光葉は別の傷から滲出し始めた。")]
+    [TestCase("A {{B|濡れた}}光葉 stops fluxing.", "{{B|濡れた}}光葉のフラックス漏れは止まった。")]
+    [TestCase("The {{B|濡れた}}光葉 takes 1 damage from leaking.", "{{B|濡れた}}光葉は液漏れで1ダメージを受けた。")]
+    [TestCase("the 樹液まみれの濡れた光葉 takes no damage from oozing.", "樹液まみれの濡れた光葉は滲出でダメージを受けなかった。")]
+    [TestCase("One of タムの wounds stops leaking.", "タムの傷のひとつの液漏れが止まった。")]
+    [TestCase("One of the 樹液まみれの濡れた光葉の wounds stops leaking.", "樹液まみれの濡れた光葉の傷のひとつの液漏れが止まった。")]
+    public void Translate_RepositoryDictionary_TranslatesCirculatoryLossEventMessages(
+        string source,
+        string expected)
+    {
+        UseRepositoryPatternDictionary();
+
+        var actual = MessagePatternTranslator.Translate(source);
+
+        Assert.That(actual, Is.EqualTo(expected), source);
+    }
+
     [Test]
     public void Translate_RepositoryDictionary_UsesSpecificWoundStopBleedingPatternBeforeGenericBleedingStopPattern()
     {
@@ -732,19 +750,6 @@ public sealed class MessagePatternTranslatorTests
         var translated = MessagePatternTranslator.Translate("One of タムの wounds stops bleeding.");
 
         Assert.That(translated, Is.EqualTo("タムの傷のひとつの出血が止まった。"));
-    }
-
-    [TestCase("One of タムの wounds stops leaking.", "タムの傷のひとつの液漏れが止まった。")]
-    [TestCase("One of the 樹液まみれの濡れた光葉の wounds stops leaking.", "樹液まみれの濡れた光葉の傷のひとつの液漏れが止まった。")]
-    public void Translate_RepositoryDictionary_TranslatesCirculatoryLossWoundStopBeforeCombatWoundsPattern(
-        string source,
-        string expected)
-    {
-        UseRepositoryPatternDictionary();
-
-        var translated = MessagePatternTranslator.Translate(source);
-
-        Assert.That(translated, Is.EqualTo(expected));
     }
 
     [TestCase("熊 nose begins leaking more heavily.", "熊の鼻が激しく液漏れし始めた。")]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs
@@ -335,7 +335,7 @@ public sealed class MessagePatternTranslatorTests
     [TestCase("Brown sludge splashes into your mouth. You wince at the metallic taste.", "茶色い汚泥が口に入った。金属の味に顔をしかめた。")]
     [TestCase("The liquids stop reacting.", "液体の反応が止まった")]
     [TestCase("The reacting liquids congeal into a SoupSludge.", "反応した液体が凝固しSoupSludgeになった")]
-    [TestCase("The primordial soup nearby starts reacting with the water.", "nearbyの原初のスープがwaterと反応を始めた")]
+    [TestCase("The primordial soup nearby starts reacting with the water.", "近くの原初のスープが水と反応を始めた")]
     [TestCase("You receive tinkering bits <{{|AB}}>.", "修理ビット<{{|AB}}>を受け取った。")]
     [TestCase("You make some progress disarming 地雷.", "地雷の解除が少し進んだ。")]
     [TestCase("An image of タム disappears.", "タムの映像が消えた。")]
@@ -348,16 +348,21 @@ public sealed class MessagePatternTranslatorTests
     [TestCase("The タレット hits you with a 鉛スラッグ, but your mental attack has no effect.", "タレットの鉛スラッグが命中したが、精神攻撃は効果がない")]
     [TestCase("The タレット hits タム with a 鉛スラッグ, but their mental attack has no effect.", "タレットは鉛スラッグでタムに命中させたが、精神攻撃は効果がない")]
     [TestCase("The タレット hits タム (x2) with a 鉛スラッグ!", "タレットは鉛スラッグでタムに命中した (x2)")]
-    [TestCase("鉛スラッグ hits you to the east! (x2)", "鉛スラッグがあなたにto the east命中！ (x2)")]
-    [TestCase("鉛スラッグ critically hits you to the east! (x2)", "鉛スラッグが会心であなたにto the east命中！ (x2)")]
-    [TestCase("鉛スラッグ hits you to the east, but your mental attack has no effect.", "鉛スラッグがあなたに命中した to the east, but your mental attack has no effect。")]
-    [TestCase("鉛スラッグ critically hits you to the east.", "鉛スラッグが会心であなたに命中した to the east。")]
-    [TestCase("鉛スラッグ hits タム to the east, but your mental attack has no effect.", "鉛スラッグがタムに命中した to the east, but your mental attack has no effect。")]
-    [TestCase("鉛スラッグ critically hits タム to the east.", "鉛スラッグが会心でタムに命中した to the east。")]
-    [TestCase("鉛スラッグ hits you (x2) to the east!", "鉛スラッグがあなたにto the east命中！ (x2)")]
-    [TestCase("鉛スラッグ critically hits you (x2) to the east!", "鉛スラッグが会心であなたにto the east命中！ (x2)")]
-    [TestCase("鉛スラッグ hits タム (x2) to the east!", "鉛スラッグがタムにto the east命中！ (x2)")]
-    [TestCase("鉛スラッグ critically hits タム (x2) to the east!", "鉛スラッグが会心でタムにto the east命中！ (x2)")]
+    [TestCase("鉛スラッグ hits you to the east! (x2)", "鉛スラッグがあなたに東側に命中！ (x2)")]
+    [TestCase("鉛スラッグ critically hits you to the east! (x2)", "鉛スラッグが会心であなたに東側に命中！ (x2)")]
+    [TestCase("鉛スラッグ hits you to the east, but your mental attack has no effect.", "鉛スラッグがあなたに東側に命中したが、精神攻撃は効果がない")]
+    [TestCase("鉛スラッグ critically hits you to the east.", "鉛スラッグが会心であなたに東側に命中した。")]
+    [TestCase("鉛スラッグ hits タム to the east, but your mental attack has no effect.", "鉛スラッグがタムに東側に命中したが、精神攻撃は効果がない")]
+    [TestCase("鉛スラッグ critically hits タム to the east.", "鉛スラッグが会心でタムに東側に命中した。")]
+    [TestCase("鉛スラッグ hits you (x2) to the east!", "鉛スラッグがあなたに東側に命中！ (x2)")]
+    [TestCase("鉛スラッグ critically hits you (x2) to the east!", "鉛スラッグが会心であなたに東側に命中！ (x2)")]
+    [TestCase("鉛スラッグ hits タム (x2) to the east!", "鉛スラッグがタムに東側に命中！ (x2)")]
+    [TestCase("鉛スラッグ critically hits タム (x2) to the east!", "鉛スラッグが会心でタムに東側に命中！ (x2)")]
+    [TestCase("The スナップジョー is destroyed.", "スナップジョーは破壊された")]
+    [TestCase("An スナップジョー dies.", "スナップジョーは死んだ")]
+    [TestCase("You hit the 熊 for 3 damage.", "熊に3ダメージを与えた")]
+    [TestCase("the 熊 hits you for 2 damage.", "熊の攻撃で2ダメージを受けた")]
+    [TestCase("an ironshank misses you.", "ironshankの攻撃は外れた")]
     public void Translate_RepositoryDictionary_AppliesEmitMessageSweepPatterns(string source, string expected)
     {
         UseRepositoryPatternDictionary();
@@ -365,6 +370,17 @@ public sealed class MessagePatternTranslatorTests
         var translated = MessagePatternTranslator.Translate(source);
 
         Assert.That(translated, Is.EqualTo(expected));
+    }
+
+    [TestCase("You pass by a 編みかご.", "編みかごのそばを通り過ぎた。")]
+    [TestCase("You pass by an 編みかご.", "編みかごのそばを通り過ぎた。")]
+    [TestCase("You pass by the ウォーターヴァイン.", "ウォーターヴァインのそばを通り過ぎた。")]
+    [TestCase("You pass by ウォーターヴァイン.", "ウォーターヴァインのそばを通り過ぎた。")]
+    public void Translate_RepositoryDictionary_StripsEnglishArticlesFromPassByCapture(string source, string expected)
+    {
+        UseRepositoryPatternDictionary();
+
+        Assert.That(MessagePatternTranslator.Translate(source), Is.EqualTo(expected));
     }
 
     [Test]
@@ -510,11 +526,12 @@ public sealed class MessagePatternTranslatorTests
     public void Translate_AppliesMentalAttackNoEffectPattern()
     {
         WritePatternDictionary(
-            ("^Your mental attack does not affect (.+?)\\.$", "あなたの精神攻撃は{0}に効かない。"));
+            ("^Your mental attack does not affect (.+?)\\.$", "あなたの精神攻撃は{t0}に効かない。"));
+        WriteExactDictionary(("turret", "タレット"));
 
         var translated = MessagePatternTranslator.Translate("Your mental attack does not affect the turret.");
 
-        Assert.That(translated, Is.EqualTo("あなたの精神攻撃はthe turretに効かない。"));
+        Assert.That(translated, Is.EqualTo("あなたの精神攻撃はタレットに効かない。"));
     }
 
     [Test]
@@ -542,11 +559,12 @@ public sealed class MessagePatternTranslatorTests
     [Test]
     public void Translate_AppliesNpcHitsSomethingPatternWithExclamation()
     {
-        WritePatternDictionary(("^(.+?) hits something (.+?)[.!]?$", "{0}の射撃が{1}の何かに命中した。"));
+        WriteExactDictionary(("Turret", "タレット"));
+        WritePatternDictionary(("^(.+?) hits something (.+?)[.!]?$", "{t0}の射撃が{t1}の何かに命中した。"));
 
         var translated = MessagePatternTranslator.Translate("Turret hits something to the east!");
 
-        Assert.That(translated, Is.EqualTo("Turretの射撃がto the eastの何かに命中した。"));
+        Assert.That(translated, Is.EqualTo("タレットの射撃が東側の何かに命中した。"));
     }
 
     [Test]
@@ -714,6 +732,40 @@ public sealed class MessagePatternTranslatorTests
         var translated = MessagePatternTranslator.Translate("One of タムの wounds stops bleeding.");
 
         Assert.That(translated, Is.EqualTo("タムの傷のひとつの出血が止まった。"));
+    }
+
+    [TestCase("One of タムの wounds stops leaking.", "タムの傷のひとつの液漏れが止まった。")]
+    [TestCase("One of the 樹液まみれの濡れた光葉の wounds stops leaking.", "樹液まみれの濡れた光葉の傷のひとつの液漏れが止まった。")]
+    public void Translate_RepositoryDictionary_TranslatesCirculatoryLossWoundStopBeforeCombatWoundsPattern(
+        string source,
+        string expected)
+    {
+        UseRepositoryPatternDictionary();
+
+        var translated = MessagePatternTranslator.Translate(source);
+
+        Assert.That(translated, Is.EqualTo(expected));
+    }
+
+    [TestCase("熊 nose begins leaking more heavily.", "熊の鼻が激しく液漏れし始めた。")]
+    [TestCase("熊 noses begin oozing more heavily.", "熊の鼻が激しく滲出し始めた。")]
+    public void Translate_RepositoryDictionary_TranslatesCirculatoryLossNoseFallbackPatterns(
+        string source,
+        string expected)
+    {
+        UseRepositoryPatternDictionary();
+
+        Assert.That(MessagePatternTranslator.Translate(source), Is.EqualTo(expected), () => source);
+    }
+
+    [Test]
+    public void Translate_RepositoryDictionary_StillTranslatesCombatWoundsPattern()
+    {
+        UseRepositoryPatternDictionary();
+
+        var translated = MessagePatternTranslator.Translate("The 熊 wounds タム.");
+
+        Assert.That(translated, Is.EqualTo("熊はタムに深手を負わせた"));
     }
 
     [Test]
@@ -896,11 +948,11 @@ public sealed class MessagePatternTranslatorTests
     [Test]
     public void Translate_AppliesYellPattern()
     {
-        WritePatternDictionary(("^(.+?) yells, '(.+)'$", "{0}は「{1}」と叫んだ。"));
+        WritePatternDictionary(("^(?:The |the |[Aa]n? )?(.+?) yells, '(.+)'$", "{t0}は「{1}」と叫んだ。"));
 
         var translated = MessagePatternTranslator.Translate("The ウォーターヴァイン農家のメカニマス教徒改宗者 yells, 'Is it a dybbuk that possesses the robot? It should be sacred and still.'");
 
-        Assert.That(translated, Is.EqualTo("The ウォーターヴァイン農家のメカニマス教徒改宗者は「Is it a dybbuk that possesses the robot? It should be sacred and still.」と叫んだ。"));
+        Assert.That(translated, Is.EqualTo("ウォーターヴァイン農家のメカニマス教徒改宗者は「Is it a dybbuk that possesses the robot? It should be sacred and still.」と叫んだ。"));
     }
 
     [Test]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
@@ -119,6 +119,9 @@ public sealed class CombatAndLogMessageQueuePatchTests
     [TestCase("{{r|You take 5 {{icy|cold damage}} from the shard!}}", "{{r|shardで5{{icy|冷気ダメージ}}を受けた！}}")]
     [TestCase("{{r|You take 8 damage from your laser beam! {{R|(x2)}}}}", "{{r|your laser beamで8ダメージを受けた！ {{R|(x2)}}}}")]
     [TestCase("{{r|You take 6 damage {{R|(x2)}} from colliding with the chrome wall.}}", "{{r|{{R|(x2)}} chrome wallとの衝突で6ダメージを受けた。}}")]
+    [TestCase("The {{B|濡れた}}光葉 takes 1 damage from leaking.", "{{B|濡れた}}光葉は液漏れで1ダメージを受けた。")]
+    [TestCase("The 樹液まみれの濡れた光葉 takes no damage from oozing.", "樹液まみれの濡れた光葉は滲出でダメージを受けなかった。")]
+    [TestCase("{{r|You take 1 damage from fluxing.}}", "{{r|フラックス漏れで1ダメージを受けた。}}")]
     [TestCase(
         "{{r|You take 9 damage from your plasma you started by you near your ally and You!}}",
         "{{r|your plasma you started by you near your ally and Youで9ダメージを受けた！}}")]
@@ -6335,7 +6338,7 @@ public sealed class CombatAndLogMessageQueuePatchTests
             ("Brown sludge splashes into your mouth. You wince at the metallic taste.", "茶色い汚泥が口に入った。金属の味に顔をしかめた。"),
             ("The liquids stop reacting.", "液体の反応が止まった"),
             ("The reacting liquids congeal into a SoupSludge.", "反応した液体が凝固しSoupSludgeになった"),
-            ("The primordial soup nearby starts reacting with the water.", "nearbyの原初のスープがwaterと反応を始めた"),
+            ("The primordial soup nearby starts reacting with the water.", "近くの原初のスープが水と反応を始めた"),
             ("You receive tinkering bits <{{|AB}}>.", "修理ビット<{{|AB}}>を受け取った。"),
             ("You receive 奇妙な小物!", "奇妙な小物を受け取った"),
             ("You make some progress disarming 地雷.", "地雷の解除が少し進んだ。"),

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PhysicsEnterCellPassByTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PhysicsEnterCellPassByTranslationPatchTests.cs
@@ -129,8 +129,13 @@ public sealed class PhysicsEnterCellPassByTranslationPatchTests
         }
     }
 
-    [Test]
-    public void AggregateMessageQueuePatch_TranslatesEnterCellPassByUsingRepositoryPattern_WhenPatched()
+    [TestCase("You pass by a 編みかご.", "編みかごのそばを通り過ぎた。")]
+    [TestCase("You pass by an 編みかご.", "編みかごのそばを通り過ぎた。")]
+    [TestCase("You pass by the ウォーターヴァイン.", "ウォーターヴァインのそばを通り過ぎた。")]
+    [TestCase("You pass by ウォーターヴァイン.", "ウォーターヴァインのそばを通り過ぎた。")]
+    public void AggregateMessageQueuePatch_TranslatesArticleVariantsUsingRepositoryPattern_WhenPatched(
+        string source,
+        string expected)
     {
         UseRepositoryPatternDictionary();
 
@@ -161,12 +166,9 @@ public sealed class PhysicsEnterCellPassByTranslationPatchTests
                     typeof(string),
                     typeof(bool))));
 
-            var target = new DummyPhysicsEnterCellTarget();
-            target.PassingBy.Add("ウォーターヴァイン");
+            DummyMessageQueue.AddPlayerMessage(source, "&W", Capitalize: false);
 
-            target.EnterCell();
-
-            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo("ウォーターヴァインのそばを通り過ぎた。"));
+            Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(expected));
         }
         finally
         {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/SingleCallsiteOwnerPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/SingleCallsiteOwnerPopupTranslationPatchTests.cs
@@ -257,7 +257,7 @@ public sealed class SingleCallsiteOwnerPopupTranslationPatchTests
     [TestCase(
         nameof(DummySingleCallsiteOwnerPopupTarget.SetFactionRank),
         "You are promoted to the Warden of the Barathrumites.",
-        "あなたはthe BarathrumitesのWardenに昇進した。",
+        "あなたはBarathrumitesのWardenに昇進した。",
         "ReputationRankPromotion",
         PopupMethod.Show)]
     [TestCase(

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/XDidYTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/XDidYTranslationPatchTests.cs
@@ -101,6 +101,31 @@ public sealed class XDidYTranslationPatchTests
     }
 
     [Test]
+    public void Prefix_TranslatesXDidY_StripsGeneratedSubjectArticle()
+    {
+        WriteDictionary(tier1: new[] { ("appear", "現れた") });
+
+        var actor = new DummyCurrentDisplayNameTarget(
+            "光葉",
+            definiteDisplayName: "The 光葉",
+            indefiniteDisplayName: "An 光葉");
+
+        RunWithXDidYPatch(() =>
+        {
+            DummyXDidYTarget.XDidY(
+                Actor: actor,
+                Verb: "appear",
+                AlwaysVisible: true);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyXDidYTarget.OriginalExecuted, Is.False);
+                Assert.That(lastMessage, Is.EqualTo("\u0001光葉は現れた。"));
+            });
+        });
+    }
+
+    [Test]
     public void Prefix_TranslatesBreatherConeXDidYAndSkipsOriginalEnglishAssembly()
     {
         WriteDictionary(tier2: new[] { ("breath", "a cone of poison gas", "毒ガスを円錐状に吐き出した") });
@@ -532,6 +557,34 @@ public sealed class XDidYTranslationPatchTests
     }
 
     [Test]
+    public void Prefix_TranslatesXDidYToZWadeThroughLiquid_StripsGeneratedObjectArticle()
+    {
+        WriteDictionary(tier3: new[] { ("wade", "through {0}", "{0}の中をかき分けて進んだ") });
+
+        var liquid = new DummyCurrentDisplayNameTarget(
+            "塩水の水たまり",
+            indefiniteDisplayName: "a 塩水の水たまり");
+
+        RunWithXDidYToZPatch(() =>
+        {
+            DummyXDidYTarget.XDidYToZ(
+                Actor: null,
+                Verb: "wade",
+                Preposition: "through",
+                Object: liquid,
+                SubjectOverride: "あなた",
+                IndefiniteObject: true,
+                AlwaysVisible: true);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyXDidYTarget.OriginalExecuted, Is.False);
+                Assert.That(lastMessage, Is.EqualTo("\u0001あなたは塩水の水たまりの中をかき分けて進んだ。"));
+            });
+        });
+    }
+
+    [Test]
     public void Prefix_TranslatesXDidYToZObjectDisplayNameBeforePrepositionSuffix()
     {
         File.WriteAllText(
@@ -673,6 +726,53 @@ public sealed class XDidYTranslationPatchTests
                 IndirectObject: "青銅の短剣",
                 Extra: "for 5 damage",
                 SubjectOverride: "熊",
+                AlwaysVisible: true,
+                EndMark: "!");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyXDidYTarget.OriginalExecuted, Is.False);
+                Assert.That(lastMessage, Is.EqualTo("\u0001熊は青銅の短剣でスナップジョーに5ダメージを与えた！"));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void Prefix_TranslatesWDidXToYWithZ_StripsGeneratedObjectArticles()
+    {
+        WriteDictionary(tier3: new[] { ("strike", "{0} with {1} for {2} damage", "{1}で{0}に{2}ダメージを与えた") });
+
+        var target = new DummyCurrentDisplayNameTarget(
+            "スナップジョー",
+            indefiniteDisplayName: "an スナップジョー");
+        var weapon = new DummyCurrentDisplayNameTarget(
+            "青銅の短剣",
+            indefiniteDisplayName: "a 青銅の短剣");
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyXDidYTarget), nameof(DummyXDidYTarget.WDidXToYWithZ)),
+                prefix: new HarmonyMethod(RequireMethod(typeof(XDidYTranslationPatch), nameof(XDidYTranslationPatch.PrefixWDidXToYWithZForTests))));
+
+            DummyXDidYTarget.WDidXToYWithZ(
+                Actor: null,
+                Verb: "strike",
+                DirectPreposition: null,
+                DirectObject: target,
+                IndirectPreposition: "with",
+                IndirectObject: weapon,
+                Extra: "for 5 damage",
+                SubjectOverride: "熊",
+                IndefiniteDirectObject: true,
+                IndefiniteIndirectObject: true,
                 AlwaysVisible: true,
                 EndMark: "!");
 
@@ -886,11 +986,20 @@ public sealed class XDidYTranslationPatchTests
     private sealed class DummyCurrentDisplayNameTarget
     {
         private readonly string displayName;
+        private readonly string? definiteDisplayName;
+        private readonly string? indefiniteDisplayName;
         private readonly string toStringText;
 
-        public DummyCurrentDisplayNameTarget(string displayName, string? displayNameMember = null, string toStringText = "Object")
+        public DummyCurrentDisplayNameTarget(
+            string displayName,
+            string? displayNameMember = null,
+            string toStringText = "Object",
+            string? definiteDisplayName = null,
+            string? indefiniteDisplayName = null)
         {
             this.displayName = displayName;
+            this.definiteDisplayName = definiteDisplayName;
+            this.indefiniteDisplayName = indefiniteDisplayName;
             DisplayName = displayNameMember ?? displayName;
             this.toStringText = toStringText;
         }
@@ -927,7 +1036,7 @@ public sealed class XDidYTranslationPatchTests
             object? AsPossessedBy = null,
             bool Reference = false)
         {
-            return displayName;
+            return ResolveDisplayName(WithIndefiniteArticle);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
@@ -956,6 +1065,21 @@ public sealed class XDidYTranslationPatchTests
             object? AsPossessedBy = null,
             bool Reference = false)
         {
+            return ResolveDisplayName(WithIndefiniteArticle);
+        }
+
+        private string ResolveDisplayName(bool withIndefiniteArticle)
+        {
+            if (withIndefiniteArticle && indefiniteDisplayName is not null)
+            {
+                return indefiniteDisplayName;
+            }
+
+            if (!withIndefiniteArticle && definiteDisplayName is not null)
+            {
+                return definiteDisplayName;
+            }
+
             return displayName;
         }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -1062,6 +1062,9 @@ public sealed class TargetMethodResolutionTests
     {
         "XRL.World.Parts.BioAmmoLoader|HandleEvent|System.Boolean|XRL.World.CommandReloadEvent",
         "XRL.World.Parts.BioAmmoLoader|FireEvent|System.Boolean|XRL.World.Event",
+        "XRL.World.Parts.BioAmmoLoader|HandleEvent|System.Boolean|XRL.World.CheckLoadAmmoEvent",
+        "XRL.World.Parts.BioAmmoLoader|HandleEvent|System.Boolean|XRL.World.LoadAmmoEvent",
+        "XRL.World.Parts.BioAmmoLoader|HandleEvent|System.Boolean|XRL.World.GetNotReadyToFireMessageEvent",
         "XRL.World.Parts.LiquidAmmoLoader|HandleEvent|System.Boolean|XRL.World.CommandReloadEvent",
         "XRL.World.Parts.LiquidAmmoLoader|FireEvent|System.Boolean|XRL.World.Event",
         "XRL.World.Parts.ModLiquidCooled|HandleEvent|System.Boolean|XRL.World.CommandReloadEvent",

--- a/Mods/QudJP/Assemblies/src/Patches/PhysicsProcessTakeDamageTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PhysicsProcessTakeDamageTranslationPatch.cs
@@ -266,6 +266,11 @@ public static class PhysicsProcessTakeDamageTranslationPatch
 
     private static string TranslateDamageSource(string source)
     {
+        if (CirculatoryLossTermTranslator.TryTranslateTermPhrase(source, out var circulatoryLossTerm))
+        {
+            return circulatoryLossTerm;
+        }
+
         return source switch
         {
             "acid" => "酸",

--- a/Mods/QudJP/Assemblies/src/Patches/XDidYTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/XDidYTranslationPatch.cs
@@ -733,7 +733,7 @@ public static class XDidYTranslationPatch
     {
         if (!string.IsNullOrWhiteSpace(subjectOverride))
         {
-            return TranslateDisplayFragment(subjectOverride!);
+            return NormalizeFrameLabel(TranslateDisplayFragment(subjectOverride!));
         }
 
         if (IsPlayer(actor))
@@ -741,7 +741,7 @@ public static class XDidYTranslationPatch
             return "あなた";
         }
 
-        return GetEntityDisplayName(actor, capitalize: true, useFullNames, indefiniteSubject);
+        return NormalizeFrameLabel(GetEntityDisplayName(actor, capitalize: true, useFullNames, indefiniteSubject));
     }
 
     private static string GetOwnerPrefix(object? owner, bool useFullNames, bool indefiniteSubject)
@@ -756,7 +756,7 @@ public static class XDidYTranslationPatch
             return "あなたの";
         }
 
-        var label = GetEntityDisplayName(owner, capitalize: false, useFullNames, indefiniteSubject);
+        var label = NormalizeFrameLabel(GetEntityDisplayName(owner, capitalize: false, useFullNames, indefiniteSubject));
         return string.IsNullOrWhiteSpace(label)
             ? string.Empty
             : MakePossessiveLabel(label);
@@ -810,7 +810,7 @@ public static class XDidYTranslationPatch
             return possessive ? "あなたの" : "あなた";
         }
 
-        var label = GetEntityDisplayName(value, capitalize: false, useFullNames, indefiniteObject || indefiniteObjectForOthers);
+        var label = NormalizeFrameLabel(GetEntityDisplayName(value, capitalize: false, useFullNames, indefiniteObject || indefiniteObjectForOthers));
         if (string.IsNullOrWhiteSpace(label))
         {
             return string.Empty;
@@ -824,6 +824,14 @@ public static class XDidYTranslationPatch
         }
 
         return possessive ? MakePossessiveLabel(label) : label;
+    }
+
+    private static string NormalizeFrameLabel(string label)
+    {
+        return StringHelpers.StripLeadingEnglishArticle(
+            label,
+            includeCapitalizedDefiniteArticle: true,
+            includeCapitalizedIndefiniteArticle: true);
     }
 
     private static string GetEntityDisplayName(object? value, bool capitalize, bool useFullNames, bool indefiniteArticle)

--- a/Mods/QudJP/Assemblies/src/Translation/CirculatoryLossTermTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/CirculatoryLossTermTranslator.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace QudJP;
+
+internal static class CirculatoryLossTermTranslator
+{
+    internal static bool TryTranslateTermPhrase(string source, out string translated)
+    {
+        var normalized = source.Trim();
+        if (TryTranslateTerm(normalized, out translated))
+        {
+            return true;
+        }
+
+        if (normalized.StartsWith("is ", StringComparison.Ordinal))
+        {
+            return TryTranslateTerm(normalized.Substring(3), out translated);
+        }
+
+        if (normalized.StartsWith("are ", StringComparison.Ordinal))
+        {
+            return TryTranslateTerm(normalized.Substring(4), out translated);
+        }
+
+        translated = string.Empty;
+        return false;
+    }
+
+    private static bool TryTranslateTerm(string source, out string translated)
+    {
+        translated = source switch
+        {
+            "bleeding" => "出血",
+            "leaking" => "液漏れ",
+            "oozing" => "滲出",
+            "fluxing" => "フラックス漏れ",
+            _ => string.Empty,
+        };
+
+        return translated.Length > 0;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Translation/DirectionPhraseTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/DirectionPhraseTranslator.cs
@@ -1,0 +1,27 @@
+namespace QudJP;
+
+internal static class DirectionPhraseTranslator
+{
+    internal static bool TryTranslateNounStem(string source, out string translated)
+    {
+        translated = source switch
+        {
+            "to the north" => "北側",
+            "to the south" => "南側",
+            "to the east" => "東側",
+            "to the west" => "西側",
+            "to the northeast" => "北東側",
+            "to the northwest" => "北西側",
+            "to the southeast" => "南東側",
+            "to the southwest" => "南西側",
+            "nearby" => "近く",
+            "above" => "上方",
+            "below" => "下方",
+            "here" => "ここ",
+            "somewhere" => "どこか",
+            _ => string.Empty,
+        };
+
+        return translated.Length > 0;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Translation/MessageFrameTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessageFrameTranslator.cs
@@ -601,6 +601,21 @@ internal static class MessageFrameTranslator
             return trimmed;
         }
 
+        if (TryTranslateArticleSeparatedList(trimmed, out var translatedList))
+        {
+            return translatedList;
+        }
+
+        if (DirectionPhraseTranslator.TryTranslateNounStem(trimmed, out var direction))
+        {
+            return direction;
+        }
+
+        if (CirculatoryLossTermTranslator.TryTranslateTermPhrase(trimmed, out var circulatoryLossTerm))
+        {
+            return circulatoryLossTerm;
+        }
+
         if (string.Equals(trimmed, "you", StringComparison.OrdinalIgnoreCase))
         {
             return "あなた";
@@ -629,6 +644,11 @@ internal static class MessageFrameTranslator
         if (string.Equals(trimmed, "her", StringComparison.OrdinalIgnoreCase))
         {
             return "彼女の";
+        }
+
+        if (TryTranslatePossessivePhrase(trimmed, out var possessivePhrase))
+        {
+            return possessivePhrase;
         }
 
         if (trimmed.EndsWith("'s", StringComparison.Ordinal))
@@ -662,13 +682,60 @@ internal static class MessageFrameTranslator
             return "それらの" + TranslatePlaceholderValue(trimmed.Substring(6));
         }
 
-        if (Translator.TryGetTranslation(trimmed, out var translated)
+        if (TryGetOptionalGlobalTranslation(trimmed, out var translated)
             && !string.Equals(translated, trimmed, StringComparison.Ordinal))
         {
             return translated;
         }
 
         return trimmed;
+    }
+
+    private static bool TryTranslateArticleSeparatedList(string source, out string translated)
+    {
+        var parts = source.Split(new[] { " and " }, StringSplitOptions.None);
+        if (parts.Length < 2)
+        {
+            translated = string.Empty;
+            return false;
+        }
+
+        var hasArticle = false;
+        var translatedParts = new string[parts.Length];
+        for (var index = 0; index < parts.Length; index++)
+        {
+            var part = parts[index].Trim();
+            hasArticle |= StartsWithEnglishArticle(part);
+            translatedParts[index] = TranslatePlaceholderValue(part);
+        }
+
+        translated = hasArticle ? string.Join("と", translatedParts) : string.Empty;
+        return hasArticle;
+    }
+
+    private static bool StartsWithEnglishArticle(string source)
+    {
+        return source.StartsWith("The ", StringComparison.Ordinal)
+            || source.StartsWith("the ", StringComparison.Ordinal)
+            || source.StartsWith("A ", StringComparison.Ordinal)
+            || source.StartsWith("a ", StringComparison.Ordinal)
+            || source.StartsWith("An ", StringComparison.Ordinal)
+            || source.StartsWith("an ", StringComparison.Ordinal);
+    }
+
+    private static bool TryTranslatePossessivePhrase(string source, out string translated)
+    {
+        var index = source.IndexOf("'s ", StringComparison.Ordinal);
+        if (index <= 0)
+        {
+            translated = string.Empty;
+            return false;
+        }
+
+        var owner = TranslatePlaceholderValue(source.Substring(0, index));
+        var owned = TranslatePlaceholderValue(source.Substring(index + 3));
+        translated = owner + "の" + owned;
+        return true;
     }
 
     private static string BuildSingleObjectTail(string? preposition, string? extra)
@@ -755,7 +822,7 @@ internal static class MessageFrameTranslator
         }
 
         var normalizedText = normalized!;
-        if (Translator.TryGetTranslation(normalizedText, out var translated)
+        if (TryGetOptionalGlobalTranslation(normalizedText, out var translated)
             && !string.Equals(translated, normalizedText, StringComparison.Ordinal))
         {
             suffix = translated;
@@ -764,6 +831,19 @@ internal static class MessageFrameTranslator
 
         suffix = string.Empty;
         return false;
+    }
+
+    private static bool TryGetOptionalGlobalTranslation(string key, out string translated)
+    {
+        try
+        {
+            return Translator.TryGetTranslation(key, out translated);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            translated = key;
+            return false;
+        }
     }
 
     private static void AppendWithSpaceIfNeeded(StringBuilder builder, string? text)

--- a/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
@@ -995,6 +995,21 @@ internal static class MessagePatternTranslator
             return historySpiceComponent;
         }
 
+        if (CirculatoryLossTermTranslator.TryTranslateTermPhrase(source, out var circulatoryLossTerm))
+        {
+            return circulatoryLossTerm;
+        }
+
+        if (DirectionPhraseTranslator.TryTranslateNounStem(source, out var direction))
+        {
+            return direction;
+        }
+
+        if (TryTranslatePossessiveCapture(source, out var possessiveCapture))
+        {
+            return possessiveCapture;
+        }
+
         var direct = Translator.Translate(source);
         if (!string.Equals(direct, source, StringComparison.Ordinal))
         {
@@ -1025,9 +1040,27 @@ internal static class MessagePatternTranslator
         return source;
     }
 
+    private static bool TryTranslatePossessiveCapture(string source, out string translated)
+    {
+        var index = source.IndexOf("'s ", StringComparison.Ordinal);
+        if (index <= 0)
+        {
+            translated = string.Empty;
+            return false;
+        }
+
+        var owner = TranslateTemplateCapture(source.Substring(0, index));
+        var owned = TranslateTemplateCapture(source.Substring(index + 3));
+        translated = owner + "の" + owned;
+        return true;
+    }
+
     private static string? TranslateArticleStrippedTemplateCapture(string source)
     {
-        var strippedArticle = StringHelpers.StripLeadingEnglishArticle(source);
+        var strippedArticle = StringHelpers.StripLeadingEnglishArticle(
+            source,
+            includeCapitalizedDefiniteArticle: true,
+            includeCapitalizedIndefiniteArticle: true);
         if (string.Equals(strippedArticle, source, StringComparison.Ordinal))
         {
             return null;

--- a/Mods/QudJP/Assemblies/src/Translation/StringHelpers.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/StringHelpers.cs
@@ -12,7 +12,10 @@ internal static class StringHelpers
             : source;
     }
 
-    internal static string StripLeadingEnglishArticle(string source, bool includeCapitalizedDefiniteArticle = false)
+    internal static string StripLeadingEnglishArticle(
+        string source,
+        bool includeCapitalizedDefiniteArticle = false,
+        bool includeCapitalizedIndefiniteArticle = false)
     {
         if (source.StartsWith("a ", StringComparison.Ordinal))
         {
@@ -32,6 +35,16 @@ internal static class StringHelpers
         if (includeCapitalizedDefiniteArticle && source.StartsWith("The ", StringComparison.Ordinal))
         {
             return source.Substring(4);
+        }
+
+        if (includeCapitalizedIndefiniteArticle && source.StartsWith("A ", StringComparison.Ordinal))
+        {
+            return source.Substring(2);
+        }
+
+        if (includeCapitalizedIndefiniteArticle && source.StartsWith("An ", StringComparison.Ordinal))
+        {
+            return source.Substring(3);
         }
 
         return source;

--- a/Mods/QudJP/Localization/Conversations.jp.xml
+++ b/Mods/QudJP/Localization/Conversations.jp.xml
@@ -258,8 +258,7 @@
       <choice GotoID="End">生きて飲め。</choice>
     </start>
     <node ID="Welcome">
-      <!-- Upstream Conversations.xml 1.0.4 keeps Tzedech/Welcome text empty; choices provide the visible content. -->
-      <text />
+      <!-- Upstream Conversations.xml 1.0.4 keeps Tzedech/Welcome text empty; omit it here so validation stays clean. -->
       <choice GotoID="Name">私は =name=。君は？</choice>
       <choice GotoID="Upset">何かあったのか？</choice>
       <choice IfTestState="GyredreamKnown" GotoID="Gyredream">ジァイドリームのことか？</choice>

--- a/Mods/QudJP/Localization/Dictionaries/messages.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/messages.ja.json
@@ -799,7 +799,7 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+) begins (bleeding|leaking|oozing|fluxing) from another wound[.!]?$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) begins (bleeding|leaking|oozing|fluxing) from another wound[.!]?$",
       "template": "{0}は別の傷から{t1}し始めた。",
       "route": "emit-message"
     },
@@ -859,7 +859,7 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+) begins (bleeding|leaking|oozing|fluxing)[.!]?$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) begins (bleeding|leaking|oozing|fluxing)[.!]?$",
       "template": "{0}は{t1}し始めた。",
       "route": "emit-message"
     },
@@ -869,7 +869,7 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+) stops (bleeding|leaking|oozing|fluxing)[.!]?$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) stops (bleeding|leaking|oozing|fluxing)[.!]?$",
       "template": "{0}の{t1}は止まった。",
       "route": "emit-message"
     },
@@ -879,12 +879,12 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+) takes (\\d+) damage from (bleeding|leaking|oozing|fluxing)[.!]?$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) takes (\\d+) damage from (bleeding|leaking|oozing|fluxing)[.!]?$",
       "template": "{0}は{t2}で{1}ダメージを受けた。",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+) takes no damage from (bleeding|leaking|oozing|fluxing)[.!]?$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) takes no damage from (bleeding|leaking|oozing|fluxing)[.!]?$",
       "template": "{0}は{t1}でダメージを受けなかった。",
       "route": "emit-message"
     },

--- a/Mods/QudJP/Localization/Dictionaries/messages.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/messages.ja.json
@@ -144,32 +144,32 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^You hit (.+) for (\\d+) damage[.!]?$",
+      "pattern": "^You hit (?:the |a |an )?(.+) for (\\d+) damage[.!]?$",
       "template": "{0}に{1}ダメージを与えた",
       "route": "emit-message"
     },
     {
-      "pattern": "^You crit (.+) for (\\d+) damage[.!]?$",
+      "pattern": "^You crit (?:the |a |an )?(.+) for (\\d+) damage[.!]?$",
       "template": "{0}に会心の一撃で{1}ダメージを与えた",
       "route": "emit-message"
     },
     {
-      "pattern": "^You attack (.+?)[.!]?$",
+      "pattern": "^You attack (?:the |a |an )?(.+?)[.!]?$",
       "template": "{0}に攻撃した",
       "route": "emit-message"
     },
     {
-      "pattern": "^(?:The )?(.+) hits you for (\\d+) damage[.!]?$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+) hits you for (\\d+) damage[.!]?$",
       "template": "{0}の攻撃で{1}ダメージを受けた",
       "route": "emit-message"
     },
     {
-      "pattern": "^(?:The )?(.+) crits you for (\\d+) damage[.!]?$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+) crits you for (\\d+) damage[.!]?$",
       "template": "{0}の会心の一撃で{1}ダメージを受けた",
       "route": "emit-message"
     },
     {
-      "pattern": "^(?:The )?(.+) attacks you[.!]?$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+) attacks you[.!]?$",
       "template": "{0}があなたを攻撃してきた",
       "route": "emit-message"
     },
@@ -199,7 +199,7 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(?:The )?(.+) misses you[.!]?$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+) misses you[.!]?$",
       "template": "{0}の攻撃は外れた",
       "route": "emit-message"
     },
@@ -224,7 +224,7 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(?:The )?(.+?) takes (\\d+) damage from (?:the )?(.+?)の acid![.!]?$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) takes (\\d+) damage from (?:the |a |an )?(.+?)の acid![.!]?$",
       "template": "{0}は{2}の酸で{1}ダメージを受けた！",
       "route": "emit-message"
     },
@@ -354,13 +354,13 @@
       "route": "message-frame"
     },
     {
-      "pattern": "^(.+?) is destroyed[.!]?$",
-      "template": "{0}は破壊された",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) is destroyed[.!]?$",
+      "template": "{t0}は破壊された",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) dies[.!]?$",
-      "template": "{0}は死んだ",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) dies[.!]?$",
+      "template": "{t0}は死んだ",
       "route": "emit-message"
     },
     {
@@ -439,32 +439,32 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(?:The )?(.+) critically hits \\((x\\d+)\\) for (\\d+) damage with (?:his|her|its) (.+?)[.!] \\[(.+?)\\]$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+) critically hits \\((x\\d+)\\) for (\\d+) damage with (?:his|her|its) (.+?)[.!] \\[(.+?)\\]$",
       "template": "{0}の{3}が会心し、{2}ダメージを受けた。({1}) [{4}]",
       "route": "emit-message"
     },
     {
-      "pattern": "^(?:The )?(.+) critically hits \\((x\\d+)\\) for (\\d+) damage with their (.+?)[.!] \\[(.+?)\\]$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+) critically hits \\((x\\d+)\\) for (\\d+) damage with their (.+?)[.!] \\[(.+?)\\]$",
       "template": "{0}の{3}が会心し、{2}ダメージを受けた。({1}) [{4}]",
       "route": "emit-message"
     },
     {
-      "pattern": "^(?:The )?(.+) hits \\((x\\d+)\\) for (\\d+) damage with (?:his|her|its) (.+?)[.!] \\[(.+?)\\]$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+) hits \\((x\\d+)\\) for (\\d+) damage with (?:his|her|its) (.+?)[.!] \\[(.+?)\\]$",
       "template": "{0}の{3}で{2}ダメージを受けた。({1}) [{4}]",
       "route": "emit-message"
     },
     {
-      "pattern": "^(?:The )?(.+) hits \\((x\\d+)\\) for (\\d+) damage with their (.+?)[.!] \\[(.+?)\\]$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+) hits \\((x\\d+)\\) for (\\d+) damage with their (.+?)[.!] \\[(.+?)\\]$",
       "template": "{0}の{3}で{2}ダメージを受けた。({1}) [{4}]",
       "route": "emit-message"
     },
     {
-      "pattern": "^(?:The )?(.+) misses you with (?:his|her|its) (.+?)[.!] \\[(.+?) vs (.+?)\\]$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+) misses you with (?:his|her|its) (.+?)[.!] \\[(.+?) vs (.+?)\\]$",
       "template": "{0}の{1}は外れた。[{2} vs {3}]",
       "route": "emit-message"
     },
     {
-      "pattern": "^(?:The )?(.+) misses you with their (.+?)[.!] \\[(.+?) vs (.+?)\\]$",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+) misses you with their (.+?)[.!] \\[(.+?) vs (.+?)\\]$",
       "template": "{0}の{1}は外れた。[{2} vs {3}]",
       "route": "emit-message"
     },
@@ -630,12 +630,12 @@
     },
     {
       "pattern": "^You hit something (.+?)[.!]?$",
-      "template": "{0}の方角の何かに命中した",
+      "template": "{t0}の方角の何かに命中した",
       "route": "emit-message"
     },
     {
       "pattern": "^(?:The |the |[Aa]n? )?(.+?) (?:hits|hit) something (.+?)[.!]?$",
-      "template": "{0}は{1}の方角の何かに命中させた",
+      "template": "{t0}は{t1}の方角の何かに命中させた",
       "route": "message-frame"
     },
     {
@@ -799,28 +799,28 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+) begins bleeding from another wound[.!]?$",
-      "template": "{0}はさらに出血し始めた。",
+      "pattern": "^(.+) begins (bleeding|leaking|oozing|fluxing) from another wound[.!]?$",
+      "template": "{0}は別の傷から{t1}し始めた。",
       "route": "emit-message"
     },
     {
       "pattern": "^Your (?:noses?|nose) (?:begins?|begin) (.+?) more heavily[.!]?$",
-      "template": "あなたの鼻からさらに激しく{0}が始まった",
+      "template": "あなたの鼻からさらに激しく{t0}が始まった",
       "route": "emit-message"
     },
     {
       "pattern": "^Your (?:noses?|nose) (?:begins?|begin) (.+?)[.!]?$",
-      "template": "あなたの鼻から{0}が始まった",
+      "template": "あなたの鼻から{t0}が始まった",
       "route": "emit-message"
     },
     {
       "pattern": "^Your (?:noses?|nose) (?:stops?|stop) (.+?) quite so heavily[.!]?$",
-      "template": "あなたの鼻からの{0}が少し治まった",
+      "template": "あなたの鼻からの{t0}が少し治まった",
       "route": "emit-message"
     },
     {
       "pattern": "^Your (?:noses?|nose) (?:stops?|stop) (.+?)[.!]?$",
-      "template": "あなたの鼻からの{0}が止まった",
+      "template": "あなたの鼻からの{t0}が止まった",
       "route": "emit-message"
     },
     {
@@ -840,52 +840,52 @@
     },
     {
       "pattern": "^(?:The |the |[Aa]n? )?(.+?)(?:'s|s') (?:noses?|nose) (?:begins?|begin) (.+?) more heavily[.!]?$",
-      "template": "{0}の鼻からさらに激しく{1}が始まった",
+      "template": "{0}の鼻からさらに激しく{t1}が始まった",
       "route": "emit-message"
     },
     {
       "pattern": "^(?:The |the |[Aa]n? )?(.+?)(?:'s|s') (?:noses?|nose) (?:begins?|begin) (.+?)[.!]?$",
-      "template": "{0}の鼻から{1}が始まった",
+      "template": "{0}の鼻から{t1}が始まった",
       "route": "emit-message"
     },
     {
       "pattern": "^(?:The |the |[Aa]n? )?(.+?)(?:'s|s') (?:noses?|nose) (?:stops?|stop) (.+?) quite so heavily[.!]?$",
-      "template": "{0}の鼻からの{1}が少し治まった",
+      "template": "{0}の鼻からの{t1}が少し治まった",
       "route": "emit-message"
     },
     {
       "pattern": "^(?:The |the |[Aa]n? )?(.+?)(?:'s|s') (?:noses?|nose) (?:stops?|stop) (.+?)[.!]?$",
-      "template": "{0}の鼻からの{1}が止まった",
+      "template": "{0}の鼻からの{t1}が止まった",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+) begins bleeding[.!]?$",
-      "template": "{0}は出血し始めた。",
+      "pattern": "^(.+) begins (bleeding|leaking|oozing|fluxing)[.!]?$",
+      "template": "{0}は{t1}し始めた。",
       "route": "emit-message"
     },
     {
-      "pattern": "^One of (.+?)の wounds stops bleeding[.!]?$",
-      "template": "{0}の傷のひとつの出血が止まった。",
+      "pattern": "^One of (?:the |a |an )?(.+?)の wounds stops (bleeding|leaking|oozing|fluxing)[.!]?$",
+      "template": "{0}の傷のひとつの{t1}が止まった。",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+) stops bleeding[.!]?$",
-      "template": "{0}の出血は止まった。",
+      "pattern": "^(.+) stops (bleeding|leaking|oozing|fluxing)[.!]?$",
+      "template": "{0}の{t1}は止まった。",
       "route": "emit-message"
     },
     {
-      "pattern": "^You take (\\d+) damage from bleeding[.!]?$",
-      "template": "あなたは出血で{0}ダメージを受けた。",
+      "pattern": "^You take (\\d+) damage from (bleeding|leaking|oozing|fluxing)[.!]?$",
+      "template": "あなたは{t1}で{0}ダメージを受けた。",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+) takes (\\d+) damage from bleeding[.!]?$",
-      "template": "{0}は出血で{1}ダメージを受けた。",
+      "pattern": "^(.+) takes (\\d+) damage from (bleeding|leaking|oozing|fluxing)[.!]?$",
+      "template": "{0}は{t2}で{1}ダメージを受けた。",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+) takes no damage from bleeding[.!]?$",
-      "template": "{0}は出血でダメージを受けなかった。",
+      "pattern": "^(.+) takes no damage from (bleeding|leaking|oozing|fluxing)[.!]?$",
+      "template": "{0}は{t1}でダメージを受けなかった。",
       "route": "emit-message"
     },
     {
@@ -919,12 +919,7 @@
       "route": "popup"
     },
     {
-      "pattern": "^You pass by a (.+?)[.!]?$",
-      "template": "{0}のそばを通り過ぎた。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^You pass by (.+?)[.!]?$",
+      "pattern": "^You pass by (?:a |an |the )?(.+?)[.!]?$",
       "template": "{0}のそばを通り過ぎた。",
       "route": "emit-message"
     },
@@ -1109,8 +1104,8 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) takes (\\d+) damage from your freezing weapon![.!]?$",
-      "template": "{0}はあなたの凍てつく武器で{1}ダメージを受けた！",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) takes (\\d+) damage from your freezing weapon![.!]?$",
+      "template": "{t0}はあなたの凍てつく武器で{1}ダメージを受けた！",
       "route": "emit-message"
     },
     {
@@ -1225,7 +1220,7 @@
     },
     {
       "pattern": "^Your mental attack does not affect (.+?)\\.$",
-      "template": "あなたの精神攻撃は{0}に効かない。",
+      "template": "あなたの精神攻撃は{t0}に効かない。",
       "route": "emit-message"
     },
     {
@@ -1289,18 +1284,18 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) ogled you lovingly after you employed your charm\\.$",
-      "template": "あなたの魅了術を受けて{0}がうっとりとこちらを見つめた。",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) ogled you lovingly after you employed your charm\\.$",
+      "template": "あなたの魅了術を受けて{t0}がうっとりとこちらを見つめた。",
       "route": "emit-message"
     },
     {
-      "pattern": "^With the help of Pax Klanq and the Barathrumites, you constructed (.+?)\\.$",
-      "template": "パクス・クランクとバラサラム派の助けを借りて{0}を建造した。",
+      "pattern": "^With the help of Pax Klanq and the Barathrumites, you constructed (?:the |a |an )?(.+?)\\.$",
+      "template": "パクス・クランクとバラサラム派の助けを借りて{t0}を建造した。",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) provided you with insightful commentary on (.+?)\\.$",
-      "template": "{0}が{1}について洞察に満ちた解説をしてくれた。",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) provided you with insightful commentary on (?:the |a |an )?(.+?)\\.$",
+      "template": "{t0}が{t1}について洞察に満ちた解説をしてくれた。",
       "route": "emit-message"
     },
     {
@@ -1410,7 +1405,7 @@
     },
     {
       "pattern": "^(?:The |the |[Aa]n? )?(.+?) (?:whizzes|whiz|flies|fly|zooms|zoom|streaks|streak|whistles|whistle|hurtles|hurtle|sails|sail|zips|zip|buzzes|buzz|passes|pass|speeds|speed|races|race|rushes|rush|whooshes|whoosh|goes|go|hisses|hiss|screams|scream) past (.+?)[.!]?$",
-      "template": "{0}が{1}のそばを通り過ぎた",
+      "template": "{t0}が{t1}のそばを通り過ぎた",
       "route": "emit-message"
     },
     {
@@ -1530,7 +1525,7 @@
     },
     {
       "pattern": "^The primordial soup (.+?) starts reacting with the (.+?)[.!]?$",
-      "template": "{0}の原初のスープが{1}と反応を始めた",
+      "template": "{t0}の原初のスープが{t1}と反応を始めた",
       "route": "emit-message"
     },
     {
@@ -1539,8 +1534,8 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) applied to (.+?)[.!]?$",
-      "template": "{0}が{1}に適用された",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) applied to (?:the |a |an )?(.+?)[.!]?$",
+      "template": "{t0}が{t1}に適用された",
       "route": "emit-message"
     },
     {
@@ -1555,7 +1550,7 @@
     },
     {
       "pattern": "^One of (?:the |a |an )?(.+?)(?:'s|s') wounds stops (.+?)[.!]?$",
-      "template": "{0}の傷のひとつの{1}が止まった",
+      "template": "{0}の傷のひとつの{t1}が止まった",
       "route": "emit-message"
     },
     {
@@ -1625,7 +1620,7 @@
     },
     {
       "pattern": "^In a glissade of light, (?:the |a |an )?(.+?)(?:'s|s') visage morphs into an image pleasing to (.+?)[.!]?$",
-      "template": "光が滑るように走り、{0}の顔貌は{1}に好ましい姿へと変化した",
+      "template": "光が滑るように走り、{t0}の顔貌は{t1}に好ましい姿へと変化した",
       "route": "emit-message"
     },
     {
@@ -1635,7 +1630,7 @@
     },
     {
       "pattern": "^Suddenly (?:the |a |an )?(.+?) (?:starts|start) flailing around and battering (?:the |a |an )?(.+?)!$",
-      "template": "突然{0}が暴れ出し、{1}を殴りつけた！",
+      "template": "突然{t0}が暴れ出し、{t1}を殴りつけた！",
       "route": "emit-message"
     },
     {
@@ -1645,7 +1640,7 @@
     },
     {
       "pattern": "^Two tubular sections of (?:the |a |an )?(.+?) flail around and batter (?:the |a |an )?(.+?)!$",
-      "template": "{0}の2本の管状の部分が暴れ、{1}を殴りつけた！",
+      "template": "{t0}の2本の管状の部分が暴れ、{t1}を殴りつけた！",
       "route": "emit-message"
     },
     {
@@ -1709,8 +1704,8 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) rind softens while (.+?) recrystallizes?\\.$",
-      "template": "{0}の外皮が軟化し、{1}が再結晶化した。",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) rind softens while (?:the |a |an )?(.+?) recrystallizes?\\.$",
+      "template": "{t0}の外皮が軟化し、{t1}が再結晶化した。",
       "route": "emit-message"
     },
     {
@@ -1734,78 +1729,33 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) noses? begins? (.+) more heavily\\.$",
-      "template": "{0}の鼻が激しく{1}し始めた。",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) noses? begins? (.+) more heavily\\.$",
+      "template": "{t0}の鼻が激しく{t1}し始めた。",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) noses? begins? (.+)\\.$",
-      "template": "{0}の鼻が{1}し始めた。",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) noses? begins? (.+)\\.$",
+      "template": "{t0}の鼻が{t1}し始めた。",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) noses? stops? (.+)\\.$",
-      "template": "{0}の鼻の{1}が止まった。",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) noses? stops? (.+)\\.$",
+      "template": "{t0}の鼻の{t1}が止まった。",
       "route": "emit-message"
     },
     {
       "pattern": "^Your noses? begins? (.+) more heavily\\.$",
-      "template": "あなたの鼻が激しく{0}し始めた。",
+      "template": "あなたの鼻が激しく{t0}し始めた。",
       "route": "emit-message"
     },
     {
       "pattern": "^Your noses? begins? (.+)\\.$",
-      "template": "あなたの鼻が{0}し始めた。",
+      "template": "あなたの鼻が{t0}し始めた。",
       "route": "emit-message"
     },
     {
       "pattern": "^Your noses? stops? (.+)\\.$",
-      "template": "あなたの鼻の{0}が止まった。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^(.+?) fails? to penetrate (.+?)'s armor with (.+?)[!.](.*)$",
-      "template": "{0}は{2}で{1}の装甲を貫通できなかった！{3}",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^(.+?) fails? to penetrate your armor with (.+?)[!.](.*)$",
-      "template": "{0}は{1}であなたの装甲を貫通できなかった！{2}",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^(.+?) suppressive fire locks (.+) in place\\.$",
-      "template": "{0}の制圧射撃が{1}を釘付けにした。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^(.+?) flattening fire drops (.+) to the ground!$",
-      "template": "{0}の鎮圧射撃が{1}を地面に叩き伏せた！",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^(.+?) wounds? (.+)\\.$",
-      "template": "{0}が{1}を負傷させた。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^(.+?) disorients? (.+)\\.$",
-      "template": "{0}が{1}を混乱させた。",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^(.+?)'s shot goes wild!$",
-      "template": "{0}の射撃が逸れた！",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^Something hits (.+?) with (.+?) for (\\d+) damage[.!]?(.*)$",
-      "template": "何かが{1}で{0}に{2}ダメージを与えた。{3}",
-      "route": "emit-message"
-    },
-    {
-      "pattern": "^(.+?) hits something (.+?)[.!]?$",
-      "template": "{0}の射撃が{1}の何かに命中した。",
+      "template": "あなたの鼻の{t0}が止まった。",
       "route": "emit-message"
     },
     {
@@ -1814,53 +1764,133 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) hits you (.+?) for (\\d+) damage[.!]?(.*)$",
-      "template": "{0}があなたに{1}命中、{2}ダメージ！{3}",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits you (to the (?:north|south|east|west|northeast|northwest|southeast|southwest)) for (\\d+) damage[.!]?(.*)$",
+      "template": "{t0}があなたに{t1}に命中、{2}ダメージ！{3}",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) hits (.+?) (.+?) for (\\d+) damage[.!]?(.*)$",
-      "template": "{0}が{1}に{2}命中、{3}ダメージ！{4}",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits (?:the |a |an )?(.+?) (to the (?:north|south|east|west|northeast|northwest|southeast|southwest)) for (\\d+) damage[.!]?(.*)$",
+      "template": "{t0}が{t1}に{t2}に命中、{3}ダメージ！{4}",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) critically hits you (.+?)[!.] \\(x(\\d+)\\)$",
-      "template": "{0}が会心であなたに{1}命中！ (x{2})",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) critically hits you (to the (?:north|south|east|west|northeast|northwest|southeast|southwest))[!.] \\(x(\\d+)\\)$",
+      "template": "{t0}が会心であなたに{t1}に命中！ (x{2})",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) hits you (.+?)[!.] \\(x(\\d+)\\)$",
-      "template": "{0}があなたに{1}命中！ (x{2})",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits you (to the (?:north|south|east|west|northeast|northwest|southeast|southwest))[!.] \\(x(\\d+)\\)$",
+      "template": "{t0}があなたに{t1}に命中！ (x{2})",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) critically hits (.+?) (.+?)[!.] \\(x(\\d+)\\)$",
-      "template": "{0}が会心で{1}に{2}命中！ (x{3})",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) critically hits (?:the |a |an )?(.+?) (to the (?:north|south|east|west|northeast|northwest|southeast|southwest))[!.] \\(x(\\d+)\\)$",
+      "template": "{t0}が会心で{t1}に{t2}に命中！ (x{3})",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) hits (.+?) (.+?)[!.] \\(x(\\d+)\\)$",
-      "template": "{0}が{1}に{2}命中！ (x{3})",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits (?:the |a |an )?(.+?) (to the (?:north|south|east|west|northeast|northwest|southeast|southwest))[!.] \\(x(\\d+)\\)$",
+      "template": "{t0}が{t1}に{t2}に命中！ (x{3})",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) critically hits you \\(x(\\d+)\\) (.+?)!$",
-      "template": "{0}が会心であなたに{2}命中！ (x{1})",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) critically hits you \\(x(\\d+)\\) (to the (?:north|south|east|west|northeast|northwest|southeast|southwest))!$",
+      "template": "{t0}が会心であなたに{t2}に命中！ (x{1})",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) hits you \\(x(\\d+)\\) (.+?)!$",
-      "template": "{0}があなたに{2}命中！ (x{1})",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits you \\(x(\\d+)\\) (to the (?:north|south|east|west|northeast|northwest|southeast|southwest))!$",
+      "template": "{t0}があなたに{t2}に命中！ (x{1})",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) critically hits (.+?) \\(x(\\d+)\\) (.+?)!$",
-      "template": "{0}が会心で{1}に{3}命中！ (x{2})",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) critically hits (?:the |a |an )?(.+?) \\(x(\\d+)\\) (to the (?:north|south|east|west|northeast|northwest|southeast|southwest))!$",
+      "template": "{t0}が会心で{t1}に{t3}に命中！ (x{2})",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) hits (.+?) \\(x(\\d+)\\) (.+?)!$",
-      "template": "{0}が{1}に{3}命中！ (x{2})",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits (?:the |a |an )?(.+?) \\(x(\\d+)\\) (to the (?:north|south|east|west|northeast|northwest|southeast|southwest))!$",
+      "template": "{t0}が{t1}に{t3}に命中！ (x{2})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits you (.+?) for (\\d+) damage[.!]?(.*)$",
+      "template": "{t0}があなたに{1}命中、{2}ダメージ！{3}",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits (?:the |a |an )?(.+?) (.+?) for (\\d+) damage[.!]?(.*)$",
+      "template": "{t0}が{t1}に{2}命中、{3}ダメージ！{4}",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) critically hits you (.+?)[!.] \\(x(\\d+)\\)$",
+      "template": "{t0}が会心であなたに{1}命中！ (x{2})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits you (.+?)[!.] \\(x(\\d+)\\)$",
+      "template": "{t0}があなたに{1}命中！ (x{2})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) critically hits (?:the |a |an )?(.+?) (.+?)[!.] \\(x(\\d+)\\)$",
+      "template": "{t0}が会心で{t1}に{2}命中！ (x{3})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits (?:the |a |an )?(.+?) (.+?)[!.] \\(x(\\d+)\\)$",
+      "template": "{t0}が{t1}に{2}命中！ (x{3})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) critically hits you \\(x(\\d+)\\) (.+?)!$",
+      "template": "{t0}が会心であなたに{2}命中！ (x{1})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits you \\(x(\\d+)\\) (.+?)!$",
+      "template": "{t0}があなたに{2}命中！ (x{1})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) critically hits (?:the |a |an )?(.+?) \\(x(\\d+)\\) (.+?)!$",
+      "template": "{t0}が会心で{t1}に{3}命中！ (x{2})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits (?:the |a |an )?(.+?) \\(x(\\d+)\\) (.+?)!$",
+      "template": "{t0}が{t1}に{3}命中！ (x{2})",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) critically hits you (to the (?:north|south|east|west|northeast|northwest|southeast|southwest)), but your mental attack has no effect[.!]?$",
+      "template": "{t0}が会心であなたに{t1}に命中したが、精神攻撃は効果がない",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits you (to the (?:north|south|east|west|northeast|northwest|southeast|southwest)), but your mental attack has no effect[.!]?$",
+      "template": "{t0}があなたに{t1}に命中したが、精神攻撃は効果がない",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) critically hits (?:the |a |an )?(.+?) (to the (?:north|south|east|west|northeast|northwest|southeast|southwest)), but (?:his|her|its|their|your) mental attack has no effect[.!]?$",
+      "template": "{t0}が会心で{t1}に{t2}に命中したが、精神攻撃は効果がない",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits (?:the |a |an )?(.+?) (to the (?:north|south|east|west|northeast|northwest|southeast|southwest)), but (?:his|her|its|their|your) mental attack has no effect[.!]?$",
+      "template": "{t0}が{t1}に{t2}に命中したが、精神攻撃は効果がない",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) critically hits you (to the (?:north|south|east|west|northeast|northwest|southeast|southwest))\\.$",
+      "template": "{t0}が会心であなたに{t1}に命中した。",
+      "route": "emit-message"
+    },
+    {
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits you (to the (?:north|south|east|west|northeast|northwest|southeast|southwest))\\.$",
+      "template": "{t0}があなたに{t1}に命中した。",
       "route": "emit-message"
     },
     {
@@ -1874,18 +1904,18 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) critically hits (.+?) (to the .+?)\\.$",
-      "template": "{0}が会心で{1}に命中した {2}。",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) critically hits (?:the |a |an )?(.+?) (to the (?:north|south|east|west|northeast|northwest|southeast|southwest))\\.$",
+      "template": "{t0}が会心で{t1}に{t2}に命中した。",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) hits (.+?) (to the .+?)\\.$",
-      "template": "{0}が{1}に命中した {2}。",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) hits (?:the |a |an )?(.+?) (to the (?:north|south|east|west|northeast|northwest|southeast|southwest))\\.$",
+      "template": "{t0}が{t1}に{t2}に命中した。",
       "route": "emit-message"
     },
     {
-      "pattern": "^(.+?) noses? begins? to bleed\\.$",
-      "template": "{0}の鼻が出血し始めた。",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) noses? begins? to bleed\\.$",
+      "template": "{t0}の鼻が出血し始めた。",
       "route": "emit-message"
     },
     {

--- a/Mods/QudJP/Localization/Dictionaries/messages.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/messages.ja.json
@@ -630,12 +630,12 @@
     },
     {
       "pattern": "^You hit something (.+?)[.!]?$",
-      "template": "{t0}の方角の何かに命中した",
+      "template": "{t0}の何かに命中した",
       "route": "emit-message"
     },
     {
       "pattern": "^(?:The |the |[Aa]n? )?(.+?) (?:hits|hit) something (.+?)[.!]?$",
-      "template": "{t0}は{t1}の方角の何かに命中させた",
+      "template": "{t0}は{t1}の何かに命中させた",
       "route": "message-frame"
     },
     {

--- a/Mods/QudJP/Localization/Dictionaries/messages.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/messages.ja.json
@@ -1760,7 +1760,7 @@
     },
     {
       "pattern": "^Your shot goes wild!$",
-      "template": "あなたの射撃が逸れた！",
+      "template": "あなたの弾が逸れた！",
       "route": "emit-message"
     },
     {

--- a/Mods/QudJP/Localization/Dictionaries/messages.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/messages.ja.json
@@ -1119,8 +1119,8 @@
       "route": "emit-message"
     },
     {
-      "pattern": "^(?:The )?(.+?) yells, '(.+)'$",
-      "template": "{0}は「{1}」と叫んだ。",
+      "pattern": "^(?:The |the |[Aa]n? )?(.+?) yells, '(.+)'$",
+      "template": "{t0}は「{1}」と叫んだ。",
       "route": "emit-message"
     },
     {

--- a/Mods/QudJP/Localization/MessageFrames/verbs.ja.json
+++ b/Mods/QudJP/Localization/MessageFrames/verbs.ja.json
@@ -1779,7 +1779,7 @@
     {
       "verb": "stare",
       "extra": "at {0} menacingly",
-      "text": "{0}を睨みつけた"
+      "text": "{t0}を睨みつけた"
     },
     {
       "verb": "stare",
@@ -2051,7 +2051,7 @@
     {
       "verb": "are",
       "extra": "promoted to the {0} of {1}",
-      "text": "{1}の{0}に昇進した"
+      "text": "{t1}の{t0}に昇進した"
     },
     {
       "verb": "are",
@@ -2091,7 +2091,7 @@
     {
       "verb": "assume",
       "extra": "the form of {0}",
-      "text": "{0}の姿をとった"
+      "text": "{t0}の姿をとった"
     },
     {
       "verb": "atomize",
@@ -2146,27 +2146,27 @@
     {
       "verb": "begin",
       "extra": "acting like {0} {1}",
-      "text": "{1}のふりをし始めた"
+      "text": "{t1}のふりをし始めた"
     },
     {
       "verb": "begin",
       "extra": "acting like {0} {1} from another wound",
-      "text": "{1}のふりをし始めた（別の傷から）"
+      "text": "{t1}のふりをし始めた（別の傷から）"
     },
     {
       "verb": "begin",
       "extra": "{0}",
-      "text": "{0}が始まった"
+      "text": "{t0}が始まった"
     },
     {
       "verb": "begin",
       "extra": "{0} from another wound",
-      "text": "別の傷から{0}"
+      "text": "別の傷から{t0}が始まった"
     },
     {
       "verb": "break",
       "extra": "free from {0}",
-      "text": "{0}から抜け出した"
+      "text": "{t0}から抜け出した"
     },
     {
       "verb": "butcher",
@@ -2191,7 +2191,7 @@
     {
       "verb": "cleave",
       "extra": "through (?:the |a |an )?(.+?)",
-      "text": "{subject}は{0}を両断した"
+      "text": "{subject}は{t0}を両断した"
     },
     {
       "verb": "cleave",
@@ -2421,7 +2421,7 @@
     {
       "verb": "hit",
       "extra": "{0} for {1} damage",
-      "text": "{0}に{1}ダメージを与えた"
+      "text": "{t0}に{1}ダメージを与えた"
     },
     {
       "verb": "hum",
@@ -2611,7 +2611,7 @@
     {
       "verb": "rifle",
       "extra": "through (?:the |a |an )?(.+?)",
-      "text": "{subject}は{0}を漁った"
+      "text": "{subject}は{t0}を漁った"
     },
     {
       "verb": "rip",
@@ -2731,7 +2731,7 @@
     {
       "verb": "stop",
       "extra": "{0}",
-      "text": "{0}が止まった"
+      "text": "{t0}が止まった"
     },
     {
       "verb": "strike",
@@ -2781,7 +2781,7 @@
     {
       "verb": "teleport",
       "extra": "{0} away",
-      "text": "{0}をテレポートさせた"
+      "text": "{t0}をテレポートさせた"
     },
     {
       "verb": "tighten",

--- a/Mods/QudJP/Localization/MessageFrames/verbs.ja.json
+++ b/Mods/QudJP/Localization/MessageFrames/verbs.ja.json
@@ -2146,12 +2146,12 @@
     {
       "verb": "begin",
       "extra": "acting like {0} {1}",
-      "text": "{t1}のふりをし始めた"
+      "text": "{t0} {t1}のふりをし始めた"
     },
     {
       "verb": "begin",
       "extra": "acting like {0} {1} from another wound",
-      "text": "{t1}のふりをし始めた（別の傷から）"
+      "text": "{t0} {t1}のふりをし始めた（別の傷から）"
     },
     {
       "verb": "begin",
@@ -2716,12 +2716,12 @@
     {
       "verb": "stop",
       "extra": "acting like {0} {1}",
-      "text": "{1}のふりをやめた"
+      "text": "{t0} {t1}のふりをやめた"
     },
     {
       "verb": "stop",
       "extra": "acting like {0} {1} so much",
-      "text": "{1}のふりをするのをやめた"
+      "text": "{t0} {t1}のふりをするのをやめた"
     },
     {
       "verb": "stop",

--- a/docs/release-notes/unreleased/issue-711-article-stripping.md
+++ b/docs/release-notes/unreleased/issue-711-article-stripping.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Strip English articles from pass-by, XDidY owner-routed labels, and combat message captures before they appear in Japanese output.
+- Translate bleeding/leaking/oozing/fluxing terms in message frames, damage sources, and wound-stop log patterns.
+- Remove the empty Tzedech/Welcome conversation text override that produced a localization validation warning.

--- a/docs/reports/2026-05-16-issue-711-text-construction-separation.md
+++ b/docs/reports/2026-05-16-issue-711-text-construction-separation.md
@@ -1,0 +1,137 @@
+# Issue 711 Text-Construction Queue Separation
+
+Date: 2026-05-16
+
+## Scope
+
+This pass separates the largest `text-construction-surface-queue` families into
+reviewed buckets without claiming a project-wide untranslated-zero state.
+
+The queue is static Roslyn evidence over likely player-visible text construction
+families. It is not runtime untranslated proof. A family can remain in the
+queue because it mixes fixed popup leaves, already-covered owner routes, runtime
+payloads, and still-unowned generated text in one upstream method.
+
+## Evidence
+
+Commands:
+
+```bash
+just text-construction-surface-queue
+uv run python scripts/text_construction_surface_policy.py \
+  --inventory /tmp/roslyn-text-construction-inventory.json \
+  --format json \
+  --include valuable \
+  --limit 0
+uv run python scripts/text_construction_surface_policy.py \
+  --inventory /tmp/roslyn-text-construction-inventory.json \
+  --format lanes-json \
+  --include valuable \
+  --limit 0
+```
+
+Baseline before this pass:
+
+| Lane | Entries | Text constructions | Reviewed status before |
+| --- | ---: | ---: | --- |
+| `combat_message_frame_does` | 500 | 6,518 | 1 covered, 499 action-required |
+| `history_generated_text` | 78 | 2,351 | all action-required |
+| `journal_quest_routes` | 65 | 1,277 | all action-required |
+| `producer_message_popup` | 687 | 5,447 | all action-required |
+| `description_effect_detail` | 843 | 2,001 | all action-required |
+| `display_name_composition` | 242 | 860 | all action-required |
+| `screen_ui_direct_text` | 76 | 595 | all action-required |
+| `activated_ability_names` | 114 | 506 | all action-required |
+
+Reviewed status after this pass:
+
+| Lane | Reviewed covered | Partial | Runtime | Likely true gap | Still unreviewed |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `combat_message_frame_does` | 4 | 7 | 0 | 3 | 486 |
+| `history_generated_text` | 0 | 3 | 2 | 2 | 71 |
+| `journal_quest_routes` | 0 | 1 | 0 | 0 | 64 |
+| `producer_message_popup` | 1 | 5 | 1 | 1 | 679 |
+| `description_effect_detail` | 0 | 1 | 0 | 2 | 840 |
+| `display_name_composition` | 0 | 2 | 0 | 1 | 239 |
+| `screen_ui_direct_text` | 2 | 1 | 0 | 0 | 73 |
+| `activated_ability_names` | 1 | 1 | 0 | 1 | 111 |
+
+## Reviewed Covered
+
+These families have focused owner-route or asset evidence and can be counted as
+reviewed coverage in the text-construction overlay.
+
+| Family | Reason |
+| --- | --- |
+| `Combat.MeleeAttackWithWeaponInternal` | Existing overlay; covered by Does/message-pattern/L2 combat queue tests. |
+| `MissileWeapon.MissileHit` | Missile hit multiplier and vital-area message shapes are covered by `MissileWeaponHitTranslationPatch`, message patterns, and L2 queue tests. |
+| `GameObject.PerformThrow` | Throw hit/self-target popup routes are covered by owner tests and L2G target resolution. |
+| `GameObject.Move` | Movement queue/popup owner routes are covered by owner tests and L2G target resolution. |
+| `PickTarget.ShowPicker` | Range and visibility popup owner route is covered by focused popup tests and existing fixed popup leaves. |
+| `GameSummaryScreen._ShowGameSummary` | Cause/details route is owned by `GameSummaryScreenShowTranslationPatch` and `GameSummaryTextTranslator`. |
+| `SkillsAndPowersStatusScreen.UpdateDetailsFromNode` | Details panel fields are owned by `SkillsAndPowersStatusScreenDetailsPatch`. |
+| `PhotosyntheticSkin.Mutate` | `Bask` ability name is covered by activated ability assets and localization coverage tests. |
+
+## Partial Coverage
+
+These families have real existing coverage, but whole-family closure would hide
+unreviewed branches or runtime payloads.
+
+| Family | Split decision |
+| --- | --- |
+| `Inventory.FireEvent` | Graveyard-zone queue and container-ownership popup are covered; runtime inventory action failure messages remain unowned. |
+| `MissileWeapon.FireEvent` | Fixed and pattern-covered fire messages exist; ammo/load event `Message` and `Message2` remain runtime deferrals. |
+| `TradeUI.ShowTradeScreen` | Vendor popups are covered; haggle `StringBuilder` text is runtime trade-state text. |
+| `LongBladesCore.FireEvent` | Lunge/swipe/guard routes are covered; other branch text needs callsite-level comparison. |
+| `LiquidVolume.HandleEvent` | Fixed liquid owner routes exist; several liquid interaction string builders remain runtime detail text. |
+| `Tonic.HandleEvent` | Some tonic queue routes are covered; tonic inventory-action popup text is runtime supplied. |
+| `Village.BuildZone` / `VillageCoda.BuildZone` | Village gospels and era history are covered; generated pets, origins, names, and story fragments need separate route proof. |
+| `ZoneManager.SetActiveZone` | One generated time-suffix route is covered; zone names and journal note payloads remain runtime data. |
+| `CherubimSpawner.HandleEvent` | Replace-description crash path is covered; generated cherub display-name/text remains unowned. |
+| `SultanShrine.ShrineInitialize` | Description wrapper route is covered; generated shrine display-name needs route audit. |
+| `StatusScreen.Show` | Some popups are covered; psychic glimmer description remains runtime-generated. |
+| `XRLCore.PlayerTurn` | Several popup/message/journal routes are covered; runtime lines called out in issue-576 remain deferred. |
+| `TinkeringScreen.Show` | Footer and prompt routes are covered; central list and branch-specific text need screen-owner review. |
+| `InventoryScreen.Show` | Prompt/footer routes are covered; category/weight builders need runtime evidence. |
+| `AbilityManager.Show` | Cooldown queue message is covered; selected ability `NotUsableDescription` remains runtime text. |
+| `TinkeringDetailsLine.setData` | Bit cost and ingredient details are covered; display name, description, and mod description remain likely gaps. |
+| `PsychicCombatSifrah..ctor` | Constructor popup route is partly covered; slot/detail text needs Sifrah screen evidence. |
+| `MultiHorns.Mutate` | `Wrecking Charge` ability label is covered; mutation display-name variants need separate audit. |
+| `MissileWeapon.ShowPicker` | Fixed popup leaves and hotkey text have coverage; aiming overlay text should be separated by route. |
+| `Physic_AmputateLimb.FireEvent` | One owner route is covered; reach/no-target/no-limb branches need further proof. |
+
+## Runtime Required
+
+These are generated or runtime-state routes where static shape is not enough.
+
+| Family | Reason |
+| --- | --- |
+| `OptionsUI.Show` | Restart prompt depends on runtime option display text. |
+| `SultanRegion.FireEvent` | Region reveal description uses government, terrain, and HistorySpice data. |
+| `Tombstone.GenerateTombstone` | Inscription text uses generated names, factions, objects, and random cause frames. |
+
+## Likely True Gaps
+
+These are the best next implementation targets from this separation pass.
+
+| Family | Why |
+| --- | --- |
+| `VillageBase.getAVillageWall` / `VillageCodaBase.getAVillageWall` | Generated wall display names and descriptions have no focused owner translator. |
+| `CherubimSpawner.BestowElement` | Element adjective, rules text, and generated cherub names are not safely exact leaves. |
+| `TurretTinker.FireEvent` | Count-bearing `Tinker Turret [N remaining]` activated ability name needs a generated ability-name route. |
+| `XRLCore._Start` | Legacy main-menu direct buffer text may still be visible and has no current owner proof. |
+| `RandomAltarBaetylRewardManager.HandleRewardNode` | XML reward `Description` data source is not currently owned. |
+| `ModGigantic.GetDescription(int,GameObject)` | Static world-mod descriptions are covered, but dynamic item-specific descriptions are not. |
+| `BandageMedication.PerformBandaging` | MessageFrame/Does action feedback lacks a focused owner patch or owner-route proof. |
+| `Tactics_Charge.PerformCharge` | Charge action feedback lacks focused runtime and owner-route evidence. |
+| `MultiHorns.PerformCharge` | Charge/stopped/stomp message frames lack focused owner-route evidence. |
+
+## Next Work
+
+1. Use the likely-gap table as the next issue-711 implementation queue.
+2. Do not add exact dictionary leaves for generated village, cherub, tombstone,
+   SultanRegion, or dynamic ability-name text.
+3. When a partial family is revisited, split it by callsite or route before
+   changing the whole-family overlay status.
+4. Runtime-required rows need fresh `Player.log` or targeted in-game evidence
+   before owner promotion.

--- a/justfile
+++ b/justfile
@@ -103,7 +103,7 @@ python-test-filter pattern:
 localization-check:
   {{python}} scripts/check_encoding.py Mods/QudJP/Localization scripts
   {{python}} scripts/check_glossary_consistency.py Mods/QudJP/Localization
-  {{python}} scripts/validate_pattern_routes.py Mods/QudJP/Localization/Dictionaries/messages.ja.json --require-needs-harmony-patch-deferrals --expect-count message-frame=53 --expect-count popup=14 --expect-count journal=1 --expect-count leaf=0 --expect-count emit-message=336 --expect-count does-verb=0 --expect-count message-log=1 --expect-count description=10 --expect-count effect-cripple=1 --expect-count needs-harmony-patch=0 --expect-count unclassified=0
+  {{python}} scripts/validate_pattern_routes.py Mods/QudJP/Localization/Dictionaries/messages.ja.json --require-needs-harmony-patch-deferrals --expect-count message-frame=53 --expect-count popup=14 --expect-count journal=1 --expect-count leaf=0 --expect-count emit-message=342 --expect-count does-verb=0 --expect-count message-log=1 --expect-count description=10 --expect-count effect-cripple=1 --expect-count needs-harmony-patch=0 --expect-count unclassified=0
   {{python}} scripts/validate_xml.py Mods/QudJP/Localization --strict --warning-baseline scripts/validate_xml_warning_baseline.json
 
 # Check placeholder and markup-token parity in JSON localization assets.

--- a/scripts/static_producer_closure.py
+++ b/scripts/static_producer_closure.py
@@ -13028,11 +13028,11 @@ COVERED_OWNER_FAMILIES: Final = (
             EvidenceFile(
                 "Mods/QudJP/Assemblies/QudJP.Tests/L2/PhysicsEnterCellPassByTranslationPatchTests.cs",
                 (
-                    "AggregateMessageQueuePatch_TranslatesEnterCellPassByUsingRepositoryPattern_WhenPatched",
+                    "AggregateMessageQueuePatch_TranslatesArticleVariantsUsingRepositoryPattern_WhenPatched",
                     "AggregateMessageQueuePatch_PreservesPrefixOrder_WhenPatched",
                     "AggregateMessageQueuePatch_PassesThroughEmptyAndDirectMarkedMessages_WhenPatched",
                     "Prefix_PassesThroughEnglishWhenPatternDoesNotMatch_WhenPatched",
-                    "DummyPhysicsEnterCellTarget",
+                    "DummyMessageQueue",
                     "string.Empty",
                     "MessageFrameTranslator.MarkDirectTranslation",
                     "You pass by ",
@@ -13056,8 +13056,7 @@ COVERED_OWNER_FAMILIES: Final = (
             EvidenceFile(
                 "Mods/QudJP/Localization/Dictionaries/messages.ja.json",
                 (
-                    "^You pass by a (.+?)[.!]?$",
-                    "^You pass by (.+?)[.!]?$",
+                    "^You pass by (?:a |an |the )?(.+?)[.!]?$",
                 ),
             ),
         ),
@@ -13145,7 +13144,7 @@ COVERED_OWNER_FAMILIES: Final = (
                 "Mods/QudJP/Localization/Dictionaries/messages.ja.json",
                 (
                     "^You miss with your (.+?)[.!] ",
-                    "^(?:The )?(.+) misses you[.!]?$",
+                    "^(?:The |the |[Aa]n? )?(.+) misses you[.!]?$",
                     "^Your mental attack does not affect (.+?)\\\\.$",
                     "^You fail to deal damage with your attack! ",
                     "^You don't penetrate (?:the )?(.+?)(?:'s|s'|の) armor[.!]?$",

--- a/scripts/tests/test_text_construction_surface_policy.py
+++ b/scripts/tests/test_text_construction_surface_policy.py
@@ -208,6 +208,54 @@ def test_policy_applies_reviewed_closure_overlay_for_high_risk_combat_lane() -> 
     assert action_required["closure_status"] == "action_required"
 
 
+def test_policy_separates_reviewed_issue711_work_without_overclaiming_closure() -> None:
+    """Reviewed issue-711 families distinguish closed, partial, runtime, and likely-gap work."""
+    missile_hit_family_id = (
+        "XRL.World.Parts/MissileWeapon.cs::MissileWeapon.MissileHit("
+        "GameObject,GameObject,GameObject,GameObject,Projectile,GameObject,GameObject,"
+        "MissilePath,Cell,FireType,int,int,int,bool,GameObject,bool,ref bool,ref bool,ref bool,bool,bool)"
+    )
+    inventory_family_id = "XRL.World.Parts/Inventory.cs::Inventory.FireEvent(Event)"
+    tombstone_family_id = "XRL.World.Parts/Tombstone.cs::Tombstone.GenerateTombstone()"
+    mod_gigantic_family_id = "XRL.World.Parts/ModGigantic.cs::ModGigantic.GetDescription(int,GameObject)"
+
+    inventory = _inventory(
+        [
+            _family(
+                missile_hit_family_id,
+                "XRL.World.Parts/MissileWeapon.cs",
+                "MissileHit",
+                {"Does": 1, "EmitMessage": 1},
+            ),
+            _family(
+                inventory_family_id,
+                "XRL.World.Parts/Inventory.cs",
+                "FireEvent",
+                {"Popup": 1, "MessageFrame": 1},
+            ),
+            _family(
+                tombstone_family_id,
+                "XRL.World.Parts/Tombstone.cs",
+                "GenerateTombstone",
+                {"HistoricStringExpander": 1},
+            ),
+            _family(
+                mod_gigantic_family_id,
+                "XRL.World.Parts/ModGigantic.cs",
+                "GetDescription",
+                {"EffectDescriptionReturn": 1},
+            ),
+        ]
+    )
+
+    entries = {entry["family_id"]: entry for entry in valuable_surface_queue(inventory)}
+
+    assert entries[missile_hit_family_id]["closure_status"] == "covered_by_owner_route"
+    assert entries[inventory_family_id]["closure_status"] == "partial_coverage"
+    assert entries[tombstone_family_id]["closure_status"] == "runtime_required"
+    assert entries[mod_gigantic_family_id]["closure_status"] == "likely_true_gap"
+
+
 def test_lane_summary_payload_reports_counts_and_top_families() -> None:
     """Lane output must summarize counts and representative high-risk families."""
     inventory = _inventory(

--- a/scripts/tests/test_validate_pattern_routes.py
+++ b/scripts/tests/test_validate_pattern_routes.py
@@ -12,7 +12,7 @@ _EXPECTED_MESSAGE_ROUTE_COUNTS = {
     "popup": 14,
     "journal": 1,
     "leaf": 0,
-    "emit-message": 336,
+    "emit-message": 342,
     "does-verb": 0,
     "message-log": 1,
     "description": 10,

--- a/scripts/text_construction_surface_policy.py
+++ b/scripts/text_construction_surface_policy.py
@@ -15,7 +15,13 @@ Classification = Literal[
     "non_target",
 ]
 OutputFormat = Literal["text", "json", "lanes-json"]
-ClosureStatus = Literal["action_required", "covered_by_owner_route"]
+ClosureStatus = Literal[
+    "action_required",
+    "covered_by_owner_route",
+    "partial_coverage",
+    "runtime_required",
+    "likely_true_gap",
+]
 ClosureLane = Literal[
     "activated_ability_names",
     "combat_message_frame_does",
@@ -135,6 +141,326 @@ TEXT_CONSTRUCTION_CLOSURE_OVERLAY: Final[dict[str, ClosureOverlayEntry]] = {
             "Mods/QudJP/Assemblies/QudJP.Tests/L1/DoesVerbFamilyTests.cs",
             "Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs",
             "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+        ],
+    },
+    (
+        "XRL.World.Parts/MissileWeapon.cs::MissileWeapon.MissileHit("
+        "GameObject,GameObject,GameObject,GameObject,Projectile,GameObject,GameObject,"
+        "MissilePath,Cell,FireType,int,int,int,bool,GameObject,bool,ref bool,ref bool,ref bool,bool,bool)"
+    ): {
+        "closure_status": "covered_by_owner_route",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/MissileWeaponHitTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+            "docs/reports/2026-05-15-issue-699-static-producer-message-candidates.md",
+        ],
+    },
+    "XRL.World/GameObject.cs::GameObject.PerformThrow(GameObject,Cell,GameObject,MissilePath,int,int?,int?,int?)": {
+        "closure_status": "covered_by_owner_route",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/GameObjectPerformThrowTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+        ],
+    },
+    (
+        "XRL.World/GameObject.cs::GameObject.Move("
+        "string,out GameObject,bool,bool,bool,bool,bool,bool,GameObject,GameObject,"
+        "bool,int?,string,int?,bool,bool,GameObject,GameObject,int)"
+    ): {
+        "closure_status": "covered_by_owner_route",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/GameObjectMoveTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+        ],
+    },
+    (
+        "XRL.UI/PickTarget.cs::PickTarget.ShowPicker("
+        "PickStyle,int,int,int,int,bool,AllowVis,Predicate<XRL.World.GameObject>,"
+        "Predicate<XRL.World.GameObject>,XRL.World.GameObject,Point2D?,string,bool,bool)"
+    ): {
+        "closure_status": "covered_by_owner_route",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/PickTargetShowPickerTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/PickTargetShowPickerTranslationPatchTests.cs",
+            "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+        ],
+    },
+    "Qud.UI/GameSummaryScreen.cs::GameSummaryScreen._ShowGameSummary(string,string,string,bool)": {
+        "closure_status": "covered_by_owner_route",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/GameSummaryScreenShowTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/src/Patches/GameSummaryTextTranslator.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L1/GameSummaryTextTranslatorTests.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/GameSummaryAndAsleepTranslationPatchTests.cs",
+        ],
+    },
+    "Qud.UI/SkillsAndPowersStatusScreen.cs::SkillsAndPowersStatusScreen.UpdateDetailsFromNode(SPNode)": {
+        "closure_status": "covered_by_owner_route",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/SkillsAndPowersStatusScreenDetailsPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/SkillsAndAbilitiesOwnerPatchTests.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs",
+        ],
+    },
+    "XRL.World.Parts.Mutation/PhotosyntheticSkin.cs::PhotosyntheticSkin.Mutate(GameObject,int)": {
+        "closure_status": "covered_by_owner_route",
+        "closure_evidence": [
+            "Mods/QudJP/Localization/ActivatedAbilities.jp.xml",
+            "Mods/QudJP/Localization/Dictionaries/ui-skillsandpowers.ja.json",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs",
+        ],
+    },
+    "XRL.World.Parts/Inventory.cs::Inventory.FireEvent(Event)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/InventoryFireEventTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryFireEventTranslationPatchTests.cs",
+            "docs/reports/2026-05-15-issue-576-static-producer-runtime-deferrals.md",
+        ],
+    },
+    "XRL.World.Parts/MissileWeapon.cs::MissileWeapon.FireEvent(Event)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/QudJP.Tests/L1/MessagePatternTranslatorTests.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+            "docs/reports/2026-05-15-issue-576-static-producer-runtime-deferrals.md",
+            "docs/reports/2026-05-15-issue-699-static-producer-message-candidates.md",
+        ],
+    },
+    "XRL.UI/TradeUI.cs::TradeUI.ShowTradeScreen(GameObject,float,TradeScreenMode)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/TradeUiPopupTranslationPatchTests.cs",
+            "docs/reports/2026-05-15-issue-576-static-producer-runtime-deferrals.md",
+        ],
+    },
+    "XRL.World.Parts/LongBladesCore.cs::LongBladesCore.FireEvent(Event)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/LongBladesCoreTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/LongBladesCoreTranslationPatchTests.cs",
+        ],
+    },
+    "XRL.World.Parts/LiquidVolume.cs::LiquidVolume.HandleEvent(InventoryActionEvent)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/LiquidVolumeTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L1/WorldPartsFragmentTranslatorTests.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/WorldPartsProducerTranslationPatchTests.cs",
+            "docs/reports/2026-05-15-issue-576-static-producer-runtime-deferrals.md",
+        ],
+    },
+    "XRL.World.Parts/Tonic.cs::Tonic.HandleEvent(InventoryActionEvent)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/TonicTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/SingleCallsiteOwnerQueueTranslationPatchTests.cs",
+            "docs/reports/2026-05-15-issue-576-static-producer-runtime-deferrals.md",
+        ],
+    },
+    "XRL.World.ZoneBuilders/Village.cs::Village.BuildZone(Zone)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/AddVillageGospelsTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/src/Patches/GenerateVillageEraHistoryTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/HistoricNarrativeTranslationPatchesTests.cs",
+        ],
+    },
+    "XRL.World.ZoneBuilders/VillageCoda.cs::VillageCoda.BuildZone(Zone)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/AddVillageGospelsTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/src/Patches/GenerateVillageEraHistoryTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/HistoricNarrativeTranslationPatchesTests.cs",
+        ],
+    },
+    "XRL.World/ZoneManager.cs::ZoneManager.SetActiveZone(Zone)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/ZoneManagerSetActiveZoneTranslationPatchTests.cs",
+            "docs/reports/2026-05-15-issue-576-static-producer-runtime-deferrals.md",
+            "docs/reports/2026-05-15-static-uncovered-coverage-triage.md",
+        ],
+    },
+    "XRL.World.Parts/CherubimSpawner.cs::CherubimSpawner.HandleEvent(BeforeObjectCreatedEvent)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/CherubimSpawnerReplaceDescriptionPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/CherubimSpawnerReplaceDescriptionPatchTests.cs",
+        ],
+    },
+    "XRL.World.Parts/SultanShrine.cs::SultanShrine.ShrineInitialize()": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/SultanShrineWrapperTranslator.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs",
+        ],
+    },
+    "XRL.UI/StatusScreen.cs::StatusScreen.Show(GameObject)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/StatusScreenPopupTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/StatusScreenPopupTranslationPatchTests.cs",
+            "docs/reports/2026-05-15-issue-576-static-producer-runtime-deferrals.md",
+        ],
+    },
+    "XRL.Core/XRLCore.cs::XRLCore.PlayerTurn()": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/XrlCorePlayerTurnTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/XrlCorePlayerTurnTranslationPatchTests.cs",
+            "docs/reports/2026-05-15-issue-576-static-producer-runtime-deferrals.md",
+        ],
+    },
+    "XRL.UI/TinkeringScreen.cs::TinkeringScreen.Show(GameObject,GameObject,IEvent)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/TinkeringScreenTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/TinkeringTranslationPatchTests.cs",
+        ],
+    },
+    "XRL.UI/InventoryScreen.cs::InventoryScreen.Show(GameObject)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/InventoryScreenTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/LegacyGamepadPromptTranslationPatchTests.cs",
+        ],
+    },
+    "XRL.UI/AbilityManager.cs::AbilityManager.Show(XRL.World.GameObject)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/AbilityManagerShowTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+            "docs/reports/2026-05-15-issue-576-static-producer-runtime-deferrals.md",
+        ],
+    },
+    "Qud.UI/TinkeringDetailsLine.cs::TinkeringDetailsLine.setData(FrameworkDataElement)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/TinkeringDetailsLineTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/TinkeringTranslationPatchTests.cs",
+            "docs/reports/2026-05-15-static-uncovered-coverage-triage.md",
+        ],
+    },
+    "XRL.World/PsychicCombatSifrah.cs::PsychicCombatSifrah.PsychicCombatSifrah(GameObject,string,int,int,string)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/SifrahPureOwnerPopupTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/SifrahPureOwnerPopupTranslationPatchTests.cs",
+        ],
+    },
+    "XRL.World.Parts.Mutation/MultiHorns.cs::MultiHorns.Mutate(GameObject,int)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Localization/Dictionaries/ui-skillsandpowers.ja.json",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs",
+        ],
+    },
+    (
+        "XRL.World.Parts/MissileWeapon.cs::MissileWeapon.ShowPicker("
+        "int,int,bool,AllowVis,int,bool,GameObject,ref FireType,int)"
+    ): {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/UITextSkinTranslationPatchTests.cs",
+        ],
+    },
+    "XRL.UI/OptionsUI.cs::OptionsUI.Show()": {
+        "closure_status": "runtime_required",
+        "closure_evidence": [
+            "docs/reports/2026-05-15-issue-576-static-producer-runtime-deferrals.md",
+            "Mods/QudJP/Localization/Dictionaries/ui-options.ja.json",
+        ],
+    },
+    "XRL.World.Parts/SultanRegion.cs::SultanRegion.FireEvent(Event)": {
+        "closure_status": "runtime_required",
+        "closure_evidence": [
+            "docs/reports/2026-05-16-issue-711-text-construction-separation.md",
+        ],
+    },
+    "XRL.World.Parts/Tombstone.cs::Tombstone.GenerateTombstone()": {
+        "closure_status": "runtime_required",
+        "closure_evidence": [
+            "docs/reports/2026-05-16-issue-711-text-construction-separation.md",
+        ],
+    },
+    "XRL.World.ZoneBuilders/VillageBase.cs::VillageBase.getAVillageWall()": {
+        "closure_status": "likely_true_gap",
+        "closure_evidence": [
+            "docs/reports/2026-05-15-static-uncovered-coverage-triage.md",
+            "docs/reports/2026-05-16-issue-711-text-construction-separation.md",
+        ],
+    },
+    "XRL.World.ZoneBuilders/VillageCodaBase.cs::VillageCodaBase.getAVillageWall()": {
+        "closure_status": "likely_true_gap",
+        "closure_evidence": [
+            "docs/reports/2026-05-15-static-uncovered-coverage-triage.md",
+            "docs/reports/2026-05-16-issue-711-text-construction-separation.md",
+        ],
+    },
+    "XRL.World.Parts/CherubimSpawner.cs::CherubimSpawner.BestowElement(GameObject,string,bool)": {
+        "closure_status": "likely_true_gap",
+        "closure_evidence": [
+            "docs/reports/2026-05-15-static-uncovered-coverage-triage.md",
+            "docs/reports/2026-05-16-issue-711-text-construction-separation.md",
+        ],
+    },
+    "XRL.World.Parts/TurretTinker.cs::TurretTinker.FireEvent(Event)": {
+        "closure_status": "likely_true_gap",
+        "closure_evidence": [
+            "docs/reports/2026-05-16-issue-711-text-construction-separation.md",
+        ],
+    },
+    "XRL.Core/XRLCore.cs::XRLCore._Start()": {
+        "closure_status": "likely_true_gap",
+        "closure_evidence": [
+            "docs/reports/2026-05-16-issue-711-text-construction-separation.md",
+        ],
+    },
+    "XRL.World/RandomAltarBaetylRewardManager.cs::RandomAltarBaetylRewardManager.HandleRewardNode(XmlDataHelper)": {
+        "closure_status": "likely_true_gap",
+        "closure_evidence": [
+            "docs/reports/2026-05-16-issue-711-text-construction-separation.md",
+        ],
+    },
+    "XRL.World.Parts/ModGigantic.cs::ModGigantic.GetDescription(int,GameObject)": {
+        "closure_status": "likely_true_gap",
+        "closure_evidence": [
+            "docs/reports/2026-05-16-issue-711-text-construction-separation.md",
+        ],
+    },
+    "XRL.World.Parts/BandageMedication.cs::BandageMedication.PerformBandaging(GameObject,GameObject)": {
+        "closure_status": "likely_true_gap",
+        "closure_evidence": [
+            "docs/reports/2026-05-15-static-uncovered-coverage-triage.md",
+            "docs/reports/2026-05-16-issue-711-text-construction-separation.md",
+        ],
+    },
+    "XRL.World.Parts.Skill/Tactics_Charge.cs::Tactics_Charge.PerformCharge()": {
+        "closure_status": "likely_true_gap",
+        "closure_evidence": [
+            "docs/reports/2026-05-15-static-uncovered-coverage-triage.md",
+            "docs/reports/2026-05-16-issue-711-text-construction-separation.md",
+        ],
+    },
+    "XRL.World.Parts.Mutation/MultiHorns.cs::MultiHorns.PerformCharge(List<Cell>,bool)": {
+        "closure_status": "likely_true_gap",
+        "closure_evidence": [
+            "docs/reports/2026-05-15-static-uncovered-coverage-triage.md",
+            "docs/reports/2026-05-16-issue-711-text-construction-separation.md",
+        ],
+    },
+    "XRL.World.Parts.Skill/Physic_AmputateLimb.cs::Physic_AmputateLimb.FireEvent(Event)": {
+        "closure_status": "partial_coverage",
+        "closure_evidence": [
+            "Mods/QudJP/Assemblies/src/Patches/PhysicAmputateLimbTranslationPatch.cs",
+            "Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs",
+            "docs/reports/2026-05-16-issue-711-text-construction-separation.md",
         ],
     },
 }


### PR DESCRIPTION
## Summary
- normalize leading English articles across generated message/frame capture routes, including XDidY labels, pass-by text, popup/message-frame placeholders, and combat/message patterns
- add dedicated translation helpers for circulatory loss terms and direction/location phrase noun stems so direction particles stay template-owned
- update route-count/static-producer metadata, release notes, and coverage tests for the expanded article handling contract

## Verification
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --filter "TestCategory=L1&FullyQualifiedName~MessagePatternTranslatorTests"
- just test-l1
- just test-l2
- just test-l2g
- just localization-check
- just translation-token-check
- just release-note-check origin/main HEAD
- just python-test
- just build-dev
- just sync-mod
- git diff --check

## Polishment
- Review verdict: APPROVE. Subagent review could not start because the thread hit the agent limit, so I ran the code-review fallback locally against the full diff.
- Simplify result: no behavior-preserving cleanup changes were needed.

Closes #711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 英語の冠詞・前置詞の残存を除去し、通行・対象表示などの日本語表現を自然化しました
  * 出血／漏出系（bleeding/leaking/oozing/fluxing）用語を日本語で正しく表示するよう修正しました
  * 空の会話テキストによる検証警告を解消しました

* **改善**
  * 方向表現・所有表現の翻訳精度と適用範囲を拡張しました
  * メッセージテンプレート参照を統一（{t…}形式）し参照整合を強化しました

* **テスト**
  * 翻訳動作・パターン処理の期待値テストを多数追加・更新しました

* **ドキュメント**
  * リリースノートと調査レポートを追記しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->