### PR TITLE
[codex] Fix v0.3.21 release build analyzer

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/GetDisplayNameRouteTranslatorTests.cs
@@ -664,7 +664,16 @@ public sealed class GetDisplayNameRouteTranslatorTests
     [TestCase(
         "{{r|a{{R|m{{Y|a{{y|r{{r|a{{R|n}}t}}h}}i}}n}}e}} prism",
         "{{r|ア}}{{R|マ}}{{Y|ラ}}{{y|ン}}{{r|ス}}{{R|色}}のプリズム")]
-    public void TranslatePreservingColors_TranslatesCyclopeanPrismGeneratedDisplayNames(
+    [TestCase(
+        "{{Y|Schemasoft [{{C|Pistols, Mid Tier}}]}}",
+        "{{Y|スキーマソフト [{{C|ピストル, 中位}}]}}")]
+    [TestCase(
+        "Schemasoft [Ammo and Energy Cells, Low Tier]",
+        "スキーマソフト [弾薬とエネルギーセル, 下位]")]
+    [TestCase(
+        "{{Y|Schemasoft [{{C|Heavy Weapons, High Tier}}]}}",
+        "{{Y|スキーマソフト [{{C|重火器, 上位}}]}}")]
+    public void TranslatePreservingColors_TranslatesShippedGeneratedDisplayNames(
         string source,
         string expected)
     {
@@ -702,26 +711,6 @@ public sealed class GetDisplayNameRouteTranslatorTests
     {
         WriteDictionary(("snapjaw", "スナップジョー"));
 
-        var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
-            source,
-            nameof(GetDisplayNamePatch));
-
-        Assert.That(translated, Is.EqualTo(expected));
-    }
-
-    [TestCase(
-        "{{Y|Schemasoft [{{C|Pistols, Mid Tier}}]}}",
-        "{{Y|スキーマソフト [{{C|ピストル, 中位}}]}}")]
-    [TestCase(
-        "Schemasoft [Ammo and Energy Cells, Low Tier]",
-        "スキーマソフト [弾薬とエネルギーセル, 下位]")]
-    [TestCase(
-        "{{Y|Schemasoft [{{C|Heavy Weapons, High Tier}}]}}",
-        "{{Y|スキーマソフト [{{C|重火器, 上位}}]}}")]
-    public void TranslatePreservingColors_TranslatesCyberneticsSchemasoftGeneratedDisplayName(
-        string source,
-        string expected)
-    {
         var translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
             source,
             nameof(GetDisplayNamePatch));


### PR DESCRIPTION
## Summary

- Combine the Cyclopean Prism and Schemasoft generated display-name cases into one parameterized test.
- Remove the duplicate test method body that tripped Sonar `S4144` in the tag-triggered Release workflow.

## Validation

- `dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release`
- `just test-l1` (`4124 passed`)

## Release Note

This is a release-build-only test cleanup. It does not change shipped runtime behavior or localization assets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * ジェネリックされた表示名に関するテストケースを更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/769?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->