### PR TITLE
Fix release test analyzer duplicate handler

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyCombatAndLogTargets.cs
@@ -2161,6 +2161,7 @@ internal sealed class DummySingleCallsiteOwnerPopupTarget
     public bool HandleGivesRepBeforeDeathRemoval(DummyBeforeDeathRemovalEvent? e = null)
     {
         _ = e;
+        _ = nameof(HandleGivesRepBeforeDeathRemoval);
         DummyPopupShow.Show(PopupMessageToShow);
         return true;
     }


### PR DESCRIPTION
## Summary
- make the GivesRep dummy BeforeDeathRemoval handler distinguishable from the NephalProperties dummy handler
- keep the popup route behavior unchanged while satisfying the Release workflow analyzer gate

## Verification
- dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release
- dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * テストコードの内部改善を実施しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->