### PR TITLE
docs: record workshop v0.3.00 release results

### DIFF
--- a/docs/reports/2026-05-20-workshop-v0.3.00.md
+++ b/docs/reports/2026-05-20-workshop-v0.3.00.md
@@ -69,12 +69,12 @@ v0.3.00 / 9557895af670
 - [x] `uv run pytest scripts/tests/test_build_release.py scripts/tests/test_build_workshop_upload.py scripts/tests/test_sync_mod.py scripts/tests/test_tokenize_corpus.py -q`
 - [x] `just localization-check`
 - [x] `just translation-token-check`
-- [x] `just release-zip-check dist/QudJP-v0.3.00.zip`
-- [x] `just build-workshop-upload dist/QudJP-v0.3.00.zip /tmp/qudjp-workshop-changenote.txt`
-- [x] `just workshop-upload-preflight dist/QudJP-v0.3.00.zip 0.3.00`
-- [x] `just release-zip-check dist/release-assets/v0.3.00/QudJP-v0.3.00.zip`
-- [x] `just build-workshop-upload dist/release-assets/v0.3.00/QudJP-v0.3.00.zip /tmp/qudjp-workshop-changenote.txt`
-- [x] `just workshop-upload-preflight dist/release-assets/v0.3.00/QudJP-v0.3.00.zip 0.3.00`
+- [x] Initial local dry-run artifact: `just release-zip-check dist/QudJP-v0.3.00.zip`
+- [x] Initial local dry-run artifact: `just build-workshop-upload dist/QudJP-v0.3.00.zip /tmp/qudjp-workshop-changenote.txt`
+- [x] Initial local dry-run artifact: `just workshop-upload-preflight dist/QudJP-v0.3.00.zip 0.3.00`
+- [x] Canonical GitHub Release ZIP used for Workshop upload: `just release-zip-check dist/release-assets/v0.3.00/QudJP-v0.3.00.zip`
+- [x] Canonical GitHub Release ZIP used for Workshop upload: `just build-workshop-upload dist/release-assets/v0.3.00/QudJP-v0.3.00.zip /tmp/qudjp-workshop-changenote.txt`
+- [x] Canonical GitHub Release ZIP used for Workshop upload: `just workshop-upload-preflight dist/release-assets/v0.3.00/QudJP-v0.3.00.zip 0.3.00`
 
 ## Upload
 

--- a/docs/reports/2026-05-20-workshop-v0.3.00.md
+++ b/docs/reports/2026-05-20-workshop-v0.3.00.md
@@ -3,11 +3,11 @@
 ## Identity
 
 - Version: `0.3.00`
-- Git commit: pending final `main` release commit after PR merge
-- Git tag: pending `v0.3.00`
-- Previous release tag/range: `v0.2.52..HEAD`, established from local tag and remote tag evidence
+- Git commit: `9557895af670`
+- Git tag: `v0.3.00`
+- Previous release tag/range: `v0.2.52..v0.3.00`, established from local tag and remote tag evidence
 - Version source: `Mods/QudJP/manifest.json`
-- GitHub Release URL: pending tag workflow
+- GitHub Release URL: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.00
 - Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
 - Steam app ID: `333640`
 - Published file ID: `3718988020`
@@ -15,7 +15,7 @@
 ## Changenote
 
 ```text
-v0.3.00 / <release-commit>
+v0.3.00 / 9557895af670
 
 翻訳追加・改善:
 - 生成される歴史、墓碑文、村の伝承、クエスト会話、料理本名、レリック文、地下聖堂の銘文、墓石、称号、集落名の日本語表示を大幅に拡充しました。
@@ -43,10 +43,10 @@ v0.3.00 / <release-commit>
 
 ## Artifacts
 
-- Release ZIP: `dist/QudJP-v0.3.00.zip` local dry-run artifact; final Workshop upload must use `dist/release-assets/v0.3.00/QudJP-v0.3.00.zip` from the draft GitHub Release
-- Release ZIP SHA256: `3bdf48072ef10733dfec6482825161b1cfe74295c543e7ff999501c9f8e08b66`
-- GitHub Release asset: pending `QudJP-v0.3.00.zip`
-- GitHub Release asset SHA256: pending
+- Release ZIP: `dist/release-assets/v0.3.00/QudJP-v0.3.00.zip`
+- Release ZIP SHA256: `a5cfa3b767b1e49bc8cd002dd9fddf4e43ea9c234d9b98632dea3d70bd26c876`
+- GitHub Release asset: `QudJP-v0.3.00.zip`
+- GitHub Release asset SHA256: `a5cfa3b767b1e49bc8cd002dd9fddf4e43ea9c234d9b98632dea3d70bd26c876`
 - Workshop content folder: `dist/workshop/QudJP/`
 - Workshop VDF: `dist/workshop/workshop_item.vdf`
 
@@ -54,12 +54,12 @@ v0.3.00 / <release-commit>
 
 - [x] `git status --short --branch`
 - [x] Release range established from previous tag, release report, changelog/GitHub release, or explicit user range
-- [ ] `Mods/QudJP/manifest.json` version, `v0.3.00` tag, release ZIP name, changenote first line, and report version match
-- [ ] `git rev-list -n1 v0.3.00` matches `git rev-parse HEAD`
+- [x] `Mods/QudJP/manifest.json` version, `v0.3.00` tag, release ZIP name, changenote first line, and report version match
+- [x] `git rev-list -n1 v0.3.00` matches `git rev-parse HEAD`
 - [x] `git merge-base --is-ancestor HEAD origin/main`
-- [ ] Draft GitHub Release created by tag workflow
+- [x] Draft GitHub Release created by tag workflow
 - [x] Workshop changenote rewritten in player-facing terms and checked by local dry-run `workshop-upload-preflight`
-- [ ] `just download-release-zip 0.3.00`
+- [x] `just download-release-zip 0.3.00`
 - [x] `just workshop-preflight 0.3.00`
 - [x] `just changelog-link-check`
 - [x] `just release-note-check origin/main HEAD`
@@ -72,20 +72,24 @@ v0.3.00 / <release-commit>
 - [x] `just release-zip-check dist/QudJP-v0.3.00.zip`
 - [x] `just build-workshop-upload dist/QudJP-v0.3.00.zip /tmp/qudjp-workshop-changenote.txt`
 - [x] `just workshop-upload-preflight dist/QudJP-v0.3.00.zip 0.3.00`
+- [x] `just release-zip-check dist/release-assets/v0.3.00/QudJP-v0.3.00.zip`
+- [x] `just build-workshop-upload dist/release-assets/v0.3.00/QudJP-v0.3.00.zip /tmp/qudjp-workshop-changenote.txt`
+- [x] `just workshop-upload-preflight dist/release-assets/v0.3.00/QudJP-v0.3.00.zip 0.3.00`
 
 ## Upload
 
 - steamcmd command: `/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +workshop_build_item <repo-root>/dist/workshop/workshop_item.vdf +quit`
-- Upload completed at: pending
-- Steam output summary: pending
-- GitHub Release published at: pending
+- Upload completed at: 2026-05-20 22:22 JST
+- Steam output summary: `Preparing update... Preparing content... Uploading content... Uploading preview image... Committing update...Success.`
+- GitHub Release published at: 2026-05-20 22:24 JST
 
 ## Post-Publish Smoke
 
-- [ ] Workshop page title, description, preview image, visibility, file size, and changenote checked
+- [x] Workshop page title, description, preview image, visibility, file size, and changenote checked
 - [ ] Subscribe/resubscribe checked
-- [ ] `steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit`
-- [ ] `just workshop-download-check 0.3.00 dist/release-assets/v0.3.00/QudJP-v0.3.00.zip`
+- [x] `steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit`
+- [x] `just workshop-download-check 0.3.00 dist/release-assets/v0.3.00/QudJP-v0.3.00.zip`
+- [x] Downloaded `Launch CavesOfQud (Rosetta).command`, `Install Native Apple Silicon Harmony.command`, and `Restore Game Harmony.command` exist and are executable
 - [ ] Mod Manager lists QudJP with expected version and preview
 - [ ] Options screen renders Japanese text and CJK glyphs
 - [ ] One short conversation renders Japanese text and CJK glyphs
@@ -94,6 +98,6 @@ v0.3.00 / <release-commit>
 
 ## Decision
 
-- Result: NO-GO until the release PR is merged, `v0.3.00` is created on the merged `main` commit and pushed with explicit approval, the draft GitHub Release ZIP is downloaded, and the final Workshop upload preflight is rerun against that ZIP.
-- Notes: Local dry-run staging verified the manifest version, required release files, required DLL markers, Workshop item ID `3718988020`, and generated VDF shape. Replace the changenote first-line hash with the actual release commit hash after the final `main` release commit exists.
+- Result: GO - Steam Workshop upload completed, public Workshop download matched the GitHub Release ZIP DLL, and GitHub Release `v0.3.00` was published.
+- Notes: Prepared release identity through PR #741, tagged merged `main` commit `9557895af670`, downloaded the draft GitHub Release ZIP, regenerated Workshop staging from that ZIP, and reran the final upload preflight before `steamcmd`. Steam Workshop page `?l=japanese` showed title `Caves of Qud Japanese Mod`, file size `21.057 MB`, update time `5月20日 6時22分`, and changenote `v0.3.00 / 9557895af670`. The page still displays Steam-side removed/incompatible banners; this was recorded as Steam-side metadata/moderation state, while the authenticated Workshop download succeeded and matched the release ZIP DLL SHA256 `4ecde93fe98d4654b7a1ef511b8927637f4f778832bbe5e168f99e48eabe134b`.
 - Rollback tag, if needed: `v0.2.52`


### PR DESCRIPTION
## Summary
- Record final Steam Workshop v0.3.00 upload evidence
- Mark GitHub Release ZIP, final upload preflight, Steam upload, download verification, and release publication results

## Verification
- just markdown-report-check origin/main HEAD
- Steam upload completed successfully
- steamcmd workshop_download_item 333640 3718988020 validate succeeded
- just workshop-download-check 0.3.00 dist/release-assets/v0.3.00/QudJP-v0.3.00.zip succeeded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * v0.3.00 のワークショップリリース記録を確定。識別情報（コミット／タグ／前回リリース範囲／バージョン情報／公開URL等）、配布アセット参照先およびアセットのSHA256が確定。事前検証・アップロード・公開後チェックの完了時刻と検証結果（ダウンロード整合性含む）、公開ページの表示情報とチェンジノートが追記され、最終判定が GO に更新されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->