### PR TITLE
Release QudJP v0.3.01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.3.01] - 2026-05-22
+
+### Fixed
+
+- metabolized effect や long blade stance など、active effects 画面に残っていた英語表示の日本語カバレッジを改善しました。
+- Charge、Death From Above、Juke、Hook and Drag、Proselytize、Slam、Make Camp、field amputation、Tinkering recharge、repair outcome など、スキル由来の失敗ログ・確認ポップアップ・メッセージ表現を追加で日本語化しました。
+- 生成クエスト、journal text、message frame で日本語化される表示文の範囲を広げました。
+- 料理効果名と食事効果ポップアップで使われる `metabolized` 系の日本語表現を統一しました。
+- 終了確認ポップアップの長押し承認文とセーブせず終了するボタン表示を日本語化しました。
+
+---
+
 ## [0.3.00] - 2026-05-20
 
 ### Changed
@@ -339,7 +351,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.3.00...HEAD
+[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.3.01...HEAD
+[0.3.01]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.01
 [0.3.00]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.00
 [0.2.52]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.52
 [0.2.51]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.51

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.3.00",
+  "Version": "0.3.01",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/release-notes/unreleased/issue-739-active-effects.md
+++ b/docs/release-notes/unreleased/issue-739-active-effects.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Improved active-effects UI coverage for metabolizing effects and long blade stance details.

--- a/docs/release-notes/unreleased/issue-747-skill-journal-history-coverage.md
+++ b/docs/release-notes/unreleased/issue-747-skill-journal-history-coverage.md
@@ -1,4 +1,0 @@
-### Fixed
-
-- Close issue-747 static coverage for generated quest/journal text and skill-originated message-log and popup text.
-- Translate additional source-backed skill failures, prompts, and message frames for Charge, Death From Above, Juke, Hook and Drag, Proselytize, Slam, Make Camp, field amputation, Tinkering recharge, and repair outcomes.

--- a/docs/release-notes/unreleased/metabolized-meal-translation.md
+++ b/docs/release-notes/unreleased/metabolized-meal-translation.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Unified the Japanese wording for meal metabolizing popups and the `metabolized effect` cooking-effect label.

--- a/docs/release-notes/unreleased/qudtest-quit-popup.md
+++ b/docs/release-notes/unreleased/qudtest-quit-popup.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Translate the quit confirmation popup's hold-to-accept and quit-without-saving button labels.


### PR DESCRIPTION
## Summary
- bump QudJP manifest to 0.3.01
- add the 0.3.01 changelog entry
- consume the unreleased release-note fragments included in this release

## Verification
- just changelog-link-check
- just release-note-check main HEAD
- git diff --check
- just build-release
- just release-zip-check dist/QudJP-v0.3.01.zip
- just build-workshop-upload dist/QudJP-v0.3.01.zip /tmp/qudjp-workshop-changenote.txt
- just workshop-upload-preflight dist/QudJP-v0.3.01.zip 0.3.01

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * バージョン 0.3.01 をリリース。
  * 日本語ローカライズの改善内容をCHANGELOGに記録。スキル、生成文、ポップアップ、ログ、終了確認等における日本語化範囲の拡充と表現の統一を実施。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/753?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->