### PR TITLE
Release QudJP v0.3.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.3.20] - 2026-05-22
+
+### Fixed
+
+- item modifier の prefix、with-clause、flexiweaved の段階表示など、アイテム名に残っていた英語断片を追加で日本語化しました。
+- インベントリ操作名と、歴史的な場面説明文の一部に残っていた英語表示を日本語化しました。
+- 固定アイテム、effect、ability、option、object description の訳文を見直し、不自然な表現や残っていた英語用語を改善しました。
+
+---
+
 ## [0.3.01] - 2026-05-22
 
 ### Fixed
@@ -351,7 +361,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.3.01...HEAD
+[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.3.20...HEAD
+[0.3.20]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.20
 [0.3.01]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.01
 [0.3.00]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.00
 [0.2.52]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.2.52

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.3.01",
+  "Version": "0.3.20",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/release-notes/unreleased/issue-748-modifier-inventory.md
+++ b/docs/release-notes/unreleased/issue-748-modifier-inventory.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Improved Japanese item names for Caves of Qud item modification prefixes and with-clauses, including flexiweaved modifier levels and source-owned with-clause color spans.

--- a/docs/release-notes/unreleased/runtime-translation-slices.md
+++ b/docs/release-notes/unreleased/runtime-translation-slices.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Translated additional inventory actions and historic scene description wrappers that could still appear in English.

--- a/docs/release-notes/unreleased/translation-quality-slice-1.md
+++ b/docs/release-notes/unreleased/translation-quality-slice-1.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Improved Japanese text for fixed item, effect, ability, option, and object description strings that still showed English terms or awkward wording.


### PR DESCRIPTION
## Summary
- bump QudJP manifest to 0.3.20
- add the 0.3.20 changelog entry
- consume the unreleased release-note fragments included in this release

## Verification
- just changelog-link-check
- just release-note-check main HEAD
- git diff --check
- just build-release
- just release-zip-check dist/QudJP-v0.3.20.zip