### PR TITLE
[codex] Fix tutorial Mehmet POI highlight

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyIssue289OrphanTargets.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/DummyTargets/DummyIssue289OrphanTargets.cs
@@ -160,6 +160,8 @@ internal interface IDummyRectTransform
 
 internal sealed class DummyTutorialManagerInstanceTarget
 {
+    public string LastHighlightCid { get; private set; } = string.Empty;
+
     public string LastHighlightText { get; private set; } = string.Empty;
 
     public string LastCellHighlightText { get; private set; } = string.Empty;
@@ -175,13 +177,13 @@ internal sealed class DummyTutorialManagerInstanceTarget
         float bottomMargin = 0f,
         string style = "horiz")
     {
-        _ = cid;
         _ = directionHint;
         _ = paddingX;
         _ = paddingY;
         _ = bottomMargin;
         _ = style;
 
+        LastHighlightCid = cid;
         LastHighlightText = text is null ? string.Empty : "{{y|" + text + "}}";
         return true;
     }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/Issue289OrphanRoutePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/Issue289OrphanRoutePatchTests.cs
@@ -295,7 +295,54 @@ public sealed class Issue289OrphanRoutePatchTests
 
             Assert.Multiple(() =>
             {
+                Assert.That(target.LastHighlightCid, Is.EqualTo("QudTextMenuItem:look"));
                 Assert.That(target.LastHighlightText, Is.EqualTo("{{y|スナップジョーを調べろ。}}"));
+                Assert.That(
+                    DynamicTextObservability.GetRouteFamilyHitCountForTests(nameof(TutorialManagerHighlightTranslationPatch), "TutorialManager.HighlightText"),
+                    Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+
+    [Test]
+    public void TutorialManagerHighlightPrefix_RewritesMehmetPoiControlId_WhenDisplayNameIsLocalized()
+    {
+        WriteDictionary(("Choose Mehmet.", "メフメットを選んでください。"));
+
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        try
+        {
+            harmony.Patch(
+                original: RequireMethod(
+                    typeof(DummyTutorialManagerInstanceTarget),
+                    nameof(DummyTutorialManagerInstanceTarget.HighlightByCID),
+                    new[]
+                    {
+                        typeof(string),
+                        typeof(string),
+                        typeof(string),
+                        typeof(int),
+                        typeof(int),
+                        typeof(float),
+                        typeof(string),
+                    }),
+                prefix: new HarmonyMethod(RequireMethod(typeof(TutorialManagerHighlightTranslationPatch), nameof(TutorialManagerHighlightTranslationPatch.Prefix))));
+
+            var target = new DummyTutorialManagerInstanceTarget();
+            target.HighlightByCID(
+                "QudTextMenuItem:mehmet [ne]",
+                "Choose Mehmet.",
+                "ne");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(target.LastHighlightCid, Is.EqualTo("QudTextMenuItem:メフメット [ne]"));
+                Assert.That(target.LastHighlightText, Is.EqualTo("{{y|メフメットを選んでください。}}"));
                 Assert.That(
                     DynamicTextObservability.GetRouteFamilyHitCountForTests(nameof(TutorialManagerHighlightTranslationPatch), "TutorialManager.HighlightText"),
                     Is.EqualTo(1));

--- a/Mods/QudJP/Assemblies/src/Patches/TutorialManagerHighlightTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/TutorialManagerHighlightTranslationPatch.cs
@@ -9,6 +9,8 @@ namespace QudJP.Patches;
 public static class TutorialManagerHighlightTranslationPatch
 {
     private const string Context = nameof(TutorialManagerHighlightTranslationPatch);
+    private const string MehmetPoiEnglishControlId = "QudTextMenuItem:mehmet [ne]";
+    private const string MehmetPoiLocalizedControlId = "QudTextMenuItem:メフメット [ne]";
 
     [HarmonyTargetMethod]
     private static MethodBase? TargetMethod()
@@ -41,10 +43,11 @@ public static class TutorialManagerHighlightTranslationPatch
         return method;
     }
 
-    public static void Prefix(ref string text)
+    public static void Prefix(ref string __0, ref string text)
     {
         try
         {
+            __0 = TranslateLocalizedTutorialControlId(__0);
             if (TutorialManagerTranslationHelpers.IsControlSentinel(text))
             {
                 return;
@@ -56,5 +59,12 @@ public static class TutorialManagerHighlightTranslationPatch
         {
             Trace.TraceError("QudJP: TutorialManagerHighlightTranslationPatch.Prefix failed: {0}", ex);
         }
+    }
+
+    private static string TranslateLocalizedTutorialControlId(string cid)
+    {
+        return string.Equals(cid, MehmetPoiEnglishControlId, StringComparison.Ordinal)
+            ? MehmetPoiLocalizedControlId
+            : cid;
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #800 by rewriting the vanilla tutorial Mehmet POI control id to the localized QudJP control id before `TutorialManager.HighlightByCID` runs.
- Adds an L2 regression test for the localized Mehmet POI row while preserving normal tutorial menu control ids.

## Root Cause
The vanilla Joppa tutorial hardcodes `QudTextMenuItem:mehmet [ne]`, but the POI menu derives its control id from visible row text. QudJP localizes Mehmet to `メフメット`, so the tutorial highlight needs the localized control id for the row to be found.

## Independent Review
- Code-review subagent recommendation: APPROVE
- Findings: 0
- Reviewer checks: `just lsp-check`, Release build of `QudJP.Tests.csproj`, focused TutorialManagerHighlightPrefix tests, `just test-l2`, `just localization-check`

## Test Plan
- `git diff --check`
- `just test-l2` (4469 passed)
- `just build` (0 warnings, 0 errors)
- `just python-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * チュートリアルのハイライト表示が日本語ローカライズに対応し、翻訳済みの表示名を使用する際の制御IDの処理が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->