### PR TITLE
Localize mutation pick-option UI

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyQudMutationsModuleWindow.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyQudMutationsModuleWindow.cs
@@ -12,6 +12,13 @@ internal sealed class DummyQudMutationsModuleWindow
             new DummyMutationMenuOption("Stinger (Confusing Venom)", "Stinger (Confusing Venom) [{{W|V}}]", "Sting things.", hasVariantSelector: true)),
     ];
 
+    public List<DummyMutationNode> mutationNodes =
+    [
+        new DummyMutationNode("Esper"),
+        new DummyMutationNode("Adrenal Control"),
+        new DummyMutationNode("Stinger (Confusing Venom)"),
+    ];
+
     public void UpdateControls()
     {
         foreach (var categoryMenu in categoryMenus)
@@ -31,6 +38,45 @@ internal sealed class DummyQudMutationsModuleWindow
             ? string.Concat(entryId, " [{{W|V}}]")
             : entryId;
     }
+}
+
+internal sealed class DummyMutationNode
+{
+    public DummyMutationNode(string entryName, string variant = "")
+    {
+        Entry = new DummyMutationWindowEntry(entryName, variant);
+        Variant = variant;
+        Exemplar = new DummyMutationWindowExemplar(variant);
+    }
+
+    public DummyMutationWindowEntry Entry { get; }
+
+    public string Variant { get; set; }
+
+    public DummyMutationWindowExemplar Exemplar { get; }
+}
+
+internal sealed class DummyMutationWindowEntry
+{
+    public DummyMutationWindowEntry(string name, string variant)
+    {
+        Name = name;
+        Variant = variant;
+    }
+
+    public string Name { get; }
+
+    public string Variant { get; }
+}
+
+internal sealed class DummyMutationWindowExemplar
+{
+    public DummyMutationWindowExemplar(string variant)
+    {
+        Variant = variant;
+    }
+
+    public string Variant { get; }
 }
 
 internal sealed class DummyMutationCategoryMenuData

--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyStatusScreenPopupTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyStatusScreenPopupTargets.cs
@@ -6,6 +6,20 @@ internal static class DummyStatusScreenPopupTarget
 {
     public static string MessageToSend { get; set; } = string.Empty;
 
+    public static string PickOptionTitleToSend { get; set; } = string.Empty;
+
+    public static string PickOptionIntroToSend { get; set; } = string.Empty;
+
+    public static IReadOnlyList<string>? PickOptionOptionsToSend { get; set; }
+
+    public static void Reset()
+    {
+        MessageToSend = string.Empty;
+        PickOptionTitleToSend = string.Empty;
+        PickOptionIntroToSend = string.Empty;
+        PickOptionOptionsToSend = null;
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void BuyStat(DummyGameObject go, string chosenStat)
     {
@@ -18,6 +32,17 @@ internal static class DummyStatusScreenPopupTarget
     public static bool BuyRandomMutation(DummyGameObject go)
     {
         _ = go;
+        if (!string.IsNullOrEmpty(PickOptionTitleToSend)
+            || !string.IsNullOrEmpty(PickOptionIntroToSend)
+            || PickOptionOptionsToSend is not null)
+        {
+            DummyPopupGenericTarget.PickOption(
+                Title: PickOptionTitleToSend,
+                Intro: PickOptionIntroToSend,
+                Options: PickOptionOptionsToSend);
+            return true;
+        }
+
         DummyPopupShow.Show(MessageToSend);
         return true;
     }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyStatusScreens.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyStatusScreens.cs
@@ -106,6 +106,8 @@ internal sealed class DummyCharacterMutation
 
     public int Level { get; set; } = 1;
 
+    public string Variant { get; set; } = string.Empty;
+
     public string GetDisplayName()
     {
         return DisplayName;

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ChargenStructuredTextTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ChargenStructuredTextTranslatorTests.cs
@@ -164,6 +164,31 @@ public sealed class ChargenStructuredTextTranslatorTests
         });
     }
 
+    [TestCase("Freezing Ray", "Icy Vapor", "任意の方向へ冷気の光線を放つ。", "選んだ方向に9マスの冷気線を放つ。")]
+    [TestCase("Flaming Ray", "Ghostly Flames", "任意の方向へ火炎の光線を放つ。", "選んだ方向に9マスの火炎線を放つ。")]
+    [TestCase("Horns", "Horns Antlers", "頭から鋭い角が生えている。", "枝角で敵を突く。")]
+    public void TryTranslateMutationLongDescription_UsesExplicitVariantRankKey(
+        string mutationName,
+        string variant,
+        string description,
+        string rankText)
+    {
+        WriteDictionary(
+            ($"mutation:{mutationName}", description),
+            ($"mutation:{mutationName}:{variant}:rank:1", rankText));
+
+        var translated = ChargenStructuredTextTranslator.TryTranslateMutationLongDescription(
+            mutationName,
+            variant,
+            out var result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(result, Is.EqualTo($"{description}\n\n{rankText}"));
+        });
+    }
+
     [Test]
     public void Translate_UsesMutationDictionaryForRawBeakDescription()
     {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ChargenStructuredTextTranslatorTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ChargenStructuredTextTranslatorTests.cs
@@ -190,6 +190,26 @@ public sealed class ChargenStructuredTextTranslatorTests
     }
 
     [Test]
+    public void TryTranslateMutationLongDescription_PrefersExplicitVariantRankKey()
+    {
+        WriteDictionary(
+            ("mutation:Freezing Ray", "任意の方向へ冷気の光線を放つ。"),
+            ("mutation:Freezing Ray:rank:1", "汎用の凍結線ランク説明。"),
+            ("mutation:Freezing Ray:Icy Vapor:rank:1", "選んだ方向に9マスの冷気線を放つ。"));
+
+        var translated = ChargenStructuredTextTranslator.TryTranslateMutationLongDescription(
+            "Freezing Ray",
+            "Icy Vapor",
+            out var result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translated, Is.True);
+            Assert.That(result, Is.EqualTo("任意の方向へ冷気の光線を放つ。\n\n選んだ方向に9マスの冷気線を放つ。"));
+        });
+    }
+
+    [Test]
     public void Translate_UsesMutationDictionaryForRawBeakDescription()
     {
         WriteDictionary(("mutation:Beak", "顔に立派なくちばしが生えている。\n\n{{rules|+1}} 意力。時おり敵をついばむ。"));

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorTagAllowlistCoverageTests.cs
@@ -176,7 +176,7 @@ public sealed class ColorTagAllowlistCoverageTests
             ["Mods/QudJP/Assemblies/src/Patches/InventoryFireEventTranslationPatch.cs:226:GetPopupFamilyDetail"] = "Audited Strip call: predicate-only popup family classifier; color ownership is not modified.",
             ["Mods/QudJP/Assemblies/src/Patches/JournalNotificationTranslator.cs:20:TryTranslate"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/KeyMappingUiTranslationPatch.cs:112:TryTranslatePopupMessage"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
-            ["Mods/QudJP/Assemblies/src/Patches/LevelerTranslationPatch.cs:109:TryTranslate"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
+            ["Mods/QudJP/Assemblies/src/Patches/LevelerTranslationPatch.cs:113:TryTranslate"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/LiquidVolumeFragmentTranslator.cs:325:TryTranslate"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/LongBladesCoreTranslationPatch.cs:116:TryTranslatePopupMessage"] = "Audited Strip call: popup target colors are restored through the local MarkupAwareRestoreCapture helper.",
             ["Mods/QudJP/Assemblies/src/Patches/LongBladesCoreTranslationPatch.cs:136:TryTranslateQueuedMessage"] = "Audited Strip call: queued actor/target colors are restored through the local MarkupAwareRestoreCapture helper.",
@@ -206,8 +206,8 @@ public sealed class ColorTagAllowlistCoverageTests
             ["Mods/QudJP/Assemblies/src/Patches/PhysicsInventoryActionPopupTranslationPatch.cs:94:TryTranslatePopupMessage"] = "Audited Strip call: ownership-pour colors are restored by LiquidVolumeFragmentTranslator, cleaning-liquid captures use MarkupAwareRestoreCapture, and attack-confirm target colors are restored by PopupTranslationPatch.TryTranslatePhysicsAttackConfirmText.",
             ["Mods/QudJP/Assemblies/src/Patches/PhysicAmputateLimbTranslationPatch.cs:125:TryTranslatePopupMessage"] = "Audited Strip call: field-amputation popup captures are restored through RestoreCapture and whole-source boundary wrappers are restored through RestoreWhole.",
             ["Mods/QudJP/Assemblies/src/Patches/PhysicsProcessTakeDamageTranslationPatch.cs:260:TryTranslateDamageFrame"] = "Audited Strip call: damage-frame source and damage-type captures are restored through local MarkupAwareRestoreCapture helpers.",
-            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:1416:TranslateCookingRecipeNameForInventoryActionMenu"] = "Audited Strip call: recipe-name colors are restored through CookbookDisplayNameTranslator after inventory action menu parsing.",
-            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:1821:IsAlreadyLocalizedPopupText"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
+            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:1428:TranslateCookingRecipeNameForInventoryActionMenu"] = "Audited Strip call: recipe-name colors are restored through CookbookDisplayNameTranslator after inventory action menu parsing.",
+            ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:1833:IsAlreadyLocalizedPopupText"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:270:TranslatePopupTextForRoute"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs:386:TryTranslatePopupProducerText"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/PowerEntryRequirementPopupTranslationPatch.cs:110:TryTranslatePrerequisitePopup"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
@@ -230,7 +230,7 @@ public sealed class ColorTagAllowlistCoverageTests
             ["Mods/QudJP/Assemblies/src/Patches/StatusScreenMutationPopupTranslationPatch.cs:291:TryTranslateTail"] = "Audited Strip call: mutation popup tail colors are restored by RestoreWhole and RestoreCapture.",
             ["Mods/QudJP/Assemblies/src/Patches/StatusScreenMutationPopupTranslationPatch.cs:328:TryTranslateIncreasedRankLine"] = "Audited Strip call: mutation rank-up colors are restored by RestoreWhole and RestoreCapture.",
             ["Mods/QudJP/Assemblies/src/Patches/StatusScreenMutationPopupTranslationPatch.cs:417:TryTranslateRankBoostLine"] = "Audited Strip call: rank-boost line colors are restored by RestoreWhole; whole-line color wrappers are covered by L2 tests.",
-            ["Mods/QudJP/Assemblies/src/Patches/StatusScreenPopupTranslationPatch.cs:119:TryTranslatePopupMessage"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
+            ["Mods/QudJP/Assemblies/src/Patches/StatusScreenPopupTranslationPatch.cs:127:TryTranslatePopupMessage"] = "Audited Strip call: color ownership is restored in a downstream branch/helper or the call is predicate/observation-only.",
             ["Mods/QudJP/Assemblies/src/Patches/SurvivalCampAttemptCampPopupTranslationPatch.cs:151:TryTranslateExistingCampfireHere"] = "Audited Strip call: campfire capture colors are restored through the local RestoreCapture helper.",
             ["Mods/QudJP/Assemblies/src/Patches/SurvivalCampAttemptCampPopupTranslationPatch.cs:168:TryTranslateExistingCampfireNavigation"] = "Audited Strip call: campfire capture colors are restored through the local RestoreCapture helper.",
             ["Mods/QudJP/Assemblies/src/Patches/SurvivalCampAttemptCampPopupTranslationPatch.cs:185:TryTranslateCampfireInPool"] = "Audited Strip call: liquid capture colors are restored through the local RestoreCapture helper.",
@@ -277,7 +277,7 @@ public sealed class ColorTagAllowlistCoverageTests
     private static readonly SortedDictionary<string, string> NameLikeRestoreCaptureWithoutGuardAllowlist =
         new(StringComparer.Ordinal)
         {
-            ["Mods/QudJP/Assemblies/src/Patches/ChargenStructuredTextTranslator.cs:423:TryTranslateCyberneticsSlot:name"] =
+            ["Mods/QudJP/Assemblies/src/Patches/ChargenStructuredTextTranslator.cs:438:TryTranslateCyberneticsSlot:name"] =
                 "Cybernetics slot names are exact static labels, not display-name owner captures.",
         };
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
@@ -522,6 +522,27 @@ public sealed class LocalizationCoverageTests
     }
 
     [Test]
+    public void MutationDescriptionsDictionary_CoversAllMutationEntriesFromAssets()
+    {
+        var mutationNames = LoadMutationNamesWithDisplayName(Path.Combine(localizationRoot, "Mutations.jp.xml"))
+            .Concat(LoadMutationNamesWithDisplayName(Path.Combine(localizationRoot, "HiddenMutations.jp.xml")))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        var descriptionKeys = LoadEntries(Path.Combine(localizationRoot, "Dictionaries", "mutation-descriptions.ja.json"))
+            .Select(static entry => entry.Key)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missing = mutationNames
+            .Where(name => !descriptionKeys.Contains($"mutation:{name}"))
+            .ToArray();
+
+        Assert.That(
+            missing,
+            Is.Empty,
+            "Every mutation asset entry should have a mutation:<Name> long-description key for popup and menu owner routes.");
+    }
+
+    [Test]
     public void ChargenStructuredTextTranslator_CoversRuntimeObservedSkillLeaves()
     {
         var expectedTranslations = new Dictionary<string, string>(StringComparer.Ordinal)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/LocalizationCoverageTests.cs
@@ -531,15 +531,34 @@ public sealed class LocalizationCoverageTests
         var descriptionKeys = LoadEntries(Path.Combine(localizationRoot, "Dictionaries", "mutation-descriptions.ja.json"))
             .Select(static entry => entry.Key)
             .ToHashSet(StringComparer.Ordinal);
+        var rankKeys = LoadEntries(Path.Combine(localizationRoot, "Dictionaries", "mutation-ranktext.ja.json"))
+            .Select(static entry => entry.Key)
+            .ToHashSet(StringComparer.Ordinal);
+        var mutationVariants = LoadMutationNameVariantsWithDisplayName(Path.Combine(localizationRoot, "Mutations.jp.xml"))
+            .Concat(LoadMutationNameVariantsWithDisplayName(Path.Combine(localizationRoot, "HiddenMutations.jp.xml")))
+            .Where(static entry => !string.IsNullOrWhiteSpace(entry.variant))
+            .Distinct()
+            .ToArray();
 
         var missing = mutationNames
             .Where(name => !descriptionKeys.Contains($"mutation:{name}"))
             .ToArray();
+        var missingVariantRanks = mutationVariants
+            .Where(entry => !rankKeys.Contains($"mutation:{entry.name}:{entry.variant}:rank:1"))
+            .Select(entry => $"{entry.name}:{entry.variant}")
+            .ToArray();
 
-        Assert.That(
-            missing,
-            Is.Empty,
-            "Every mutation asset entry should have a mutation:<Name> long-description key for popup and menu owner routes.");
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                missing,
+                Is.Empty,
+                "Every mutation asset entry should have a mutation:<Name> long-description key for popup and menu owner routes.");
+            Assert.That(
+                missingVariantRanks,
+                Is.Empty,
+                "Every mutation asset entry with Variant should have a mutation:<Name>:<Variant>:rank:1 rank-text key.");
+        });
     }
 
     [Test]
@@ -1503,6 +1522,19 @@ public sealed class LocalizationCoverageTests
             .Select(element => element.Attribute("Name")?.Value)
             .Where(static value => !string.IsNullOrWhiteSpace(value))
             .Cast<string>()
+            .ToArray();
+    }
+
+    private static (string name, string variant)[] LoadMutationNameVariantsWithDisplayName(string path)
+    {
+        var document = XDocument.Load(path);
+        return document.Root!
+            .Descendants("mutation")
+            .Where(element => element.Attribute("DisplayName") is not null)
+            .Select(element => (
+                name: element.Attribute("Name")?.Value ?? string.Empty,
+                variant: element.Attribute("Variant")?.Value.Trim() ?? string.Empty))
+            .Where(static entry => !string.IsNullOrWhiteSpace(entry.name))
             .ToArray();
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CharacterStatusScreenMutationDetailsPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CharacterStatusScreenMutationDetailsPatchTests.cs
@@ -77,6 +77,51 @@ public sealed class CharacterStatusScreenMutationDetailsPatchTests
         }
     }
 
+    [TestCase("Freezing Ray", "Icy Vapor", "任意の方向へ冷気の光線を放つ。", "選んだ方向に9マスの冷気線を放つ。")]
+    [TestCase("Flaming Ray", "Ghostly Flames", "任意の方向へ火炎の光線を放つ。", "選んだ方向に9マスの火炎線を放つ。")]
+    [TestCase("Horns", "Horns Antlers", "頭から鋭い角が生えている。", "枝角で敵を突く。")]
+    public void Postfix_TranslatesMutationDetailsUsingVariantRankKey_WhenPatched(
+        string mutationName,
+        string variant,
+        string description,
+        string rankText)
+    {
+        WriteDictionary(
+            ($"mutation:{mutationName}", description),
+            ($"mutation:{mutationName}:{variant}:rank:1", rankText));
+
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyCharacterStatusMutationScreen), nameof(DummyCharacterStatusMutationScreen.HandleHighlightMutation)),
+                postfix: new HarmonyMethod(RequireMethod(typeof(CharacterStatusScreenMutationDetailsPatch), nameof(CharacterStatusScreenMutationDetailsPatch.Postfix))));
+
+            var screen = new DummyCharacterStatusMutationScreen();
+            screen.HandleHighlightMutation(new DummyCharacterMutationLineData
+            {
+                mutation = new DummyCharacterMutation
+                {
+                    Name = mutationName.Replace(" ", string.Empty, StringComparison.Ordinal),
+                    EntryName = mutationName,
+                    DisplayName = mutationName,
+                    Variant = variant,
+                    Level = 1,
+                },
+            });
+
+            Assert.That(
+                screen.mutationsDetails.Text,
+                Is.EqualTo($"{description}\n\n{rankText}"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
     [Test]
     public void Postfix_RecordsMutationDetailsOwnerRouteTransform_WithoutUITextSkinSinkObservation_WhenPatched()
     {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/CharacterStatusScreenMutationDetailsPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/CharacterStatusScreenMutationDetailsPatchTests.cs
@@ -123,6 +123,46 @@ public sealed class CharacterStatusScreenMutationDetailsPatchTests
     }
 
     [Test]
+    public void Postfix_PrefersMutationVariantRankKey_WhenGenericRankExists()
+    {
+        WriteDictionary(
+            ("mutation:Freezing Ray", "任意の方向へ冷気の光線を放つ。"),
+            ("mutation:Freezing Ray:rank:1", "汎用の凍結線ランク説明。"),
+            ("mutation:Freezing Ray:Icy Vapor:rank:1", "選んだ方向に9マスの冷気線を放つ。"));
+
+        var harmonyId = $"qudjp.tests.{Guid.NewGuid():N}";
+        var harmony = new Harmony(harmonyId);
+
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(typeof(DummyCharacterStatusMutationScreen), nameof(DummyCharacterStatusMutationScreen.HandleHighlightMutation)),
+                postfix: new HarmonyMethod(RequireMethod(typeof(CharacterStatusScreenMutationDetailsPatch), nameof(CharacterStatusScreenMutationDetailsPatch.Postfix))));
+
+            var screen = new DummyCharacterStatusMutationScreen();
+            screen.HandleHighlightMutation(new DummyCharacterMutationLineData
+            {
+                mutation = new DummyCharacterMutation
+                {
+                    Name = "FreezingRay",
+                    EntryName = "Freezing Ray",
+                    DisplayName = "Freezing Ray",
+                    Variant = "Icy Vapor",
+                    Level = 1,
+                },
+            });
+
+            Assert.That(
+                screen.mutationsDetails.Text,
+                Is.EqualTo("任意の方向へ冷気の光線を放つ。\n\n選んだ方向に9マスの冷気線を放つ。"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
     public void Postfix_RecordsMutationDetailsOwnerRouteTransform_WithoutUITextSkinSinkObservation_WhenPatched()
     {
         WriteDictionary(

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/LevelerTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/LevelerTranslationPatchTests.cs
@@ -71,6 +71,45 @@ public sealed class LevelerTranslationPatchTests
     }
 
     [Test]
+    public void Patch_TranslatesRapidAdvancementPickOptionTitle_WhenOwnerPatched()
+    {
+        const string source = "Choose a physical mutation to rapidly advance.";
+
+        LevelerTranslationPatch.Prefix();
+        try
+        {
+            new DummyLevelerProducer
+            {
+                PickOptionTitleToShow = source,
+            }.RapidAdvancement(3, new DummyGameObject());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupGenericTarget.LastPickOptionTitle, Is.EqualTo("急速に成長させる身体的変異を選んでください。"));
+                Assert.That(PickOptionHitCount("LevelerRapidAdvancementPickOption"), Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            _ = LevelerTranslationPatch.Finalizer(null);
+        }
+    }
+
+    [Test]
+    public void Patch_DoesNotTranslateRapidAdvancementPickOptionTitle_WhenOwnerAbsent()
+    {
+        const string source = "Choose a physical mutation to rapidly advance.";
+
+        CallPickOption(source);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPopupGenericTarget.LastPickOptionTitle, Is.EqualTo(source));
+            Assert.That(PickOptionHitCount("LevelerRapidAdvancementPickOption"), Is.Zero);
+        });
+    }
+
+    [Test]
     public void Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
     {
         const string source = "You have no physical mutations to rapidly advance!";
@@ -140,16 +179,60 @@ public sealed class LevelerTranslationPatchTests
         return OwnerPopupRouteTestHarness.RouteHitCount(typeof(LevelerTranslationPatch), detail);
     }
 
+    private static int PickOptionHitCount(string detail)
+    {
+        return DynamicTextObservability.GetRouteFamilyHitCountForTests(
+            nameof(PopupPickOptionTranslationPatch),
+            "Popup.ProducerText." + nameof(LevelerTranslationPatch) + "." + detail);
+    }
+
     private sealed class DummyLevelerProducer
     {
         public string PopupMessageToShow { get; set; } = string.Empty;
+
+        public string PickOptionTitleToShow { get; set; } = string.Empty;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void RapidAdvancement(int amount, DummyGameObject parentObject)
         {
             _ = amount;
             _ = parentObject;
+            if (!string.IsNullOrEmpty(PickOptionTitleToShow))
+            {
+                CallPickOption(PickOptionTitleToShow);
+                return;
+            }
+
             DummyPopupShow.Show(PopupMessageToShow);
+        }
+    }
+
+    private static void CallPickOption(string title)
+    {
+        string? intro = null;
+        var spacingText = string.Empty;
+        IReadOnlyList<string>? options = null;
+        object? buttons = null;
+        string? popupId = null;
+
+        PopupPickOptionTranslationPatch.Prefix(
+            ref title,
+            ref intro,
+            ref spacingText,
+            ref options,
+            buttons,
+            popupId);
+        try
+        {
+            DummyPopupGenericTarget.PickOption(
+                Title: title,
+                Intro: intro,
+                SpacingText: spacingText,
+                Options: options);
+        }
+        finally
+        {
+            PopupPickOptionTranslationPatch.Finalizer();
         }
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/LevelerTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/LevelerTranslationPatchTests.cs
@@ -17,12 +17,14 @@ public sealed class LevelerTranslationPatchTests
         DynamicTextObservability.ResetForTests();
         MessageFrameTranslator.ResetForTests();
         DummyPopupShow.Reset();
+        DummyPopupGenericTarget.Reset();
     }
 
     [TearDown]
     public void TearDown()
     {
         DummyPopupShow.Reset();
+        DummyPopupGenericTarget.Reset();
         MessageFrameTranslator.ResetForTests();
         DynamicTextObservability.ResetForTests();
     }
@@ -109,6 +111,42 @@ public sealed class LevelerTranslationPatchTests
         });
     }
 
+    [TestCase(
+        "Choose a physical mutation to rapidly advance.",
+        "急速に成長させる身体的変異を選んでください。",
+        1)]
+    [TestCase(
+        "Choose a mutation to rapidly advance.",
+        "急速に成長させる変異を選んでください。",
+        1)]
+    [TestCase(
+        "Choose a lattice to rapidly advance.",
+        "Choose a lattice to rapidly advance.",
+        0)]
+    [TestCase("", "", 0)]
+    [TestCase(
+        "<color=#ff0>Choose a physical mutation to rapidly advance.</color>",
+        "<color=#ff0>急速に成長させる身体的変異を選んでください。</color>",
+        1)]
+    public void Patch_HandlesRapidAdvancementPickOptionTitleEdges_WhenOwnerPatched(
+        string source,
+        string expected,
+        int expectedHits)
+    {
+        AssertOwnerPickOptionTitle(source, expected, expectedHits);
+    }
+
+    [Test]
+    public void Patch_DoesNotRetranslateDirectMarkedPickOptionTitle_WhenOwnerPatched()
+    {
+        const string source = "Choose a physical mutation to rapidly advance.";
+
+        AssertOwnerPickOptionTitle(
+            MessageFrameTranslator.MarkDirectTranslation(source),
+            source,
+            expectedHits: 0);
+    }
+
     [Test]
     public void Patch_DoesNotRetranslateDirectMarkedPopup_WhenOwnerPatched()
     {
@@ -161,6 +199,25 @@ public sealed class LevelerTranslationPatchTests
                     Assert.That(HitCount(detail), Is.EqualTo(expectedHits));
                 });
             });
+    }
+
+    private static void AssertOwnerPickOptionTitle(string source, string expected, int expectedHits)
+    {
+        LevelerTranslationPatch.Prefix();
+        try
+        {
+            CallPickOption(source);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupGenericTarget.LastPickOptionTitle, Is.EqualTo(expected));
+                Assert.That(PickOptionHitCount("LevelerRapidAdvancementPickOption"), Is.EqualTo(expectedHits));
+            });
+        }
+        finally
+        {
+            _ = LevelerTranslationPatch.Finalizer(null);
+        }
     }
 
     private static MethodInfo RequireOwnerMethod()

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PickTargetWindowUpdateTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PickTargetWindowUpdateTranslationPatchTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using HarmonyLib;
 using QudJP.Patches;
+using QudJP.Tests.DummyTargets;
 
 namespace QudJP.Tests.L2;
 
@@ -106,6 +107,31 @@ public sealed class PickTargetWindowUpdateTranslationPatchTests
                     nameof(PickTargetWindowUpdateTranslationPatch),
                     "PickTarget.CommandBar"),
                 Is.GreaterThan(0));
+        });
+    }
+
+    [Test]
+    public void Prefix_DoesNotCallSetTextAgain_WhenProducerRegeneratesSameEnglishCommandBar()
+    {
+        WriteDictionary(
+            ("Look", "見る"),
+            ("lock", "ロック"),
+            ("interact", "操作する"),
+            ("walk", "歩く"));
+        const string source = "Look | {{W|ESC}} | {{hotkey|({{hotkey|F1}})}} {{W|l}}ock | {{hotkey|space}} interact | {{hotkey|{{hotkey|W}}}} walk";
+        const string expected = "見る | {{W|ESC}} | {{hotkey|({{hotkey|F1}})}} {{W|ロ}}ック | {{hotkey|space}} 操作する | {{hotkey|{{hotkey|W}}}} 歩く";
+        DummyPickTargetWindow.currentText = source;
+
+        RunWithPickTargetWindowUpdatePatch(() => DummyPickTargetWindow.Update());
+        DummyPickTargetWindow.currentText = source;
+        RunWithPickTargetWindowUpdatePatch(() => DummyPickTargetWindow.Update());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DummyPickTargetWindow.currentText, Is.EqualTo(expected));
+            Assert.That(DummyPickTargetWindow.text.text, Is.EqualTo(expected));
+            Assert.That(DummyPickTargetWindow.text.SetTextCallCount, Is.EqualTo(1));
+            Assert.That(DummyPickTargetWindow.UpdateCallCount, Is.EqualTo(2));
         });
     }
 
@@ -316,16 +342,23 @@ public sealed class PickTargetWindowUpdateTranslationPatchTests
     {
         public static string currentText = string.Empty;
 
+        public static DummyUITextSkin text = new();
+
         public static int UpdateCallCount { get; private set; }
 
         public static void Update()
         {
             UpdateCallCount++;
+            if (text.text != currentText)
+            {
+                text.SetText(currentText);
+            }
         }
 
         public static void Reset()
         {
             currentText = string.Empty;
+            text = new DummyUITextSkin();
             UpdateCallCount = 0;
         }
     }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudMutationsModuleWindowTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudMutationsModuleWindowTranslationPatchTests.cs
@@ -120,6 +120,44 @@ public sealed class QudMutationsModuleWindowTranslationPatchTests
         Assert.That(translated, Is.EqualTo(source));
     }
 
+    [TestCase("Freezing Ray", "Icy Vapor", "任意の方向へ冷気の光線を放つ。", "選んだ方向に9マスの冷気線を放つ。")]
+    [TestCase("Flaming Ray", "Ghostly Flames", "任意の方向へ火炎の光線を放つ。", "選んだ方向に9マスの火炎線を放つ。")]
+    [TestCase("Horns", "Horns Antlers", "頭から鋭い角が生えている。", "枝角で敵を突く。")]
+    public void Postfix_UsesMutationNodeVariantForLongDescriptionRankText(
+        string mutationName,
+        string variant,
+        string description,
+        string rankText)
+    {
+        WriteDictionary(
+            ($"mutation:{mutationName}", description),
+            ($"mutation:{mutationName}:{variant}:rank:1", rankText));
+
+        var window = new DummyQudMutationsModuleWindow
+        {
+            categoryMenus =
+            [
+                new DummyMutationCategoryMenuData(
+                    new DummyMutationMenuOption(
+                        mutationName,
+                        mutationName,
+                        "English description that should be replaced.")),
+            ],
+            mutationNodes =
+            [
+                new DummyMutationNode(mutationName, variant),
+            ],
+        };
+
+        QudMutationsModuleWindowTranslationPatch.Postfix(window);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(window.categoryMenus[0].menuOptions[0].LongDescription, Is.EqualTo($"{description}\n\n{rankText}"));
+            Assert.That(window.prefabComponent.LastRenderedLongDescriptions[0], Is.EqualTo($"{description}\n\n{rankText}"));
+        });
+    }
+
     private static MethodInfo RequireMethod(Type type, string methodName)
     {
         return AccessTools.Method(type, methodName)

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/StatusScreenPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/StatusScreenPopupTranslationPatchTests.cs
@@ -120,6 +120,69 @@ public sealed class StatusScreenPopupTranslationPatchTests
     }
 
     [Test]
+    public void BuyRandomMutation_HandlesMutationPickOptionDirectMarkers_WhenOwnerPatched()
+    {
+        var (intro, options) = TranslateMutationPickOption(
+            MessageFrameTranslator.MarkDirectTranslation("Choose a mutation."),
+            new[]
+            {
+                MessageFrameTranslator.MarkDirectTranslation(
+                    "{{W|Two-hearted}} - You have two hearts.\n+2 Toughness\nYou can sprint for 30% longer."),
+            });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(intro, Is.EqualTo("Choose a mutation."));
+            Assert.That(options, Is.Not.Null);
+            Assert.That(options![0], Is.EqualTo("{{W|Two-hearted}} - You have two hearts.\n+2 Toughness\nYou can sprint for 30% longer."));
+        });
+    }
+
+    [Test]
+    public void BuyRandomMutation_LeavesEmptyMutationPickOptionFieldsUnchanged_WhenOwnerPatched()
+    {
+        var (intro, options) = TranslateMutationPickOption(string.Empty, Array.Empty<string>());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(intro, Is.Empty);
+            Assert.That(options, Is.Not.Null);
+            Assert.That(options, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void BuyRandomMutation_PreservesColoredMutationPickOptionPromptAndFallbackOption_WhenOwnerPatched()
+    {
+        const string sourceIntro = "<color=#ff0>Choose a mutation.</color>";
+        const string sourceOption = "<color=#ff0>unhandled choice</color>";
+
+        var (intro, options) = TranslateMutationPickOption(sourceIntro, new[] { sourceOption });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(intro, Is.EqualTo("<color=#ff0>変異を選んでください。</color>"));
+            Assert.That(options, Is.Not.Null);
+            Assert.That(options![0], Is.EqualTo(sourceOption));
+        });
+    }
+
+    [Test]
+    public void BuyRandomMutation_LeavesUnsupportedMutationPickOptionPromptUnchanged_WhenOwnerPatched()
+    {
+        const string sourceIntro = "<color=#ff0>Choose an artifact.</color>";
+
+        var (intro, options) = TranslateMutationPickOption(sourceIntro, Array.Empty<string>());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(intro, Is.EqualTo(sourceIntro));
+            Assert.That(options, Is.Not.Null);
+            Assert.That(options, Is.Empty);
+        });
+    }
+
+    [Test]
     public void Show_TranslatesPsychicGlimmerDebugPopup_WhenOwnerPatched()
     {
         AssertPopupMessage(
@@ -458,6 +521,36 @@ public sealed class StatusScreenPopupTranslationPatchTests
             _ = ownerMethod.Invoke(null, CreateOwnerArguments(ownerMethod));
 
             return DummyPopupShow.LastShowMessage ?? string.Empty;
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    private static (string? intro, IReadOnlyList<string>? options) TranslateMutationPickOption(
+        string intro,
+        IReadOnlyList<string> options)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPickOption(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(
+                    typeof(DummyStatusScreenPopupTarget),
+                    nameof(DummyStatusScreenPopupTarget.BuyRandomMutation),
+                    typeof(DummyGameObject)));
+
+            DummyStatusScreenPopupTarget.PickOptionTitleToSend = "";
+            DummyStatusScreenPopupTarget.PickOptionIntroToSend = intro;
+            DummyStatusScreenPopupTarget.PickOptionOptionsToSend = options;
+
+            _ = DummyStatusScreenPopupTarget.BuyRandomMutation(new DummyGameObject());
+
+            return (DummyPopupGenericTarget.LastPickOptionIntro, DummyPopupGenericTarget.LastPickOptionOptions);
         }
         finally
         {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/StatusScreenPopupTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/StatusScreenPopupTranslationPatchTests.cs
@@ -19,7 +19,8 @@ public sealed class StatusScreenPopupTranslationPatchTests
         StatusScreenPopupTranslationPatch.ResetForTests();
         StatusScreenMutationPopupTranslationPatch.ResetForTests();
         DummyPopupShow.Reset();
-        DummyStatusScreenPopupTarget.MessageToSend = string.Empty;
+        DummyPopupGenericTarget.Reset();
+        DummyStatusScreenPopupTarget.Reset();
     }
 
     [TearDown]
@@ -74,6 +75,48 @@ public sealed class StatusScreenPopupTranslationPatchTests
             ownerMethod: RequireMethod(typeof(DummyStatusScreenPopupTarget), nameof(DummyStatusScreenPopupTarget.BuyRandomMutation), typeof(DummyGameObject)),
             source,
             expected);
+    }
+
+    [Test]
+    public void BuyRandomMutation_TranslatesMutationPickOptionIntroAndOptions_WhenOwnerPatched()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            PatchPickOption(harmony);
+            PatchOwner(
+                harmony,
+                RequireMethod(
+                    typeof(DummyStatusScreenPopupTarget),
+                    nameof(DummyStatusScreenPopupTarget.BuyRandomMutation),
+                    typeof(DummyGameObject)));
+
+            DummyStatusScreenPopupTarget.PickOptionTitleToSend = "";
+            DummyStatusScreenPopupTarget.PickOptionIntroToSend = "Choose a mutation.";
+            DummyStatusScreenPopupTarget.PickOptionOptionsToSend = new[]
+            {
+                "{{W|Photosynthetic Skin}}{{G| + grow a new body part}} {{y|- You replenish yourself by absorbing sunlight through your hearty green skin.\nYou can bask in the sunlight instead of eating a meal to gain a special metabolizing effect for 1 day: +30% to natural healing rate and +15 Quickness}}",
+                "{{W|Two-hearted}} - You have two hearts.\n+2 Toughness\nYou can sprint for 30% longer.",
+                "{{W|Double-muscled}} - You are possessed of hulking strength.\n+2 Strength\n15% chance to daze your opponent on a successful melee attack for 2-3 rounds",
+            };
+
+            _ = DummyStatusScreenPopupTarget.BuyRandomMutation(new DummyGameObject());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(DummyPopupGenericTarget.LastPickOptionTitle, Is.Empty);
+                Assert.That(DummyPopupGenericTarget.LastPickOptionIntro, Is.EqualTo("変異を選んでください。"));
+                Assert.That(DummyPopupGenericTarget.LastPickOptionOptions, Is.Not.Null);
+                Assert.That(DummyPopupGenericTarget.LastPickOptionOptions![0], Does.StartWith("{{W|光合成皮膚}}{{G| + 新しい身体部位が生える}} - たくましい緑の皮膚で日光を吸収し、そこから養分を得る。"));
+                Assert.That(DummyPopupGenericTarget.LastPickOptionOptions![1], Does.StartWith("{{W|二重心臓}} - 心臓が2つある。"));
+                Assert.That(DummyPopupGenericTarget.LastPickOptionOptions![2], Does.StartWith("{{W|二重筋肉}} - あなたは怪力を振るうことができる。"));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
     }
 
     [Test]
@@ -452,6 +495,14 @@ public sealed class StatusScreenPopupTranslationPatchTests
                 typeof(bool),
                 typeof(bool)),
             prefix: new HarmonyMethod(RequireMethod(typeof(PopupShowTranslationPatch), nameof(PopupShowTranslationPatch.Prefix))));
+    }
+
+    private static void PatchPickOption(Harmony harmony)
+    {
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupGenericTarget), nameof(DummyPopupGenericTarget.PickOption)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(PopupPickOptionTranslationPatch), nameof(PopupPickOptionTranslationPatch.Prefix))),
+            finalizer: new HarmonyMethod(RequireMethod(typeof(PopupPickOptionTranslationPatch), nameof(PopupPickOptionTranslationPatch.Finalizer))));
     }
 
     private static void PatchOwner(Harmony harmony, MethodInfo original)

--- a/Mods/QudJP/Assemblies/src/Patches/CharacterStatusScreenTextTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/CharacterStatusScreenTextTranslator.cs
@@ -215,11 +215,12 @@ internal static class CharacterStatusScreenTextTranslator
 
         var description = GetMutationDictionaryValue($"mutation:{mutationName}");
         var level = GetIntMemberValue(mutation, "Level");
+        var variant = GetStringMemberValue(mutation, "Variant");
         var currentRank = level.HasValue
-            ? GetMutationRankDictionaryValue(mutationName!, level.Value)
+            ? GetMutationRankDictionaryValue(mutationName!, variant, level.Value)
             : null;
         var nextRank = level.HasValue
-            ? GetMutationRankDictionaryValue(mutationName!, level.Value + 1)
+            ? GetMutationRankDictionaryValue(mutationName!, variant, level.Value + 1)
             : null;
 
 #pragma warning disable CA2249
@@ -524,12 +525,21 @@ internal static class CharacterStatusScreenTextTranslator
             : null;
     }
 
-    private static string? GetMutationRankDictionaryValue(string mutationName, int level)
+    private static string? GetMutationRankDictionaryValue(string mutationName, string? variant, int level)
     {
         var simpleRank = GetMutationDictionaryValue($"mutation:{mutationName}:rank:{level}");
         if (!string.IsNullOrEmpty(simpleRank))
         {
             return simpleRank;
+        }
+
+        if (!string.IsNullOrWhiteSpace(variant))
+        {
+            var variantRank = GetMutationDictionaryValue($"mutation:{mutationName}:{variant!.Trim()}:rank:{level}");
+            if (!string.IsNullOrEmpty(variantRank))
+            {
+                return variantRank;
+            }
         }
 
         return TryGetStingerRankKey(mutationName, level, out var stingerRankKey)

--- a/Mods/QudJP/Assemblies/src/Patches/CharacterStatusScreenTextTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/CharacterStatusScreenTextTranslator.cs
@@ -527,12 +527,6 @@ internal static class CharacterStatusScreenTextTranslator
 
     private static string? GetMutationRankDictionaryValue(string mutationName, string? variant, int level)
     {
-        var simpleRank = GetMutationDictionaryValue($"mutation:{mutationName}:rank:{level}");
-        if (!string.IsNullOrEmpty(simpleRank))
-        {
-            return simpleRank;
-        }
-
         if (!string.IsNullOrWhiteSpace(variant))
         {
             var variantRank = GetMutationDictionaryValue($"mutation:{mutationName}:{variant!.Trim()}:rank:{level}");
@@ -540,6 +534,12 @@ internal static class CharacterStatusScreenTextTranslator
             {
                 return variantRank;
             }
+        }
+
+        var simpleRank = GetMutationDictionaryValue($"mutation:{mutationName}:rank:{level}");
+        if (!string.IsNullOrEmpty(simpleRank))
+        {
+            return simpleRank;
         }
 
         return TryGetStingerRankKey(mutationName, level, out var stingerRankKey)

--- a/Mods/QudJP/Assemblies/src/Patches/ChargenStructuredTextTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/ChargenStructuredTextTranslator.cs
@@ -167,6 +167,11 @@ internal static class ChargenStructuredTextTranslator
 
     internal static bool TryTranslateMutationLongDescription(string mutationName, out string translated)
     {
+        return TryTranslateMutationLongDescription(mutationName, variant: null, out translated);
+    }
+
+    internal static bool TryTranslateMutationLongDescription(string mutationName, string? variant, out string translated)
+    {
         if (string.IsNullOrWhiteSpace(mutationName))
         {
             translated = mutationName;
@@ -177,7 +182,7 @@ internal static class ChargenStructuredTextTranslator
         var rankKey = string.Concat(descriptionKey, ":rank:1");
         var hasDescription = Translator.TryGetTranslation(descriptionKey, out var description)
             && !string.Equals(description, descriptionKey, StringComparison.Ordinal);
-        var hasRank = TryGetMutationRankText(mutationName!, rankKey, out var rankText);
+        var hasRank = TryGetMutationRankText(mutationName!, variant, rankKey, out var rankText);
 
         if (!hasDescription && !hasRank)
         {
@@ -228,12 +233,22 @@ internal static class ChargenStructuredTextTranslator
         return false;
     }
 
-    private static bool TryGetMutationRankText(string mutationName, string simpleRankKey, out string rankText)
+    private static bool TryGetMutationRankText(string mutationName, string? variant, string simpleRankKey, out string rankText)
     {
         if (Translator.TryGetTranslation(simpleRankKey, out rankText)
             && !string.Equals(rankText, simpleRankKey, StringComparison.Ordinal))
         {
             return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(variant))
+        {
+            var variantRankKey = string.Concat("mutation:", mutationName, ":", variant!.Trim(), ":rank:1");
+            if (Translator.TryGetTranslation(variantRankKey, out rankText)
+                && !string.Equals(rankText, variantRankKey, StringComparison.Ordinal))
+            {
+                return true;
+            }
         }
 
         if (!TryGetStingerRankKey(mutationName, out var stingerRankKey))

--- a/Mods/QudJP/Assemblies/src/Patches/ChargenStructuredTextTranslator.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/ChargenStructuredTextTranslator.cs
@@ -235,12 +235,6 @@ internal static class ChargenStructuredTextTranslator
 
     private static bool TryGetMutationRankText(string mutationName, string? variant, string simpleRankKey, out string rankText)
     {
-        if (Translator.TryGetTranslation(simpleRankKey, out rankText)
-            && !string.Equals(rankText, simpleRankKey, StringComparison.Ordinal))
-        {
-            return true;
-        }
-
         if (!string.IsNullOrWhiteSpace(variant))
         {
             var variantRankKey = string.Concat("mutation:", mutationName, ":", variant!.Trim(), ":rank:1");
@@ -249,6 +243,12 @@ internal static class ChargenStructuredTextTranslator
             {
                 return true;
             }
+        }
+
+        if (Translator.TryGetTranslation(simpleRankKey, out rankText)
+            && !string.Equals(rankText, simpleRankKey, StringComparison.Ordinal))
+        {
+            return true;
         }
 
         if (!TryGetStingerRankKey(mutationName, out var stingerRankKey))

--- a/Mods/QudJP/Assemblies/src/Patches/LevelerTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/LevelerTranslationPatch.cs
@@ -24,6 +24,10 @@ public static class LevelerTranslationPatch
         "^You have no physical (?<term>.+?) to rapidly advance!$",
         RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
+    private static readonly Regex RapidAdvancementPickOptionPattern = new(
+        "^Choose (?<term>.+?) to rapidly advance\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
     [ThreadStatic]
     private static int activeDepth;
 
@@ -144,6 +148,18 @@ public static class LevelerTranslationPatch
                 stripped.Length,
                 source);
             detail = "LevelerNoPhysicalMutations";
+            return true;
+        }
+
+        var pickOptionMatch = RapidAdvancementPickOptionPattern.Match(stripped);
+        if (pickOptionMatch.Success)
+        {
+            translated = RestoreWhole(
+                $"急速に成長させる{TranslateMutationTerm(pickOptionMatch.Groups["term"], spans)}を選んでください。",
+                spans,
+                stripped.Length,
+                source);
+            detail = "LevelerRapidAdvancementPickOption";
             return true;
         }
 

--- a/Mods/QudJP/Assemblies/src/Patches/LevelerTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/LevelerTranslationPatch.cs
@@ -154,8 +154,15 @@ public static class LevelerTranslationPatch
         var pickOptionMatch = RapidAdvancementPickOptionPattern.Match(stripped);
         if (pickOptionMatch.Success)
         {
+            if (!TryTranslateMutationTerm(pickOptionMatch.Groups["term"], spans, out var translatedTerm))
+            {
+                translated = source;
+                detail = string.Empty;
+                return false;
+            }
+
             translated = RestoreWhole(
-                $"急速に成長させる{TranslateMutationTerm(pickOptionMatch.Groups["term"], spans)}を選んでください。",
+                $"急速に成長させる{translatedTerm}を選んでください。",
                 spans,
                 stripped.Length,
                 source);
@@ -197,18 +204,28 @@ public static class LevelerTranslationPatch
 
     private static string TranslateMutationTerm(Group group, IReadOnlyList<ColorSpan> spans)
     {
+        return TryTranslateMutationTerm(group, spans, out var translated)
+            ? translated
+            : RestoreArticleStrippedCapture(group, spans);
+    }
+
+    private static bool TryTranslateMutationTerm(Group group, IReadOnlyList<ColorSpan> spans, out string translated)
+    {
         var stripped = StringHelpers.StripLeadingEnglishArticle(group.Value).Trim();
-        var translated = stripped.ToUpperInvariant() switch
+        translated = stripped.ToUpperInvariant() switch
         {
             "MUTATION" or "MUTATIONS" => "変異",
             "ESPER MUTATION" or "ESPER MUTATIONS" => "超能力変異",
             "MENTAL MUTATION" or "MENTAL MUTATIONS" => "精神変異",
             "PHYSICAL MUTATION" or "PHYSICAL MUTATIONS" => "身体的変異",
-            _ => null,
+            _ => string.Empty,
         };
+        if (string.IsNullOrEmpty(translated))
+        {
+            return false;
+        }
 
-        return translated is null
-            ? RestoreArticleStrippedCapture(group, spans)
-            : ColorAwareTranslationComposer.RestoreCapture(translated, spans, group).Trim();
+        translated = ColorAwareTranslationComposer.RestoreCapture(translated, spans, group).Trim();
+        return true;
     }
 }

--- a/Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs
@@ -487,6 +487,18 @@ public static class PopupTranslationPatch
             return true;
         }
 
+        if (LevelerTranslationPatch.TryTranslatePopupMessage(source, route, family, out var levelerTranslated))
+        {
+            translated = levelerTranslated;
+            return true;
+        }
+
+        if (StatusScreenPopupTranslationPatch.TryTranslatePopupMessage(source, route, family, out var statusScreenTranslated))
+        {
+            translated = statusScreenTranslated;
+            return true;
+        }
+
         if (WaterRitualTextTranslator.TryTranslateReputationMessage(
                 source,
                 route,

--- a/Mods/QudJP/Assemblies/src/Patches/QudMutationsModuleWindowTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/QudMutationsModuleWindowTranslationPatch.cs
@@ -123,14 +123,14 @@ public static class QudMutationsModuleWindowTranslationPatch
                     continue;
                 }
 
-                changed |= TranslateMenuOption(menuOption);
+                changed |= TranslateMenuOption(instance, menuOption);
             }
         }
 
         return changed;
     }
 
-    private static bool TranslateMenuOption(object menuOption)
+    private static bool TranslateMenuOption(object windowInstance, object menuOption)
     {
         if (!TryGetStringMemberValue(menuOption, "Id", out var mutationName)
             || string.IsNullOrWhiteSpace(mutationName))
@@ -150,7 +150,8 @@ public static class QudMutationsModuleWindowTranslationPatch
             }
         }
 
-        if (ChargenStructuredTextTranslator.TryTranslateMutationLongDescription(mutationName!, out var translatedLongDescription)
+        var variant = TryGetMutationNodeVariant(windowInstance, mutationName!);
+        if (ChargenStructuredTextTranslator.TryTranslateMutationLongDescription(mutationName!, variant, out var translatedLongDescription)
             && (!TryGetStringMemberValue(menuOption, "LongDescription", out var longDescription)
                 || !string.Equals(longDescription, translatedLongDescription, StringComparison.Ordinal)))
         {
@@ -159,6 +160,57 @@ public static class QudMutationsModuleWindowTranslationPatch
         }
 
         return changed;
+    }
+
+    private static string? TryGetMutationNodeVariant(object instance, string mutationName)
+    {
+        if (!TryGetMemberValue(instance, "mutationNodes", out var mutationNodesValue)
+            || mutationNodesValue is not IEnumerable mutationNodes)
+        {
+            return null;
+        }
+
+        foreach (var node in mutationNodes)
+        {
+            if (node is null)
+            {
+                continue;
+            }
+
+            if (!TryGetMemberValue(node, "Entry", out var entry)
+                || entry is null
+                || !TryGetStringMemberValue(entry, "Name", out var entryName)
+                || !string.Equals(entryName, mutationName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (TryGetStringMemberValue(node, "Variant", out var variant)
+                && !string.IsNullOrWhiteSpace(variant))
+            {
+                return variant;
+            }
+
+            if (TryGetStringMemberValue(entry, "Variant", out var entryVariant)
+                && !string.IsNullOrWhiteSpace(entryVariant))
+            {
+                return entryVariant;
+            }
+
+            var exemplar = TryGetMemberValue(node, "Exemplar", out var exemplarValue)
+                ? exemplarValue
+                : null;
+            if (exemplar is not null
+                && TryGetStringMemberValue(exemplar, "Variant", out var exemplarVariant)
+                && !string.IsNullOrWhiteSpace(exemplarVariant))
+            {
+                return exemplarVariant;
+            }
+
+            return null;
+        }
+
+        return null;
     }
 
     private static void RefreshMenuOptions(object instance)

--- a/Mods/QudJP/Assemblies/src/Patches/StatusScreenPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/StatusScreenPopupTranslationPatch.cs
@@ -39,6 +39,14 @@ public static class StatusScreenPopupTranslationPatch
         "^You have all available (?<term>.+?)\\.$",
         RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
+    private static readonly Regex MutationChoicePromptPattern = new(
+        "^Choose (?:(?:a|an) )?(?<term>.+?)\\.$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex MutationChoiceOptionPattern = new(
+        "^(?<name>.+?)(?<extraLimb> \\+ grow a new body part)? - [\\s\\S]+$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
     private static readonly Regex PsychicGlimmerDebugPattern = new(
         "^TODOJASON GLIMMER=(?<value>.+)$",
         RegexOptions.CultureInvariant | RegexOptions.Compiled);
@@ -144,6 +152,11 @@ public static class StatusScreenPopupTranslationPatch
         IReadOnlyList<ColorSpan> spans,
         out string translated)
     {
+        if (TryTranslateMutationChoicePickOption(source, stripped, spans, out translated))
+        {
+            return true;
+        }
+
         if (TryTranslateAttributePopup(source, stripped, spans, out translated))
         {
             return true;
@@ -171,6 +184,45 @@ public static class StatusScreenPopupTranslationPatch
 
         translated = source;
         return false;
+    }
+
+    private static bool TryTranslateMutationChoicePickOption(
+        string source,
+        string stripped,
+        IReadOnlyList<ColorSpan> spans,
+        out string translated)
+    {
+        var promptMatch = MutationChoicePromptPattern.Match(stripped);
+        if (promptMatch.Success)
+        {
+            translated = RestoreWhole(
+                $"{TranslateMutationTerm(promptMatch.Groups["term"].Value)}を選んでください。",
+                source,
+                stripped,
+                spans);
+            return true;
+        }
+
+        var match = MutationChoiceOptionPattern.Match(stripped);
+        if (!match.Success)
+        {
+            translated = source;
+            return false;
+        }
+
+        var mutationName = match.Groups["name"].Value.Trim();
+        if (!ChargenStructuredTextTranslator.TryTranslateMutationLongDescription(mutationName, out var longDescription))
+        {
+            translated = source;
+            return false;
+        }
+
+        var translatedName = TranslateMutationName(Restore(match, spans, "name"));
+        var extraLimb = match.Groups["extraLimb"].Success
+            ? "{{G| + 新しい身体部位が生える}}"
+            : string.Empty;
+        translated = $"{translatedName}{extraLimb} - {longDescription}";
+        return !string.Equals(translated, source, StringComparison.Ordinal);
     }
 
     private static bool TryTranslateAttributePopup(

--- a/Mods/QudJP/Assemblies/src/Patches/StatusScreenPopupTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/StatusScreenPopupTranslationPatch.cs
@@ -195,8 +195,14 @@ public static class StatusScreenPopupTranslationPatch
         var promptMatch = MutationChoicePromptPattern.Match(stripped);
         if (promptMatch.Success)
         {
+            if (!TryTranslateMutationTerm(promptMatch.Groups["term"].Value, out var translatedTerm))
+            {
+                translated = source;
+                return false;
+            }
+
             translated = RestoreWhole(
-                $"{TranslateMutationTerm(promptMatch.Groups["term"].Value)}を選んでください。",
+                $"{translatedTerm}を選んでください。",
                 source,
                 stripped,
                 spans);
@@ -415,8 +421,14 @@ public static class StatusScreenPopupTranslationPatch
             return false;
         }
 
+        if (!TryTranslateMutationTerm(match.Groups["term"].Value, out var translatedTerm))
+        {
+            translated = source;
+            return false;
+        }
+
         translated = RestoreWhole(
-            $"利用可能な{TranslateMutationTerm(match.Groups["term"].Value)}はすべて持っている。",
+            $"利用可能な{translatedTerm}はすべて持っている。",
             source,
             stripped,
             spans);
@@ -477,14 +489,15 @@ public static class StatusScreenPopupTranslationPatch
         };
     }
 
-    private static string TranslateMutationTerm(string term)
+    private static bool TryTranslateMutationTerm(string term, out string translated)
     {
-        return term switch
+        translated = term switch
         {
             "mutation" or "mutations" => "変異",
             "defect" or "defects" => "欠陥",
-            _ => term,
+            _ => string.Empty,
         };
+        return !string.IsNullOrEmpty(translated);
     }
 
     internal static string TranslateMutationDisplayName(string source)

--- a/Mods/QudJP/Localization/Dictionaries/ui-pick-target.ja.json
+++ b/Mods/QudJP/Localization/Dictionaries/ui-pick-target.ja.json
@@ -24,6 +24,26 @@
       "text": "対象をマーク"
     },
     {
+      "key": "Look",
+      "context": "PickTarget.CommandBar",
+      "text": "見る"
+    },
+    {
+      "key": "lock",
+      "context": "PickTarget.CommandBar",
+      "text": "ロック"
+    },
+    {
+      "key": "interact",
+      "context": "PickTarget.CommandBar",
+      "text": "操作する"
+    },
+    {
+      "key": "walk",
+      "context": "PickTarget.CommandBar",
+      "text": "歩く"
+    },
+    {
       "key": "Dig to where?",
       "context": "PickTarget.Digging.Label",
       "text": "どこまで掘る？"

--- a/docs/release-notes/unreleased/mutation-ui-pickoption.md
+++ b/docs/release-notes/unreleased/mutation-ui-pickoption.md
@@ -1,1 +1,3 @@
+### Fixed
+
 - Localize mutation selection and rapid advancement popup option text, and stabilize pick-target command bar updates.

--- a/docs/release-notes/unreleased/mutation-ui-pickoption.md
+++ b/docs/release-notes/unreleased/mutation-ui-pickoption.md
@@ -1,0 +1,1 @@
+- Localize mutation selection and rapid advancement popup option text, and stabilize pick-target command bar updates.

--- a/scripts/translation_token_duplicate_baseline.json
+++ b/scripts/translation_token_duplicate_baseline.json
@@ -521,9 +521,10 @@
       "scope": "cross_file",
       "path": "Dictionaries",
       "key": "Look",
-      "entry_count": 3,
+      "entry_count": 4,
       "texts": [
         "見よ",
+        "見る",
         "見る",
         "見る"
       ],
@@ -536,6 +537,11 @@
         {
           "path": "Dictionaries/ui-default.ja.json",
           "entry_index": 81,
+          "text": "見る"
+        },
+        {
+          "path": "Dictionaries/ui-pick-target.ja.json",
+          "entry_index": 4,
           "text": "見る"
         },
         {
@@ -2321,9 +2327,10 @@
       "scope": "cross_file",
       "path": "Dictionaries",
       "key": "interact",
-      "entry_count": 2,
+      "entry_count": 3,
       "texts": [
         "インタラクト",
+        "操作する",
         "操作する"
       ],
       "occurrences": [
@@ -2331,6 +2338,11 @@
           "path": "Dictionaries/ui-default.ja.json",
           "entry_index": 82,
           "text": "インタラクト"
+        },
+        {
+          "path": "Dictionaries/ui-pick-target.ja.json",
+          "entry_index": 6,
+          "text": "操作する"
         },
         {
           "path": "Dictionaries/ui-popup.ja.json",


### PR DESCRIPTION
## Summary
- Localize PickTarget command-bar labels without re-running SetText when regenerated English maps to the same Japanese text.
- Route Leveler rapid-advancement and StatusScreen mutation PickOption title/intro/options through owner-scoped popup translation.
- Add mutation long-description rank lookup for runtime variants such as Freezing Ray, Flaming Ray, Horns, and Stinger, including QudMutationsModuleWindow/status screen paths.
- Add mutation description coverage and release-note coverage.

## Verification
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~StatusScreenPopupTranslationPatchTests|FullyQualifiedName~LevelerTranslationPatchTests"` - 49 passed
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~StatusScreenPopupTranslationPatchTests"` - 38 passed
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter "FullyQualifiedName~StatusScreenPopupTranslationPatchTests|FullyQualifiedName~LevelerTranslationPatchTests|FullyQualifiedName~PickTargetWindowUpdateTranslationPatchTests|FullyQualifiedName~ChargenStructuredTextTranslatorTests|FullyQualifiedName~CharacterStatusScreenMutationDetailsPatchTests|FullyQualifiedName~QudMutationsModuleWindowTranslationPatchTests|FullyQualifiedName~LocalizationCoverageTests"` - 166 passed
- `just test-l1` - 4334 passed
- `just test-l2` - 3997 passed
- `just test-l2g` - 513 passed
- `just localization-check`
- `just release-note-check origin/main HEAD`
- `uv run pytest scripts/tests/test_mutation_description_semantics.py scripts/tests/test_json_markup_parity.py -q` - 151 passed
- `just build`
- `git diff --check`

## Review and cleanup
- Independent review 1: REQUEST_CHANGES for StatusScreen PickOption intro route; fixed and retested.
- Independent review 2: REQUEST_CHANGES for Chimera `+ grow a new body part` option suffix; fixed and retested.
- Independent review 3: APPROVE.
- `ai-slop-cleaner` scope: approved diff only. Behavior lock: targeted regression tests and L1/L2 gates. Cleanup made one behavior-preserving simplification: removed an unused regex capture in `StatusScreenPopupTranslationPatch`.
- Post-cleanup independent review: APPROVE.

AI SLOP CLEANUP REPORT
======================
Scope: Current PR diff only
Behavior Lock: Targeted regression tests for PickTarget SetText stability, Leveler PickOption, StatusScreen PickOption intro/options including Chimera suffix, variant rank lookup, mutation description coverage
Cleanup Plan: dead code scan, duplication scan, naming/route scan, test reinforcement review
Passes Completed:
1. Pass 1: Dead code deletion - no unused helpers/debug leftovers in the changed scope
2. Pass 2: Duplicate removal - no safe consolidation without adding speculative abstraction
3. Pass 3: Naming/error handling cleanup - removed unused `details` regex capture
4. Pass 4: Test reinforcement - retained added intro, extra-limb, variant, and coverage regression tests
Quality Gates:
- Regression tests: PASS
- Lint/typecheck proxy: PASS via dotnet build/test and lsp review checks
- Tests: PASS
- Static/security scan: PASS in independent review
Remaining Risks:
- No known residual risk beyond normal runtime validation of game UI routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 変異の「variant」を考慮した長文説明・ランク文言の翻訳対応を追加しました
  * 変異選択（タイトル・イントロ・選択肢）と急速成長のピックオプションを翻訳対象に追加しました
  * Pick Target のコマンド（見る／ロック／操作する／歩く）を日本語化しました

* **Bug Fixes**
  * Pick Target コマンドバーの再描画・更新挙動を安定化しました

* **Tests**
  * 多数の翻訳関連テスト（変異 variant を含むケース、ピックオプション等）を追加しました
  * ローカライズ網羅性検証テストを追加しました

* **Documentation**
  * 未リリースのリリースノートを追記しました

* **Chores**
  * 翻訳重複ベースラインを更新しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->