### PR TITLE
Codify Roslyn wrapper validation guidance

### DIFF
--- a/.codex/skills/roslyn-static-analysis/SKILL.md
+++ b/.codex/skills/roslyn-static-analysis/SKILL.md
@@ -203,6 +203,16 @@ For repo-local scanner tools:
 - Build with the SDK version already used by repo tools, currently `net10.0`.
 - Add or update a smoke test that builds the `.csproj`, so CI catches tool rot.
 - Keep build-time analysis separate from shipped runtime DLLs.
+- In Python wrappers, normalize external input/output paths once at the wrapper
+  boundary with `Path.expanduser().resolve()` and use the normalized `Path`
+  consistently for directory creation, subprocess arguments, and JSON readback.
+  The wrapper and Roslyn process may not share the caller's current directory.
+- Any pytest that reaches a Roslyn tool through a Python wrapper is still
+  `dotnet`-dependent. Mark it with the same `pytest.mark.skipif(not
+  shutil.which("dotnet"), reason="dotnet SDK not available")` guard used by
+  direct Roslyn tool tests.
+- Add a wrapper regression when relative output paths are supported, so the
+  scanner output path and Python JSON readback path cannot drift apart.
 
 Use these Roslyn defaults unless the task proves otherwise:
 


### PR DESCRIPTION
## Summary
- add Roslyn scanner guidance for normalizing wrapper input/output paths once at the Python boundary
- document that wrapper tests invoking Roslyn tools still need the dotnet skip guard
- require a relative-output regression when wrappers support relative output paths

## Checks
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Roslyn静的分析ツール経由の運用ガイドを更新しました。パス正規化の実装方法、テスト環境での実行条件、相対出力パス対応時の一貫性検証に関する手順が明文化されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/766?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->