### PR TITLE
[codex] Release QudJP v0.3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.3.21] - 2026-05-23
+
+### Fixed
+
+- turret tinkering、long blade stance、schemasoft chip、Cyclopean Prism、PitMaterial、Evil Twin、Cherubim/Hexacherubim element text などの生成・表示名テキストを追加で日本語化しました。
+- gigantic item mod description、sparking baetyl reward description、bandaging、multi-horns charge message などの説明文・報酬文・戦闘ログに残っていた英語表示を改善しました。
+- アイテム表示名の翻訳時に、angle suffix より前にある色 markup が失われる場合がある問題を修正しました。
+- エネルギーセルの充電状態ラベルを見直し、インベントリや詳細表示に残っていた不自然な表現を改善しました。
+
+---
+
 ## [0.3.20] - 2026-05-22
 
 ### Fixed
@@ -361,7 +372,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.3.20...HEAD
+[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.3.21...HEAD
+[0.3.21]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.21
 [0.3.20]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.20
 [0.3.01]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.01
 [0.3.00]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.00

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.3.20",
+  "Version": "0.3.21",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/release-notes/unreleased/issue-762-text-construction-gaps.md
+++ b/docs/release-notes/unreleased/issue-762-text-construction-gaps.md
@@ -1,9 +1,0 @@
-### Fixed
-
-- Translated additional generated text across issue #762 surfaces:
-  - Abilities: turret tinkering and long blade stances.
-  - Display names: schemasoft chips, Cyclopean Prism, PitMaterial, Evil Twin, and Cherubim/Hexacherubim element text.
-  - Behavior descriptions: schemasoft chip effects.
-  - Item modifications: gigantic item mod descriptions.
-  - Rewards: sparking baetyl reward descriptions.
-  - Combat actions: bandaging and multi-horns charge messages.


### PR DESCRIPTION
## Summary

- Bump QudJP to `0.3.21`.
- Move the accumulated user-facing release notes into `CHANGELOG.md`.
- Consume the `issue-762-text-construction-gaps` unreleased fragment.

## Release Scope

This release includes the latest `main` changes through `26dc0a3319b7`, including additional generated/display-name translation coverage, item description/reward/combat log improvements, display-name color preservation before angle suffixes, and revised energy-cell charge status labels.

Workshop target remains item `3718988020`. Steam upload, tag creation, and tag push are intentionally not part of this PR.

## Validation

- `just build`
- `just python-check`
- `just python-test` (`1333 passed, 1 skipped`)
- `just localization-check`
- `just translation-token-check`
- `just release-note-check origin/main HEAD`
- `just test-l1` (`4124 passed`)
- `just test-l2` (`3894 passed`)
- `just test-l2g` (`507 passed`)

## After Merge

- Create and push annotated tag `v0.3.21` from merged `main` only after explicit release confirmation.
- Wait for the draft GitHub Release ZIP.
- Run release ZIP checks, build Workshop staging, run upload preflight, then stop at the Steam upload confirmation gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 生成テキストの日本語化を改善
  * 説明文・報酬文・戦闘ログなどのテキスト表示を修正
  * アイテム表示名翻訳時の色マークアップ問題を解決
  * エネルギーセルの充電状態ラベル表現を改善

* **Chores**
  * リリースノート更新とバージョン番号の更新

バージョン: v0.3.21 (2026-05-23)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->