### PR TITLE
[codex] Refresh QudJP v0.4.00 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [0.4.00] - 2026-05-28
+## [0.4.00] - 2026-05-29
 
 ### Fixed
 
@@ -18,9 +18,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - mutation 選択と rapid advancement popup option、ability bar label、direction prompt、targeting footer、fire-mode prompt、ability manager、trade、tinkering、inventory、main menu などの UI 表示を追加で日本語化しました。
 - inventory action、campfire ingredient row、liquid collect/fill、firefighting、sleeping target wake-up、companion dismissal、auto-collect など、条件で変わる操作ラベルと失敗メッセージを改善しました。
 - active-effect adjective chain、stuck-in effect target、複数形の combat miss、ForceProjector access failure、liquid slip、NPC wild-shot、lost-travel failure、Water Ritual reputation article residue など、Player.log で観測された未翻訳 runtime text を修正しました。
+- Player.log で追加確認された combat log、mutation prompt、inventory action、energy-cell UI、auto-disassembly message、graffiti/readout description、powered-off stat bonus、lost-chance description、liquid-covered effect name、`water-stained` item prefix などの未翻訳表示を修正しました。
 - schemasoft chip、Cyclopean Prism、PitMaterial、Evil Twin、Cherubim/Hexacherubim element text、brackish liquid puddle、water-bond、compound stained、solar pumping station、hydraulic liquid/flywheel、Oboroqoru worshipper title suffix などの生成表示名・説明文を日本語化しました。
 - generated journal location discovery、painted/engraved Sultan challenge tooltip、Jewel-Encrusted short description、stat adjustment description で、英語残りや color markup の崩れが出る経路を修正しました。
 - ray mutation message log、ability bar hotkey suffix、generated liquid color tag、attack-confirmation target name などで、日本語化済みの body-part/source/target と色タグが保たれるようにしました。
+- translated item name、charge cell、recipe name、tinkering bit code などで、日本語化後も color markup が保たれるようにしました。
 
 ---
 

--- a/docs/release-notes/unreleased/player-log-untranslated-runtime-text.md
+++ b/docs/release-notes/unreleased/player-log-untranslated-runtime-text.md
@@ -1,5 +1,0 @@
-### Fixed
-
-- Translated additional runtime combat logs, mutation prompts, inventory actions, and energy-cell UI text reported from Player.log.
-- Improved color preservation for translated item names, charge cells, recipe names, and tinkering bit codes.
-- Covered additional Player.log leftovers for auto-disassembly messages, graffiti/readout description lines, powered-off stat bonuses, lost-chance descriptions, liquid-covered effect names, and `water-stained` item prefixes.


### PR DESCRIPTION
## Summary
- Move the 0.4.00 changelog date to 2026-05-29 for the refreshed release
- Add the Player.log runtime text fixes from #796 to the 0.4.00 changelog
- Consume the new unreleased release-note fragment

## Verification
- git diff --check
- just changelog-link-check
- just release-note-check origin/main HEAD
- just python-check

## Release note
This prepares retagging v0.4.00 onto the refreshed main commit after merge. Existing v0.4.00 tag and draft GitHub Release still point at the previous release commit and must be replaced only after explicit confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Player.logおよびUIに表示される複数のテキスト項目を日本語化しました。
  * 日本語化されたテキスト内の表示色フォーマットが正しく保持されるよう改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/797?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->