### PR TITLE
Fix release workflow Python tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: Install Python tools
-        run: pip install hypothesis pytest ruff
+        run: pip install hypothesis pytest ruff uv
 
       - name: Install Node tool dependencies
         run: npm ci

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -39,7 +39,7 @@ def test_release_workflow_installs_python_test_tooling() -> None:
     workflow = _workflow_text()
     node_bin_path_step = 'echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"'
 
-    assert "pip install hypothesis pytest ruff" in workflow
+    assert "pip install hypothesis pytest ruff uv" in workflow
     assert "npm ci" in workflow
     assert node_bin_path_step in workflow
     assert "npm install -g @ast-grep/cli" not in workflow


### PR DESCRIPTION
## Summary
- install uv in the tag-triggered Release workflow Python tooling step
- tighten the release workflow contract test so full-suite Python tests keep their external CLI dependencies

## Verification
- uv run pytest scripts/tests/test_release_workflow_contract.py -q
- just python-check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * リリースワークフローのPythonツールインストール手順を更新し、開発環境の一貫性を強化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->