### PR TITLE
Fix inventory color shape prefix chains

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorShapeCaptureObservabilityTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorShapeCaptureObservabilityTests.cs
@@ -1,0 +1,47 @@
+namespace QudJP.Tests.L1;
+
+[TestFixture]
+[Category("L1")]
+[NonParallelizable]
+public sealed class ColorShapeCaptureObservabilityTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        ColorShapeCaptureObservability.ResetForTests();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        ColorShapeCaptureObservability.ResetForTests();
+    }
+
+    [Test]
+    public void Record_EmitsStructuredColorShapeArtifact()
+    {
+        var output = TestTraceHelper.CaptureTrace(() =>
+            ColorShapeCaptureObservability.Record(
+                "InventoryLineTranslationPatch > field=text",
+                "InventoryLine.GameObjectDisplayName",
+                "{{c|chem cell}} {{y|[{{g|fresh water}}]}}",
+                "{{c|ケムセル}} {{y|[{{g|清水}}]}}"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(output, Does.Contain("ColorShapeProbe/v1"));
+            Assert.That(output, Does.Contain("route='InventoryLineTranslationPatch'"));
+            Assert.That(output, Does.Contain("producer='InventoryLine.GameObjectDisplayName'"));
+            Assert.That(output, Does.Contain("source_visible='chem cell [fresh water]'"));
+            Assert.That(output, Does.Contain("final_visible='ケムセル [清水]'"));
+            Assert.That(output, Does.Contain("; source_color_spans=0:{{c|"));
+            Assert.That(output, Does.Contain("; final_color_spans=0:{{c|"));
+            Assert.That(output, Does.Contain("; markup_semantic_status=clean;"));
+            Assert.That(
+                ColorShapeCaptureObservability.GetRouteProducerHitCountForTests(
+                    "InventoryLineTranslationPatch",
+                    "InventoryLine.GameObjectDisplayName"),
+                Is.EqualTo(1));
+        });
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -99,6 +99,8 @@ public sealed class ColorTagAllowlistCoverageTests
         new(StringComparer.Ordinal)
         {
             // Keys identify the ColorAwareTranslationComposer.Strip call site, not the containing method declaration.
+            ["Mods/QudJP/Assemblies/src/Observability/ColorShapeCaptureObservability.cs:116:Capture"] = "Audited Strip call: observation-only shape capture, color ownership is not modified.",
+            ["Mods/QudJP/Assemblies/src/Observability/ColorShapeCaptureObservability.cs:117:Capture"] = "Audited Strip call: observation-only shape capture, color ownership is not modified.",
             ["Mods/QudJP/Assemblies/src/Observability/FinalOutputObservability.cs:109:RecordDirectMarker"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs:264:HasColorMarkup"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/ActionManagerRunSegmentTranslationPatch.cs:113:TryTranslatePopupMessage"] = "Audited Strip call: popup target colors are restored through the local MarkupAwareRestoreCapture helper.",
@@ -158,7 +160,8 @@ public sealed class ColorTagAllowlistCoverageTests
             ["Mods/QudJP/Assemblies/src/Patches/GameObjectStatPopupTranslationPatch.cs:111:TryTranslatePopupMessage"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/GeneratedQueueDoesVerbTranslationPatch.cs:145:TryTranslateQueuedMessage"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/GeneratedSubjectQueueTranslationPatch.cs:144:TryTranslateQueuedMessage"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
-            ["Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs:1267:TranslateDisplayNameWithClause"] = "Audited Strip call: with-clause colors are restored by source-markup-aware clause helpers after dictionary lookup.",
+            ["Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs:190:TranslatePreservingColors"] = "Audited Strip call: display-name route colors are restored by route-specific suffix/fragment branches or preserved by source-markup-aware helpers.",
+            ["Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs:1506:TranslateDisplayNameWithClause"] = "Audited Strip call: with-clause colors are restored by source-markup-aware clause helpers after dictionary lookup.",
             ["Mods/QudJP/Assemblies/src/Patches/HiddenRenderTranslationPatch.cs:95:TryTranslateRevealMessage"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/IExamineEventProcessIdentifyTranslationPatch.cs:85:TryTranslatePopupMessage"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/ITeleporterTranslationPatch.cs:131:TryTranslatePopupMessage"] = "Audited Strip call: generated subject/plane colors are restored through the local MarkupAwareRestoreCapture helper.",

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -99,8 +99,8 @@ public sealed class ColorTagAllowlistCoverageTests
         new(StringComparer.Ordinal)
         {
             // Keys identify the ColorAwareTranslationComposer.Strip call site, not the containing method declaration.
-            ["Mods/QudJP/Assemblies/src/Observability/ColorShapeCaptureObservability.cs:116:Capture"] = "Audited Strip call: observation-only shape capture, color ownership is not modified.",
-            ["Mods/QudJP/Assemblies/src/Observability/ColorShapeCaptureObservability.cs:117:Capture"] = "Audited Strip call: observation-only shape capture, color ownership is not modified.",
+            ["Mods/QudJP/Assemblies/src/Observability/ColorShapeCaptureObservability.cs:144:Capture"] = "Audited Strip call: observation-only shape capture, color ownership is not modified.",
+            ["Mods/QudJP/Assemblies/src/Observability/ColorShapeCaptureObservability.cs:145:Capture"] = "Audited Strip call: observation-only shape capture, color ownership is not modified.",
             ["Mods/QudJP/Assemblies/src/Observability/FinalOutputObservability.cs:109:RecordDirectMarker"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/AbilityBarAfterRenderTranslationPatch.cs:264:HasColorMarkup"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/ActionManagerRunSegmentTranslationPatch.cs:113:TryTranslatePopupMessage"] = "Audited Strip call: popup target colors are restored through the local MarkupAwareRestoreCapture helper.",
@@ -161,7 +161,7 @@ public sealed class ColorTagAllowlistCoverageTests
             ["Mods/QudJP/Assemblies/src/Patches/GeneratedQueueDoesVerbTranslationPatch.cs:145:TryTranslateQueuedMessage"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/GeneratedSubjectQueueTranslationPatch.cs:144:TryTranslateQueuedMessage"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs:190:TranslatePreservingColors"] = "Audited Strip call: display-name route colors are restored by route-specific suffix/fragment branches or preserved by source-markup-aware helpers.",
-            ["Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs:1506:TranslateDisplayNameWithClause"] = "Audited Strip call: with-clause colors are restored by source-markup-aware clause helpers after dictionary lookup.",
+            ["Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs:1554:TranslateDisplayNameWithClause"] = "Audited Strip call: with-clause colors are restored by source-markup-aware clause helpers after dictionary lookup.",
             ["Mods/QudJP/Assemblies/src/Patches/HiddenRenderTranslationPatch.cs:95:TryTranslateRevealMessage"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/IExamineEventProcessIdentifyTranslationPatch.cs:85:TryTranslatePopupMessage"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/ITeleporterTranslationPatch.cs:131:TryTranslatePopupMessage"] = "Audited Strip call: generated subject/plane colors are restored through the local MarkupAwareRestoreCapture helper.",

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs
@@ -977,6 +977,43 @@ public sealed class GetDisplayNameRouteTranslatorTests
     }
 
     [Test]
+    public void TranslatePreservingColors_PreservesUnknownModifierInProducerDerivedPrefixChain()
+    {
+        WriteContextDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("{{B|wet}}", "GetDisplayName.Adjective", "{{B|接頭辞wet}}"),
+            ("{{Y|masterwork}}", "GetDisplayName.Adjective", "{{Y|接頭辞masterwork}}"),
+            ("[empty]", "GetDisplayName.Adjective", "[空]"),
+            ("steel long sword", null, "鋼のロングソード"));
+
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            "{{B|wet}} {{unmapped|slick}} {{Y|masterwork}} steel long sword [empty]",
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(
+            translated,
+            Is.EqualTo("{{B|接頭辞wet}} {{unmapped|slick}} {{Y|接頭辞masterwork}} 鋼のロングソード [空]"));
+    }
+
+    [Test]
+    public void TranslatePreservingColors_PreservesDirectMarkerSegmentInProducerDerivedPrefixChain()
+    {
+        WriteContextDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("{{B|wet}}", "GetDisplayName.Adjective", "{{B|接頭辞wet}}"),
+            ("[empty]", "GetDisplayName.Adjective", "[空]"),
+            ("steel long sword", null, "鋼のロングソード"));
+        var source = MessageFrameTranslator.DirectTranslationMarker
+            + "{{B|wet}} steel long sword [empty]";
+
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            source,
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(translated, Is.EqualTo(source));
+    }
+
+    [Test]
     public void TranslatePreservingColors_UsesDisplayNameAdjectiveContextForBracketedMarkupWeaponModifiers()
     {
         WriteContextDictionaryFile(

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs
@@ -948,6 +948,35 @@ public sealed class GetDisplayNameRouteTranslatorTests
     }
 
     [Test]
+    public void TranslatePreservingColors_PreservesSeparatorsAcrossProducerDerivedLongPrefixChains()
+    {
+        WriteContextDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("{{B|wet}}", "GetDisplayName.Adjective", "{{B|接頭辞wet}}"),
+            ("{{slimy|slimy}}", "GetDisplayName.Adjective", "{{slimy|接頭辞slimy}}"),
+            ("{{r|bloody}}", "GetDisplayName.Adjective", "{{r|接頭辞bloody}}"),
+            ("{{Y|masterwork}}", "GetDisplayName.Adjective", "{{Y|接頭辞masterwork}}"),
+            ("scoped", "GetDisplayName.Adjective", "接頭辞scoped"),
+            ("{{electrical|electrified}}", "GetDisplayName.Adjective", "{{electrical|接頭辞electrified}}"),
+            ("{{fiery|flaming}}", "GetDisplayName.Adjective", "{{fiery|接頭辞flaming}}"),
+            ("{{freezing|freezing}}", "GetDisplayName.Adjective", "{{freezing|接頭辞freezing}}"),
+            ("{{freezing|frozen}}", "GetDisplayName.Adjective", "{{freezing|接頭辞frozen}}"),
+            ("{{painted|painted}}", "GetDisplayName.Adjective", "{{painted|接頭辞painted}}"),
+            ("{{lacquered|lacquered}}", "GetDisplayName.Adjective", "{{lacquered|接頭辞lacquered}}"),
+            ("{{phase-harmonic|phase-harmonic}}", "GetDisplayName.Adjective", "{{phase-harmonic|接頭辞phase-harmonic}}"),
+            ("[empty]", "GetDisplayName.Adjective", "[空]"),
+            ("steel long sword", null, "鋼のロングソード"));
+
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            "{{B|wet}} {{slimy|slimy}} {{r|bloody}} {{Y|masterwork}} scoped {{electrical|electrified}} {{fiery|flaming}} {{freezing|freezing}} {{freezing|frozen}} {{painted|painted}} {{lacquered|lacquered}} {{phase-harmonic|phase-harmonic}} steel long sword \u001a8 \u00031d6 [empty]",
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(
+            translated,
+            Is.EqualTo("{{B|接頭辞wet}} {{slimy|接頭辞slimy}} {{r|接頭辞bloody}} {{Y|接頭辞masterwork}} 接頭辞scoped {{electrical|接頭辞electrified}} {{fiery|接頭辞flaming}} {{freezing|接頭辞freezing}} {{freezing|接頭辞frozen}} {{painted|接頭辞painted}} {{lacquered|接頭辞lacquered}} {{phase-harmonic|接頭辞phase-harmonic}} 鋼のロングソード {{c|\u001a}}8 {{r|\u0003}}1d6 [空]"));
+    }
+
+    [Test]
     public void TranslatePreservingColors_UsesDisplayNameAdjectiveContextForBracketedMarkupWeaponModifiers()
     {
         WriteContextDictionaryFile(
@@ -963,6 +992,21 @@ public sealed class GetDisplayNameRouteTranslatorTests
             nameof(GetDisplayNamePatch));
 
         Assert.That(translated, Is.EqualTo("[{{Y|接頭辞masterwork}}] 鋼のロングソード"));
+    }
+
+    [Test]
+    public void TranslatePreservingColors_TranslatesProducerDerivedBracketedPrefixModifiers()
+    {
+        WriteContextDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("[illuminated]", "GetDisplayName.Adjective", "[{{illuminated|接頭辞illuminated}}]"),
+            ("steel long sword", null, "鋼のロングソード"));
+
+        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
+            "[{{illuminated|illuminated}}] steel long sword",
+            nameof(GetDisplayNamePatch));
+
+        Assert.That(translated, Is.EqualTo("[{{illuminated|接頭辞illuminated}}] 鋼のロングソード"));
     }
 
     [Test]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/QudTestRuntimeHarnessTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/QudTestRuntimeHarnessTests.cs
@@ -145,6 +145,7 @@ public sealed class QudTestRuntimeHarnessTests
     [TestCase("bottom-context-item", "{{y|{{W|[space]}} Continue}}", "{{W|[Space]}} {{y|続ける}}")]
     [TestCase("game-summary-menu-literal", "Save Tombstone File", "墓碑ファイルを保存")]
     [TestCase("game-summary-menu-literal", "Exit", "終了")]
+    [TestCase("inventory-display-name", "{{c|copper nugget}} {{y|[empty]}}", "{{c|銅塊}} {{y|[空]}}")]
     public void ExecuteRoute_ProducesFinalRuntimeText(string route, string source, string expected)
     {
         Assert.That(QudTestRouteExecutor.Execute(route, source), Is.EqualTo(expected));
@@ -183,6 +184,35 @@ public sealed class QudTestRuntimeHarnessTests
                 "start-replace.slip-ink",
                 "message-log.direct-marker",
             }));
+        });
+    }
+
+    [Test]
+    public void Run_RecordsColorShapeArtifactForInventoryDisplayName()
+    {
+        WriteFixture(
+            "runtime-smoke.json",
+            suite: "runtime",
+            """
+            {"id":"inventory-display-name.game-object-colored-state","route":"inventory-display-name","input":"{{c|copper nugget}} {{y|[empty]}}","expected":"{{c|銅塊}} {{y|[空]}}"}
+            """);
+
+        var result = QudTestRunner.Run("qudtest:runtime", fixturesDirectory, "ja");
+        var colorShape = result.Cases[0].ColorShape;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Passed, Is.True);
+            Assert.That(colorShape, Is.Not.Null);
+            Assert.That(colorShape!.Route, Is.EqualTo(nameof(InventoryLineTranslationPatch)));
+            Assert.That(colorShape.Producer, Is.EqualTo("QudTest.InventoryDisplayNameFixture"));
+            Assert.That(colorShape.Source, Is.EqualTo("{{c|copper nugget}} {{y|[empty]}}"));
+            Assert.That(colorShape.SourceVisible, Is.EqualTo("copper nugget [empty]"));
+            Assert.That(colorShape.Final, Is.EqualTo("{{c|銅塊}} {{y|[空]}}"));
+            Assert.That(colorShape.FinalVisible, Is.EqualTo("銅塊 [空]"));
+            Assert.That(colorShape.SourceColorSpans, Does.Contain("0:{{c|"));
+            Assert.That(colorShape.FinalColorSpans, Does.Contain("0:{{c|"));
+            Assert.That(colorShape.MarkupSemanticStatus, Is.EqualTo("clean"));
         });
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryLineTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryLineTranslationPatchTests.cs
@@ -21,6 +21,7 @@ public sealed partial class Issue201StatusScreensBatch2Tests
 
         Translator.ResetForTests();
         Translator.SetDictionaryDirectoryForTests(tempDirectory);
+        ColorShapeCaptureObservability.ResetForTests();
         DynamicTextObservability.ResetForTests();
         SinkObservation.ResetForTests();
     }
@@ -29,6 +30,7 @@ public sealed partial class Issue201StatusScreensBatch2Tests
     public void TearDown()
     {
         Translator.ResetForTests();
+        ColorShapeCaptureObservability.ResetForTests();
         DynamicTextObservability.ResetForTests();
         SinkObservation.ResetForTests();
 
@@ -231,6 +233,59 @@ public sealed partial class Issue201StatusScreensBatch2Tests
             Assert.That(
                 itemTarget.text.Text,
                 Is.EqualTo("クローム・リボルバー {{c|\u001a}}7 {{r|\u0003}}1d6 {{y|[鉛スラッグ x6]}} [{{r|錆びた}}] [{{r|破損}}] {{y|<{{|{{B|C}}{{B|C}}{{g|2}}}}>}}"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void InventoryLinePostfix_EmitsColorShapeCaptureArtifact_ForProducerDisplayName()
+    {
+        WriteDictionary(
+            ("items", "個"));
+        WriteDictionaryFile(
+            "ui-displayname-atomic.ja.json",
+            ("chem cell", "ケムセル"));
+        WriteDictionaryFile(
+            "ui-displayname-adjectives.ja.json",
+            ("[fresh water]", "[清水]"));
+
+        const string source = "{{c|chem cell}} {{y|[{{g|fresh water}}]}}";
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyInventoryLineTarget), nameof(DummyInventoryLineTarget.setData)),
+                postfix: new HarmonyMethod(RequireMethod(typeof(InventoryLineTranslationPatch), nameof(InventoryLineTranslationPatch.Postfix))));
+
+            var itemTarget = new DummyInventoryLineTarget();
+            var output = TestTraceHelper.CaptureTrace(() =>
+                itemTarget.setData(new DummyInventoryLineDataTarget
+                {
+                    category = false,
+                    go = new DummyStatusGameObject { DisplayName = source, Weight = 7 },
+                }));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(itemTarget.OriginalExecuted, Is.True);
+                Assert.That(itemTarget.text.Text, Is.EqualTo("{{c|ケムセル}} {{y|[清水]}}"));
+                Assert.That(output, Does.Contain("ColorShapeProbe/v1"));
+                Assert.That(output, Does.Contain("producer='InventoryLine.GameObjectDisplayName'"));
+                Assert.That(output, Does.Contain("source_visible='chem cell [fresh water]'"));
+                Assert.That(output, Does.Contain("final_visible='ケムセル [清水]'"));
+                Assert.That(itemTarget.text.Text, Does.Not.Contain("{{c|{{c|"));
+                Assert.That(itemTarget.text.Text, Does.Not.Contain("[{{g|清水]}}"));
+                Assert.That(
+                    ColorShapeCaptureObservability.GetRouteProducerHitCountForTests(
+                        nameof(InventoryLineTranslationPatch),
+                        "InventoryLine.GameObjectDisplayName"),
+                    Is.EqualTo(1));
+            });
         }
         finally
         {

--- a/Mods/QudJP/Assemblies/src/Observability/ColorShapeCaptureObservability.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/ColorShapeCaptureObservability.cs
@@ -8,29 +8,57 @@ namespace QudJP;
 
 internal sealed class ColorShapeCapture
 {
-    internal string Route { get; init; } = string.Empty;
+    internal ColorShapeCapture(
+        string route,
+        string producer,
+        string sourceText,
+        string sourceVisibleText,
+        string finalText,
+        string finalVisibleText,
+        string sourceColorSpans,
+        string finalColorSpans,
+        string sourceVisibleSha256,
+        string finalVisibleSha256,
+        string markupSemanticStatus,
+        string markupSemanticFlags)
+    {
+        Route = route;
+        Producer = producer;
+        SourceText = sourceText;
+        SourceVisibleText = sourceVisibleText;
+        FinalText = finalText;
+        FinalVisibleText = finalVisibleText;
+        SourceColorSpans = sourceColorSpans;
+        FinalColorSpans = finalColorSpans;
+        SourceVisibleSha256 = sourceVisibleSha256;
+        FinalVisibleSha256 = finalVisibleSha256;
+        MarkupSemanticStatus = markupSemanticStatus;
+        MarkupSemanticFlags = markupSemanticFlags;
+    }
 
-    internal string Producer { get; init; } = string.Empty;
+    internal string Route { get; }
 
-    internal string SourceText { get; init; } = string.Empty;
+    internal string Producer { get; }
 
-    internal string SourceVisibleText { get; init; } = string.Empty;
+    internal string SourceText { get; }
 
-    internal string FinalText { get; init; } = string.Empty;
+    internal string SourceVisibleText { get; }
 
-    internal string FinalVisibleText { get; init; } = string.Empty;
+    internal string FinalText { get; }
 
-    internal string SourceColorSpans { get; init; } = string.Empty;
+    internal string FinalVisibleText { get; }
 
-    internal string FinalColorSpans { get; init; } = string.Empty;
+    internal string SourceColorSpans { get; }
 
-    internal string SourceVisibleSha256 { get; init; } = string.Empty;
+    internal string FinalColorSpans { get; }
 
-    internal string FinalVisibleSha256 { get; init; } = string.Empty;
+    internal string SourceVisibleSha256 { get; }
 
-    internal string MarkupSemanticStatus { get; init; } = string.Empty;
+    internal string FinalVisibleSha256 { get; }
 
-    internal string MarkupSemanticFlags { get; init; } = string.Empty;
+    internal string MarkupSemanticStatus { get; }
+
+    internal string MarkupSemanticFlags { get; }
 }
 
 internal static class ColorShapeCaptureObservability
@@ -117,21 +145,19 @@ internal static class ColorShapeCaptureObservability
         var (finalVisible, finalSpans) = ColorAwareTranslationComposer.Strip(finalValue);
         var semanticDiagnostics = MarkupSemanticDiagnostics.Analyze(finalValue);
 
-        return new ColorShapeCapture
-        {
-            Route = normalizedRoute,
-            Producer = normalizedProducer,
-            SourceText = sourceValue,
-            SourceVisibleText = sourceVisible,
-            FinalText = finalValue,
-            FinalVisibleText = finalVisible,
-            SourceColorSpans = BuildSpanSignature(sourceSpans),
-            FinalColorSpans = BuildSpanSignature(finalSpans),
-            SourceVisibleSha256 = ObservabilityHelpers.ComputeSha256Hex(sourceVisible),
-            FinalVisibleSha256 = ObservabilityHelpers.ComputeSha256Hex(finalVisible),
-            MarkupSemanticStatus = semanticDiagnostics.Status,
-            MarkupSemanticFlags = semanticDiagnostics.Flags,
-        };
+        return new ColorShapeCapture(
+            normalizedRoute,
+            normalizedProducer,
+            sourceValue,
+            sourceVisible,
+            finalValue,
+            finalVisible,
+            BuildSpanSignature(sourceSpans),
+            BuildSpanSignature(finalSpans),
+            ObservabilityHelpers.ComputeSha256Hex(sourceVisible),
+            ObservabilityHelpers.ComputeSha256Hex(finalVisible),
+            semanticDiagnostics.Status,
+            semanticDiagnostics.Flags);
     }
 
     private static string BuildCounterKey(string route, string producer)

--- a/Mods/QudJP/Assemblies/src/Observability/ColorShapeCaptureObservability.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/ColorShapeCaptureObservability.cs
@@ -128,8 +128,8 @@ internal static class ColorShapeCaptureObservability
                 + "; final_color_spans=" + ObservabilityHelpers.EscapeStructuredValue(capture.FinalColorSpans)
                 + "; source_visible_sha256=" + capture.SourceVisibleSha256
                 + "; final_visible_sha256=" + capture.FinalVisibleSha256
-                + "; markup_semantic_status=" + capture.MarkupSemanticStatus
-                + "; markup_semantic_flags=" + capture.MarkupSemanticFlags;
+                + "; markup_semantic_status=" + ObservabilityHelpers.EscapeStructuredValue(capture.MarkupSemanticStatus)
+                + "; markup_semantic_flags=" + ObservabilityHelpers.EscapeStructuredValue(capture.MarkupSemanticFlags);
         });
     }
 

--- a/Mods/QudJP/Assemblies/src/Observability/ColorShapeCaptureObservability.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/ColorShapeCaptureObservability.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace QudJP;
+
+internal sealed class ColorShapeCapture
+{
+    internal string Route { get; init; } = string.Empty;
+
+    internal string Producer { get; init; } = string.Empty;
+
+    internal string SourceText { get; init; } = string.Empty;
+
+    internal string SourceVisibleText { get; init; } = string.Empty;
+
+    internal string FinalText { get; init; } = string.Empty;
+
+    internal string FinalVisibleText { get; init; } = string.Empty;
+
+    internal string SourceColorSpans { get; init; } = string.Empty;
+
+    internal string FinalColorSpans { get; init; } = string.Empty;
+
+    internal string SourceVisibleSha256 { get; init; } = string.Empty;
+
+    internal string FinalVisibleSha256 { get; init; } = string.Empty;
+
+    internal string MarkupSemanticStatus { get; init; } = string.Empty;
+
+    internal string MarkupSemanticFlags { get; init; } = string.Empty;
+}
+
+internal static class ColorShapeCaptureObservability
+{
+    private const string ProbeVersion = "v1";
+    private const int MaxRouteProducers = 2048;
+    private const int MaxValueLength = 200;
+    private const string OverflowKey = "__overflow__";
+
+    private static readonly ConcurrentDictionary<string, int> RouteProducerCounts =
+        new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
+
+    internal static void ResetForTests()
+    {
+        RouteProducerCounts.Clear();
+    }
+
+    internal static int GetRouteProducerHitCountForTests(string route, string producer)
+    {
+        return ObservabilityHelpers.GetCounterValue(RouteProducerCounts, BuildCounterKey(route, producer));
+    }
+
+    internal static void Record(string? route, string producer, string? source, string? final)
+    {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            return;
+        }
+
+        var sourceValue = source ?? string.Empty;
+        var finalValue = final ?? string.Empty;
+        var normalizedRoute = ObservabilityHelpers.ExtractPrimaryContext(route);
+        var structuredRoute = route ?? ObservabilityHelpers.NoContextLabel;
+        var normalizedProducer = string.IsNullOrWhiteSpace(producer)
+            ? ObservabilityHelpers.NoContextLabel
+            : producer.Trim();
+
+        var counterKey = BuildCounterKey(normalizedRoute, normalizedProducer);
+        var hitCount = AddOrUpdateCapped(RouteProducerCounts, counterKey, MaxRouteProducers);
+        if (!ObservabilityHelpers.ShouldLogMissingHit(hitCount))
+        {
+            return;
+        }
+
+        RuntimeDiagnostics.LogVerboseProbe(() =>
+        {
+            var capture = Capture(normalizedRoute, normalizedProducer, sourceValue, finalValue);
+
+            return "[QudJP] ColorShapeProbe/" + ProbeVersion
+                + ": route='" + SanitizeQuotedValue(capture.Route)
+                + "' producer='" + SanitizeQuotedValue(capture.Producer)
+                + "' hit=" + hitCount.ToString(CultureInfo.InvariantCulture)
+                + " source='" + SanitizeQuotedValue(capture.SourceText)
+                + "' source_visible='" + SanitizeQuotedValue(capture.SourceVisibleText)
+                + "' final='" + SanitizeQuotedValue(capture.FinalText)
+                + "' final_visible='" + SanitizeQuotedValue(capture.FinalVisibleText) + "'"
+                + ObservabilityHelpers.BuildHelperStructuredSuffix(
+                    structuredRoute,
+                    capture.Producer,
+                    capture.SourceText)
+                + "; producer=" + ObservabilityHelpers.EscapeStructuredValue(capture.Producer)
+                + "; source_text_sample=" + EscapeStructuredSample(capture.SourceText)
+                + "; source_visible_text_sample=" + EscapeStructuredSample(capture.SourceVisibleText)
+                + "; final_text_sample=" + EscapeStructuredSample(capture.FinalText)
+                + "; final_visible_text_sample=" + EscapeStructuredSample(capture.FinalVisibleText)
+                + "; source_color_spans=" + ObservabilityHelpers.EscapeStructuredValue(capture.SourceColorSpans)
+                + "; final_color_spans=" + ObservabilityHelpers.EscapeStructuredValue(capture.FinalColorSpans)
+                + "; source_visible_sha256=" + capture.SourceVisibleSha256
+                + "; final_visible_sha256=" + capture.FinalVisibleSha256
+                + "; markup_semantic_status=" + capture.MarkupSemanticStatus
+                + "; markup_semantic_flags=" + capture.MarkupSemanticFlags;
+        });
+    }
+
+    internal static ColorShapeCapture Capture(string? route, string producer, string? source, string? final)
+    {
+        var sourceValue = source ?? string.Empty;
+        var finalValue = final ?? string.Empty;
+        var normalizedRoute = ObservabilityHelpers.ExtractPrimaryContext(route);
+        var normalizedProducer = string.IsNullOrWhiteSpace(producer)
+            ? ObservabilityHelpers.NoContextLabel
+            : producer.Trim();
+        var (sourceVisible, sourceSpans) = ColorAwareTranslationComposer.Strip(sourceValue);
+        var (finalVisible, finalSpans) = ColorAwareTranslationComposer.Strip(finalValue);
+        var semanticDiagnostics = MarkupSemanticDiagnostics.Analyze(finalValue);
+
+        return new ColorShapeCapture
+        {
+            Route = normalizedRoute,
+            Producer = normalizedProducer,
+            SourceText = sourceValue,
+            SourceVisibleText = sourceVisible,
+            FinalText = finalValue,
+            FinalVisibleText = finalVisible,
+            SourceColorSpans = BuildSpanSignature(sourceSpans),
+            FinalColorSpans = BuildSpanSignature(finalSpans),
+            SourceVisibleSha256 = ObservabilityHelpers.ComputeSha256Hex(sourceVisible),
+            FinalVisibleSha256 = ObservabilityHelpers.ComputeSha256Hex(finalVisible),
+            MarkupSemanticStatus = semanticDiagnostics.Status,
+            MarkupSemanticFlags = semanticDiagnostics.Flags,
+        };
+    }
+
+    private static string BuildCounterKey(string route, string producer)
+    {
+        return route + ObservabilityHelpers.ContextSeparator + producer;
+    }
+
+    private static int AddOrUpdateCapped(ConcurrentDictionary<string, int> counters, string key, int maxKeys)
+    {
+        if (counters.ContainsKey(key) || counters.Count < maxKeys)
+        {
+            return counters.AddOrUpdate(key, 1, ObservabilityHelpers.IncrementCounter);
+        }
+
+        return counters.AddOrUpdate(OverflowKey, 1, ObservabilityHelpers.IncrementCounter);
+    }
+
+    private static string BuildSpanSignature(IReadOnlyList<ColorSpan> spans)
+    {
+        if (spans.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        for (var index = 0; index < spans.Count; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append('|');
+            }
+
+            var span = spans[index];
+            builder.Append(span.Index.ToString(CultureInfo.InvariantCulture));
+            builder.Append(':');
+            builder.Append(span.Token);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string SanitizeQuotedValue(string value)
+    {
+        return ObservabilityHelpers.SanitizeForLog(value, MaxValueLength).Replace("'", "\\'");
+    }
+
+    private static string EscapeStructuredSample(string value)
+    {
+        return ObservabilityHelpers.EscapeStructuredValue(ObservabilityHelpers.SanitizeForLog(value, MaxValueLength));
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs
@@ -210,6 +210,12 @@ internal static class GetDisplayNameRouteTranslator
             return zeroWidthPrefixTranslation;
         }
 
+        if ((source![0] == '{' || source[0] == '[')
+            && TryTranslateLeadingModifierChain(source, route, out var modifierChainTranslation))
+        {
+            return modifierChainTranslation;
+        }
+
         if (TryTranslateLeadingMarkupWrappedModifier(source!, route, out var markupLeadingTranslation))
         {
             return markupLeadingTranslation;
@@ -469,6 +475,12 @@ internal static class GetDisplayNameRouteTranslator
         if (TryTranslateGeneratedCanvasTentName(transformed, route, out var canvasTentTranslated))
         {
             translated = canvasTentTranslated;
+            return true;
+        }
+
+        if (TryTranslateLeadingModifierChain(transformed, route, out var modifierChainTranslated))
+        {
+            translated = modifierChainTranslated;
             return true;
         }
 
@@ -957,6 +969,233 @@ internal static class GetDisplayNameRouteTranslator
         translated = translatedModifier + GetModifierRestSeparator(modifier, restSource) + rest;
         DynamicTextObservability.RecordTransform(route, "DisplayName.MarkupLeadingModifier", source, translated);
         return true;
+    }
+
+    private static bool TryTranslateLeadingModifierChain(string source, string route, out string translated)
+    {
+        translated = source;
+        var translatedModifiers = new List<string>();
+        var sourceModifiers = new List<string>();
+        var position = 0;
+
+        while (TryReadLeadingModifierToken(source, position, out var modifier, out var restStart))
+        {
+            var translatedModifier = TranslateDisplayNameModifierForChain(modifier);
+            if (translatedModifier is null)
+            {
+                break;
+            }
+
+            translatedModifiers.Add(translatedModifier);
+            sourceModifiers.Add(modifier);
+            position = restStart;
+
+            if (position >= source.Length)
+            {
+                break;
+            }
+        }
+
+        if (translatedModifiers.Count == 0 || position >= source.Length)
+        {
+            return false;
+        }
+
+        if (translatedModifiers.Count == 1 && source[0] != '{' && source[0] != '[')
+        {
+            return false;
+        }
+
+        var restSource = source.Substring(position);
+        var rest = TranslatePreservingColors(restSource, route);
+        var builder = new StringBuilder();
+        for (var index = 0; index < translatedModifiers.Count; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(' ');
+            }
+
+            builder.Append(translatedModifiers[index]);
+        }
+
+        builder.Append(GetModifierRestSeparator(sourceModifiers[sourceModifiers.Count - 1], restSource));
+        builder.Append(rest);
+        translated = builder.ToString();
+
+        if (string.Equals(translated, source, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        DynamicTextObservability.RecordTransform(route, "DisplayName.LeadingModifierChain", source, translated);
+        return true;
+    }
+
+    private static bool TryReadLeadingModifierToken(
+        string source,
+        int start,
+        out string modifier,
+        out int restStart)
+    {
+        modifier = string.Empty;
+        restStart = start;
+        int modifierEnd;
+
+        if (start < 0 || start >= source.Length)
+        {
+            return false;
+        }
+
+        if (source[start] == '['
+            && start + 2 < source.Length
+            && source[start + 1] == '{'
+            && source[start + 2] == '{')
+        {
+            var wrappedEnd = FindQudMarkupEnd(source, start + 1);
+            if (wrappedEnd < 0 || wrappedEnd >= source.Length || source[wrappedEnd] != ']')
+            {
+                return false;
+            }
+
+            modifierEnd = wrappedEnd + 1;
+        }
+        else if (source[start] == '['
+            && start + 2 < source.Length
+            && IsAsciiModifierStart(source[start + 1]))
+        {
+            var close = source.IndexOf(']', start + 2);
+            if (close < 0)
+            {
+                return false;
+            }
+
+            for (var index = start + 1; index < close; index++)
+            {
+                if (!IsAsciiModifierCharacter(source[index]) && source[index] != ' ')
+                {
+                    return false;
+                }
+            }
+
+            modifierEnd = close + 1;
+        }
+        else if (start + 1 < source.Length && source[start] == '{' && source[start + 1] == '{')
+        {
+            var wrappedEnd = FindQudMarkupEnd(source, start);
+            if (wrappedEnd < 0)
+            {
+                return false;
+            }
+
+            modifierEnd = wrappedEnd;
+        }
+        else if (IsAsciiModifierStart(source[start]))
+        {
+            modifierEnd = start + 1;
+            while (modifierEnd < source.Length && IsAsciiModifierCharacter(source[modifierEnd]))
+            {
+                modifierEnd++;
+            }
+
+            if (modifierEnd < source.Length && source[modifierEnd] == '(')
+            {
+                var close = source.IndexOf(')', modifierEnd + 1);
+                if (close > modifierEnd + 1)
+                {
+                    var digitsOnly = true;
+                    for (var index = modifierEnd + 1; index < close; index++)
+                    {
+                        if (source[index] < '0' || source[index] > '9')
+                        {
+                            digitsOnly = false;
+                            break;
+                        }
+                    }
+
+                    if (digitsOnly)
+                    {
+                        modifierEnd = close + 1;
+                    }
+                }
+            }
+        }
+        else
+        {
+            return false;
+        }
+
+        if (modifierEnd <= start || modifierEnd >= source.Length || source[modifierEnd] != ' ')
+        {
+            return false;
+        }
+
+        restStart = modifierEnd + 1;
+        while (restStart < source.Length && source[restStart] == ' ')
+        {
+            restStart++;
+        }
+
+        if (restStart >= source.Length)
+        {
+            return false;
+        }
+
+        modifier = source.Substring(start, modifierEnd - start);
+        return true;
+    }
+
+    private static int FindQudMarkupEnd(string source, int start)
+    {
+        if (start < 0
+            || start + 1 >= source.Length
+            || source[start] != '{'
+            || source[start + 1] != '{')
+        {
+            return -1;
+        }
+
+        var depth = 0;
+        for (var index = start; index < source.Length - 1; index++)
+        {
+            if (source[index] == '{' && source[index + 1] == '{')
+            {
+                depth++;
+                index++;
+                continue;
+            }
+
+            if (source[index] == '}' && source[index + 1] == '}')
+            {
+                depth--;
+                index++;
+                if (depth == 0)
+                {
+                    return index + 1;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool IsAsciiModifierStart(char character)
+    {
+        return character >= 'A' && character <= 'Z'
+            || character >= 'a' && character <= 'z';
+    }
+
+    private static bool IsAsciiModifierCharacter(char character)
+    {
+        return character >= 'A' && character <= 'Z'
+            || character >= 'a' && character <= 'z'
+            || character == '-'
+            || character == '\'';
+    }
+
+    private static string? TranslateDisplayNameModifierForChain(string source)
+    {
+        return TranslateDisplayNameModifierCore(source, allowGlobalFallback: false);
     }
 
     private static bool TryTranslateLeadingZeroWidthMarkupPrefix(string source, string route, out string translated)
@@ -2469,6 +2708,17 @@ internal static class GetDisplayNameRouteTranslator
 
     private static string? TranslateDisplayNameModifier(string source)
     {
+        return TranslateDisplayNameModifierCore(source, allowGlobalFallback: true);
+    }
+
+    private static string? TranslateDisplayNameModifierCore(string source, bool allowGlobalFallback)
+    {
+        var directSource = TranslateDisplayNameModifierExact(source);
+        if (directSource is not null)
+        {
+            return directSource;
+        }
+
         var bracketWrapped = source.Length >= 2
             && source[0] == '['
             && source[source.Length - 1] == ']';
@@ -2477,8 +2727,23 @@ internal static class GetDisplayNameRouteTranslator
             : source;
 
         var direct = TranslateDisplayNameModifierExact(core);
+        if (direct is null && bracketWrapped && TryReadWrappedModifierVisible(core, out var visible))
+        {
+            var bracketedVisible = "[" + visible + "]";
+            var bracketedDirect = TranslateDisplayNameExactOrLowerAscii(bracketedVisible, DisplayNameAdjectiveContext);
+            if (bracketedDirect is not null)
+            {
+                return bracketedDirect;
+            }
+        }
+
         if (direct is null)
         {
+            if (!allowGlobalFallback)
+            {
+                return null;
+            }
+
             var global = Translator.Translate(source);
             if (string.Equals(global, source, StringComparison.Ordinal))
             {
@@ -2532,6 +2797,28 @@ internal static class GetDisplayNameRouteTranslator
     private static bool TryTranslateMarkupWrappedDisplayNameModifier(string source, out string translated)
     {
         translated = source;
+        if (!TryReadWrappedModifierVisible(source, out var visible))
+        {
+            return false;
+        }
+
+        var separator = source.IndexOf('|', 2);
+        var tag = source.Substring(2, separator - 2);
+        var direct = TranslateDisplayNameExactOrLowerAscii(visible, DisplayNameAdjectiveContext);
+        if (direct is null)
+        {
+            return false;
+        }
+
+        translated = ColorAwareTranslationComposer.HasColorMarkup(direct)
+            ? direct
+            : "{{" + tag + "|" + direct + "}}";
+        return true;
+    }
+
+    private static bool TryReadWrappedModifierVisible(string source, out string visible)
+    {
+        visible = string.Empty;
         if (!source.StartsWith("{{", StringComparison.Ordinal) || !source.EndsWith("}}", StringComparison.Ordinal))
         {
             return false;
@@ -2543,23 +2830,8 @@ internal static class GetDisplayNameRouteTranslator
             return false;
         }
 
-        var tag = source.Substring(2, separator - 2);
-        var visible = source.Substring(separator + 1, source.Length - separator - 3);
-        if (visible.Length == 0)
-        {
-            return false;
-        }
-
-        var direct = TranslateDisplayNameExactOrLowerAscii(visible, DisplayNameAdjectiveContext);
-        if (direct is null)
-        {
-            return false;
-        }
-
-        translated = ColorAwareTranslationComposer.HasColorMarkup(direct)
-            ? direct
-            : "{{" + tag + "|" + direct + "}}";
-        return true;
+        visible = source.Substring(separator + 1, source.Length - separator - 3);
+        return visible.Length > 0;
     }
 
     private static bool IsAlreadyLocalizedBracketedDisplayName(string source)

--- a/Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/GetDisplayNameRouteTranslator.cs
@@ -983,7 +983,12 @@ internal static class GetDisplayNameRouteTranslator
             var translatedModifier = TranslateDisplayNameModifierForChain(modifier);
             if (translatedModifier is null)
             {
-                break;
+                if (!IsMarkupOrBracketedModifierToken(modifier))
+                {
+                    break;
+                }
+
+                translatedModifier = modifier;
             }
 
             translatedModifiers.Add(translatedModifier);
@@ -1191,6 +1196,49 @@ internal static class GetDisplayNameRouteTranslator
             || character >= 'a' && character <= 'z'
             || character == '-'
             || character == '\'';
+    }
+
+    private static bool IsMarkupOrBracketedModifierToken(string modifier)
+    {
+        if (modifier.StartsWith("{{", StringComparison.Ordinal))
+        {
+            return TryReadWrappedModifierVisible(modifier, out var visible)
+                && IsAsciiModifierPhrase(visible);
+        }
+
+        if (modifier.Length >= 4
+            && modifier[0] == '['
+            && modifier[1] == '{'
+            && modifier[2] == '{'
+            && modifier[modifier.Length - 1] == ']')
+        {
+            var core = modifier.Substring(1, modifier.Length - 2);
+            return TryReadWrappedModifierVisible(core, out var visible)
+                && IsAsciiModifierPhrase(visible);
+        }
+
+        return modifier.Length >= 3
+            && modifier[0] == '['
+            && modifier[modifier.Length - 1] == ']'
+            && IsAsciiModifierPhrase(modifier.Substring(1, modifier.Length - 2));
+    }
+
+    private static bool IsAsciiModifierPhrase(string value)
+    {
+        if (value.Length == 0 || !IsAsciiModifierStart(value[0]))
+        {
+            return false;
+        }
+
+        for (var index = 1; index < value.Length; index++)
+        {
+            if (!IsAsciiModifierCharacter(value[index]) && value[index] != ' ')
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static string? TranslateDisplayNameModifierForChain(string source)

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs
@@ -98,14 +98,23 @@ public static class InventoryLineTranslationPatch
     {
         var go = GetMemberValue(data, "go");
         var displayName = GetStringMemberValue(data, "displayName");
+        var producerContext = "InventoryLineData.displayName";
         if (displayName is null)
         {
             var displayNameTarget = go ?? data;
             displayName = GetStringMemberValue(displayNameTarget, "DisplayName");
+            producerContext = go is null
+                ? "InventoryLineData.DisplayName"
+                : "InventoryLine.GameObjectDisplayName";
         }
         if (displayName is null) { displayName = string.Empty; }
         var itemRoute = ObservabilityHelpers.ComposeContext(Context, "field=text");
         var translatedDisplayName = TranslateItemDisplayName(displayName, itemRoute);
+        ColorShapeCaptureObservability.Record(
+            itemRoute,
+            producerContext,
+            displayName,
+            translatedDisplayName);
         var itemTextSkin = GetMemberValue(instance, "text");
         OwnerTextSetter.SetTranslatedText(
             itemTextSkin,
@@ -198,6 +207,13 @@ public static class InventoryLineTranslationPatch
         }
 
         return MessageFrameTranslator.StripAllDirectTranslationMarkers(translated);
+    }
+
+    internal static string TranslateItemDisplayNameForQudTest(string source)
+    {
+        return TranslateItemDisplayName(
+            source,
+            ObservabilityHelpers.ComposeContext(Context, "field=text"));
     }
 
     private static string TranslateCategoryWeightText(string source, int amount, int weight, bool showItemCount, string route)

--- a/Mods/QudJP/Assemblies/src/QudTest/QudTestModels.cs
+++ b/Mods/QudJP/Assemblies/src/QudTest/QudTestModels.cs
@@ -98,4 +98,46 @@ public sealed class QudTestCaseResult
 
     [JsonProperty("diagnostic")]
     public string Diagnostic { get; set; } = string.Empty;
+
+    [JsonProperty("colorShape", NullValueHandling = NullValueHandling.Ignore)]
+    public QudTestColorShapeCapture? ColorShape { get; set; }
+}
+
+public sealed class QudTestColorShapeCapture
+{
+    [JsonProperty("route")]
+    public string Route { get; set; } = string.Empty;
+
+    [JsonProperty("producer")]
+    public string Producer { get; set; } = string.Empty;
+
+    [JsonProperty("source")]
+    public string Source { get; set; } = string.Empty;
+
+    [JsonProperty("sourceVisible")]
+    public string SourceVisible { get; set; } = string.Empty;
+
+    [JsonProperty("final")]
+    public string Final { get; set; } = string.Empty;
+
+    [JsonProperty("finalVisible")]
+    public string FinalVisible { get; set; } = string.Empty;
+
+    [JsonProperty("sourceColorSpans")]
+    public string SourceColorSpans { get; set; } = string.Empty;
+
+    [JsonProperty("finalColorSpans")]
+    public string FinalColorSpans { get; set; } = string.Empty;
+
+    [JsonProperty("sourceVisibleSha256")]
+    public string SourceVisibleSha256 { get; set; } = string.Empty;
+
+    [JsonProperty("finalVisibleSha256")]
+    public string FinalVisibleSha256 { get; set; } = string.Empty;
+
+    [JsonProperty("markupSemanticStatus")]
+    public string MarkupSemanticStatus { get; set; } = string.Empty;
+
+    [JsonProperty("markupSemanticFlags")]
+    public string MarkupSemanticFlags { get; set; } = string.Empty;
 }

--- a/Mods/QudJP/Assemblies/src/QudTest/QudTestRouteExecutor.cs
+++ b/Mods/QudJP/Assemblies/src/QudTest/QudTestRouteExecutor.cs
@@ -21,7 +21,9 @@ public static class QudTestRouteExecutor
     private const string InventoryDisplayNameGameObjectRoute = "inventory-display-name-game-object";
     private const string InventoryLineColorShapeRoute = "InventoryLineTranslationPatch > field=text";
     private const string InventoryLineFixtureDisplayNameProducer = "QudTest.InventoryDisplayNameFixture";
+#if HAS_GAME_DLL
     private const string InventoryLineGameObjectDisplayNameProducer = "InventoryLine.GameObjectDisplayName";
+#endif
 
     public static string Execute(QudTestCase testCase)
     {

--- a/Mods/QudJP/Assemblies/src/QudTest/QudTestRouteExecutor.cs
+++ b/Mods/QudJP/Assemblies/src/QudTest/QudTestRouteExecutor.cs
@@ -1,19 +1,31 @@
 using System;
 using System.Collections.Generic;
+#if HAS_GAME_DLL
+using System.IO;
+using System.Linq;
+using System.Security;
+using System.Xml;
+using System.Xml.Linq;
+#endif
 using QudJP.Patches;
+#if HAS_GAME_DLL
+using XRL.World;
+using XRL.World.Parts;
+#endif
 
 namespace QudJP.QudTest;
 
 public static class QudTestRouteExecutor
 {
+    private const string InventoryDisplayNameRoute = "inventory-display-name";
+    private const string InventoryDisplayNameGameObjectRoute = "inventory-display-name-game-object";
+    private const string InventoryLineColorShapeRoute = "InventoryLineTranslationPatch > field=text";
+    private const string InventoryLineFixtureDisplayNameProducer = "QudTest.InventoryDisplayNameFixture";
+    private const string InventoryLineGameObjectDisplayNameProducer = "InventoryLine.GameObjectDisplayName";
+
     public static string Execute(QudTestCase testCase)
     {
-        if (testCase.Route == "patch-binding")
-        {
-            return QudTestPatchBindingExecutor.Execute(testCase);
-        }
-
-        return Execute(testCase.Route, testCase.Input);
+        return ExecuteWithArtifacts(testCase).Actual;
     }
 
     public static string Execute(string route, string source)
@@ -40,10 +52,207 @@ public static class QudTestRouteExecutor
                 return ExecuteBottomContextItem(source);
             case "game-summary-menu-literal":
                 return GameSummaryScreenMenuBarsTranslationPatch.TranslateLiteral(source);
+            case InventoryDisplayNameRoute:
+                return InventoryLineTranslationPatch.TranslateItemDisplayNameForQudTest(source);
             default:
                 throw new NotSupportedException("Unsupported QudTest route: " + route);
         }
     }
+
+    internal static QudTestRouteExecution ExecuteWithArtifacts(QudTestCase testCase)
+    {
+        if (testCase.Route == "patch-binding")
+        {
+            return new QudTestRouteExecution(QudTestPatchBindingExecutor.Execute(testCase), null);
+        }
+
+        if (testCase.Route == InventoryDisplayNameGameObjectRoute)
+        {
+            return ExecuteInventoryDisplayNameGameObject(testCase.Input);
+        }
+
+        var actual = Execute(testCase.Route, testCase.Input);
+        return new QudTestRouteExecution(actual, CaptureColorShape(testCase, actual));
+    }
+
+    public static QudTestColorShapeCapture? CaptureColorShape(QudTestCase testCase, string actual)
+    {
+        if (testCase.Route != InventoryDisplayNameRoute)
+        {
+            return null;
+        }
+
+        return CaptureInventoryLineColorShape(
+            testCase.Input,
+            actual,
+            InventoryLineFixtureDisplayNameProducer);
+    }
+
+    private static QudTestColorShapeCapture CaptureInventoryLineColorShape(
+        string source,
+        string actual,
+        string producer)
+    {
+        var capture = ColorShapeCaptureObservability.Capture(
+            InventoryLineColorShapeRoute,
+            producer,
+            source,
+            actual);
+        return new QudTestColorShapeCapture
+        {
+            Route = capture.Route,
+            Producer = capture.Producer,
+            Source = capture.SourceText,
+            SourceVisible = capture.SourceVisibleText,
+            Final = capture.FinalText,
+            FinalVisible = capture.FinalVisibleText,
+            SourceColorSpans = capture.SourceColorSpans,
+            FinalColorSpans = capture.FinalColorSpans,
+            SourceVisibleSha256 = capture.SourceVisibleSha256,
+            FinalVisibleSha256 = capture.FinalVisibleSha256,
+            MarkupSemanticStatus = capture.MarkupSemanticStatus,
+            MarkupSemanticFlags = capture.MarkupSemanticFlags,
+        };
+    }
+
+    private static QudTestRouteExecution ExecuteInventoryDisplayNameGameObject(string blueprint)
+    {
+#if HAS_GAME_DLL
+        var source = CreateInventoryDisplayNameSource(blueprint);
+        var actual = InventoryLineTranslationPatch.TranslateItemDisplayNameForQudTest(source);
+        return new QudTestRouteExecution(
+            actual,
+            CaptureInventoryLineColorShape(
+                source,
+                actual,
+                InventoryLineGameObjectDisplayNameProducer));
+#else
+        throw new NotSupportedException(
+            InventoryDisplayNameGameObjectRoute + " requires Assembly-CSharp.dll. Input blueprint: " + blueprint);
+#endif
+    }
+
+#if HAS_GAME_DLL
+    private static string CreateInventoryDisplayNameSource(string blueprint)
+    {
+        try
+        {
+            return GameObject.CreateSample(blueprint).DisplayName;
+        }
+        catch (SecurityException)
+        {
+            return CreateHeadlessInventoryDisplayNameSource(blueprint);
+        }
+    }
+
+    private static string CreateHeadlessInventoryDisplayNameSource(string blueprint)
+    {
+        var renderDisplayName = ReadBlueprintRenderDisplayName(blueprint);
+        var gameObject = new GameObject
+        {
+            Blueprint = blueprint,
+            Render = new Render
+            {
+                DisplayName = renderDisplayName,
+            },
+        };
+        return gameObject.DisplayName;
+    }
+
+    private static string ReadBlueprintRenderDisplayName(string blueprint)
+    {
+        foreach (var file in EnumerateObjectBlueprintFiles())
+        {
+            using var reader = XmlReader.Create(
+                file,
+                new XmlReaderSettings
+                {
+                    CheckCharacters = false,
+                });
+            var document = XDocument.Load(reader);
+            var objectElement = document
+                .Descendants("object")
+                .FirstOrDefault(element => string.Equals(
+                    (string?)element.Attribute("Name"),
+                    blueprint,
+                    StringComparison.Ordinal));
+            var displayName = objectElement?
+                .Elements("part")
+                .FirstOrDefault(element => string.Equals(
+                    (string?)element.Attribute("Name"),
+                    "Render",
+                    StringComparison.Ordinal))?
+                .Attribute("DisplayName")?
+                .Value;
+            if (displayName is { Length: > 0 })
+            {
+                return displayName;
+            }
+        }
+
+        throw new InvalidDataException("Render DisplayName not found for blueprint: " + blueprint);
+    }
+
+    private static IEnumerable<string> EnumerateObjectBlueprintFiles()
+    {
+        foreach (var file in EnumerateLocalizedObjectBlueprintFiles())
+        {
+            yield return file;
+        }
+
+        foreach (var directory in EnumerateObjectBlueprintDirectories().Where(Directory.Exists))
+        {
+            foreach (var file in Directory.EnumerateFiles(directory, "*.xml", SearchOption.AllDirectories))
+            {
+                yield return file;
+            }
+        }
+    }
+
+    private static IEnumerable<string> EnumerateLocalizedObjectBlueprintFiles()
+    {
+        var projectRoot = Environment.GetEnvironmentVariable("QUDJP_PROJECT_ROOT");
+        if (string.IsNullOrWhiteSpace(projectRoot))
+        {
+            projectRoot = Directory.GetCurrentDirectory();
+        }
+
+        var objectBlueprintsDirectory = Path.Combine(
+            projectRoot,
+            "Mods",
+            "QudJP",
+            "Localization",
+            "ObjectBlueprints");
+        return Directory.Exists(objectBlueprintsDirectory)
+            ? Directory.EnumerateFiles(objectBlueprintsDirectory, "*.jp.xml", SearchOption.AllDirectories)
+            : [];
+    }
+
+    private static IEnumerable<string> EnumerateObjectBlueprintDirectories()
+    {
+        var managedDir = Environment.GetEnvironmentVariable("COQ_MANAGED_DIR");
+        if (!string.IsNullOrWhiteSpace(managedDir))
+        {
+            yield return Path.Combine(
+                Directory.GetParent(managedDir)!.FullName,
+                "StreamingAssets",
+                "Base",
+                "ObjectBlueprints");
+        }
+
+        yield return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            "Games",
+            "CavesOfQud-stable-ref",
+            "CoQ.app",
+            "Contents",
+            "Resources",
+            "Data",
+            "StreamingAssets",
+            "Base",
+            "ObjectBlueprints");
+    }
+#endif
 
     private static string ExecuteStartReplace(string source)
     {
@@ -119,4 +328,17 @@ public static class QudTestRouteExecutor
             this.text = text;
         }
     }
+}
+
+internal sealed class QudTestRouteExecution
+{
+    public QudTestRouteExecution(string actual, QudTestColorShapeCapture? colorShape)
+    {
+        Actual = actual;
+        ColorShape = colorShape;
+    }
+
+    public string Actual { get; }
+
+    public QudTestColorShapeCapture? ColorShape { get; }
 }

--- a/Mods/QudJP/Assemblies/src/QudTest/QudTestRunner.cs
+++ b/Mods/QudJP/Assemblies/src/QudTest/QudTestRunner.cs
@@ -109,17 +109,18 @@ public static class QudTestRunner
         var expected = QudTestPatchBindingExecutor.Expected(testCase);
         try
         {
-            var actual = QudTestRouteExecutor.Execute(testCase);
-            var passed = string.Equals(actual, expected, StringComparison.Ordinal);
+            var execution = QudTestRouteExecutor.ExecuteWithArtifacts(testCase);
+            var passed = string.Equals(execution.Actual, expected, StringComparison.Ordinal);
             return new QudTestCaseResult
             {
                 Id = testCase.Id,
                 Route = testCase.Route,
                 Input = testCase.Input,
                 Expected = expected,
-                Actual = actual,
+                Actual = execution.Actual,
                 Passed = passed,
                 Diagnostic = passed ? string.Empty : "actual did not match expected",
+                ColorShape = execution.ColorShape,
             };
         }
         catch (Exception ex)

--- a/Mods/QudJP/QudTest/fixtures/inventory-shapes.json
+++ b/Mods/QudJP/QudTest/fixtures/inventory-shapes.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": 1,
+  "suite": "inventory-shapes",
+  "description": "Producer-derived inventory display-name shape capture cases.",
+  "cases": [
+    {
+      "id": "inventory-display-name-game-object.copper-nugget",
+      "route": "inventory-display-name-game-object",
+      "input": "Copper Nugget",
+      "expected": "{{w|銅のナゲット}}"
+    },
+    {
+      "id": "inventory-display-name-game-object.grit-gate-recoiler",
+      "route": "inventory-display-name-game-object",
+      "input": "Grit Gate Recoiler",
+      "expected": "{{c|グリット・ゲート}}リコイラー"
+    },
+    {
+      "id": "inventory-display-name.producer-derived-long-prefix-chain",
+      "route": "inventory-display-name",
+      "input": "{{B|wet}} {{slimy|slimy}} {{r|bloody}} {{Y|masterwork}} scoped {{electrical|electrified}} {{fiery|flaming}} {{freezing|freezing}} {{freezing|frozen}} {{painted|painted}} {{lacquered|lacquered}} {{phase-harmonic|phase-harmonic}} チェーンピストル \u001a8 \u00031d6 [empty]",
+      "expected": "{{B|濡れた}} {{slimy|粘液質の}} {{r|血まみれの}} {{Y|傑作}} スコープ付き {{electrical|帯電}} {{fiery|燃え盛る}} {{freezing|凍結した}} {{freezing|凍結した}} {{painted|彩色された}} {{lacquered|漆仕上げ}} {{phase-harmonic|位相調和}} チェーンピストル {{c|\u001a}}8 {{r|\u0003}}1d6 [空]"
+    },
+    {
+      "id": "inventory-display-name.producer-derived-bracketed-prefix",
+      "route": "inventory-display-name",
+      "input": "[{{illuminated|illuminated}}] チェーンピストル \u001a8 \u00031d6 [empty]",
+      "expected": "[{{illuminated|彩飾}}] チェーンピストル {{c|\u001a}}8 {{r|\u0003}}1d6 [空]"
+    }
+  ]
+}

--- a/Mods/QudJP/QudTest/fixtures/runtime-smoke.json
+++ b/Mods/QudJP/QudTest/fixtures/runtime-smoke.json
@@ -116,6 +116,12 @@
       "route": "game-summary-menu-literal",
       "input": "Exit",
       "expected": "終了"
+    },
+    {
+      "id": "inventory-display-name.game-object-colored-state",
+      "route": "inventory-display-name",
+      "input": "{{c|copper nugget}} {{y|[empty]}}",
+      "expected": "{{c|銅塊}} {{y|[空]}}"
     }
   ]
 }

--- a/docs/runtime-color-shape-capture.md
+++ b/docs/runtime-color-shape-capture.md
@@ -1,0 +1,81 @@
+# Runtime color-shape capture
+
+## 目的
+
+色タグを含む runtime text route では、手書きの source 例だけでは実 producer が出す
+組み合わせの drift を検出しきれない。`ColorShapeProbe/v1` は、実行時 route から
+producer-derived text shape を捕捉し、後続の invariant test に昇格するための証跡である。
+
+初期 lane は inventory item display name に置く。`InventoryLineTranslationPatch` は
+`InventoryLineData.displayName` または `go.DisplayName` を受け取り、翻訳後に
+`OwnerTextSetter` へ渡す owner route なので、source text、visible text、color span、
+final output を同じ地点で観測できる。
+
+## Artifact format
+
+QudTest の inventory color-shape routes は、`results.json` の該当 case に
+`colorShape` object を出力する。`inventory-display-name` は固定 source string を
+translator route に流す L1/smoke 用 route、`inventory-display-name-game-object` は
+`GameObject.DisplayName` 経由で producer-derived source を生成する route である。
+dev build の verbose probe では同じ内容を
+`ColorShapeProbe/v1` として `Player.log` にも出力できる。1 record には少なくとも次を含める。
+
+- `route`: owner route。例: `InventoryLineTranslationPatch`
+- `producer`: text の由来。例: `InventoryLine.GameObjectDisplayName`
+- `source`: producer 由来の raw source text
+- `sourceVisible`: `ColorAwareTranslationComposer.Strip` 後の visible text
+- `final`: route translation 後の output
+- `finalVisible`: final output の visible text
+- `sourceColorSpans` / `finalColorSpans`: stripped visible index と color token の signature
+- `sourceVisibleSha256` / `finalVisibleSha256`: long text 比較用 hash
+- `markupSemanticStatus` / `markupSemanticFlags`: final output の markup semantic diagnostics
+
+この artifact は exact English string を固定するためではなく、捕捉した family を構造
+invariant に変換する入口として使う。たとえば inventory display-name family では、
+base name、bracket state、loaded cell、weapon stat、angle code、outer color wrapper の
+保持や、二重 wrapper・壊れた bracket/tag 断片の不在を検証対象にする。
+
+## Onboarding order
+
+次の color-sensitive route は、`ColorRouteCatalogTests` の route catalog と owner-route
+境界に沿って段階的に onboard する。
+
+1. Message log / message queue
+   - `MessageQueue.AddPlayerMessage` と message pattern producer helpers を優先する。
+   - Combat, pass-by, generated queue text の source/final と direct-translation marker 状態を捕捉する。
+
+2. Popup and menu routes
+   - `Popup.Show` 系の fixed popup text と menu item text を分ける。
+   - Generic popup producer route は allowlist 理由を保ち、dynamic option producer は owner helper 側で捕捉する。
+
+3. UI text skin sink surfaces
+   - `UITextSkin` は owner ではなく sink observation として扱う。
+   - sink-only artifact は missing owner triage 用に限定し、修正は producer/binding route へ戻す。
+
+4. Equipment, trade, and inventory-adjacent rows
+   - `EquipmentLineTranslationPatch`、`TradeLineTranslationPatch`、trade totals/labels を route ごとに分ける。
+   - display-name fragment と weight/value/stat suffix を別 invariant として扱う。
+
+5. Ability, status, and active-effect text
+   - ability name/status line/effect detail の owner route ごとに producer context を付ける。
+   - cooldown、hotkey、TMP rich-text、status bracket fragment を color span invariant に含める。
+
+## Verification
+
+最初の自動検証は L1/L2 で行う。
+
+- L1: `ColorShapeCaptureObservability` と QudTest `inventory-display-name` route が source/final visible text と color span を出すこと。
+- L2: `InventoryLineTranslationPatch` が producer-derived display name を捕捉し、その captured shape 由来の structural invariant を満たすこと。
+- Headless QudTest: `just qudtest-headless qudtest:runtime .artifacts/qudtest` の `results.json` に `inventory-display-name.game-object-colored-state.colorShape` が含まれること。
+- Producer-derived headless QudTest: `just qudtest-headless qudtest:inventory-shapes .artifacts/qudtest-inventory-shapes` の `results.json` に `inventory-display-name-game-object.copper-nugget.colorShape` と `inventory-display-name-game-object.grit-gate-recoiler.colorShape` が含まれ、`input` は blueprint name、`colorShape.source` は `GameObject.DisplayName` から得た colored display name になること。`grit-gate-recoiler` は inline source wrapper の visible length が翻訳で変わっても wrapper span が clean に保たれることを検証する。
+- L3: 実ゲーム起動後の `Player.log` で `ColorShapeProbe/v1` の inventory record を確認すること。
+
+L3 は runtime smoke evidence であり、CI の代替ではない。実ゲーム型生成や Unity/TMP 表示に入る検証は
+`docs/test-architecture.md` の L3 境界に従う。
+Headless .NET では Unity ECall を伴う `GameObject.CreateSample` が実行できない場合があるため、
+`inventory-display-name-game-object` はその場合だけ blueprint XML の `Render.DisplayName` から
+最小 `GameObject` を組み立て、同じ `GameObject.DisplayName` property を通して source を生成する。
+この fallback は repo の `Mods/QudJP/Localization/ObjectBlueprints/*.jp.xml` を base game XML より
+優先して読む。`Chem Cell` や `Grit Gate Recoiler` のような item display name は display-name
+辞書 lookup ではなく ObjectBlueprint overlay で既に日本語化されるため、producer-derived capture
+では `source` と `final` が同じ日本語 display name になる。

--- a/scripts/tests/test_qudtest_headless.py
+++ b/scripts/tests/test_qudtest_headless.py
@@ -51,6 +51,14 @@ def test_qudtest_headless_writes_inspectable_runtime_artifact(tmp_path: Path) ->
     assert payload["modLanguage"] == "ja"
     assert payload["passed"] is True
     assert payload["totalCount"] > 0
+    inventory_case = next(
+        case for case in payload["cases"] if case["id"] == "inventory-display-name.game-object-colored-state"
+    )
+    assert inventory_case["colorShape"]["producer"] == "QudTest.InventoryDisplayNameFixture"
+    assert inventory_case["colorShape"]["sourceVisible"] == "copper nugget [empty]"
+    assert inventory_case["colorShape"]["finalVisible"] == "銅塊 [空]"
+    assert inventory_case["colorShape"]["sourceColorSpans"]
+    assert inventory_case["colorShape"]["finalColorSpans"]
 
     inspected = subprocess.run(
         [
@@ -72,6 +80,82 @@ def test_qudtest_headless_writes_inspectable_runtime_artifact(tmp_path: Path) ->
 
     assert inspected.returncode == 0, inspected.stderr
     assert "QudTest passed" in inspected.stdout
+
+
+def test_qudtest_headless_captures_inventory_shape_from_game_object(tmp_path: Path) -> None:
+    """Inventory shape capture should record the GameObject-produced display name."""
+    _skip_without_game_managed_dir()
+    output = tmp_path / "QudTest"
+
+    completed = subprocess.run(
+        [
+            "dotnet",
+            "run",
+            "--project",
+            str(PROJECT),
+            "--",
+            "--command",
+            "qudtest:inventory-shapes",
+            "--fixtures",
+            str(FIXTURES),
+            "--output",
+            str(output),
+            "--mod-language",
+            "ja",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    results = output / "results.json"
+    payload = json.loads(results.read_text(encoding="utf-8"))
+    assert payload["suite"] == "inventory-shapes"
+    assert payload["modLanguage"] == "ja"
+    assert payload["passed"] is True
+    assert all(case["colorShape"]["markupSemanticStatus"] == "clean" for case in payload["cases"])
+    inventory_case = next(
+        case for case in payload["cases"] if case["id"] == "inventory-display-name-game-object.copper-nugget"
+    )
+    assert inventory_case["input"] == "Copper Nugget"
+    assert inventory_case["actual"] == "{{w|銅のナゲット}}"
+    assert inventory_case["colorShape"]["producer"] == "InventoryLine.GameObjectDisplayName"
+    assert inventory_case["colorShape"]["source"] == "{{w|銅のナゲット}}"
+    assert inventory_case["colorShape"]["sourceVisible"] == "銅のナゲット"
+    assert inventory_case["colorShape"]["final"] == "{{w|銅のナゲット}}"
+    assert inventory_case["colorShape"]["finalVisible"] == "銅のナゲット"
+    assert inventory_case["colorShape"]["sourceColorSpans"]
+    assert inventory_case["colorShape"]["finalColorSpans"]
+    assert inventory_case["colorShape"]["markupSemanticStatus"] == "clean"
+
+    inline_case = next(
+        case for case in payload["cases"] if case["id"] == "inventory-display-name-game-object.grit-gate-recoiler"
+    )
+    assert inline_case["input"] == "Grit Gate Recoiler"
+    assert inline_case["actual"] == "{{c|グリット・ゲート}}リコイラー"
+    assert inline_case["colorShape"]["source"] == "{{c|グリット・ゲート}}リコイラー"
+    assert inline_case["colorShape"]["sourceVisible"] == "グリット・ゲートリコイラー"
+    assert inline_case["colorShape"]["finalVisible"] == "グリット・ゲートリコイラー"
+    assert inline_case["colorShape"]["sourceColorSpans"] == "0:{{c||8:}}"
+    assert inline_case["colorShape"]["finalColorSpans"] == "0:{{c||8:}}"
+
+    long_chain_case = next(
+        case for case in payload["cases"] if case["id"] == "inventory-display-name.producer-derived-long-prefix-chain"
+    )
+    assert long_chain_case["actual"] == long_chain_case["expected"]
+    assert long_chain_case["colorShape"]["markupSemanticStatus"] == "clean"
+    assert "}}{{" not in long_chain_case["actual"]
+    assert "{{freezing|凍結した}} {{painted|彩色された}}" in long_chain_case["actual"]
+    assert "{{lacquered|漆仕上げ}} {{phase-harmonic|位相調和}}" in long_chain_case["actual"]
+
+    bracketed_prefix_case = next(
+        case for case in payload["cases"] if case["id"] == "inventory-display-name.producer-derived-bracketed-prefix"
+    )
+    assert bracketed_prefix_case["actual"] == bracketed_prefix_case["expected"]
+    assert bracketed_prefix_case["colorShape"]["markupSemanticStatus"] == "clean"
+    assert "illuminated" not in bracketed_prefix_case["colorShape"]["finalVisible"]
 
 
 def test_qudtest_headless_writes_inspectable_binding_artifact(tmp_path: Path) -> None:

--- a/scripts/tools/QudTestHeadless/Program.cs
+++ b/scripts/tools/QudTestHeadless/Program.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
 using QudJP;
 using QudJP.Patches;
 using QudJP.QudTest;
@@ -18,6 +20,7 @@ internal static class Program
         try
         {
             var options = CliOptions.Parse(args);
+            ConfigureGameAssemblyResolution();
             ConfigureHeadlessLocalization(options.ProjectRoot);
 
             var result = QudTestRunner.Run(options.Command, options.FixturesDirectory, options.ModLanguage);
@@ -52,9 +55,45 @@ internal static class Program
 
     private static void ConfigureHeadlessLocalization(string projectRoot)
     {
+        Environment.SetEnvironmentVariable("QUDJP_PROJECT_ROOT", projectRoot);
         var dictionariesDirectory = Path.Combine(projectRoot, "Mods", "QudJP", "Localization", "Dictionaries");
         Translator.SetDictionaryDirectoryForTests(dictionariesDirectory);
         StartReplaceTranslationPatch.SetDictionaryPathForTests(Path.Combine(dictionariesDirectory, "templates-variable.ja.json"));
+    }
+
+    private static void ConfigureGameAssemblyResolution()
+    {
+        AssemblyLoadContext.Default.Resolving += static (_, assemblyName) =>
+        {
+            foreach (var directory in EnumerateManagedAssemblyDirectories())
+            {
+                var path = Path.Combine(directory, assemblyName.Name + ".dll");
+                if (File.Exists(path))
+                {
+                    return AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.GetFullPath(path));
+                }
+            }
+
+            return null;
+        };
+    }
+
+    private static string[] EnumerateManagedAssemblyDirectories()
+    {
+        var envDir = Environment.GetEnvironmentVariable("COQ_MANAGED_DIR");
+        var defaultDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            "Games",
+            "CavesOfQud-stable-ref",
+            "CoQ.app",
+            "Contents",
+            "Resources",
+            "Data",
+            "Managed");
+
+        return string.IsNullOrWhiteSpace(envDir)
+            ? [AppContext.BaseDirectory, defaultDir]
+            : [AppContext.BaseDirectory, envDir, defaultDir];
     }
 
     private sealed record CliOptions(


### PR DESCRIPTION
## Summary

- Add inventory display-name color-shape capture for QudTest artifacts and verbose runtime probes.
- Add producer-derived inventory shape fixtures, including GameObject display-name cases and long generated prefix chains.
- Fix leading display-name modifier chain handling so color-tagged prefixes keep semantic spaces, bracketed prefix states translate, and cooking ingredient phrases are not hijacked as display-name modifier chains.

Closes #748

## Verification

- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~PreservesSeparatorsAcrossProducerDerivedLongPrefixChains|FullyQualifiedName~TranslatesProducerDerivedBracketedPrefixModifiers|FullyQualifiedName~EveryStripCallSite_HasMatchingRestoreCallSite|FullyQualifiedName~CookingIngredientFragmentTranslatorTests.TryTranslate_TranslatesMeasuredAndArticleIngredientFragments|FullyQualifiedName~CookingMealDescriptionTranslatorTests.TryTranslate_TranslatesCookTemplateFrames"` - 217 passed
- `just test-l1` - 4079 passed
- `just qudtest-headless qudtest:inventory-shapes .artifacts/qudtest-inventory-shapes-polished` - 4 passed, inspector passed
- `uv run pytest scripts/tests/test_qudtest_headless.py` - 4 passed
- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj` - passed
- `git diff --check` - passed

## Polishment

- Independent subagent review: APPROVE, no issues.
- Post-cleanup independent subagent review: APPROVE, no issues.

## AI Slop Cleanup

Scope: issue #748 changed files only.

Behavior lock: focused prefix/bracket/cooking/color tests, full L1 suite, QudTest inventory-shapes, Python headless tests, C# build, and diff check.

Passes completed:
- Dead code cleanup: removed an unused modifier-token out parameter.
- Duplication cleanup: centralized display-name modifier translation core while preserving chain-only no-global-fallback behavior.
- Naming/boundary check: kept fixture-source and GameObject-source producer labels separate.
- Test reinforcement: no extra tests needed after cleanup; existing targeted checks covered the touched behavior.

Remaining risks: L3 in-game visual/TMP rendering remains runtime evidence rather than CI coverage, as documented in `docs/runtime-color-shape-capture.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 実行時に表示名の色・マークアップ形状（colorShape）を捕捉しテスト結果に含める機能を追加。テスト実行時にアーティファクトとして出力。

* **Tests**
  * 在庫表示名や接頭辞変換を含む多数のテストを追加・拡張し、colorShape の生成と各フィールド内容を検証。
  * ヘッドレス実行テストで colorShape の検証を強化。

* **Documentation**
  * runtime color-shape capture の仕様と検証手順を追加。

* **Chores**
  * ヘッドレス実行時のアセンブリ解決とローカライズ設定を改善。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->