### PR TITLE
Improve unused-code scanner reference resolution

### DIFF
--- a/.codex/skills/roslyn-static-analysis/SKILL.md
+++ b/.codex/skills/roslyn-static-analysis/SKILL.md
@@ -134,15 +134,18 @@ routes still need owner review before deleting code.
 - Scanner config: `scripts/unused_code_inventory_config.json`
 - Focused tests: `scripts/tests/test_scan_unused_code_inventory.py`
 - Local preview: `just unused-code-preview`
+- Zero-candidate gate: `just unused-code-gate`
 - Scanner validation: `just unused-code-check`
 
 The default config scans production, test, analyzer, and analyzer-test C#
 sources so test-only static references count as usage. It reports candidates
 only from production `src` and analyzer sources, enables `HAS_GAME_DLL`,
-`HAS_TMP`, and `QUDJP_DEV_BUILD`, roots
-Harmony patch entrypoints, and excludes known test-helper suffixes such as
-`ForTests`. Do not add `--fail-on-candidates` to PR gates until the current
-candidate baseline has been triaged and false-positive policy is documented.
+`HAS_TMP`, and `QUDJP_DEV_BUILD`, resolves configured external metadata
+references from `COQ_MANAGED_DIR`, the stable reference install, or an explicit
+`managed_dir` recipe argument, roots Harmony patch entrypoints, and excludes
+known test-helper suffixes such as `ForTests`. Do not add
+`--fail-on-candidates` to PR gates until the current candidate baseline has been
+triaged and false-positive policy is documented.
 
 Current semantic target owners:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,12 @@ QudJP is the Japanese localization mod for Caves of Qud `1.0.4`. The repo contai
   `.codex/skills/roslyn-static-analysis/SKILL.md`. Purpose-built Roslyn
   inventories are still the source-of-truth path for durable or tracked
   artifacts; runtime evidence is still required for live route proof.
+- For unused private/internal QudJP C# declaration candidates, run
+  `just unused-code-preview`. Use `just unused-code-gate` when a task needs a
+  zero-candidate check, and `just unused-code-check` when changing the scanner
+  implementation itself. The unused-code scanner resolves configured external
+  metadata references from `COQ_MANAGED_DIR`, the stable reference install, or
+  an explicit `managed_dir` recipe argument.
 - Prefer `just` recipes for routine validation so local runs match the repo task runner.
   Raw commands below document what the recipes execute.
 - Create and use a git worktree for implementation work by default. Use the

--- a/Mods/QudJP/Assemblies/AGENTS.md
+++ b/Mods/QudJP/Assemblies/AGENTS.md
@@ -57,6 +57,8 @@ just --list
 just ast-search-cs '<pattern>' Mods/QudJP/Assemblies/src
 just ast-search-cs '<pattern>'
 just lsp-check
+just unused-code-preview
+just unused-code-gate
 ```
 
 `just ast-search-cs '<pattern>'` without a path searches the configured
@@ -64,6 +66,14 @@ decompiled-source target. Use it with `~/dev/coq-decompiled_stable/` to trace
 upstream producers, verify signatures, and investigate unclaimed routes. Promote
 type-, receiver-, overload-, alias-, or inheritance-sensitive C# questions to
 the repo's Roslyn/static-analysis workflow described in the root `AGENTS.md`.
+Use `just unused-code-preview` to generate private/internal QudJP C#
+declaration candidates before cleanup. `just unused-code-gate` fails on any
+candidate and is useful for zero-candidate maintenance, but candidates still
+need owner review before deletion because Harmony, reflection, conditional
+compilation, and runtime-only routes can root code outside ordinary references.
+When the stable game reference is outside the default path, set
+`COQ_MANAGED_DIR` or pass the recipe's `managed_dir` argument so Harmony, game,
+Unity, and TMP metadata can participate in semantic resolution.
 
 When a patch reflects into upstream game members, verify the real signature in
 the decompiled source before choosing `AccessTools.Method` parameter types.

--- a/Mods/QudJP/Assemblies/src/UI/TooltipTextRepairer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/TooltipTextRepairer.cs
@@ -86,17 +86,6 @@ internal static class TooltipTextRepairer
         }
     }
 
-    internal static bool TryPinLookerTooltip(object? triggerInstance)
-    {
-        var tooltipObject = TryGetTooltipObjectFromTrigger(triggerInstance, out var tooltip);
-        if (tooltipObject == null)
-        {
-            return false;
-        }
-
-        return TryPinLookerTooltip(triggerInstance, tooltip, tooltipObject);
-    }
-
     internal static bool ShouldScheduleRepair(object? triggerInstance)
     {
         var tooltipObject = TryGetTooltipObjectFromTrigger(triggerInstance, out _);

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -322,7 +322,15 @@ uv run python scripts/sync_mod.py \
 - `just ast-search-py '<pattern>' [path]` — Python structural search (`sg-py` は後方互換 alias)
 - `just lsp-check` — repo-local `csharp-ls` による C# solution-load diagnostics
 - `just unused-code-preview` — Roslyn による private / internal C# 宣言の未参照候補 inventory
+- `just unused-code-gate` — `unused-code-preview` と同じ inventory を生成し、候補が 1 件でもあれば失敗
 - `just unused-code-check` — unused-code scanner 自体の build / pytest / Ruff / basedpyright gate
+
+`unused-code-preview` / `unused-code-gate` は削除候補の入口であり、削除証明ではありません。
+Harmony、reflection、条件コンパイル、runtime-only route で root されるコードは通常参照だけでは
+判断できないため、候補を消す前に owner review を行います。
+scanner は `scripts/unused_code_inventory_config.json` の外部 assembly 名を
+`COQ_MANAGED_DIR`、既定の stable reference install、または recipe の `managed_dir`
+引数から解決し、解決済み / 未解決の metadata reference を inventory に記録します。
 
 `just lsp-check` は `.sln` / `.csproj` / reference stub / dotnet tool manifest
 の変更時、または editor の診断と `dotnet build` の結果が食い違う時に使います。

--- a/justfile
+++ b/justfile
@@ -599,8 +599,25 @@ text-construction-surface-queue source_root=decompiled_root output="/tmp/roslyn-
   {{python}} scripts/text_construction_surface_policy.py --inventory {{quote(output)}} --limit {{quote(limit)}}
 
 # Generate unused private/internal C# declaration candidates to a disposable local output.
-unused-code-preview source_root="." config="scripts/unused_code_inventory_config.json" output="/tmp/qudjp-unused-code-inventory.json":
-  {{python}} scripts/scan_unused_code_inventory.py --source-root {{quote(source_root)}} --config {{quote(config)}} --output {{quote(output)}}
+unused-code-preview source_root="." config="scripts/unused_code_inventory_config.json" output="/tmp/qudjp-unused-code-inventory.json" managed_dir="":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  args=(--source-root {{quote(source_root)}} --config {{quote(config)}} --output {{quote(output)}})
+  if [ -n {{quote(managed_dir)}} ]; then
+    args+=(--managed-dir {{quote(managed_dir)}})
+  fi
+  {{python}} scripts/scan_unused_code_inventory.py "${args[@]}"
+  {{python}} -c 'import json, sys; doc=json.load(open(sys.argv[1], encoding="utf-8")); print(doc["totals"])' {{quote(output)}}
+
+# Fail if unused private/internal C# declaration candidates are present.
+unused-code-gate source_root="." config="scripts/unused_code_inventory_config.json" output="/tmp/qudjp-unused-code-inventory.json" managed_dir="":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  args=(--source-root {{quote(source_root)}} --config {{quote(config)}} --output {{quote(output)}} --fail-on-candidates)
+  if [ -n {{quote(managed_dir)}} ]; then
+    args+=(--managed-dir {{quote(managed_dir)}})
+  fi
+  {{python}} scripts/scan_unused_code_inventory.py "${args[@]}"
   {{python}} -c 'import json, sys; doc=json.load(open(sys.argv[1], encoding="utf-8")); print(doc["totals"])' {{quote(output)}}
 
 # Run the unused-code scanner's focused validation gate.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -36,6 +36,9 @@ just static-producer-check
 just static-producer-preview
 just annals-pattern-preview
 just text-construction-inventory
+just unused-code-preview
+just unused-code-gate
+just unused-code-check
 just ast-grep-check
 just ast-grep-smoke
 just render-skill-evals <repo-local-skill> <scenario>
@@ -77,6 +80,15 @@ just sync-mod
 - Roslyn tracked artifact recipes are intentionally named `*-tracked`;
   prefer preview recipes for review and validation unless the task explicitly
   owns the generated artifact.
+- Use `just unused-code-preview` to inspect unused private/internal QudJP C#
+  declaration candidates, `just unused-code-gate` when a zero-candidate check is
+  required, and `just unused-code-check` for scanner implementation changes.
+  The candidate inventory is cleanup evidence, not deletion proof; review
+  Harmony, reflection, conditional compilation, and runtime-only ownership
+  before removing code. External metadata references come from
+  `scripts/unused_code_inventory_config.json` and resolve against
+  `COQ_MANAGED_DIR`, the default stable reference install, or the recipe's
+  explicit `managed_dir` argument.
 - Repo-local Roslyn wrappers build into the shared
   `QUDJP_DOTNET_ARTIFACTS_ROOT` cache (default: `.artifacts/dotnet`) behind
   per-tool locks, then execute the produced tool DLL. Just validation recipes

--- a/scripts/scan_unused_code_inventory.py
+++ b/scripts/scan_unused_code_inventory.py
@@ -62,6 +62,15 @@ class GenerationPayload(TypedDict):
     includes_raw_source_text: bool
     parse_error_file_count: int
     parse_error_files: list[str]
+    metadata_references: MetadataReferencePayload
+
+
+class MetadataReferencePayload(TypedDict):
+    """Metadata references used for Roslyn semantic resolution."""
+
+    trusted_platform_assembly_count: int
+    external_references: list[str]
+    missing_external_references: list[str]
 
 
 class InventoryPayload(TypedDict):
@@ -82,6 +91,8 @@ def write_inventory(
     output_path: Path,
     *,
     fail_on_candidates: bool = False,
+    references: list[Path] | None = None,
+    managed_dir: Path | None = None,
 ) -> InventoryPayload:
     """Write the unused-code inventory JSON."""
     return _run_roslyn_scanner(
@@ -89,6 +100,8 @@ def write_inventory(
         _resolve_config_path(config_path),
         output_path,
         fail_on_candidates=fail_on_candidates,
+        references=references or [],
+        managed_dir=managed_dir,
     )
 
 
@@ -98,16 +111,29 @@ def main(argv: list[str] | None = None) -> int:
     _ = parser.add_argument("--source-root", type=Path, default=DEFAULT_SOURCE_ROOT)
     _ = parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
     _ = parser.add_argument("--output", type=Path, required=True)
+    _ = parser.add_argument("--reference", type=Path, action="append", default=[])
+    _ = parser.add_argument("--managed-dir", type=Path)
     _ = parser.add_argument("--fail-on-candidates", action="store_true")
     args = parser.parse_args(argv)
 
     source_root = cast("Path", args.source_root).expanduser()
     config_path = cast("Path", args.config).expanduser()
     output_path = cast("Path", args.output)
+    references = [path.expanduser() for path in cast("list[Path]", args.reference)]
+    managed_dir = cast("Path | None", args.managed_dir)
+    if managed_dir is not None:
+        managed_dir = managed_dir.expanduser()
     fail_on_candidates = cast("bool", args.fail_on_candidates)
 
     try:
-        _ = write_inventory(source_root, config_path, output_path, fail_on_candidates=fail_on_candidates)
+        _ = write_inventory(
+            source_root,
+            config_path,
+            output_path,
+            fail_on_candidates=fail_on_candidates,
+            references=references,
+            managed_dir=managed_dir,
+        )
     except (FileNotFoundError, RuntimeError) as exc:
         _ = sys.stderr.write(f"{exc}\n")
         return 1
@@ -136,6 +162,8 @@ def _run_roslyn_scanner(
     output_path: Path,
     *,
     fail_on_candidates: bool,
+    references: list[Path],
+    managed_dir: Path | None,
 ) -> InventoryPayload:
     normalized_output_path = output_path.expanduser().resolve()
     if not PROJECT_PATH.is_file():
@@ -151,6 +179,10 @@ def _run_roslyn_scanner(
         "--output",
         str(normalized_output_path),
     ]
+    for reference in references:
+        tool_args.extend(["--reference", str(reference.expanduser())])
+    if managed_dir is not None:
+        tool_args.extend(["--managed-dir", str(managed_dir.expanduser())])
     if fail_on_candidates:
         tool_args.append("--fail-on-candidates")
     try:

--- a/scripts/tests/test_parallel_dotnet_contract.py
+++ b/scripts/tests/test_parallel_dotnet_contract.py
@@ -150,6 +150,26 @@ def test_roslyn_build_recipes_use_run_scoped_artifacts() -> None:
         assert "trap 'rm -rf \"$artifacts_root\"' EXIT" in block
 
 
+def test_unused_code_gate_recipe_fails_on_candidates() -> None:
+    """The unused-code candidate gate should expose the scanner's fail mode."""
+    justfile = "\n" + _read_repo_file("justfile")
+    block = _recipe_block(justfile, "unused-code-gate")
+
+    assert "scripts/scan_unused_code_inventory.py" in block
+    assert "--fail-on-candidates" in block
+    assert 'doc["totals"]' in block
+
+
+def test_unused_code_scanner_enforces_sdk_analyzers() -> None:
+    """The unused-code scanner should stay clean under the SDK analyzer gate."""
+    csproj = _read_repo_file("scripts/tools/UnusedCodeInventoryScanner/UnusedCodeInventoryScanner.csproj")
+
+    assert "<TreatWarningsAsErrors>true</TreatWarningsAsErrors>" in csproj
+    assert "<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>" in csproj
+    assert "<EnableNETAnalyzers>true</EnableNETAnalyzers>" in csproj
+    assert "<AnalysisLevel>latest-all</AnalysisLevel>" in csproj
+
+
 def test_roslyn_python_check_covers_shared_dotnet_runner() -> None:
     """The shared Python runner must stay inside the Roslyn lint and type gates."""
     justfile = "\n" + _read_repo_file("justfile")

--- a/scripts/tests/test_scan_unused_code_inventory.py
+++ b/scripts/tests/test_scan_unused_code_inventory.py
@@ -1,11 +1,13 @@
 """Smoke tests for the Roslyn unused-code inventory scanner."""
-# ruff: noqa: S603,S607 -- tests invoke dotnet to drive the repo-local tool
+# ruff: noqa: S603 -- tests invoke dotnet to drive the repo-local tool
 
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
@@ -16,6 +18,16 @@ from scripts.scan_unused_code_inventory import InventoryPayload, write_inventory
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 PROJECT_PATH = _REPO_ROOT / "scripts" / "tools" / "UnusedCodeInventoryScanner" / "UnusedCodeInventoryScanner.csproj"
+DOTNET_TIMEOUT_SECONDS = 120
+
+
+@dataclass(frozen=True)
+class ToolRunOptions:
+    """Optional arguments for invoking the scanner fixture."""
+
+    references: list[Path] | None = None
+    managed_dir: Path | None = None
+    env: dict[str, str] | None = None
 
 
 @pytest.fixture(scope="session")
@@ -148,6 +160,303 @@ public static class DemoTests
 
 
 @pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
+def test_unused_code_inventory_resolves_external_attribute_references(
+    tmp_path: Path,
+    inventory_tool_dll: Path,
+) -> None:
+    """External metadata references should make semantic attribute roots available."""
+    external_dll = _build_external_root_attribute(tmp_path)
+    source_root = tmp_path / "repo"
+    production = source_root / "Mods" / "QudJP" / "Assemblies" / "src"
+    production.mkdir(parents=True)
+    _ = (production / "ExternalRooted.cs").write_text(
+        """
+using External;
+
+namespace QudJP;
+
+[Root]
+internal static class ExternalRooted
+{
+    private static void Prefix() {}
+    private static void HelperUnusedByRoot() {}
+}
+""",
+        encoding="utf-8",
+    )
+    config = source_root / "config.json"
+    _ = config.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "include_path_prefixes": ["Mods/QudJP/Assemblies/src/"],
+                "exclude_path_contains": [],
+                "report_path_prefixes": ["Mods/QudJP/Assemblies/src/"],
+                "candidate_accessibilities": ["private", "internal"],
+                "root_attribute_type_suffixes": ["External.RootAttribute"],
+                "root_member_names_in_attribute_rooted_types": ["Prefix"],
+                "exclude_symbol_patterns": [],
+                "exclude_declaration_name_suffixes": [],
+            },
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "unused.json"
+
+    _run_tool(
+        inventory_tool_dll,
+        source_root,
+        config,
+        output,
+        options=ToolRunOptions(references=[external_dll]),
+    )
+    payload = cast("InventoryPayload", json.loads(output.read_text(encoding="utf-8")))
+
+    assert payload["generation"]["parse_error_file_count"] == 0
+    assert str(external_dll) in payload["generation"]["metadata_references"]["external_references"]
+    candidate_ids = _candidate_ids(payload)
+    assert "QudJP.ExternalRooted" not in candidate_ids
+    assert "QudJP.ExternalRooted.Prefix()" not in candidate_ids
+    assert "QudJP.ExternalRooted.HelperUnusedByRoot()" in candidate_ids
+
+
+@pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
+def test_unused_code_inventory_matches_non_private_accessibilities_as_lowercase(
+    tmp_path: Path,
+    inventory_tool_dll: Path,
+) -> None:
+    """Configured accessibility tokens should match Roslyn accessibility names."""
+    source_root = tmp_path / "repo"
+    production = source_root / "Mods" / "QudJP" / "Assemblies" / "src"
+    production.mkdir(parents=True)
+    _ = (production / "Demo.cs").write_text(
+        """
+namespace QudJP;
+
+internal class Demo
+{
+    protected void NeverCalled() {}
+}
+""",
+        encoding="utf-8",
+    )
+    config = source_root / "config.json"
+    _ = config.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "include_path_prefixes": ["Mods/QudJP/Assemblies/src/"],
+                "exclude_path_contains": [],
+                "report_path_prefixes": ["Mods/QudJP/Assemblies/src/"],
+                "candidate_accessibilities": ["protected"],
+                "root_attribute_type_suffixes": [],
+                "root_member_names_in_attribute_rooted_types": [],
+                "exclude_symbol_patterns": [],
+                "exclude_declaration_name_suffixes": [],
+            },
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "unused.json"
+
+    _run_tool(inventory_tool_dll, source_root, config, output)
+    payload = cast("InventoryPayload", json.loads(output.read_text(encoding="utf-8")))
+
+    assert "QudJP.Demo.NeverCalled()" in _candidate_ids(payload)
+
+
+@pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
+def test_unused_code_inventory_resolves_configured_managed_dir_references(
+    tmp_path: Path,
+    inventory_tool_dll: Path,
+) -> None:
+    """Configured assembly names should resolve against an explicit managed directory."""
+    external_dll = _build_external_root_attribute(tmp_path)
+    source_root = tmp_path / "repo"
+    production = source_root / "Mods" / "QudJP" / "Assemblies" / "src"
+    production.mkdir(parents=True)
+    _ = (production / "ExternalRooted.cs").write_text(
+        """
+using External;
+
+namespace QudJP;
+
+[Root]
+internal static class ExternalRooted
+{
+    private static void Prefix() {}
+}
+""",
+        encoding="utf-8",
+    )
+    config = source_root / "config.json"
+    _ = config.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "include_path_prefixes": ["Mods/QudJP/Assemblies/src/"],
+                "exclude_path_contains": [],
+                "report_path_prefixes": ["Mods/QudJP/Assemblies/src/"],
+                "candidate_accessibilities": ["private", "internal"],
+                "root_attribute_type_suffixes": ["External.RootAttribute"],
+                "root_member_names_in_attribute_rooted_types": ["Prefix"],
+                "reference_assembly_names": [external_dll.name],
+                "exclude_symbol_patterns": [],
+                "exclude_declaration_name_suffixes": [],
+            },
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "unused.json"
+
+    _run_tool(
+        inventory_tool_dll,
+        source_root,
+        config,
+        output,
+        options=ToolRunOptions(managed_dir=external_dll.parent),
+    )
+    payload = cast("InventoryPayload", json.loads(output.read_text(encoding="utf-8")))
+
+    assert str(external_dll) in payload["generation"]["metadata_references"]["external_references"]
+    assert not payload["generation"]["metadata_references"]["missing_external_references"]
+    assert not _candidate_ids(payload)
+
+
+@pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
+def test_unused_code_inventory_reports_configured_references_when_managed_dir_is_missing(
+    tmp_path: Path,
+    inventory_tool_dll: Path,
+) -> None:
+    """Configured assembly names should not disappear when no managed directory resolves."""
+    source_root = tmp_path / "repo"
+    production = source_root / "Mods" / "QudJP" / "Assemblies" / "src"
+    missing_managed_dir = tmp_path / "missing-managed"
+    production.mkdir(parents=True)
+    _ = (production / "Demo.cs").write_text(
+        """
+namespace QudJP;
+
+internal static class Demo
+{
+    private static void Unused() {}
+}
+""",
+        encoding="utf-8",
+    )
+    config = source_root / "config.json"
+    _ = config.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "include_path_prefixes": ["Mods/QudJP/Assemblies/src/"],
+                "exclude_path_contains": [],
+                "report_path_prefixes": ["Mods/QudJP/Assemblies/src/"],
+                "candidate_accessibilities": ["private", "internal"],
+                "root_attribute_type_suffixes": [],
+                "root_member_names_in_attribute_rooted_types": [],
+                "reference_assembly_names": ["Missing.External.dll"],
+                "exclude_symbol_patterns": [],
+                "exclude_declaration_name_suffixes": [],
+            },
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "unused.json"
+
+    _run_tool(
+        inventory_tool_dll,
+        source_root,
+        config,
+        output,
+        options=ToolRunOptions(managed_dir=missing_managed_dir),
+    )
+    payload = cast("InventoryPayload", json.loads(output.read_text(encoding="utf-8")))
+
+    metadata = payload["generation"]["metadata_references"]
+    assert metadata["external_references"] == []
+    assert metadata["missing_external_references"] == [str(missing_managed_dir / "Missing.External.dll")]
+
+
+@pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
+def test_unused_code_inventory_falls_back_when_env_managed_dir_is_missing(
+    tmp_path: Path,
+    inventory_tool_dll: Path,
+) -> None:
+    """A bad COQ_MANAGED_DIR should not hide a later existing managed directory."""
+    external_dll = _build_external_root_attribute(tmp_path)
+    fake_home = tmp_path / "home"
+    default_managed_dir = (
+        fake_home
+        / "Games"
+        / "CavesOfQud-stable-ref"
+        / "CoQ.app"
+        / "Contents"
+        / "Resources"
+        / "Data"
+        / "Managed"
+    )
+    default_managed_dir.mkdir(parents=True)
+    default_reference = default_managed_dir / external_dll.name
+    _ = shutil.copy2(external_dll, default_reference)
+    source_root = tmp_path / "repo"
+    production = source_root / "Mods" / "QudJP" / "Assemblies" / "src"
+    production.mkdir(parents=True)
+    _ = (production / "ExternalRooted.cs").write_text(
+        """
+using External;
+
+namespace QudJP;
+
+[Root]
+internal static class ExternalRooted
+{
+    private static void Prefix() {}
+}
+""",
+        encoding="utf-8",
+    )
+    config = source_root / "config.json"
+    _ = config.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "include_path_prefixes": ["Mods/QudJP/Assemblies/src/"],
+                "exclude_path_contains": [],
+                "report_path_prefixes": ["Mods/QudJP/Assemblies/src/"],
+                "candidate_accessibilities": ["private", "internal"],
+                "root_attribute_type_suffixes": ["External.RootAttribute"],
+                "root_member_names_in_attribute_rooted_types": ["Prefix"],
+                "reference_assembly_names": [external_dll.name],
+                "exclude_symbol_patterns": [],
+                "exclude_declaration_name_suffixes": [],
+            },
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "unused.json"
+
+    _run_tool(
+        inventory_tool_dll,
+        source_root,
+        config,
+        output,
+        options=ToolRunOptions(
+            env={
+                "COQ_MANAGED_DIR": str(tmp_path / "missing-env-managed"),
+                "HOME": str(fake_home),
+            },
+        ),
+    )
+    payload = cast("InventoryPayload", json.loads(output.read_text(encoding="utf-8")))
+
+    metadata = payload["generation"]["metadata_references"]
+    assert metadata["external_references"] == [str(default_reference)]
+    assert not metadata["missing_external_references"]
+    assert not _candidate_ids(payload)
+
+
+@pytest.mark.skipif(not shutil.which("dotnet"), reason="dotnet SDK not available")
 def test_python_wrapper_runs_scanner(tmp_path: Path) -> None:
     """The Python wrapper should build and execute the Roslyn scanner."""
     source_root = tmp_path / "repo"
@@ -234,8 +543,58 @@ internal static class Demo
     assert (tmp_path / "nested" / "unused.json").is_file()
 
 
-def _run_tool(tool_dll: Path, source_root: Path, config: Path, output: Path) -> None:
-    result = subprocess.run(
+def _build_external_root_attribute(tmp_path: Path) -> Path:
+    project = tmp_path / "external" / "External.csproj"
+    project.parent.mkdir()
+    _ = project.write_text(
+        """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>
+""",
+        encoding="utf-8",
+    )
+    _ = (project.parent / "RootAttribute.cs").write_text(
+        """
+namespace External;
+
+public sealed class RootAttribute : System.Attribute;
+""",
+        encoding="utf-8",
+    )
+    result = _run_dotnet(
+        ["dotnet", "build", str(project), "--configuration", "Release"],
+        cwd=None,
+    )
+    assert result.returncode == 0, (
+        f"external fixture build failed (exit {result.returncode}). stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    return project.parent / "bin" / "Release" / "net10.0" / "External.dll"
+
+
+def _run_tool(
+    tool_dll: Path,
+    source_root: Path,
+    config: Path,
+    output: Path,
+    *,
+    options: ToolRunOptions | None = None,
+) -> None:
+    tool_options = options or ToolRunOptions()
+    reference_args = [
+        arg
+        for reference in tool_options.references or []
+        for arg in ("--reference", str(reference))
+    ]
+    managed_dir_args = (
+        []
+        if tool_options.managed_dir is None
+        else ["--managed-dir", str(tool_options.managed_dir)]
+    )
+    result = _run_dotnet(
         [
             "dotnet",
             str(tool_dll),
@@ -245,14 +604,43 @@ def _run_tool(tool_dll: Path, source_root: Path, config: Path, output: Path) -> 
             str(config),
             "--output",
             str(output),
+            *reference_args,
+            *managed_dir_args,
         ],
-        capture_output=True,
-        text=True,
-        check=False,
+        cwd=None,
+        env=tool_options.env,
     )
     assert result.returncode == 0, (
         f"scanner failed (exit {result.returncode}). stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
+
+
+def _run_dotnet(
+    args: list[str],
+    *,
+    cwd: Path | None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    run_env = None if env is None else {**dict(os.environ), **env}
+    try:
+        return subprocess.run(
+            args,
+            cwd=cwd,
+            env=run_env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=DOTNET_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        message = "\n".join(
+            [
+                f"dotnet command timed out after {DOTNET_TIMEOUT_SECONDS}s: {' '.join(args)}",
+                f"stdout:\n{exc.stdout or ''}",
+                f"stderr:\n{exc.stderr or ''}",
+            ]
+        )
+        pytest.fail(message)
 
 
 def _candidate_ids(payload: InventoryPayload) -> set[str]:

--- a/scripts/tools/UnusedCodeInventoryScanner/Program.cs
+++ b/scripts/tools/UnusedCodeInventoryScanner/Program.cs
@@ -17,7 +17,7 @@ internal static class Program
         if (parsed.ShowHelp)
         {
             Console.Out.WriteLine(
-                "Usage: UnusedCodeInventoryScanner --source-root <dir> --config <json-path> --output <json-path> [--fail-on-candidates]");
+                "Usage: UnusedCodeInventoryScanner --source-root <dir> --config <json-path> --output <json-path> [--reference <dll>] [--managed-dir <dir>] [--fail-on-candidates]");
             return 0;
         }
 
@@ -39,7 +39,11 @@ internal static class Program
             return 1;
         }
 
-        var inventory = UnusedCodeScanner.Scan(parsed.SourceRoot!, parsed.ConfigPath!);
+        var inventory = UnusedCodeScanner.Scan(
+            parsed.SourceRoot!,
+            parsed.ConfigPath!,
+            parsed.ReferencePaths,
+            parsed.ManagedDir);
         InventoryWriter.Write(inventory, parsed.OutputPath!);
         Console.Out.WriteLine(
             $"[unused-code-inventory] wrote {inventory.Totals.Candidates} candidate(s) to {parsed.OutputPath}");
@@ -58,6 +62,8 @@ internal sealed class CliArguments
     public string? SourceRoot { get; private init; }
     public string? ConfigPath { get; private init; }
     public string? OutputPath { get; private init; }
+    public IReadOnlyList<string> ReferencePaths { get; private init; } = Array.Empty<string>();
+    public string? ManagedDir { get; private init; }
     public string? Error { get; private init; }
     public bool FailOnCandidates { get; private init; }
     public bool ShowHelp { get; private init; }
@@ -67,6 +73,8 @@ internal sealed class CliArguments
         string? sourceRoot = null;
         string? configPath = null;
         string? outputPath = null;
+        var referencePaths = new List<string>();
+        string? managedDir = null;
         var failOnCandidates = false;
 
         for (var index = 0; index < args.Count; index++)
@@ -99,6 +107,22 @@ internal sealed class CliArguments
 
                     outputPath = args[++index];
                     break;
+                case "--reference":
+                    if (index + 1 >= args.Count)
+                    {
+                        return new CliArguments { Error = "Missing value for --reference" };
+                    }
+
+                    referencePaths.Add(ExpandHome(args[++index]));
+                    break;
+                case "--managed-dir":
+                    if (index + 1 >= args.Count)
+                    {
+                        return new CliArguments { Error = "Missing value for --managed-dir" };
+                    }
+
+                    managedDir = ExpandHome(args[++index]);
+                    break;
                 case "--fail-on-candidates":
                     failOnCandidates = true;
                     break;
@@ -117,6 +141,8 @@ internal sealed class CliArguments
             SourceRoot = ExpandHome(sourceRoot),
             ConfigPath = ExpandHome(configPath),
             OutputPath = ExpandHome(outputPath),
+            ReferencePaths = referencePaths,
+            ManagedDir = managedDir,
             FailOnCandidates = failOnCandidates,
         };
     }
@@ -161,20 +187,25 @@ internal static class UnusedCodeScanner
 {
     private const string SchemaVersion = "1.0";
     private const string GameVersion = "1.0.4";
-    public static InventoryDocument Scan(string sourceRoot, string configPath)
+    public static InventoryDocument Scan(
+        string sourceRoot,
+        string configPath,
+        IReadOnlyList<string> referencePaths,
+        string? managedDir)
     {
         var root = Path.GetFullPath(sourceRoot);
         var config = ScannerConfig.Load(configPath);
         var syntaxTrees = LoadSyntaxTrees(root, config);
+        var resolvedReferences = ReferenceResolver.ResolveReferences(root, config, referencePaths, managedDir);
         var compilation = CSharpCompilation.Create(
             "QudJP.UnusedCodeInventory",
             syntaxTrees,
-            ReferenceResolver.ResolveReferences(),
+            resolvedReferences.References,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
         var declarations = DeclarationCollector.Collect(compilation, config);
         var references = ReferenceCollector.Collect(compilation, declarations.Symbols);
         var classified = CandidateClassifier.Classify(declarations, references, config);
-        return BuildInventory(config, syntaxTrees, classified);
+        return BuildInventory(config, syntaxTrees, classified, resolvedReferences);
     }
 
     private static List<SyntaxTree> LoadSyntaxTrees(string sourceRoot, ScannerConfig config)
@@ -195,7 +226,8 @@ internal static class UnusedCodeScanner
     private static InventoryDocument BuildInventory(
         ScannerConfig config,
         IReadOnlyList<SyntaxTree> syntaxTrees,
-        IReadOnlyList<ClassifiedDeclaration> classified)
+        IReadOnlyList<ClassifiedDeclaration> classified,
+        ReferenceResolution resolvedReferences)
     {
         var candidates = classified
             .Where(row => row.Status == CandidateStatus.Candidate)
@@ -233,6 +265,7 @@ internal static class UnusedCodeScanner
                 IncludesRawSourceText = false,
                 ParseErrorFileCount = diagnostics.Count,
                 ParseErrorFiles = diagnostics,
+                MetadataReferences = resolvedReferences.ToRecord(),
             },
             Totals = new TotalsRecord
             {
@@ -275,6 +308,11 @@ internal sealed class SourceFile
 
 internal sealed class ScannerConfig
 {
+    private static readonly JsonSerializerOptions LoadOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
     [JsonPropertyName("schema_version")]
     public string SchemaVersion { get; init; } = "1.0";
 
@@ -305,12 +343,17 @@ internal sealed class ScannerConfig
     [JsonPropertyName("preprocessor_symbols")]
     public IReadOnlyList<string> PreprocessorSymbols { get; init; } = Array.Empty<string>();
 
+    [JsonPropertyName("reference_assembly_names")]
+    public IReadOnlyList<string> ReferenceAssemblyNames { get; init; } = Array.Empty<string>();
+
+    [JsonPropertyName("reference_paths")]
+    public IReadOnlyList<string> ReferencePaths { get; init; } = Array.Empty<string>();
+
     private IReadOnlyList<Regex>? excludeSymbolRegexes;
 
     public static ScannerConfig Load(string path)
     {
-        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-        var config = JsonSerializer.Deserialize<ScannerConfig>(File.ReadAllText(path), options)
+        var config = JsonSerializer.Deserialize<ScannerConfig>(File.ReadAllText(path), LoadOptions)
             ?? throw new InvalidOperationException($"empty scanner config: {path}");
         if (config.SchemaVersion != "1.0")
         {
@@ -330,7 +373,7 @@ internal sealed class ScannerConfig
 
     public bool IsCandidateAccessibility(Accessibility accessibility)
     {
-        return CandidateAccessibilities.Contains(accessibility.ToString().ToLowerInvariant(), StringComparer.Ordinal);
+        return CandidateAccessibilities.Contains(SymbolText.AccessibilityName(accessibility), StringComparer.Ordinal);
     }
 
     public bool IsExcludedSymbol(ISymbol symbol)
@@ -488,7 +531,7 @@ internal sealed class DeclarationInfo
     public bool IsRoot { get; }
     public bool IsExcluded { get; }
     public string SymbolId => Symbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
-    public string Accessibility => Symbol.DeclaredAccessibility.ToString().ToLowerInvariant();
+    public string Accessibility => SymbolText.AccessibilityName(Symbol.DeclaredAccessibility);
 
     public static DeclarationInfo Create(ISymbol symbol, SyntaxNode node, ScannerConfig config)
     {
@@ -525,7 +568,7 @@ internal sealed class DeclarationInfo
             IPropertySymbol => "property",
             IFieldSymbol => "field",
             IEventSymbol => "event",
-            _ => symbol.Kind.ToString().ToLowerInvariant(),
+            _ => symbol.Kind.ToString(),
         };
     }
 
@@ -597,6 +640,24 @@ internal sealed class DeclarationInfo
         }
 
         return false;
+    }
+}
+
+internal static class SymbolText
+{
+    public static string AccessibilityName(Accessibility accessibility)
+    {
+        return accessibility switch
+        {
+            Microsoft.CodeAnalysis.Accessibility.NotApplicable => "notapplicable",
+            Microsoft.CodeAnalysis.Accessibility.Private => "private",
+            Microsoft.CodeAnalysis.Accessibility.ProtectedAndInternal => "protectedandinternal",
+            Microsoft.CodeAnalysis.Accessibility.Protected => "protected",
+            Microsoft.CodeAnalysis.Accessibility.Internal => "internal",
+            Microsoft.CodeAnalysis.Accessibility.ProtectedOrInternal => "protectedorinternal",
+            Microsoft.CodeAnalysis.Accessibility.Public => "public",
+            _ => "unknown",
+        };
     }
 }
 
@@ -681,6 +742,11 @@ internal static class ReferenceCollector
 
     private static ISymbol? NormalizeReferencedSymbol(ISymbol? symbol)
     {
+        if (symbol is null)
+        {
+            return null;
+        }
+
         return symbol switch
         {
             IMethodSymbol { MethodKind: MethodKind.Constructor, ContainingType: { } type } => type.OriginalDefinition,
@@ -689,12 +755,17 @@ internal static class ReferenceCollector
             IFieldSymbol field => field.OriginalDefinition,
             IEventSymbol eventSymbol => eventSymbol.OriginalDefinition,
             INamedTypeSymbol type => type.OriginalDefinition,
-            _ => symbol?.OriginalDefinition,
+            _ => symbol.OriginalDefinition,
         };
     }
 
     private static ISymbol? NormalizeEnclosingSymbol(ISymbol? symbol)
     {
+        if (symbol is null)
+        {
+            return null;
+        }
+
         return symbol switch
         {
             IMethodSymbol { AssociatedSymbol: { } associated } => associated.OriginalDefinition,
@@ -703,7 +774,7 @@ internal static class ReferenceCollector
             IFieldSymbol field => field.OriginalDefinition,
             IEventSymbol eventSymbol => eventSymbol.OriginalDefinition,
             INamedTypeSymbol type => type.OriginalDefinition,
-            _ => symbol?.OriginalDefinition,
+            _ => symbol.OriginalDefinition,
         };
     }
 }
@@ -812,17 +883,150 @@ internal sealed class CandidateStatus
 
 internal static class ReferenceResolver
 {
-    public static IReadOnlyList<MetadataReference> ResolveReferences()
+    public static ReferenceResolution ResolveReferences(
+        string sourceRoot,
+        ScannerConfig config,
+        IReadOnlyList<string> referencePaths,
+        string? managedDir)
     {
         var trustedPlatformAssemblies =
             (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)?.Split(Path.PathSeparator)
             ?? Array.Empty<string>();
-        return trustedPlatformAssemblies
+        var trustedReferences = trustedPlatformAssemblies
             .Where(File.Exists)
             .Distinct(StringComparer.Ordinal)
             .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+        var externalCandidates = ExternalReferenceCandidates(sourceRoot, config, referencePaths, managedDir);
+        var externalReferences = externalCandidates
+            .Where(File.Exists)
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+        var missingReferences = externalCandidates
+            .Where(path => !File.Exists(path))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+        var references = trustedReferences
+            .Concat(externalReferences)
             .Select(path => MetadataReference.CreateFromFile(path))
             .ToList();
+
+        return new ReferenceResolution(
+            references,
+            trustedReferences.Count,
+            externalReferences,
+            missingReferences);
+    }
+
+    private static IReadOnlyList<string> ExternalReferenceCandidates(
+        string sourceRoot,
+        ScannerConfig config,
+        IReadOnlyList<string> referencePaths,
+        string? managedDir)
+    {
+        var candidates = new List<string>();
+        candidates.AddRange(config.ReferencePaths.Select(path => ResolvePath(sourceRoot, path)));
+        candidates.AddRange(referencePaths.Select(path => ResolvePath(sourceRoot, path)));
+
+        var resolvedManagedDir = ResolveManagedDir(managedDir);
+        if (resolvedManagedDir is not null)
+        {
+            candidates.AddRange(config.ReferenceAssemblyNames.Select(name => Path.Combine(resolvedManagedDir, name)));
+        }
+
+        return candidates;
+    }
+
+    private static string ResolvePath(string sourceRoot, string path)
+    {
+        var expanded = ExpandHome(path);
+        return Path.IsPathFullyQualified(expanded) ? expanded : Path.Combine(sourceRoot, expanded);
+    }
+
+    private static string? ResolveManagedDir(string? managedDir)
+    {
+        if (!string.IsNullOrWhiteSpace(managedDir))
+        {
+            return Path.GetFullPath(ExpandHome(managedDir));
+        }
+
+        string? firstCandidate = null;
+        foreach (var candidate in ManagedDirCandidates(null))
+        {
+            var fullPath = Path.GetFullPath(ExpandHome(candidate));
+            firstCandidate ??= fullPath;
+            if (Directory.Exists(fullPath))
+            {
+                return fullPath;
+            }
+        }
+
+        return firstCandidate;
+    }
+
+    private static IEnumerable<string> ManagedDirCandidates(string? managedDir)
+    {
+        if (!string.IsNullOrWhiteSpace(managedDir))
+        {
+            yield return managedDir;
+        }
+
+        var envManagedDir = Environment.GetEnvironmentVariable("COQ_MANAGED_DIR");
+        if (!string.IsNullOrWhiteSpace(envManagedDir))
+        {
+            yield return envManagedDir;
+        }
+
+        yield return "~/Games/CavesOfQud-stable-ref/CoQ.app/Contents/Resources/Data/Managed";
+    }
+
+    private static string ExpandHome(string path)
+    {
+        if (path == "~")
+        {
+            return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        }
+
+        if (path.StartsWith("~/", StringComparison.Ordinal))
+        {
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), path[2..]);
+        }
+
+        return path;
+    }
+}
+
+internal sealed class ReferenceResolution
+{
+    public ReferenceResolution(
+        IReadOnlyList<MetadataReference> references,
+        int trustedPlatformAssemblyCount,
+        IReadOnlyList<string> externalReferences,
+        IReadOnlyList<string> missingExternalReferences)
+    {
+        References = references;
+        TrustedPlatformAssemblyCount = trustedPlatformAssemblyCount;
+        ExternalReferences = externalReferences;
+        MissingExternalReferences = missingExternalReferences;
+    }
+
+    public IReadOnlyList<MetadataReference> References { get; }
+    public int TrustedPlatformAssemblyCount { get; }
+    public IReadOnlyList<string> ExternalReferences { get; }
+    public IReadOnlyList<string> MissingExternalReferences { get; }
+
+    public MetadataReferenceRecord ToRecord()
+    {
+        return new MetadataReferenceRecord
+        {
+            TrustedPlatformAssemblyCount = TrustedPlatformAssemblyCount,
+            ExternalReferences = ExternalReferences,
+            MissingExternalReferences = MissingExternalReferences,
+        };
     }
 }
 
@@ -866,6 +1070,21 @@ internal sealed class GenerationInfo
 
     [JsonPropertyName("parse_error_files")]
     public IReadOnlyList<string> ParseErrorFiles { get; init; } = Array.Empty<string>();
+
+    [JsonPropertyName("metadata_references")]
+    public MetadataReferenceRecord MetadataReferences { get; init; } = new();
+}
+
+internal sealed class MetadataReferenceRecord
+{
+    [JsonPropertyName("trusted_platform_assembly_count")]
+    public int TrustedPlatformAssemblyCount { get; init; }
+
+    [JsonPropertyName("external_references")]
+    public IReadOnlyList<string> ExternalReferences { get; init; } = Array.Empty<string>();
+
+    [JsonPropertyName("missing_external_references")]
+    public IReadOnlyList<string> MissingExternalReferences { get; init; } = Array.Empty<string>();
 }
 
 internal sealed class TotalsRecord

--- a/scripts/tools/UnusedCodeInventoryScanner/UnusedCodeInventoryScanner.csproj
+++ b/scripts/tools/UnusedCodeInventoryScanner/UnusedCodeInventoryScanner.csproj
@@ -7,6 +7,10 @@
     <RootNamespace>QudJP.Tools.UnusedCodeInventoryScanner</RootNamespace>
     <AssemblyName>UnusedCodeInventoryScanner</AssemblyName>
     <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest-all</AnalysisLevel>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />

--- a/scripts/unused_code_inventory_config.json
+++ b/scripts/unused_code_inventory_config.json
@@ -23,6 +23,19 @@
     "HAS_TMP",
     "QUDJP_DEV_BUILD"
   ],
+  "reference_assembly_names": [
+    "Assembly-CSharp.dll",
+    "0Harmony.dll",
+    "Unity.TextMeshPro.dll",
+    "UnityEngine.CoreModule.dll",
+    "UnityEngine.SharedInternalsModule.dll",
+    "UnityEngine.TextCoreFontEngineModule.dll",
+    "UnityEngine.TextCoreTextEngineModule.dll",
+    "UnityEngine.TextRenderingModule.dll",
+    "UnityEngine.UI.dll",
+    "UnityEngine.UIModule.dll"
+  ],
+  "reference_paths": [],
   "root_attribute_type_suffixes": [
     "HarmonyPatch",
     "HarmonyPatchAttribute",


### PR DESCRIPTION
## Summary
- Add external metadata reference resolution to the unused-code Roslyn scanner via `--reference`, `--managed-dir`, `COQ_MANAGED_DIR`, and configured game/Harmony/Unity/TMP assembly names.
- Add `just unused-code-gate` for zero-candidate enforcement and record resolved/missing metadata references in inventory output.
- Remove one newly detected unused internal tooltip helper wrapper and update agent/docs conduits for the unused-code workflow.
- Strengthen the unused-code scanner project with SDK analyzer gates and add focused regression coverage.

## Review and cleanup
- Independent pre-cleanup review: REQUEST_CHANGES for missing-reference reporting when managed dir could not be resolved.
- Fix applied with regression test for missing configured references.
- Independent re-review verdict: APPROVE.
- `ai-slop-cleaner` pass: consolidated duplicate accessibility-name conversion in `Program.cs`; no behavior changes.
- Post-cleanup independent review verdict: APPROVE.

## Verification
- `uv run pytest scripts/tests/test_scan_unused_code_inventory.py::test_unused_code_inventory_resolves_external_attribute_references -q`
- `uv run pytest scripts/tests/test_scan_unused_code_inventory.py::test_unused_code_inventory_resolves_configured_managed_dir_references -q`
- `uv run pytest scripts/tests/test_scan_unused_code_inventory.py::test_unused_code_inventory_reports_configured_references_when_managed_dir_is_missing -q`
- `uv run pytest scripts/tests/test_scan_unused_code_inventory.py scripts/tests/test_parallel_dotnet_contract.py -q`
- `dotnet build scripts/tools/UnusedCodeInventoryScanner/UnusedCodeInventoryScanner.csproj --configuration Release --no-incremental`
- `just unused-code-check`
- `just unused-code-gate . scripts/unused_code_inventory_config.json /tmp/qudjp-unused-code-inventory-gate.json`
- `just check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 未使用コード検出にプレビュー/ゲート機能を追加し、候補ゼロの状態をチェック可能にしました
  * スキャンで外部参照やmanagedディレクトリを指定できるCLI/レシピを導入しました

* **ドキュメント**
  * 未使用コードスキャン手順と設定のガイドを各所で追記・整理しました

* **バグ修正**
  * ツールチップ修復処理の動作を改善しました

* **テスト**
  * 参照解決とゲート挙動を検証するテスト群を追加しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->