### PR TITLE
Codify message route count CI check

### DIFF
--- a/.codex/skills/qudjp-localization-triage/SKILL.md
+++ b/.codex/skills/qudjp-localization-triage/SKILL.md
@@ -85,6 +85,12 @@ Use this skill to turn runtime untranslated text into the smallest correct QudJP
    - C# behavior tests: `just test-l1`, `just test-l2`, `just test-l2g`
    - Analyzer-inclusive local gates: `just build`, `just check`, or `just pr-check`
    - Localization checks: `just localization-check`, `just translation-token-check`
+   - When changing message-pattern route counts, verify the CI workflow contract too. Run
+     `just python-test-filter test_ci_message_pattern_route_counts_match_python_contract`
+     or the broader `just python-test` after updating `justfile`,
+     `scripts/tests/test_validate_pattern_routes.py`, and `.github/workflows/ci.yml`;
+     `just localization-check` alone does not prove those duplicated
+     `--expect-count` values are synchronized.
    - Static coverage map check: `just localization-coverage-map-check`
    - Broad local gate: `just check`
    - Sync only when the user wants local game deployment: `just sync-mod`


### PR DESCRIPTION
## Summary
- Add QudJP localization triage guidance for message-pattern route count changes.
- Call out the CI workflow contract check so `.github/workflows/ci.yml` count drift is caught locally.

## Test Plan
- `just python-test-filter test_ci_message_pattern_route_counts_match_python_contract`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメンテーション**
  * ローカライゼーション手順ドキュメントを更新し、メッセージパターンルート数の変更時にCI設定の複数箇所を同期する必要があること、および単体コマンドでは同期確認ができないことを明記しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToaruPen/coq-japanese_stable/pull/798?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->