### PR TITLE
[codex] Enable nullable in analyzer tests

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/AnalyzerVerifier.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/AnalyzerVerifier.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace QudJP.Analyzers.Tests;
+
+internal static class AnalyzerVerifier<TAnalyzer>
+    where TAnalyzer : DiagnosticAnalyzer, new()
+{
+    public const string NullableEnableDirective = "#nullable enable\n";
+
+    public static DiagnosticResult Diagnostic(string diagnosticId)
+    {
+        return CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic(diagnosticId);
+    }
+
+    public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+    {
+        return CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.VerifyAnalyzerAsync(
+            NullableEnableDirective + source,
+            expected);
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/FallbackLoggingAnalyzerTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/FallbackLoggingAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp.Testing.NUnit;
 using NUnit.Framework;
 using QudJP.Analyzers;
 

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/HarmonyPatchTryCatchAnalyzerTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/HarmonyPatchTryCatchAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp.Testing.NUnit;
 using NUnit.Framework;
 using QudJP.Analyzers;
 

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/PipelineTranslatorEntrypointAnalyzerTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/PipelineTranslatorEntrypointAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp.Testing.NUnit;
 using NUnit.Framework;
 using QudJP.Analyzers;
 

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/ProbeLoggingAnalyzerTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/ProbeLoggingAnalyzerTests.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Testing;
-using Microsoft.CodeAnalysis.CSharp.Testing.NUnit;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Testing;
 using NUnit.Framework;
 using QudJP.Analyzers;
 
@@ -384,10 +383,9 @@ namespace QudJP
 }
 """;
 
-#pragma warning disable CS0618 // Existing analyzer test package exposes NUnitVerifier as obsolete.
-        var test = new CSharpAnalyzerTest<ProbeLoggingAnalyzer, NUnitVerifier>();
-#pragma warning restore CS0618
-        test.TestState.Sources.Add(("RuntimeDiagnostics.cs", source));
+        var test = new CSharpAnalyzerTest<ProbeLoggingAnalyzer, DefaultVerifier>();
+        test.TestState.Sources.Add(
+            ("RuntimeDiagnostics.cs", AnalyzerVerifier<ProbeLoggingAnalyzer>.NullableEnableDirective + source));
 
         await test.RunAsync().ConfigureAwait(false);
     }

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/QudJP.Analyzers.Tests.csproj
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/QudJP.Analyzers.Tests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />

--- a/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/TraceLogPrefixAnalyzerTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/TraceLogPrefixAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp.Testing.NUnit;
 using NUnit.Framework;
 using QudJP.Analyzers;
 


### PR DESCRIPTION
## Summary
- Migrate analyzer tests from the obsolete Roslyn `.NUnit` testing package to the generic analyzer testing package with `DefaultVerifier`.
- Add a local analyzer verifier wrapper that prepends `#nullable enable` to analyzer test sources.
- Remove the obsolete `NUnitVerifier` usage and related `CS0618` suppression from the direct analyzer test path.

## AI Slop Cleanup Report
Scope: analyzer test project files only.
Behavior Lock: `dotnet test Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/QudJP.Analyzers.Tests.csproj --verbosity minimal`.
Cleanup Plan: remove obsolete package/suppression residue, keep the nullable enable mechanism centralized, avoid broad test rewrites.

Passes Completed:
1. Pass 1: Dead code deletion - removed obsolete `.NUnit` using directives and `CS0618` suppression.
2. Pass 2: Duplicate removal - centralized nullable test-source prefixing in `AnalyzerVerifier<TAnalyzer>`.
3. Pass 3: Naming/error handling cleanup - kept the existing verifier alias pattern and switched the direct test to `DefaultVerifier`.
4. Pass 4: Test reinforcement - reused the full analyzer test suite as the regression lock.

## Validation
- `dotnet test Mods/QudJP/Assemblies/QudJP.Analyzers.Tests/QudJP.Analyzers.Tests.csproj --verbosity minimal` - 47 passed
- `just build` - 0 warnings, 0 errors
- `git diff --cached --check` - passed

## Remaining Risks
- NUnit remains as the test framework; only the obsolete Roslyn analyzer testing `.NUnit` adapter was removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テスト基盤を改善し、アナライザー検証のセットアップをより簡潔に

* **Chores**
  * テストフレームワーク依存関係を更新し、テスト環境の安定性を向上

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->