### PR TITLE
Remove unused test helper wrappers

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -270,7 +270,7 @@ public sealed class ColorTagAllowlistCoverageTests
             ["Mods/QudJP/Assemblies/src/Patches/WorldModsTextTranslator.cs:1195:TryTranslateTemplate"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/ZoneWindChangeTranslationPatch.cs:114:TryTranslate"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Translation/ColorAwareTranslationComposer.cs:30:Strip"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
-            ["Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs:97:Translate"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
+            ["Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs:87:Translate"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs:99:Translate"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/UI/FontManager.cs:250:TryWarmPrimaryFontCharactersForUi"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
         };

--- a/Mods/QudJP/Assemblies/src/Patches/CookbookDisplayNameTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/CookbookDisplayNameTranslationPatch.cs
@@ -46,11 +46,6 @@ public static class CookbookDisplayNameTranslationPatch
         }
     }
 
-    internal static bool TryTranslateDisplayNameForTests(object? instance)
-    {
-        return TryTranslateDisplayName(instance);
-    }
-
     private static bool TryTranslateDisplayName(object? instance)
     {
         if (instance is null

--- a/Mods/QudJP/Assemblies/src/Patches/MarkovCorpusTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/MarkovCorpusTranslationPatch.cs
@@ -76,11 +76,6 @@ public static class MarkovCorpusTranslationPatch
         return string.Equals(corpus, VanillaCorpusName, StringComparison.Ordinal);
     }
 
-    internal static void SetCorpusPathForTests(string? path)
-    {
-        corpusPathOverride = path;
-    }
-
     internal static void ResetForTests()
     {
         corpusPathOverride = null;

--- a/Mods/QudJP/Assemblies/src/Patches/ModScrollerOneTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/ModScrollerOneTranslationPatch.cs
@@ -57,8 +57,4 @@ public static class ModScrollerOneTranslationPatch
         }
     }
 
-    internal static string TranslateLiteralForTests(string source)
-    {
-        return ModManagementSemanticPipeline.TranslateDisabledScriptsSuffix(source);
-    }
 }

--- a/Mods/QudJP/Assemblies/src/Patches/SultanRegionRevealDescriptionTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/SultanRegionRevealDescriptionTranslationPatch.cs
@@ -52,11 +52,6 @@ public static class SultanRegionRevealDescriptionTranslationPatch
         }
     }
 
-    internal static bool TryTranslateRevealedDescriptionForTests(object? instance)
-    {
-        return TryTranslateRevealedDescription(instance);
-    }
-
     private static bool TryTranslateRevealedDescription(object? instance)
     {
         if (instance is null

--- a/Mods/QudJP/Assemblies/src/Patches/UITextSkinTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/UITextSkinTranslationPatch.cs
@@ -422,16 +422,6 @@ public static class UITextSkinTranslationPatch
                 || source.Contains(" unlock ("));
     }
 
-    internal static bool ShouldSkipTranslationForTests(string source)
-    {
-        return ShouldSkipTranslation(source, nameof(UITextSkinTranslationPatch));
-    }
-
-    internal static bool ShouldSkipTranslationForTests(string source, string? context)
-    {
-        return ShouldSkipTranslation(source, context);
-    }
-
     internal static bool IsAlreadyLocalizedDirectRouteTextForContext(string source, string? context)
     {
         return IsAlreadyLocalizedDirectRouteText(source, context);

--- a/Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/JournalPatternTranslator.cs
@@ -75,16 +75,6 @@ internal static class JournalPatternTranslator
         return patternLoadSummary;
     }
 
-    internal static int GetMissingPatternHitCountForTests(string source)
-    {
-        return ObservabilityHelpers.GetCounterValue(MissingPatternCounts, source);
-    }
-
-    internal static int GetMissingRouteHitCountForTests(string? context)
-    {
-        return ObservabilityHelpers.GetCounterValue(MissingRouteCounts, ObservabilityHelpers.NormalizeContext(context));
-    }
-
     internal static string Translate(string? source, string? context = null)
     {
         using var _ = Translator.PushLogContext(context);

--- a/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/MessagePatternTranslator.cs
@@ -439,11 +439,6 @@ internal static class MessagePatternTranslator
     }
 #endif
 
-    internal static bool ShouldLogMissingHitForTests(int hitCount)
-    {
-        return ObservabilityHelpers.ShouldLogMissingHit(hitCount);
-    }
-
     private static void LogDuplicatePatternSummary(Dictionary<string, int> duplicatePatternCounts)
     {
         if (duplicatePatternCounts.Count == 0)

--- a/Mods/QudJP/Assemblies/src/Translation/Translator.cs
+++ b/Mods/QudJP/Assemblies/src/Translation/Translator.cs
@@ -344,11 +344,6 @@ public static class Translator
     }
 #endif
 
-    internal static bool ShouldLogMissingHitForTests(int hitCount)
-    {
-        return ObservabilityHelpers.ShouldLogMissingHit(hitCount);
-    }
-
     private static void LogDuplicateKeySummary(Dictionary<string, int> duplicateKeyCounts)
     {
         if (duplicateKeyCounts.Count == 0)


### PR DESCRIPTION
## Summary

- Remove unused `ForTests` wrapper methods that the unused-code scanner only reports when test-helper exclusions are disabled.
- Keep the two book wrapping helpers because existing tests resolve them through reflection.
- Update the color-strip allowlist line number after removing unused methods from `JournalPatternTranslator`.

## Verification

- `dotnet build Mods/QudJP/Assemblies/QudJP.csproj`
- `just unused-code-preview . scripts/unused_code_inventory_config.json /tmp/qudjp-unused-code-inventory-cleanup-default.json`
- `just unused-code-gate . scripts/unused_code_inventory_config.json /tmp/qudjp-unused-code-inventory-cleanup-pr-gate.json`
- temporary no-excludes unused-code preview: candidates reduced from 12 to 2, remaining 2 are reflection-used book helpers
- `just test-l1`
- `just check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テスト インフラストラクチャの内部ヘルパー メソッドをクリーンアップしました。

このリリースは主に内部テスト環境の保守・最適化に関連する変更です。ユーザー向けの機能変更はございません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->