### PR TITLE
[codex] Fix metabolized meal translation

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
@@ -996,6 +996,9 @@ public sealed class LocalizationCoverageTests
                 Does.Contain(new DictionaryEntry("{{W|metabolizing}}", "XRL.World.Effects.ProceduralCookingEffect.GetDescription", "{{W|代謝中}}")));
             Assert.That(
                 cookingEntries,
+                Does.Contain(new DictionaryEntry("{{w|metabolized effect}}", "XRL.World.Effects.BasicTriggeredCookingEffect.GetDescription", "{{w|代謝効果}}")));
+            Assert.That(
+                cookingEntries,
                 Does.Contain(new DictionaryEntry(
                     "@thisCreature thirst@s at half rate.",
                     "XRL.World.Effects.ProceduralCookingEffectUnit_LessThirst.GetDescription",

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/MutationGeneratedTextTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/MutationGeneratedTextTranslationPatchTests.cs
@@ -32,8 +32,8 @@ public sealed class MutationGeneratedTextTranslationPatchTests
 
     [TestCase(
         PhotosyntheticSkinOwner,
-        "You start to metabolize the meal, gaining the following effect for the rest of the day:\n\n{{W|+5% to quickness}}",
-        "食事を消化し始め、今日の残りの間、以下の効果を得る:\n\n{{W|+5% to quickness}}",
+        "You start to metabolize the meal, gaining the following effect for the rest of the day:\n\n{{W|+30% to natural healing rate\n+15 Quickness\n}}",
+        "食事の代謝が始まり、一日中次の効果を得る:\n\n{{W|自然治癒速度+30%\nクイックネス+15\n}}",
         "PhotosyntheticSkinMetabolize")]
     [TestCase(
         LifeDrainOwner,

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupTranslationPatchTests.cs
@@ -858,9 +858,9 @@ public sealed class PopupTranslationPatchTests
         "{{|starapple stew}}の新しいレシピを生み出した！")]
     [TestCase(
         "You start to metabolize the meal, gaining the following effect for the rest of the day:\n\n{{W|{0}}}",
-        "食事を消化し始め、今日の残りの間、以下の効果を得る:\n\n{{W|{0}}}",
+        "食事の代謝が始まり、一日中次の効果を得る:\n\n{{W|{0}}}",
         "You start to metabolize the meal, gaining the following effect for the rest of the day:\n\n{{W|+5 to heat resistance}}",
-        "食事を消化し始め、今日の残りの間、以下の効果を得る:\n\n{{W|+5 to heat resistance}}")]
+        "食事の代謝が始まり、一日中次の効果を得る:\n\n{{W|+5 to heat resistance}}")]
     public void TranslatePopupTextForProducerRoute_TranslatesCampfireSinglePlaceholderPatterns(
         string templateKey,
         string templateText,

--- a/Mods/QudJP/Assemblies/src/Patches/CookingRuntimeTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/CookingRuntimeTranslationPatch.cs
@@ -372,20 +372,20 @@ public static class CookingRuntimeTranslationPatch
 
     private static string TranslateCookingEffectLines(string source)
     {
+        var (effectStripped, effectSpans) = ColorAwareTranslationComposer.Strip(source);
         if (source.IndexOf('\n') < 0)
         {
-            var (stripped, spans) = ColorAwareTranslationComposer.Strip(source);
-            return CookingEffectFragmentTranslator.TryTranslate(stripped, Context, "CookingRuntime.ApplyEffectsTo", out var translated)
+            return CookingEffectFragmentTranslator.TryTranslate(effectStripped, Context, "CookingRuntime.ApplyEffectsTo", out var translated)
                 ? ColorAwareTranslationComposer.RestoreWholeSourceBoundaryWrappersPreservingTranslatedOwnership(
                     translated,
-                    spans,
-                    stripped.Length,
+                    effectSpans,
+                    effectStripped.Length,
                     source)
                 : source;
         }
 
         var changed = false;
-        var lines = source.Split('\n');
+        var lines = effectStripped.Split('\n');
         for (var index = 0; index < lines.Length; index++)
         {
             var (stripped, spans) = ColorAwareTranslationComposer.Strip(lines[index]);
@@ -400,7 +400,17 @@ public static class CookingRuntimeTranslationPatch
             }
         }
 
-        return changed ? string.Join("\n", lines) : source;
+        if (!changed)
+        {
+            return source;
+        }
+
+        var translatedLines = string.Join("\n", lines);
+        return ColorAwareTranslationComposer.RestoreWholeSourceBoundaryWrappersPreservingTranslatedOwnership(
+            translatedLines,
+            effectSpans,
+            effectStripped.Length,
+            source);
     }
 
     private static bool TryTranslateWellFedIntro(string source, out string translated)

--- a/Mods/QudJP/Assemblies/src/Patches/MutationGeneratedTextTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/MutationGeneratedTextTranslationPatch.cs
@@ -176,8 +176,13 @@ public static class MutationGeneratedTextTranslationPatch
         var match = PhotosyntheticMetabolizePattern.Match(stripped);
         if (match.Success && OwnerMatches(ownerKey, PhotosyntheticSkinHandleEventOwner))
         {
-            translated = "食事を消化し始め、今日の残りの間、以下の効果を得る:\n\n"
-                + RestoreCapture(match, spans, "effect");
+            if (!CookingRuntimeTranslationPatch.TryTranslateMetabolizeMealPopup(source, out translated))
+            {
+                translated = source;
+                detail = string.Empty;
+                return false;
+            }
+
             detail = "PhotosyntheticSkinMetabolize";
             return true;
         }

--- a/Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-popup.ja.json
@@ -2411,7 +2411,7 @@
         },
         {
             "key": "You start to metabolize the meal, gaining the following effect for the rest of the day:\n\n{{W|{0}}}",
-            "text": "食事を消化し始め、今日の残りの間、以下の効果を得る:\n\n{{W|{0}}}"
+            "text": "食事の代謝が始まり、一日中次の効果を得る:\n\n{{W|{0}}}"
         },
         {
             "key": "{0}: how many do you want to preserve? (max = {1})",

--- a/Mods/QudJP/Localization/Dictionaries/world-effects-cooking.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/world-effects-cooking.ja.json
@@ -11,7 +11,7 @@
         {
             "key": "{{w|metabolized effect}}",
             "context": "XRL.World.Effects.BasicTriggeredCookingEffect.GetDescription",
-            "text": "{{w|代謝中の効果}}"
+            "text": "{{w|代謝効果}}"
         },
         {
             "key": "+10-15 Acid Resistance",

--- a/docs/release-notes/unreleased/metabolized-meal-translation.md
+++ b/docs/release-notes/unreleased/metabolized-meal-translation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Unified the Japanese wording for meal metabolizing popups and the `metabolized effect` cooking-effect label.


### PR DESCRIPTION
## Summary

- Unify the Japanese wording for meal metabolizing popups across cooking, generic popup fallback, and Photosynthetic Skin routes.
- Route Photosynthetic Skin metabolize popup effects through the cooking-effect fragment translator so multiline effect details are translated.
- Change `{{w|metabolized effect}}` from `{{w|代謝中の効果}}` to `{{w|代謝効果}}` and add an unreleased release-note fragment.

## Validation

- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~MutationGeneratedTextTranslationPatchTests|FullyQualifiedName~PopupTranslationPatchTests|FullyQualifiedName~LocalizationCoverageTests|FullyQualifiedName~CookingRuntimeTranslationPatchTests"`
- `just localization-check`
- `just translation-token-check`
- `git diff --check`
- `just test-l1`
- `just test-l2`
- `just build`
- `just release-note-check origin/main HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 食事のメタボライズ時に表示されるポップアップの日本語表現を統一しました。翻訳処理の改善により、より正確で一貫した表現表示が可能になりました。

* **Documentation**
  * 翻訳改善に関するリリースノートを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->