### PR TITLE
Optimize CI test runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,8 @@ jobs:
             awk '/^scripts\// && !/^scripts\/tools\// { found = 1 } END { exit found ? 0 : 1 }' changed-files.txt
           }
 
-          matches_annals_extractor_tests() {
-            grep -Eq '^scripts/tests/(test_extract_annals_patterns\.py|fixtures/annals/)' changed-files.txt
+          matches_roslyn_python_tests() {
+            grep -Eq '^(docs/static-producer-inventory\.json|scripts/(dotnet_tool_runner|extract_annals_patterns|roslyn_semantic_probe|scan_static_producer_inventory|static_producer_closure|text_construction_surface_policy)\.py|scripts/tests/(test_extract_annals_patterns\.py|test_parallel_dotnet_contract\.py|test_roslyn_extractor_smoke\.py|test_roslyn_semantic_probe\.py|test_roslyn_text_construction_inventory\.py|test_scan_static_producer_inventory\.py|test_static_producer_closure\.py|test_text_construction_surface_policy\.py|fixtures/(annals|roslyn_semantic_probe|static_producer_inventory)/))' changed-files.txt
           }
 
           run_all=false
@@ -83,7 +83,7 @@ jobs:
           if [[ "$run_all" == true ]] || matches '^Mods/QudJP/Assemblies/'; then
             qudjp_dotnet=true
           fi
-          if [[ "$run_all" == true ]] || matches '^scripts/tools/' || matches_annals_extractor_tests; then
+          if [[ "$run_all" == true ]] || matches '^scripts/tools/' || matches_roslyn_python_tests || matches '^(pyproject\.toml|uv\.lock)$'; then
             roslyn_tools=true
           fi
           if [[ "$run_all" == true ]] || matches '^(\.codex/hooks/|\.codex/hooks\.json|pyproject\.toml|uv\.lock|dotnet-tools\.json|package(-lock)?\.json|CHANGELOG\.md|Mods/QudJP/manifest\.json|docs/release-notes/)' || matches_python_scripts; then
@@ -218,38 +218,55 @@ jobs:
             ${{ runner.os }}-nuget-roslyn-tools-
             ${{ runner.os }}-nuget-
 
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install Python test tools
+        run: pip install pytest
+
       - name: Build script tools
         if: hashFiles('scripts/tools/**/*.csproj') != ''
-        shell: bash
         run: |
-          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
 
-          mapfile -t projects < <(find scripts/tools -name '*.csproj' -type f | sort)
-          if (( ${#projects[@]} == 0 )); then
-            echo "No script tool projects found."
-            exit 0
-          fi
+          from scripts.dotnet_tool_runner import build_tool_project
 
-          for project in "${projects[@]}"; do
-            echo "::group::dotnet build ${project}"
-            dotnet build "${project}" --configuration Release
-            echo "::endgroup::"
-          done
+          projects = sorted(Path("scripts/tools").glob("**/*.csproj"))
+          if not projects:
+              print("No script tool projects found.")
+          for project in projects:
+              print(f"::group::dotnet build {project}")
+              print(build_tool_project(project))
+              print("::endgroup::")
+          PY
+
+      - name: Test Roslyn-backed Python tools
+        run: >
+          pytest
+          scripts/tests/test_extract_annals_patterns.py
+          scripts/tests/test_parallel_dotnet_contract.py
+          scripts/tests/test_roslyn_extractor_smoke.py
+          scripts/tests/test_roslyn_semantic_probe.py
+          scripts/tests/test_roslyn_text_construction_inventory.py
+          scripts/tests/test_scan_static_producer_inventory.py
+          scripts/tests/test_static_producer_closure.py
+          scripts/tests/test_text_construction_surface_policy.py
+          -q
+          --durations=20
 
   python:
     runs-on: ubuntu-latest
-    needs: [detect-changes, roslyn-tools]
-    if: always() && needs.detect-changes.outputs.python == 'true' && (needs.roslyn-tools.result == 'success' || needs.roslyn-tools.result == 'skipped')
+    needs: detect-changes
+    if: needs.detect-changes.outputs.python == 'true'
     timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v5
-
-      - name: Setup .NET for Roslyn-backed Python tests
-        if: needs.detect-changes.outputs.roslyn_tools == 'true'
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 10.0.x
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -273,7 +290,17 @@ jobs:
 
       - name: Test Python
         if: hashFiles('scripts/tests/**/*.py') != ''
-        run: pytest scripts/tests/
+        run: >
+          pytest scripts/tests/
+          --ignore=scripts/tests/test_extract_annals_patterns.py
+          --ignore=scripts/tests/test_parallel_dotnet_contract.py
+          --ignore=scripts/tests/test_roslyn_extractor_smoke.py
+          --ignore=scripts/tests/test_roslyn_semantic_probe.py
+          --ignore=scripts/tests/test_roslyn_text_construction_inventory.py
+          --ignore=scripts/tests/test_scan_static_producer_inventory.py
+          --ignore=scripts/tests/test_static_producer_closure.py
+          --ignore=scripts/tests/test_text_construction_surface_policy.py
+          --durations=30
 
       - name: Check CHANGELOG release links
         run: python scripts/release_notes.py check-changelog-links

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CombatAndLogMessageQueuePatchTests.cs
@@ -107,101 +107,109 @@ public sealed class CombatAndLogMessageQueuePatchTests
         }
     }
 
-    [TestCase("{{r|You take 7 damage from the acid!}}", "{{r|酸で7ダメージを受けた！}}")]
-    [TestCase("{{r|You take 7 damage from the acid}}", "{{r|酸で7ダメージを受けた}}")]
-    [TestCase("{{r|You take 7 damage while phased!}}", "{{r|You take 7 damage while phased!}}")]
-    [TestCase("{{r|You take no damage from the acid!}}", "{{r|酸でダメージを受けなかった！}}")]
-    [TestCase("The snapjaw takes 4 damage from the acid!", "snapjawは酸で4ダメージを受けた！")]
-    [TestCase("The snapjaw takes no damage from the acid!", "snapjawは酸でダメージを受けなかった！")]
-    [TestCase("snapjaws take 4 damage from the acid!", "snapjawsは酸で4ダメージを受けた！")]
-    [TestCase("{{r|You take 3 damage being run over by the chrome pyramid!}}", "{{r|chrome pyramidに轢かれて3ダメージを受けた！}}")]
-    [TestCase("{{r|You take 5 heat from the blaze!}}", "{{r|blazeで5熱ダメージを受けた！}}")]
-    [TestCase("{{r|You take 5 {{icy|cold damage}} from the shard!}}", "{{r|shardで5{{icy|冷気ダメージ}}を受けた！}}")]
-    [TestCase("{{r|You take 8 damage from your laser beam! {{R|(x2)}}}}", "{{r|あなたのレーザービームで8ダメージを受けた！ {{R|(x2)}}}}")]
-    [TestCase("The {{B|濡れた}}グロウフィッシュ takes 7 damage from your laser beam! {{&r|(x3)}}", "{{B|濡れた}}グロウフィッシュはあなたのレーザービームで7ダメージを受けた！ {{&r|(x3)}}")]
-    [TestCase("{{r|You take 6 damage {{R|(x2)}} from colliding with the chrome wall.}}", "{{r|{{R|(x2)}} chrome wallとの衝突で6ダメージを受けた。}}")]
-    [TestCase("The {{B|濡れた}}光葉 takes 1 damage from leaking.", "{{B|濡れた}}光葉は液漏れで1ダメージを受けた。")]
-    [TestCase("The 樹液まみれの濡れた光葉 takes no damage from oozing.", "樹液まみれの濡れた光葉は滲出でダメージを受けなかった。")]
-    [TestCase("{{r|You take 1 damage from fluxing.}}", "{{r|フラックス漏れで1ダメージを受けた。}}")]
-    [TestCase("The 落葉剤グレネード mk I miner mk I takes 4 damage from your freezing effect!", "落葉剤グレネード mk I miner mk Iはあなたの凍結効果で4ダメージを受けた！")]
-    [TestCase(
-        "{{r|You take 9 damage from your plasma you started by you near your ally and You!}}",
-        "{{r|あなたのplasma you started by you near your ally and Youで9ダメージを受けた！}}")]
-    public void PhysicsProcessTakeDamage_TranslatesDamageFrames_WhenOwnerPatched(string source, string expected)
+    [Test]
+    public void PhysicsProcessTakeDamage_TranslatesDamageFrames_WhenOwnerPatched()
     {
-        AssertPhysicsProcessTakeDamageQueuedMessage(source, expected);
+        var cases = new (string Source, string Expected)[]
+        {
+            ("{{r|You take 7 damage from the acid!}}", "{{r|酸で7ダメージを受けた！}}"),
+            ("{{r|You take 7 damage from the acid}}", "{{r|酸で7ダメージを受けた}}"),
+            ("{{r|You take 7 damage while phased!}}", "{{r|You take 7 damage while phased!}}"),
+            ("{{r|You take no damage from the acid!}}", "{{r|酸でダメージを受けなかった！}}"),
+            ("The snapjaw takes 4 damage from the acid!", "snapjawは酸で4ダメージを受けた！"),
+            ("The snapjaw takes no damage from the acid!", "snapjawは酸でダメージを受けなかった！"),
+            ("snapjaws take 4 damage from the acid!", "snapjawsは酸で4ダメージを受けた！"),
+            ("{{r|You take 3 damage being run over by the chrome pyramid!}}", "{{r|chrome pyramidに轢かれて3ダメージを受けた！}}"),
+            ("{{r|You take 5 heat from the blaze!}}", "{{r|blazeで5熱ダメージを受けた！}}"),
+            ("{{r|You take 5 {{icy|cold damage}} from the shard!}}", "{{r|shardで5{{icy|冷気ダメージ}}を受けた！}}"),
+            ("{{r|You take 8 damage from your laser beam! {{R|(x2)}}}}", "{{r|あなたのレーザービームで8ダメージを受けた！ {{R|(x2)}}}}"),
+            ("The {{B|濡れた}}グロウフィッシュ takes 7 damage from your laser beam! {{&r|(x3)}}", "{{B|濡れた}}グロウフィッシュはあなたのレーザービームで7ダメージを受けた！ {{&r|(x3)}}"),
+            ("{{r|You take 6 damage {{R|(x2)}} from colliding with the chrome wall.}}", "{{r|{{R|(x2)}} chrome wallとの衝突で6ダメージを受けた。}}"),
+            ("The {{B|濡れた}}光葉 takes 1 damage from leaking.", "{{B|濡れた}}光葉は液漏れで1ダメージを受けた。"),
+            ("The 樹液まみれの濡れた光葉 takes no damage from oozing.", "樹液まみれの濡れた光葉は滲出でダメージを受けなかった。"),
+            ("{{r|You take 1 damage from fluxing.}}", "{{r|フラックス漏れで1ダメージを受けた。}}"),
+            ("The 落葉剤グレネード mk I miner mk I takes 4 damage from your freezing effect!", "落葉剤グレネード mk I miner mk Iはあなたの凍結効果で4ダメージを受けた！"),
+            ("{{r|You take 9 damage from your plasma you started by you near your ally and You!}}", "{{r|あなたのplasma you started by you near your ally and Youで9ダメージを受けた！}}"),
+        };
+
+        AssertPhysicsProcessTakeDamageQueuedMessages(cases);
     }
 
-    [TestCase("The target takes 4 damage from your pyrokinesis!", "targetはあなたの熱念動で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from 監視官イラメの cryokinesis!", "targetは監視官イラメの冷気操作で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from snapjaw's life drain!", "targetはsnapjawの生命吸収で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your disintegration!", "targetはあなたの分解で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your stunning force!", "targetはあなたの衝撃念力で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your freezing weapon!", "targetはあなたの凍てつく武器で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your flaming weapon!", "targetはあなたの火炎武器で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your damage reflection!", "targetはあなたのダメージ反射で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your pummeling!", "targetはあなたの殴打で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your shield slam!", "targetはあなたのシールドスラムで4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your explosion!", "targetはあなたの爆発で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your electrical discharge!", "targetはあなたの放電で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from an electrical discharge!", "targetは放電で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your flames!", "targetはあなたの炎で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your freeze!", "targetはあなたの凍結で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your passage!", "targetはあなたの通過で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your digestive enzymes!", "targetはあなたの消化酵素で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your tiny spines!", "targetはあなたの小さな棘で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your projectile.", "targetはあなたの投射物で4ダメージを受けた。")]
-    [TestCase("The target takes 4 damage from your attack.", "targetはあなたの攻撃で4ダメージを受けた。")]
-    [TestCase("The target takes 4 damage from your carbide armor!", "targetはあなたのcarbide装甲で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your freezing effect armor!", "targetはあなたの凍結効果装甲で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your spores!", "targetはあなたの胞子で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from your thorns.", "targetはあなたの棘で4ダメージを受けた。")]
-    [TestCase("The target takes 4 damage from your impalement.", "targetはあなたの串刺しで4ダメージを受けた。")]
-    [TestCase("{{r|You take 4 damage from your {{C|freezing effect}}!}}", "{{r|あなたの{{C|凍結効果}}で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from {{G|acid}}!}}", "{{r|{{G|酸}}で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from your {{g|poison}}!}}", "{{r|あなたの{{g|毒}}で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from {{W|plasma}}!}}", "{{r|{{W|プラズマ}}で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from {{y|normality gas}}!}}", "{{r|{{y|正常化ガス}}で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from {{y|defoliant}}!}}", "{{r|{{y|落葉剤}}で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from {{y|fungicide}}!}}", "{{r|{{y|殺真菌剤}}で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from a plume of acid!}}", "{{r|酸の噴煙で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from a {{fiery|jet of flames}}!}}", "{{r|{{fiery|火炎噴流}}で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from the {{icy|cryogenic mist}}.}}", "{{r|{{icy|極低温の霧}}で4ダメージを受けた。}}")]
-    [TestCase("{{r|You take 4 damage from your {{Y|scalding steam}}!}}", "{{r|あなたの{{Y|灼熱の蒸気}}で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from 骨灰の {{K|choking ash}}!}}", "{{r|骨灰の{{K|窒息性の灰}}で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from falling rocks! {{R|(x2)}}}}", "{{r|落石で4ダメージを受けた！ {{R|(x2)}}}}")]
-    [TestCase("{{r|You take 4 damage from being crushed by a machine press.}}", "{{r|機械プレスに押し潰されたことで4ダメージを受けた。}}")]
-    [TestCase("{{r|You take 4 damage from being forced into phase.}}", "{{r|位相に押し込まれたことで4ダメージを受けた。}}")]
-    [TestCase("{{r|You take 4 damage from slamming into {{W|two}} walls!}}", "{{r|{{W|2}}枚の壁に叩きつけられたことで4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from an electrical shock delivered by your defibrillator.}}", "{{r|あなたのdefibrillatorからの電気ショックで4ダメージを受けた。}}")]
-    [TestCase("{{r|You take 4 damage from an {{electrical|electrical shock}} delivered by your defibrillator.}}", "{{r|あなたのdefibrillatorからの{{electrical|電気ショック}}で4ダメージを受けた。}}")]
-    [TestCase("{{r|You take 4 damage from a sharp edge!}}", "{{r|鋭利な刃で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from the device.}}", "{{r|装置で4ダメージを受けた。}}")]
-    [TestCase("{{r|You take 4 damage from sitting!}}", "{{r|座ったことで4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from a nosebleed.}}", "{{r|鼻血で4ダメージを受けた。}}")]
-    [TestCase("{{r|You take 4 damage from a processor leak.}}", "{{r|プロセッサ漏れで4ダメージを受けた。}}")]
-    [TestCase("{{r|You take 4 damage from a hemorrhage.}}", "{{r|出血で4ダメージを受けた。}}")]
-    [TestCase("{{r|You take 4 damage from falling rock falling on you.}}", "{{r|falling rockがあなたに落下したことで4ダメージを受けた。}}")]
-    [TestCase("{{r|You take 4 damage from its fall.}}", "{{r|その落下で4ダメージを受けた。}}")]
-    [TestCase("{{r|You take 4 damage from geomagnetic disc flying into you!}}", "{{r|geomagnetic discがあなたに飛び込んだことで4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from scourging yourself.}}", "{{r|自分を鞭打ったことで4ダメージを受けた。}}")]
-    [TestCase("{{r|You take 4 damage from using your body as raw materials.}}", "{{r|あなたの体を原材料にしたことで4ダメージを受けた。}}")]
-    [TestCase("{{r|You take 4 damage from the cumulative trauma of your mental assault!}}", "{{r|あなたの精神攻撃による累積外傷で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from the cumulative trauma of a goatfolk's mental assault!}}", "{{r|goatfolkの精神攻撃による累積外傷で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from your failed assault on the structure of spacetime.}}", "{{r|あなたの時空構造への干渉失敗で4ダメージを受けた。}}")]
-    [TestCase("{{r|You take 4 damage from the fire you started!}}", "{{r|あなたが起こした火で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from the fire a laser turret started!}}", "{{r|laser turretが起こした火で4ダメージを受けた！}}")]
-    [TestCase("The snapjaw takes 4 damage from the fire itself started!", "snapjawは自身が起こした火で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from the fire started by snapjaw!", "targetはsnapjawが起こした火で4ダメージを受けた！")]
-    [TestCase("The snapjaw takes 4 damage from the fire started by itself!", "snapjawは自身が起こした火で4ダメージを受けた！")]
-    [TestCase("The target takes 4 damage from the fire started by the snapjaw!", "targetはsnapjawが起こした火で4ダメージを受けた！")]
-    [TestCase("{{r|You take 4 damage from {{G|drinking acid}}!}}", "{{r|{{G|酸を飲んだこと}}で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from {{lava|drinking lava}}!}}", "{{r|{{lava|溶岩を飲んだこと}}で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from {{K|drinking asphalt}}!}}", "{{r|{{K|アスファルトを飲んだこと}}で4ダメージを受けた！}}")]
-    [TestCase("{{r|You take 4 damage from the {{G|hulk}} {{w|honey}}!}}", "{{r|{{G|ハルク}} {{w|ハニー}}で4ダメージを受けた！}}")]
-    public void PhysicsProcessTakeDamage_TranslatesStaticProducerDamageSources_WhenOwnerPatched(string source, string expected)
+    [Test]
+    public void PhysicsProcessTakeDamage_TranslatesStaticProducerDamageSources_WhenOwnerPatched()
     {
-        AssertPhysicsProcessTakeDamageQueuedMessage(source, expected);
+        var cases = new (string Source, string Expected)[]
+        {
+            ("The target takes 4 damage from your pyrokinesis!", "targetはあなたの熱念動で4ダメージを受けた！"),
+            ("The target takes 4 damage from 監視官イラメの cryokinesis!", "targetは監視官イラメの冷気操作で4ダメージを受けた！"),
+            ("The target takes 4 damage from snapjaw's life drain!", "targetはsnapjawの生命吸収で4ダメージを受けた！"),
+            ("The target takes 4 damage from your disintegration!", "targetはあなたの分解で4ダメージを受けた！"),
+            ("The target takes 4 damage from your stunning force!", "targetはあなたの衝撃念力で4ダメージを受けた！"),
+            ("The target takes 4 damage from your freezing weapon!", "targetはあなたの凍てつく武器で4ダメージを受けた！"),
+            ("The target takes 4 damage from your flaming weapon!", "targetはあなたの火炎武器で4ダメージを受けた！"),
+            ("The target takes 4 damage from your damage reflection!", "targetはあなたのダメージ反射で4ダメージを受けた！"),
+            ("The target takes 4 damage from your pummeling!", "targetはあなたの殴打で4ダメージを受けた！"),
+            ("The target takes 4 damage from your shield slam!", "targetはあなたのシールドスラムで4ダメージを受けた！"),
+            ("The target takes 4 damage from your explosion!", "targetはあなたの爆発で4ダメージを受けた！"),
+            ("The target takes 4 damage from your electrical discharge!", "targetはあなたの放電で4ダメージを受けた！"),
+            ("The target takes 4 damage from an electrical discharge!", "targetは放電で4ダメージを受けた！"),
+            ("The target takes 4 damage from your flames!", "targetはあなたの炎で4ダメージを受けた！"),
+            ("The target takes 4 damage from your freeze!", "targetはあなたの凍結で4ダメージを受けた！"),
+            ("The target takes 4 damage from your passage!", "targetはあなたの通過で4ダメージを受けた！"),
+            ("The target takes 4 damage from your digestive enzymes!", "targetはあなたの消化酵素で4ダメージを受けた！"),
+            ("The target takes 4 damage from your tiny spines!", "targetはあなたの小さな棘で4ダメージを受けた！"),
+            ("The target takes 4 damage from your projectile.", "targetはあなたの投射物で4ダメージを受けた。"),
+            ("The target takes 4 damage from your attack.", "targetはあなたの攻撃で4ダメージを受けた。"),
+            ("The target takes 4 damage from your carbide armor!", "targetはあなたのcarbide装甲で4ダメージを受けた！"),
+            ("The target takes 4 damage from your freezing effect armor!", "targetはあなたの凍結効果装甲で4ダメージを受けた！"),
+            ("The target takes 4 damage from your spores!", "targetはあなたの胞子で4ダメージを受けた！"),
+            ("The target takes 4 damage from your thorns.", "targetはあなたの棘で4ダメージを受けた。"),
+            ("The target takes 4 damage from your impalement.", "targetはあなたの串刺しで4ダメージを受けた。"),
+            ("{{r|You take 4 damage from your {{C|freezing effect}}!}}", "{{r|あなたの{{C|凍結効果}}で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from {{G|acid}}!}}", "{{r|{{G|酸}}で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from your {{g|poison}}!}}", "{{r|あなたの{{g|毒}}で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from {{W|plasma}}!}}", "{{r|{{W|プラズマ}}で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from {{y|normality gas}}!}}", "{{r|{{y|正常化ガス}}で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from {{y|defoliant}}!}}", "{{r|{{y|落葉剤}}で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from {{y|fungicide}}!}}", "{{r|{{y|殺真菌剤}}で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from a plume of acid!}}", "{{r|酸の噴煙で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from a {{fiery|jet of flames}}!}}", "{{r|{{fiery|火炎噴流}}で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from the {{icy|cryogenic mist}}.}}", "{{r|{{icy|極低温の霧}}で4ダメージを受けた。}}"),
+            ("{{r|You take 4 damage from your {{Y|scalding steam}}!}}", "{{r|あなたの{{Y|灼熱の蒸気}}で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from 骨灰の {{K|choking ash}}!}}", "{{r|骨灰の{{K|窒息性の灰}}で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from falling rocks! {{R|(x2)}}}}", "{{r|落石で4ダメージを受けた！ {{R|(x2)}}}}"),
+            ("{{r|You take 4 damage from being crushed by a machine press.}}", "{{r|機械プレスに押し潰されたことで4ダメージを受けた。}}"),
+            ("{{r|You take 4 damage from being forced into phase.}}", "{{r|位相に押し込まれたことで4ダメージを受けた。}}"),
+            ("{{r|You take 4 damage from slamming into {{W|two}} walls!}}", "{{r|{{W|2}}枚の壁に叩きつけられたことで4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from an electrical shock delivered by your defibrillator.}}", "{{r|あなたのdefibrillatorからの電気ショックで4ダメージを受けた。}}"),
+            ("{{r|You take 4 damage from an {{electrical|electrical shock}} delivered by your defibrillator.}}", "{{r|あなたのdefibrillatorからの{{electrical|電気ショック}}で4ダメージを受けた。}}"),
+            ("{{r|You take 4 damage from a sharp edge!}}", "{{r|鋭利な刃で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from the device.}}", "{{r|装置で4ダメージを受けた。}}"),
+            ("{{r|You take 4 damage from sitting!}}", "{{r|座ったことで4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from a nosebleed.}}", "{{r|鼻血で4ダメージを受けた。}}"),
+            ("{{r|You take 4 damage from a processor leak.}}", "{{r|プロセッサ漏れで4ダメージを受けた。}}"),
+            ("{{r|You take 4 damage from a hemorrhage.}}", "{{r|出血で4ダメージを受けた。}}"),
+            ("{{r|You take 4 damage from falling rock falling on you.}}", "{{r|falling rockがあなたに落下したことで4ダメージを受けた。}}"),
+            ("{{r|You take 4 damage from its fall.}}", "{{r|その落下で4ダメージを受けた。}}"),
+            ("{{r|You take 4 damage from geomagnetic disc flying into you!}}", "{{r|geomagnetic discがあなたに飛び込んだことで4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from scourging yourself.}}", "{{r|自分を鞭打ったことで4ダメージを受けた。}}"),
+            ("{{r|You take 4 damage from using your body as raw materials.}}", "{{r|あなたの体を原材料にしたことで4ダメージを受けた。}}"),
+            ("{{r|You take 4 damage from the cumulative trauma of your mental assault!}}", "{{r|あなたの精神攻撃による累積外傷で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from the cumulative trauma of a goatfolk's mental assault!}}", "{{r|goatfolkの精神攻撃による累積外傷で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from your failed assault on the structure of spacetime.}}", "{{r|あなたの時空構造への干渉失敗で4ダメージを受けた。}}"),
+            ("{{r|You take 4 damage from the fire you started!}}", "{{r|あなたが起こした火で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from the fire a laser turret started!}}", "{{r|laser turretが起こした火で4ダメージを受けた！}}"),
+            ("The snapjaw takes 4 damage from the fire itself started!", "snapjawは自身が起こした火で4ダメージを受けた！"),
+            ("The target takes 4 damage from the fire started by snapjaw!", "targetはsnapjawが起こした火で4ダメージを受けた！"),
+            ("The snapjaw takes 4 damage from the fire started by itself!", "snapjawは自身が起こした火で4ダメージを受けた！"),
+            ("The target takes 4 damage from the fire started by the snapjaw!", "targetはsnapjawが起こした火で4ダメージを受けた！"),
+            ("{{r|You take 4 damage from {{G|drinking acid}}!}}", "{{r|{{G|酸を飲んだこと}}で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from {{lava|drinking lava}}!}}", "{{r|{{lava|溶岩を飲んだこと}}で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from {{K|drinking asphalt}}!}}", "{{r|{{K|アスファルトを飲んだこと}}で4ダメージを受けた！}}"),
+            ("{{r|You take 4 damage from the {{G|hulk}} {{w|honey}}!}}", "{{r|{{G|ハルク}} {{w|ハニー}}で4ダメージを受けた！}}"),
+        };
+
+        AssertPhysicsProcessTakeDamageQueuedMessages(cases);
     }
 
     [Test]
@@ -11060,6 +11068,44 @@ public sealed class CombatAndLogMessageQueuePatchTests
             target.ProcessTakeDamage(eventObject ?? new DummyGameEvent());
 
             Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(expected));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static void AssertPhysicsProcessTakeDamageQueuedMessages(
+        IReadOnlyList<(string Source, string Expected)> cases)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchQueue(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(
+                    typeof(DummyPhysicsProcessTakeDamageTarget),
+                    nameof(DummyPhysicsProcessTakeDamageTarget.ProcessTakeDamage),
+                    typeof(DummyGameEvent)),
+                typeof(PhysicsProcessTakeDamageTranslationPatch));
+
+            Assert.Multiple(() =>
+            {
+                foreach (var testCase in cases)
+                {
+                    DummyMessageQueue.Reset();
+                    var target = new DummyPhysicsProcessTakeDamageTarget
+                    {
+                        MessageToSend = testCase.Source,
+                    };
+
+                    target.ProcessTakeDamage(new DummyGameEvent());
+
+                    Assert.That(DummyMessageQueue.LastMessage, Is.EqualTo(testCase.Expected), testCase.Source);
+                }
+            });
         }
         finally
         {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudJPModTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudJPModTests.cs
@@ -85,23 +85,19 @@ public sealed class QudJPModTests
     }
 
     [Test]
-    public void InvokePatchAll_ScansCorrectAssembly_AndHandlesErrorsGracefully()
+    public void InvokePatchAll_ScansQudJPModAssembly_WithoutRequiringRealHarmonyPatchApplication()
     {
-        var harmonyId = $"qudjp.tests.patchall.{Guid.NewGuid():N}";
-        var harmony = new Harmony(harmonyId);
+        var harmony = new RecordingHarmonyProcessor();
 
-        try
-        {
-            var output = TestTraceHelper.CaptureTrace(() => Assert.That(() => QudJPMod.InvokePatchAll(harmony), Throws.Nothing));
+        Assert.That(() => QudJPMod.InvokePatchAll(harmony), Throws.Nothing);
 
-            Assert.That(output, Does.Contain("[QudJP]"),
-                "InvokePatchAll should log when patches fail to apply, " +
-                "proving PatchAll(Assembly) scanned the correct assembly");
-        }
-        finally
+        Assert.Multiple(() =>
         {
-            harmony.UnpatchAll(harmonyId);
-        }
+            Assert.That(harmony.RequestedPatchTypes, Does.Contain(typeof(MessageQueueTranslationPatch)));
+            Assert.That(harmony.RequestedPatchTypes, Does.Contain(typeof(PatchAllTestPatch)));
+            Assert.That(harmony.RequestedPatchTypes, Does.Not.Contain(typeof(QudJPModTests)));
+            Assert.That(harmony.PatchCallCount, Is.EqualTo(harmony.RequestedPatchTypes.Count));
+        });
     }
 
     [Test]
@@ -336,6 +332,32 @@ public sealed class QudJPModTests
         private static IEnumerable<MethodBase> TargetMethods()
         {
             throw new InvalidOperationException("multiple targets failed");
+        }
+    }
+
+    internal sealed class RecordingHarmonyProcessor
+    {
+        public List<Type> RequestedPatchTypes { get; } = new();
+
+        public int PatchCallCount { get; private set; }
+
+        public RecordingPatchProcessor CreateClassProcessor(Type patchType)
+        {
+            RequestedPatchTypes.Add(patchType);
+            return new RecordingPatchProcessor(this);
+        }
+
+        internal void RecordPatchCall()
+        {
+            PatchCallCount++;
+        }
+    }
+
+    internal sealed class RecordingPatchProcessor(RecordingHarmonyProcessor owner)
+    {
+        public void Patch()
+        {
+            owner.RecordPatchCall();
         }
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/ReshephHistoryTranslationTests.cs
@@ -44,7 +44,7 @@ public sealed class ReshephHistoryTranslationTests
         return Path.Combine(TestContext.CurrentContext.TestDirectory, "Fixtures", "annals-samples.json");
     }
 
-    public static IEnumerable<TestCaseData> Samples()
+    public static IReadOnlyList<ReshephSampleEntry> Samples()
     {
         var path = GetFixturePath();
         if (!File.Exists(path))
@@ -56,10 +56,7 @@ public sealed class ReshephHistoryTranslationTests
             throw new InvalidDataException($"Failed to deserialize fixture: {path}");
         if (doc.SchemaVersion != ExpectedSchemaVersion)
             throw new InvalidDataException($"Fixture schema_version mismatch: expected '{ExpectedSchemaVersion}', got '{doc.SchemaVersion}' in {path}");
-        foreach (var sample in doc.Samples)
-        {
-            yield return new TestCaseData(sample).SetName($"Resheph_{sample.CandidateId}");
-        }
+        return doc.Samples;
     }
 
     [SetUp]
@@ -83,8 +80,19 @@ public sealed class ReshephHistoryTranslationTests
         LocalizationAssetResolver.SetLocalizationRootForTests(null);
     }
 
-    [TestCaseSource(nameof(Samples))]
-    public void TranslateEventPropertiesDict_ProducesExpectedJapanese(ReshephSampleEntry sample)
+    [Test]
+    public void TranslateEventPropertiesDict_ProducesExpectedJapanese_ForAllSamples()
+    {
+        Assert.Multiple(() =>
+        {
+            foreach (var sample in Samples())
+            {
+                AssertSample(sample);
+            }
+        });
+    }
+
+    private static void AssertSample(ReshephSampleEntry sample)
     {
         var dict = new Dictionary<string, string>(System.StringComparer.Ordinal)
         {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/SultanShrineWrapperTranslatorTests.cs
@@ -78,26 +78,37 @@ public sealed class SultanShrineWrapperTranslatorTests
         });
     }
 
-    [TestCase("Perfect", "完璧")]
-    [TestCase("Fine", "良好")]
-    [TestCase("Lightly Damaged", "軽微な損傷")]
-    [TestCase("Damaged", "損傷")]
-    [TestCase("Badly Damaged", "重度の損傷")]
-    [TestCase("Undamaged", "無傷")]
-    [TestCase("Badly Wounded", "重傷")]
-    [TestCase("Wounded", "負傷")]
-    [TestCase("Injured", "軽傷")]
-    public void Translate_TranslatesAllShippedQualityRatings(string qualityEn, string qualityJa)
+    [Test]
+    public void Translate_TranslatesAllShippedQualityRatings()
     {
-        var source =
-            "The shrine depicts a significant event from the life of the ancient sultan Resheph:"
-            + "\n\nIn 3 AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks."
-            + "\n\n{{Y|" + qualityEn + "}}";
+        (string English, string Japanese)[] qualities =
+        [
+            ("Perfect", "完璧"),
+            ("Fine", "良好"),
+            ("Lightly Damaged", "軽微な損傷"),
+            ("Damaged", "損傷"),
+            ("Badly Damaged", "重度の損傷"),
+            ("Undamaged", "無傷"),
+            ("Badly Wounded", "重傷"),
+            ("Wounded", "負傷"),
+            ("Injured", "軽傷"),
+        ];
 
-        var translated = MessagePatternTranslator.Translate(source, nameof(DescriptionLongDescriptionPatch));
+        Assert.Multiple(() =>
+        {
+            foreach (var quality in qualities)
+            {
+                var source =
+                    "The shrine depicts a significant event from the life of the ancient sultan Resheph:"
+                    + "\n\nIn 3 AR, Resheph cleansed the marshlands of the plagues of the Gyre and taught Abram to sow watervine along its fertile tracks."
+                    + "\n\n{{Y|" + quality.English + "}}";
 
-        Assert.That(translated, Does.EndWith("{{Y|" + qualityJa + "}}"));
-        Assert.That(translated, Does.Not.Contain(qualityEn));
+                var translated = MessagePatternTranslator.Translate(source, nameof(DescriptionLongDescriptionPatch));
+
+                Assert.That(translated, Does.EndWith("{{Y|" + quality.Japanese + "}}"), quality.English);
+                Assert.That(translated, Does.Not.Contain(quality.English), quality.English);
+            }
+        });
     }
 
     [Test]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -442,10 +442,10 @@ L3 検証や "再現するか?" の判断は Caves of Qud のランタイムロ�
 PR を出すと GitHub Actions (`.github/workflows/ci.yml`) が変更ファイルを見て必要なゲートだけを実行します。`.github/workflows/ci.yml` 自体が変わった場合は全ゲートを実行します。
 
 - `Mods/QudJP/Assemblies/` 変更: `.NET SDK 8.0.x + 10.0.x` をインストールし、QudJP / QudJP.Tests を Release build します。build artifact を作成した後、C# テストは `L1` / `L2` / `L2G` の matrix job で並列実行します。L2G は `QudJP.Tests.csproj` の `<Exists('$(AssemblyCSharpPath)')>` 条件付き参照により、CI 環境に `Assembly-CSharp.dll` が存在しないため自動的にスキップされます。
-- `scripts/tools/` または Annals extractor のテスト / fixture 変更: `scripts/tools/**/*.csproj` を列挙し、見つかった tool projects をすべて Release build します。
-- `scripts/` (`scripts/tools/` を除く) / `.codex/hooks/**` / `.codex/hooks.json` / `dotnet-tools.json` / `package.json` / `package-lock.json` / `CHANGELOG.md` / `Mods/QudJP/manifest.json` / `docs/release-notes/` 変更: `npm ci` で Node tool dependencies を復元し、`ruff`、`pytest` をセットアップして `ruff check scripts/` と `pytest scripts/tests/` を実行します。この Python lane は QudJP C# test matrix を待たずに並列実行されます。
+- `scripts/tools/`、`docs/static-producer-inventory.json`、または Roslyn / scan 系 wrapper・テスト・fixture 変更: `scripts/tools/**/*.csproj` を列挙し、見つかった tool projects を shared artifacts cache に Release build したうえで、Roslyn-backed pytest (`test_roslyn_*`, static producer / text construction surface など) を `--durations=20` 付きで実行します。
+- `scripts/` (`scripts/tools/` を除く) / `.codex/hooks/**` / `.codex/hooks.json` / `dotnet-tools.json` / `package.json` / `package-lock.json` / `CHANGELOG.md` / `Mods/QudJP/manifest.json` / `docs/release-notes/` 変更: `npm ci` で Node tool dependencies を復元し、`ruff`、`pytest` をセットアップして Roslyn / scan 系 pytest を除く `pytest scripts/tests/ --durations=30` を実行します。この Python lane は QudJP C# test matrix と Roslyn / scan lane を待たずに並列実行され、ログに遅い pytest case を残します。
 - `Mods/QudJP/Localization/` 変更: release-note fragment requirement、translation-token check、glossary consistency check を実行します。
-- `pyproject.toml` / `uv.lock` 変更: Python tooling 変更として `ruff check scripts/` と `pytest scripts/tests/` を実行します。
+- `pyproject.toml` / `uv.lock` 変更: Python tooling 変更として core Python lane と Roslyn / scan lane の両方を実行します。
 - CI は同一 ref の古い実行を自動キャンセルし、NuGet / pip キャッシュを使います。branch protection 用の `build` job は最後に各 lane の結果を集約する互換チェックです。
 
 **全ジョブがパスしないとマージできません。**

--- a/scripts/dotnet_tool_runner.py
+++ b/scripts/dotnet_tool_runner.py
@@ -63,6 +63,26 @@ def run_cached_tool_project(
 ) -> subprocess.CompletedProcess[str]:
     """Build a repo-local tool in the shared artifacts root and execute its DLL."""
     resolved_project = project_path.resolve()
+    tool_dll = _build_cached_tool_project(resolved_project, configuration=configuration, timeout=timeout)
+    return _run_tool_dll(tool_dll, args, timeout=timeout)
+
+
+def build_tool_project(project_path: Path, *, configuration: str = "Release") -> Path:
+    """Build or reuse a repo-local dotnet tool and return the produced DLL path."""
+    resolved_project = project_path.resolve()
+    return _build_cached_tool_project(
+        resolved_project,
+        configuration=configuration,
+        timeout=BUILD_LOCK_TIMEOUT_SECONDS,
+    )
+
+
+def _build_cached_tool_project(
+    resolved_project: Path,
+    *,
+    configuration: str,
+    timeout: float,
+) -> Path:
     if not resolved_project.is_file():
         msg = f"dotnet tool project is missing: {resolved_project}"
         raise DotnetToolError(msg)
@@ -78,25 +98,8 @@ def run_cached_tool_project(
                 artifacts_root=artifacts_root,
                 timeout=timeout,
             )
-            stamp_path = _tool_sources_stamp_path(tool_dll)
-            try:
-                _ = stamp_path.write_text(_tool_sources_fingerprint(resolved_project), encoding="utf-8")
-            except OSError as exc:
-                msg = f"failed to write dotnet tool source fingerprint stamp: {stamp_path}: {exc}"
-                raise DotnetToolError(msg) from exc
-    return _run_tool_dll(tool_dll, args, timeout=timeout)
-
-
-def build_tool_project(project_path: Path, *, configuration: str = "Release") -> Path:
-    """Build a repo-local dotnet tool and return the produced DLL path."""
-    resolved_project = project_path.resolve()
-    return _build_tool_project(
-        resolved_project,
-        configuration=configuration,
-        artifacts_root=_artifacts_root(),
-        timeout=BUILD_LOCK_TIMEOUT_SECONDS,
-        use_lock=True,
-    )
+            _write_tool_sources_stamp(tool_dll, resolved_project)
+    return tool_dll
 
 
 def _build_tool_project(
@@ -163,6 +166,15 @@ def _cached_tool_is_stale(project_path: Path, tool_dll: Path) -> bool:
 
 def _tool_sources_stamp_path(tool_dll: Path) -> Path:
     return tool_dll.with_name(f"{tool_dll.name}.sources.sha256")
+
+
+def _write_tool_sources_stamp(tool_dll: Path, project_path: Path) -> None:
+    stamp_path = _tool_sources_stamp_path(tool_dll)
+    try:
+        _ = stamp_path.write_text(_tool_sources_fingerprint(project_path), encoding="utf-8")
+    except OSError as exc:
+        msg = f"failed to write dotnet tool source fingerprint stamp: {stamp_path}: {exc}"
+        raise DotnetToolError(msg) from exc
 
 
 def _tool_sources_fingerprint(project_path: Path) -> str:

--- a/scripts/tests/test_ci_workflow_contract.py
+++ b/scripts/tests/test_ci_workflow_contract.py
@@ -34,7 +34,7 @@ def test_ci_keeps_required_build_check_as_aggregator() -> None:
     build_job = _job_block(workflow, "build", None)
 
     assert "Check required jobs" in build_job
-    for job_name in ("qudjp-dotnet-build", "qudjp-dotnet-test", "python"):
+    for job_name in ("qudjp-dotnet-build", "qudjp-dotnet-test", "roslyn-tools", "python"):
         assert f"      - {job_name}" in build_job
         assert f'check_result {job_name} "${{{{ needs.{job_name}.result }}}}"' in build_job
 
@@ -75,13 +75,14 @@ def test_ci_checks_out_repo_for_qudjp_test_matrix() -> None:
 
 
 def test_ci_runs_python_and_dotnet_lanes_as_independent_jobs() -> None:
-    """Python tests should not wait for the QudJP C# test matrix."""
+    """Core Python tests should not wait for QudJP C# or Roslyn scan lanes."""
     workflow = _workflow_text()
     python_job = _job_block(workflow, "python", "localization")
 
     assert "\n  detect-changes:\n" in workflow
     assert "pytest scripts/tests/" in python_job
     assert "qudjp-dotnet-test" not in python_job
+    assert "roslyn-tools" not in python_job
 
 
 def test_ci_python_lane_restores_repo_local_node_tools() -> None:
@@ -96,6 +97,43 @@ def test_ci_python_lane_restores_repo_local_node_tools() -> None:
     assert python_job.index("npm ci") < python_job.index(node_bin_path_step)
     assert python_job.index(node_bin_path_step) < python_job.index("pytest scripts/tests/")
     assert "npm install -g @ast-grep/cli" not in python_job
+
+
+def test_ci_python_lane_reports_slowest_test_durations() -> None:
+    """CI logs should keep enough timing detail to diagnose future pytest slowdowns."""
+    workflow = _workflow_text()
+    python_job = _job_block(workflow, "python", "localization")
+
+    assert "pytest scripts/tests/" in python_job
+    assert "--durations=30" in python_job
+    assert "--ignore=scripts/tests/test_roslyn_extractor_smoke.py" in python_job
+    assert "--ignore=scripts/tests/test_scan_static_producer_inventory.py" in python_job
+
+
+def test_ci_roslyn_lane_runs_scan_backed_pytest_separately() -> None:
+    """Roslyn/scan pytest coverage should run in the Roslyn lane, not the core Python lane."""
+    workflow = _workflow_text()
+    roslyn_job = _job_block(workflow, "roslyn-tools", "python")
+
+    assert "uses: actions/setup-dotnet@v5" in roslyn_job
+    assert "uses: actions/setup-python@v6" in roslyn_job
+    assert "from scripts.dotnet_tool_runner import build_tool_project" in roslyn_job
+    assert "Test Roslyn-backed Python tools" in roslyn_job
+    assert "scripts/tests/test_roslyn_semantic_probe.py" in roslyn_job
+    assert "scripts/tests/test_scan_static_producer_inventory.py" in roslyn_job
+    assert "--durations=20" in roslyn_job
+
+
+def test_ci_roslyn_gate_covers_scan_wrapper_changes() -> None:
+    """Changes to Roslyn-backed Python wrappers and tests should trigger the Roslyn lane."""
+    workflow = _workflow_text()
+
+    assert "matches_roslyn_python_tests" in workflow
+    assert "dotnet_tool_runner" in workflow
+    assert "docs/static-producer-inventory\\.json" in workflow
+    assert "roslyn_semantic_probe" in workflow
+    assert "scan_static_producer_inventory" in workflow
+    assert "test_roslyn_text_construction_inventory" in workflow
 
 
 def test_ci_qudjp_test_matrix_uploads_category_test_results() -> None:

--- a/scripts/tests/test_extract_annals_patterns.py
+++ b/scripts/tests/test_extract_annals_patterns.py
@@ -11,10 +11,10 @@ from typing import Protocol, cast
 
 import pytest
 
+from scripts.dotnet_tool_runner import build_tool_project
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 PROJECT_PATH = _REPO_ROOT / "scripts" / "tools" / "AnnalsPatternExtractor" / "AnnalsPatternExtractor.csproj"
-BUILD_CONFIGURATION = "Release"
-TOOL_DLL = PROJECT_PATH.parent / "bin" / BUILD_CONFIGURATION / "net10.0" / "AnnalsPatternExtractor.dll"
 FIXTURES = Path(__file__).resolve().parent / "fixtures" / "annals"
 
 
@@ -24,19 +24,6 @@ class AnnalsTranslator(Protocol):
     def compute_en_template_hash(self, candidate: dict[str, object]) -> str:
         """Compute the stable template hash for an annals candidate."""
         ...
-
-
-def _tool_sources_are_newer_than(dll_path: Path) -> bool:
-    """Return whether the checked-in tool sources are newer than the built DLL."""
-    if not dll_path.exists():
-        return True
-
-    dll_mtime = dll_path.stat().st_mtime
-    sources = [
-        PROJECT_PATH,
-        *(path for path in PROJECT_PATH.parent.rglob("*.cs") if "bin" not in path.parts and "obj" not in path.parts),
-    ]
-    return any(path.stat().st_mtime > dll_mtime for path in sources)
 
 
 def _has_dotnet_10_sdk() -> bool:
@@ -51,30 +38,10 @@ def _has_dotnet_10_sdk() -> bool:
 
 
 def _ensure_extractor_dll() -> Path:
-    """Use the CI-built extractor when available, otherwise build it once for local tests."""
-    if not _tool_sources_are_newer_than(TOOL_DLL):
-        return TOOL_DLL
-
+    """Build or reuse the extractor through the shared repo-local tool cache."""
     if not _has_dotnet_10_sdk():
         pytest.skip("dotnet 10.0 SDK not available")
-
-    result = subprocess.run(
-        [
-            "dotnet",
-            "build",
-            str(PROJECT_PATH),
-            "--configuration",
-            BUILD_CONFIGURATION,
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert result.returncode == 0, (
-        f"extractor build failed (exit {result.returncode}). stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
-    assert TOOL_DLL.exists(), f"extractor build succeeded but did not produce {TOOL_DLL}"
-    return TOOL_DLL
+    return build_tool_project(PROJECT_PATH)
 
 
 def _run_extractor_batch(output: Path) -> subprocess.CompletedProcess[str]:

--- a/scripts/tests/test_parallel_dotnet_contract.py
+++ b/scripts/tests/test_parallel_dotnet_contract.py
@@ -94,6 +94,15 @@ def test_roslyn_tool_wrappers_use_run_scoped_dotnet_runner() -> None:
     assert "_remove_stale_lock" in helper
 
 
+def test_annals_golden_tests_use_shared_tool_build_cache() -> None:
+    """The Roslyn CI lane should not rebuild Annals fixtures outside the shared cache."""
+    text = _read_repo_file("scripts/tests/test_extract_annals_patterns.py")
+
+    assert "build_tool_project" in text
+    assert 'dotnet", "build"' not in text
+    assert 'PROJECT_PATH.parent / "bin"' not in text
+
+
 def test_text_construction_recipe_runs_prebuilt_tool_dll() -> None:
     """The text construction just recipe should build then execute the DLL directly."""
     justfile = "\n" + _read_repo_file("justfile")
@@ -343,6 +352,33 @@ def test_run_cached_tool_project_skips_build_when_cached_dll_is_fresh(
     result = dotnet_tool_runner.run_cached_tool_project(project_path, ["--cached"], timeout=5)
 
     assert result.stdout == "cached"
+
+
+def test_build_tool_project_skips_build_when_cached_dll_is_fresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Smoke-test fixtures should share the same fingerprinted tool build cache."""
+    project_path = _write_probe_project(tmp_path)
+    artifacts_root = tmp_path / "artifacts"
+    dll = _write_cached_probe_dll(artifacts_root, project_path)
+    monkeypatch.setattr(dotnet_tool_runner, "_dotnet_path", lambda: "dotnet")
+    monkeypatch.setattr(dotnet_tool_runner, "_artifacts_root", lambda: artifacts_root)
+
+    def fail_build(
+        command: list[str],
+        *,
+        timeout: float,
+        artifacts_root: Path,
+        assembly_name: str,
+        use_lock: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        _ = command, timeout, artifacts_root, assembly_name, use_lock
+        pytest.fail("fresh cached build fixture should not invoke dotnet build")
+
+    monkeypatch.setattr(dotnet_tool_runner, "_run_build_command", fail_build)
+
+    assert dotnet_tool_runner.build_tool_project(project_path) == dll
 
 
 def test_run_cached_tool_project_rebuilds_when_source_file_is_deleted(

--- a/scripts/tests/test_roslyn_extractor_smoke.py
+++ b/scripts/tests/test_roslyn_extractor_smoke.py
@@ -34,46 +34,38 @@ def annals_tool_dll() -> Path:
     return build_tool_project(ANNALS_PROJECT_PATH)
 
 
+@pytest.fixture(scope="session")
+def static_producer_tool_dll() -> Path:
+    """Build the static producer scanner once for smoke validation."""
+    if not shutil.which("dotnet"):
+        pytest.skip("dotnet SDK not available")
+    return build_tool_project(STATIC_PRODUCER_PROJECT_PATH)
+
+
+@pytest.fixture(scope="session")
+def semantic_probe_tool_dll() -> Path:
+    """Build the semantic probe once for smoke validation."""
+    if not shutil.which("dotnet"):
+        pytest.skip("dotnet SDK not available")
+    return build_tool_project(SEMANTIC_PROBE_PROJECT_PATH)
+
+
 @pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
-def test_extractor_csproj_builds_in_release() -> None:
+def test_extractor_csproj_builds_in_release(annals_tool_dll: Path) -> None:
     """The Roslyn extractor csproj must build cleanly so the CI step does not rot."""
-    result = subprocess.run(
-        ["dotnet", "build", str(ANNALS_PROJECT_PATH), "--configuration", "Release"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert result.returncode == 0, (
-        f"dotnet build failed (exit {result.returncode}).\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert annals_tool_dll.is_file()
 
 
 @pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
-def test_static_producer_inventory_scanner_csproj_builds_in_release() -> None:
+def test_static_producer_inventory_scanner_csproj_builds_in_release(static_producer_tool_dll: Path) -> None:
     """The Roslyn static producer scanner csproj must build cleanly."""
-    result = subprocess.run(
-        ["dotnet", "build", str(STATIC_PRODUCER_PROJECT_PATH), "--configuration", "Release"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert result.returncode == 0, (
-        f"dotnet build failed (exit {result.returncode}).\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert static_producer_tool_dll.is_file()
 
 
 @pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
-def test_semantic_probe_csproj_builds_in_release() -> None:
+def test_semantic_probe_csproj_builds_in_release(semantic_probe_tool_dll: Path) -> None:
     """The Roslyn semantic probe csproj must build cleanly."""
-    result = subprocess.run(
-        ["dotnet", "build", str(SEMANTIC_PROBE_PROJECT_PATH), "--configuration", "Release"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert result.returncode == 0, (
-        f"dotnet build failed (exit {result.returncode}).\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert semantic_probe_tool_dll.is_file()
 
 
 @pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")


### PR DESCRIPTION
## Summary

- Split Roslyn/scan-backed pytest coverage into the `roslyn-tools` CI lane and keep the core Python lane independent.
- Reuse cached repo-local dotnet tool builds from `build_tool_project()` and remove the Annals golden test's legacy direct build path.
- Batch selected high-volume L2 regression cases so expensive Harmony patch setup is reused without deleting coverage.
- Add workflow/docs/tests for slow pytest duration reporting and Roslyn path-gate coverage, including `docs/static-producer-inventory.json`.

## Timing Notes

Local pytest split after the change:

- Roslyn/scan lane: `182 passed, 1 skipped in 8.48s`
- Core Python lane: `1115 passed in 11.72s` before the final gate fix; full Python remains `1297 passed, 1 skipped in 20.10s`
- C# full local PR gate: `8373` tests, `33s`

Expected CI benefit is primarily wall-clock reduction from running Roslyn/scan pytest separately from core Python pytest, plus less repeated dotnet tool build work through the shared cache.

## Polishment / Review

- Independent review before cleanup: `APPROVE`; non-blocking note identified the Annals direct-build path.
- `ai-slop-cleaner` cleanup: removed duplicate Annals extractor build/stale-DLL logic and added a static contract preventing regression to direct `dotnet build`.
- Independent review after cleanup: `REQUEST_CHANGES`; fixed missing Roslyn lane trigger for `docs/static-producer-inventory.json`.
- Final independent review: `APPROVE`.

## Verification

- `uv run pytest scripts/tests/test_extract_annals_patterns.py scripts/tests/test_parallel_dotnet_contract.py -q --durations=20`
- `ruff check scripts/tests/test_extract_annals_patterns.py scripts/tests/test_parallel_dotnet_contract.py`
- `uv run pytest scripts/tests/test_extract_annals_patterns.py scripts/tests/test_parallel_dotnet_contract.py scripts/tests/test_roslyn_extractor_smoke.py scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_roslyn_text_construction_inventory.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_static_producer_closure.py scripts/tests/test_text_construction_surface_policy.py -q --durations=20`
- `uv run pytest scripts/tests/test_ci_workflow_contract.py scripts/tests/test_parallel_dotnet_contract.py -q --durations=20`
- `ruff check scripts/tests/test_ci_workflow_contract.py scripts/tests/test_parallel_dotnet_contract.py`
- `just pr-check origin/main HEAD`
- `git diff --check`
- `npx secretlint .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CD パイプラインの実行条件と並列化を最適化し、テスト実行を加速化しました。
  * ビルドキャッシング機構を導入し、開発環境とCI環境でのツールビルド効率を向上させました。
  * テストの実装方式を統一し、メンテナンス性を改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/751?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->