### PR TITLE
Release QudJP v0.3.00

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.3.00] - 2026-05-20
+
+### Changed
+
+- 確認ポップアップの質問文を、丁寧な `しますか？` 形式へ揃えました。
+- macOS Apple Silicon 向け Harmony 2.4.2 native ARM64 回避策に合わせて、ビルド時の `Lib.Harmony` fallback package を更新しました。
+- 既存のメッセージパターン翻訳が正しい owner surface で追跡されるよう、確認済み経路の分類を整理しました。
+
+### Fixed
+
+- アビリティ詳細、アビリティ画面のホットキー、ステータス画面タブ、飛行メッセージ、レーザー光線ダメージログに残っていた英語表示を日本語化しました。
+- 生成される歴史、墓碑文、村の伝承、クエスト会話、料理本名、レリック文、地下聖堂の銘文、墓石、サイキックハンター称号、集落名の日本語カバレッジを拡充しました。
+- 方角や近隣ロケーションを含む動的クエスト標識が、英語 prefix 断片ではなく自然な日本語の目標文として表示されるようにしました。
+- 生成される形容詞、身体特徴、地形、活動、称号の断片を、色 markup、placeholder、固有名を保ったまま自然な日本語へ置き換えました。
+- 生成アイテム説明、active effect 名、インベントリの武器状態ラベルに残っていた英語表示を日本語化しました。
+- code redemption、色選択、マウス入力、save error などの固定ポップアップ文を日本語化しました。
+- Exodus countdown、ミサイル命中出力、automatic action stop、料理 trigger、normality-lattice contest などのログ・ポップアップ文を追加で日本語化しました。
+- QudJP 有効時に、一部の Carbide Chef と手続き生成料理レシピから効果が失われる問題を修正しました。
+- サイバネティック implant の説明文を Caves of Qud 1.0.4 の効果に合わせて修正しました。
+- ゴーレム素材選択ポップアップの翻訳 patch が起動時に失敗する問題を修正しました。
+- 日本語 UI 翻訳を有効にしたとき、journal entries が消える問題を修正しました。
+- Unstable Genome、Beak、Beguiling、Domination、Psychometry、Dystechnia の mutation 説明訳を修正しました。
+- pass-by、XDidY、戦闘メッセージ、所有表現、Does subject、message/journal capture、mutation self-target prompt、belcher output、conk confirmation、生成像ラベルなどに残る英語冠詞・所有代名詞を除去しました。
+- `[swimming]`、`bloody wet`、rusted、broken、cracked、flying、wading、raised、timer/cell/chapter/ammo suffix などの状態・suffix 表示を日本語化しました。
+- bleeding、leaking、oozing、fluxing などの message frame、damage source、wound stop log 表現を日本語化しました。
+- Tzedech/Welcome 会話の空 override を削除し、localization validation warning が出ないようにしました。
+- Water Ritual の message log、summary、conversation choice に残っていた英語表示を日本語化しました。
+- campfire cooking menu、ingredient selection、recipe cooking、meal creation message、生成 journal text、HistorySpice 系の歴史名に残っていた英語表示を日本語化しました。
+- masterwork weapon mod の説明、表示名、maker mark、examine-identification message を日本語化しました。
+- schematic や data disk の bit cost など、display name の angle suffix に含まれる色付き tinkering bit tag を保持するようにしました。
+- ミサイル武器の複数 ammo・複数 projectile の runtime tooltip 行を日本語化しました。
+- cracked scrap component の item-name 表現を、より分かりやすい `ひび割れた` に修正しました。
+
+---
+
 ## [0.2.52] - 2026-05-13
 
 ### Added
@@ -304,7 +339,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.2.52...HEAD
+[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.3.00...HEAD
+[0.3.00]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.00
 [0.2.52]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.52
 [0.2.51]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.51
 [0.2.50]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.50

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.2.52",
+  "Version": "0.3.00",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/release-notes/unreleased/ability-details-and-log-fixes.md
+++ b/docs/release-notes/unreleased/ability-details-and-log-fixes.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Fixed several runtime Japanese localization leaks in ability details, ability-screen hotkeys, status-screen tab controls, flight messages, and laser-beam damage logs.

--- a/docs/release-notes/unreleased/ask-popup-question-style.md
+++ b/docs/release-notes/unreleased/ask-popup-question-style.md
@@ -1,3 +1,0 @@
-### Changed
-
-- Unified Japanese confirmation-popup question phrasing to the polite `しますか？` style.

--- a/docs/release-notes/unreleased/harmony-fallback-242.md
+++ b/docs/release-notes/unreleased/harmony-fallback-242.md
@@ -1,3 +1,0 @@
-### Changed
-
-- Align the build-time `Lib.Harmony` fallback package with the documented Harmony 2.4.2 native Apple Silicon workaround.

--- a/docs/release-notes/unreleased/historic-string-expander-annals.md
+++ b/docs/release-notes/unreleased/historic-string-expander-annals.md
@@ -1,6 +1,0 @@
-### Fixed
-
-- Expanded Japanese coverage for generated histories, tomb inscriptions, village lore, quest conversations, cookbook names, relic text, crypt plaques, tombstones, psychic hunter titles, and settlement names that could previously appear partly or entirely in English.
-- Improved generated dynamic quest signposts so targets with directions, nearby-location hints, or no direction are rendered as complete Japanese objectives instead of mixed prefix fragments.
-- Replaced more generated adjective, body-trait, terrain, activity, and title fragments with natural Japanese wording while preserving in-game color markup, placeholders, and generated proper names.
-- Kept speech-noise filters that intentionally alter line nuance as a tracked follow-up instead of applying broad generic generated-text translation.

--- a/docs/release-notes/unreleased/issue-576-runtime-description-inventory.md
+++ b/docs/release-notes/unreleased/issue-576-runtime-description-inventory.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Improved Japanese coverage for generated item descriptions, active effect names, and inventory weapon state labels.

--- a/docs/release-notes/unreleased/issue-699-static-producer-popup-leaves.md
+++ b/docs/release-notes/unreleased/issue-699-static-producer-popup-leaves.md
@@ -1,4 +1,0 @@
-### Fixed
-
-- Added Japanese text for several fixed popup messages, including code redemption, color selection, mouse input, and save-error prompts.
-- Added message-pattern coverage for Exodus countdown and additional missile hit-output variants.

--- a/docs/release-notes/unreleased/issue-702-static-producer-gaps.md
+++ b/docs/release-notes/unreleased/issue-702-static-producer-gaps.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Added Japanese coverage for additional automatic-action stop messages, cooking trigger notifications, and normality-lattice contest prompts.

--- a/docs/release-notes/unreleased/issue-704-cooking.md
+++ b/docs/release-notes/unreleased/issue-704-cooking.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Fix some Carbide Chef and procedurally generated cooking recipes losing their effects when QudJP is enabled.

--- a/docs/release-notes/unreleased/issue-704-cybernetics-behavior-descriptions.md
+++ b/docs/release-notes/unreleased/issue-704-cybernetics-behavior-descriptions.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Correct cybernetic implant behavior descriptions to match the game 1.0.4 effects.

--- a/docs/release-notes/unreleased/issue-704-golem-selection-popup.md
+++ b/docs/release-notes/unreleased/issue-704-golem-selection-popup.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Prevent a golem material selection popup translation patch failure during startup.

--- a/docs/release-notes/unreleased/issue-704-journal-hidden.md
+++ b/docs/release-notes/unreleased/issue-704-journal-hidden.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Fixed journal entries disappearing when Japanese UI translation is enabled.

--- a/docs/release-notes/unreleased/issue-704-mutation-audit.md
+++ b/docs/release-notes/unreleased/issue-704-mutation-audit.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Correct mutation description translations for Unstable Genome, Beak, Beguiling, Domination, Psychometry, and Dystechnia.

--- a/docs/release-notes/unreleased/issue-708-route-inventory.md
+++ b/docs/release-notes/unreleased/issue-708-route-inventory.md
@@ -1,3 +1,0 @@
-### Changed
-
-- Reclassified reviewed message-pattern routes so existing Japanese coverage is tracked under the correct owner surface.

--- a/docs/release-notes/unreleased/issue-711-article-stripping.md
+++ b/docs/release-notes/unreleased/issue-711-article-stripping.md
@@ -1,9 +1,0 @@
-### Fixed
-
-- Strip English articles from pass-by, XDidY owner-routed labels, and combat message captures before they appear in Japanese output.
-- Strip leading articles from generated possessive labels and player-owned Does subjects before Japanese particles are appended.
-- Translate display-name state and active-effect label residues such as `[swimming]` and `bloody wet`.
-- Translate bleeding/leaking/oozing/fluxing terms in message frames, damage sources, and wound-stop log patterns.
-- Strip leading articles and possessive pronouns from translated message/journal captures, mutation self-target prompts, belcher output messages, conk confirmations, and generated statue labels.
-- Translate statically generated display-name adjectives and bracketed states such as rusted, broken, cracked, flying, wading, raised, and dynamic timer/cell/chapter/ammo suffixes.
-- Remove the empty Tzedech/Welcome conversation text override that produced a localization validation warning.

--- a/docs/release-notes/unreleased/issue-727-water-ritual-localization.md
+++ b/docs/release-notes/unreleased/issue-727-water-ritual-localization.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Fix water ritual runtime text that could remain in English in message logs, summaries, and conversation choices.

--- a/docs/release-notes/unreleased/issue-737-hse-route-closure.md
+++ b/docs/release-notes/unreleased/issue-737-hse-route-closure.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Fix remaining English text in campfire cooking menus, ingredient selection, recipe cooking, meal creation messages, generated journal text, and HistorySpice-style historic names.

--- a/docs/release-notes/unreleased/masterwork-tooltip-description.md
+++ b/docs/release-notes/unreleased/masterwork-tooltip-description.md
@@ -1,6 +1,0 @@
-### Fixed
-
-- Translate generated masterwork weapon modification descriptions, display names, maker's marks, and examine-identification messages.
-- Preserve colored tinkering bit tags in display-name angle suffixes such as schematic/data-disk bit costs.
-- Translate missile-weapon multiple-ammo and multiple-projectile runtime tooltip lines.
-- Use the clearer item-name wording "ひび割れた" for cracked scrap components.

--- a/docs/release-notes/unreleased/runtime-ui-generated-text.md
+++ b/docs/release-notes/unreleased/runtime-ui-generated-text.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Translate generated ability detail labels, status-screen tab prompts, active-effect titles, and runtime message fragments that could still appear in English.

--- a/docs/reports/2026-05-20-workshop-v0.3.00.md
+++ b/docs/reports/2026-05-20-workshop-v0.3.00.md
@@ -1,0 +1,99 @@
+# Workshop Release v0.3.00
+
+## Identity
+
+- Version: `0.3.00`
+- Git commit: pending final `main` release commit after PR merge
+- Git tag: pending `v0.3.00`
+- Previous release tag/range: `v0.2.52..HEAD`, established from local tag and remote tag evidence
+- Version source: `Mods/QudJP/manifest.json`
+- GitHub Release URL: pending tag workflow
+- Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
+- Steam app ID: `333640`
+- Published file ID: `3718988020`
+
+## Changenote
+
+```text
+v0.3.00 / <release-commit>
+
+翻訳追加・改善:
+- 生成される歴史、墓碑文、村の伝承、クエスト会話、料理本名、レリック文、地下聖堂の銘文、墓石、称号、集落名の日本語表示を大幅に拡充しました。
+- campfire cooking menu、ingredient selection、recipe cooking、meal creation message、生成 journal text、HistorySpice 系の歴史名に残っていた英語表示を日本語化しました。
+- Water Ritual の message log、summary、conversation choice に残っていた英語表示を日本語化しました。
+- アビリティ詳細、ステータス画面タブ、飛行メッセージ、レーザー光線ダメージログ、ミサイル武器 tooltip などの runtime 表示に残っていた英語を日本語化しました。
+- code redemption、色選択、マウス入力、save error、automatic action stop、料理 trigger、normality-lattice contest などのポップアップ・ログ文を追加で日本語化しました。
+- 生成アイテム説明、active effect 名、インベントリの武器状態ラベル、masterwork weapon mod の説明・表示名・maker mark を日本語化しました。
+- 生成される形容詞、身体特徴、地形、活動、状態 suffix、timer/cell/chapter/ammo suffix を、色 markup や placeholder を保ったまま自然な日本語へ置き換えました。
+
+修正:
+- QudJP 有効時に、一部の Carbide Chef と手続き生成料理レシピから効果が失われる問題を修正しました。
+- 日本語 UI 翻訳を有効にしたとき、journal entries が消える問題を修正しました。
+- ゴーレム素材選択ポップアップの翻訳処理が起動時に失敗する問題を修正しました。
+- サイバネティック implant と mutation の説明文を Caves of Qud 1.0.4 の挙動に合わせて修正しました。
+- 日本語出力に混ざる英語冠詞・所有代名詞・状態語を追加で除去し、`[swimming]`、`bloody wet`、rusted、broken、cracked などの表示を日本語化しました。
+- schematic や data disk の bit cost など、display name の angle suffix に含まれる色付き tinkering bit tag を保持するようにしました。
+- cracked scrap component の item-name 表現を `ひび割れた` に修正しました。
+- macOS Apple Silicon の native ARM64 回避策で使う補助ファイルを、現在の案内に合わせて更新しました。
+
+既知の問題:
+- 一部の自動生成テキスト、チュートリアル、キャラクター生成画面には未翻訳または不自然な訳が残る場合があります。
+- ゲーム本体のアップデートにより、一部表示やパッチが壊れる可能性があります。
+```
+
+## Artifacts
+
+- Release ZIP: `dist/QudJP-v0.3.00.zip` local dry-run artifact; final Workshop upload must use `dist/release-assets/v0.3.00/QudJP-v0.3.00.zip` from the draft GitHub Release
+- Release ZIP SHA256: `3bdf48072ef10733dfec6482825161b1cfe74295c543e7ff999501c9f8e08b66`
+- GitHub Release asset: pending `QudJP-v0.3.00.zip`
+- GitHub Release asset SHA256: pending
+- Workshop content folder: `dist/workshop/QudJP/`
+- Workshop VDF: `dist/workshop/workshop_item.vdf`
+
+## Preflight
+
+- [x] `git status --short --branch`
+- [x] Release range established from previous tag, release report, changelog/GitHub release, or explicit user range
+- [ ] `Mods/QudJP/manifest.json` version, `v0.3.00` tag, release ZIP name, changenote first line, and report version match
+- [ ] `git rev-list -n1 v0.3.00` matches `git rev-parse HEAD`
+- [x] `git merge-base --is-ancestor HEAD origin/main`
+- [ ] Draft GitHub Release created by tag workflow
+- [x] Workshop changenote rewritten in player-facing terms and checked by local dry-run `workshop-upload-preflight`
+- [ ] `just download-release-zip 0.3.00`
+- [x] `just workshop-preflight 0.3.00`
+- [x] `just changelog-link-check`
+- [x] `just release-note-check origin/main HEAD`
+- [x] `just build`
+- [x] `just build-release`
+- [x] `just python-check`
+- [x] `uv run pytest scripts/tests/test_build_release.py scripts/tests/test_build_workshop_upload.py scripts/tests/test_sync_mod.py scripts/tests/test_tokenize_corpus.py -q`
+- [x] `just localization-check`
+- [x] `just translation-token-check`
+- [x] `just release-zip-check dist/QudJP-v0.3.00.zip`
+- [x] `just build-workshop-upload dist/QudJP-v0.3.00.zip /tmp/qudjp-workshop-changenote.txt`
+- [x] `just workshop-upload-preflight dist/QudJP-v0.3.00.zip 0.3.00`
+
+## Upload
+
+- steamcmd command: `/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +workshop_build_item <repo-root>/dist/workshop/workshop_item.vdf +quit`
+- Upload completed at: pending
+- Steam output summary: pending
+- GitHub Release published at: pending
+
+## Post-Publish Smoke
+
+- [ ] Workshop page title, description, preview image, visibility, file size, and changenote checked
+- [ ] Subscribe/resubscribe checked
+- [ ] `steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit`
+- [ ] `just workshop-download-check 0.3.00 dist/release-assets/v0.3.00/QudJP-v0.3.00.zip`
+- [ ] Mod Manager lists QudJP with expected version and preview
+- [ ] Options screen renders Japanese text and CJK glyphs
+- [ ] One short conversation renders Japanese text and CJK glyphs
+- [ ] Fresh Player.log checked for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`
+- [ ] Non-QudJP platform SDK noise, if present, recorded in notes and not conflated with QudJP blockers
+
+## Decision
+
+- Result: NO-GO until the release PR is merged, `v0.3.00` is created on the merged `main` commit and pushed with explicit approval, the draft GitHub Release ZIP is downloaded, and the final Workshop upload preflight is rerun against that ZIP.
+- Notes: Local dry-run staging verified the manifest version, required release files, required DLL markers, Workshop item ID `3718988020`, and generated VDF shape. Replace the changenote first-line hash with the actual release commit hash after the final `main` release commit exists.
+- Rollback tag, if needed: `v0.2.52`


### PR DESCRIPTION
## Summary
- Bump QudJP manifest version to 0.3.00
- Move unreleased fragments into CHANGELOG.md
- Add Workshop release evidence report for v0.3.00

## Verification
- just workshop-preflight 0.3.00
- just release-zip-check dist/QudJP-v0.3.00.zip
- just build-workshop-upload dist/QudJP-v0.3.00.zip /tmp/qudjp-workshop-changenote.txt
- just workshop-upload-preflight dist/QudJP-v0.3.00.zip 0.3.00
- just deploy-mod

## Release operator notes
- Do not push the local v0.3.00 tag from this PR branch. After merge, create v0.3.00 on the merged main commit, push it, download the draft GitHub Release ZIP, regenerate Workshop staging from that ZIP, and rerun the upload preflight before steamcmd upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート v0.3.00

* **新機能**
  * 日本語ローカライズの大幅な改善と統一
  * 確認ポップアップ表現の統一

* **バグ修正**
  * ジャーナルエントリ表示の不具合を修正
  * 料理レシピ機能の問題を修正
  * 突然変異説明文の翻訳を修正
  * 各種ゲーム内テキストの日本語化を改善

* **その他**
  * macOS Apple Silicon向けパッケージを更新
  * バージョンを 0.3.00 へ更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->