### PR TITLE
[codex] Revise energy cell charge status labels

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/EnergyStorageChargeStatusTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/EnergyStorageChargeStatusTranslationPatchTests.cs
@@ -16,17 +16,17 @@ public sealed class EnergyStorageChargeStatusTranslationPatchTests
         Assert.Multiple(() =>
         {
             Assert.That(changed, Is.True);
-            Assert.That(translated, Is.EqualTo("{{G|満充電}}"));
+            Assert.That(translated, Is.EqualTo("{{G|残量十分}}"));
             Assert.That(translated, Does.Not.Contain("全画面"));
         });
     }
 
     [TestCase("{{K|Drained}}", "{{K|空}}")]
-    [TestCase("{{r|Very Low}}", "{{r|残量ごく少}}")]
+    [TestCase("{{r|Very Low}}", "{{r|残量わずか}}")]
     [TestCase("{{R|Low}}", "{{R|残量少}}")]
-    [TestCase("{{W|Used}}", "{{W|使用済み}}")]
+    [TestCase("{{W|Used}}", "{{W|残量半分}}")]
     [TestCase("{{g|Fresh}}", "{{g|残量多}}")]
-    [TestCase("{{G|Full}}", "{{G|満充電}}")]
+    [TestCase("{{G|Full}}", "{{G|残量十分}}")]
     [TestCase("{{G|Fully Wound}}", "{{G|完全に巻かれている}}")]
     [TestCase("{{G|Full Speed}}", "{{G|最高速}}")]
     [TestCase("{{G|Fully Tensed}}", "{{G|完全に張っている}}")]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/GetDisplayNameProcessPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/GetDisplayNameProcessPatchTests.cs
@@ -612,11 +612,11 @@ public sealed class GetDisplayNameProcessPatchTests
     }
 
     [TestCase("K", "Drained", "空")]
-    [TestCase("r", "Very Low", "残量ごく少")]
+    [TestCase("r", "Very Low", "残量わずか")]
     [TestCase("R", "Low", "残量少")]
-    [TestCase("W", "Used", "使用済み")]
+    [TestCase("W", "Used", "残量半分")]
     [TestCase("g", "Fresh", "残量多")]
-    [TestCase("G", "Full", "満充電")]
+    [TestCase("G", "Full", "残量十分")]
     [TestCase("C", "Unknown", "Unknown")]
     [TestCase("M", "", "")]
     [TestCase("Y", "\u0001Low", "Low")]

--- a/Mods/QudJP/Assemblies/src/Patches/EnergyStorageChargeStatusTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/EnergyStorageChargeStatusTranslationPatch.cs
@@ -12,11 +12,11 @@ public static class EnergyStorageChargeStatusTranslationPatch
     private static readonly Dictionary<string, string> ChargeStatusTranslations = new(StringComparer.Ordinal)
     {
         { "Drained", "空" },
-        { "Very Low", "残量ごく少" },
+        { "Very Low", "残量わずか" },
         { "Low", "残量少" },
-        { "Used", "使用済み" },
+        { "Used", "残量半分" },
         { "Fresh", "残量多" },
-        { "Full", "満充電" },
+        { "Full", "残量十分" },
         { "Run Down", "巻き切れ" },
         { "Very Run Down", "巻きがかなり弱い" },
         { "Fairly Run Down", "巻きがやや弱い" },


### PR DESCRIPTION
## Summary
- Revise electrical charge-status labels to read as remaining charge rather than item-use state.
- Change `Very Low` to `残量わずか`, `Used` to `残量半分`, and `Full` to `残量十分`.
- Update L1 and L2 expectations for direct charge-status translation and display-name suffix translation.

## Test Plan
- `just test-l1`
- `just test-l2`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ローカライズ**
  * エネルギー貯蔵装置のチャージ状態を示す日本語表示を更新しました。充電レベルの各段階を示す日本語表記がより明確に区分されるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->