### PR TITLE
Improve inventory menu performance

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs
@@ -181,10 +181,6 @@ internal static class ColorRouteCatalog
                 new(
                     1,
                     "Show first checks known owner handoffs; this fallback handles fixed popup text and the controlled PopupShow message-pattern route."),
-            ["Mods/QudJP/Assemblies/src/Patches/QudMenuBottomContextTranslationPatch.cs|PopupTranslationPatch.TranslatePopupMenuItemTextForProducerRoute("] =
-                new(
-                    1,
-                    "Bottom context buttons are fixed menu labels routed through the shared popup menu-item translator."),
             ["Mods/QudJP/Assemblies/src/Patches/TradeUiPopupTranslationPatch.cs|PopupTranslationPatch.TranslatePopupTextForProducerRoute("] =
                 new(
                     1,
@@ -309,7 +305,6 @@ internal static class ColorRouteCatalog
             ["Mods/QudJP/Assemblies/src/Patches/PopupTranslationPatch.cs|MessagePatternTranslator.TranslateIfPatternMatches("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/QuestLifecyclePopupTranslationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
             ["Mods/QudJP/Assemblies/src/Patches/RepairTranslationPatch.cs|ColorAwareTranslationComposer.TranslatePreservingColors("] = 1,
-            ["Mods/QudJP/Assemblies/src/Patches/QudMenuBottomContextTranslationPatch.cs|PopupTranslationPatch.TranslatePopupMenuItemTextForProducerRoute("] = 1,
             ["Mods/QudJP/Assemblies/src/QudTest/QudTestRouteExecutor.cs|PopupTranslationPatch.TranslatePopupMenuItemTextForProducerRoute("] = 1,
             ["Mods/QudJP/Assemblies/src/QudTest/QudTestRouteExecutor.cs|PopupTranslationPatch.TranslatePopupTextForProducerRoute("] = 2,
             ["Mods/QudJP/Assemblies/src/Patches/SelectableTextMenuItemTranslationPatch.cs|PopupTranslationPatch.TranslatePopupMenuItemTextForProducerRoute("] = 1,

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineFontFixerPolicyTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineFontFixerPolicyTests.cs
@@ -18,7 +18,7 @@ public sealed class InventoryLineFontFixerPolicyTests
             "UI",
             "InventoryLineFontFixer.cs");
         var source = File.ReadAllText(sourcePath);
-        var method = ExtractMethodBody(source, "TryRefreshTextSkinWithFallbackFont");
+        var method = ExtractMethodBody(source, "internal static bool TryRefreshTextSkinWithFallbackFont(object? textSkin, string? finalText)");
 
         NUnit.Framework.Assert.That(
             method,
@@ -42,7 +42,7 @@ public sealed class InventoryLineFontFixerPolicyTests
             "UI",
             "InventoryLineFontFixer.cs");
         var source = File.ReadAllText(sourcePath);
-        var method = ExtractMethodBody(source, "TryRefreshTextSkinWithFallbackFont");
+        var method = ExtractMethodBody(source, "internal static bool TryRefreshTextSkinWithFallbackFont(object? textSkin, string? finalText)");
 
         NUnit.Framework.Assert.That(
             method,
@@ -99,7 +99,7 @@ public sealed class InventoryLineFontFixerPolicyTests
             "UI",
             "InventoryLineFontFixer.cs");
         var source = File.ReadAllText(sourcePath);
-        var method = ExtractMethodBody(source, "HasHealthySuccessfulRefreshForCurrentKey");
+        var method = ExtractMethodBody(source, "internal static bool HasHealthySuccessfulRefreshForCurrentKey");
 
         NUnit.Framework.Assert.That(
             method,
@@ -197,6 +197,159 @@ public sealed class InventoryLineFontFixerPolicyTests
             NUnit.Framework.Assert.That(
                 source,
                 NUnit.Framework.Does.Contain("CleanupSuccessfulRefreshCacheIfNeeded();"));
+        });
+    }
+
+    [NUnit.Framework.Test]
+    public void SetDataRefresh_SkipsHealthySuccessfulRefreshKeys()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "UI",
+            "InventoryLineFontFixer.cs");
+        var source = File.ReadAllText(sourcePath);
+        var method = ExtractMethodBody(source, "internal static bool TryRefreshTextSkinWithFallbackFontForSetData");
+
+        NUnit.Framework.Assert.That(method, NUnit.Framework.Does.Contain("GetActiveItemLineRefreshKey(inventoryLineInstance)"));
+        NUnit.Framework.Assert.That(method, NUnit.Framework.Does.Contain("HasHealthySuccessfulRefreshForCurrentKey(inventoryLineInstance, preRefreshKey)"));
+        NUnit.Framework.Assert.That(method, NUnit.Framework.Does.Contain("RecordSuccessfulRefreshForCurrentKey("));
+        NUnit.Framework.Assert.That(method, NUnit.Framework.Does.Contain("GetActiveItemLineRefreshKey(inventoryLineInstance)"));
+    }
+
+    [NUnit.Framework.Test]
+    public void SetDataRefresh_EmitsDevTimingForHeavyRefreshAndCacheSkips()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "UI",
+            "InventoryLineFontFixer.cs");
+        var source = File.ReadAllText(sourcePath);
+        var setDataMethod = ExtractMethodBody(source, "internal static bool TryRefreshTextSkinWithFallbackFontForSetData");
+        var heavyRefreshMethod = ExtractMethodBody(source, "internal static bool TryRefreshTextSkinWithFallbackFont(object? textSkin, string? finalText)");
+
+        NUnit.Framework.Assert.Multiple(() =>
+        {
+            NUnit.Framework.Assert.That(
+                setDataMethod,
+                NUnit.Framework.Does.Contain("LogRefreshTimingSkip("),
+                "Cache hits should be visible so runtime evidence can separate unavoidable setData volume from avoidable heavy refresh work.");
+            NUnit.Framework.Assert.That(
+                heavyRefreshMethod,
+                NUnit.Framework.Does.Contain("LogRefreshTimingProbe("),
+                "Heavy refresh should emit a bounded dev probe with timing breakdowns.");
+            NUnit.Framework.Assert.That(
+                source,
+                NUnit.Framework.Does.Contain("InventoryLineFontRefreshTiming/v1"));
+            NUnit.Framework.Assert.That(
+                source,
+                NUnit.Framework.Does.Contain("InventoryLineFontRefreshSkip/v1"));
+            NUnit.Framework.Assert.That(
+                source,
+                NUnit.Framework.Does.Contain("force_canvas_ms="));
+            NUnit.Framework.Assert.That(
+                source,
+                NUnit.Framework.Does.Contain("force_mesh_ms="));
+            NUnit.Framework.Assert.That(
+                source,
+                NUnit.Framework.Does.Contain("canvas_update_mode="));
+            NUnit.Framework.Assert.That(
+                source,
+                NUnit.Framework.Does.Contain("#if QUDJP_DEV_BUILD"));
+            NUnit.Framework.Assert.That(
+                source,
+                NUnit.Framework.Does.Contain("RuntimeDiagnostics.VerboseProbesEnabled"));
+        });
+    }
+
+    [NUnit.Framework.Test]
+    public void HeavyRefresh_BatchesForceUpdateCanvasesOncePerUnityFrame()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "UI",
+            "InventoryLineFontFixer.cs");
+        var source = File.ReadAllText(sourcePath);
+        var heavyRefreshMethod = ExtractMethodBody(source, "internal static bool TryRefreshTextSkinWithFallbackFont(object? textSkin, string? finalText)");
+        var batchingMethod = ExtractMethodBody(source, "private static bool TryForceUpdateCanvasesOncePerFrame");
+
+        NUnit.Framework.Assert.Multiple(() =>
+        {
+            NUnit.Framework.Assert.That(
+                heavyRefreshMethod,
+                NUnit.Framework.Does.Contain("TryForceUpdateCanvasesOncePerFrame()"),
+                "Inventory row refresh should not call ForceUpdateCanvases directly for every row.");
+            NUnit.Framework.Assert.That(
+                heavyRefreshMethod,
+                NUnit.Framework.Does.Not.Contain("ForceUpdateCanvases();"),
+                "The heavy canvas update must be behind the per-frame gate.");
+            NUnit.Framework.Assert.That(
+                batchingMethod,
+                NUnit.Framework.Does.Contain("Time.frameCount"));
+            NUnit.Framework.Assert.That(
+                batchingMethod,
+                NUnit.Framework.Does.Contain("lastForceUpdateCanvasesFrame"));
+            NUnit.Framework.Assert.That(
+                batchingMethod,
+                NUnit.Framework.Does.Contain("return false;"));
+            NUnit.Framework.Assert.That(
+                batchingMethod,
+                NUnit.Framework.Does.Contain("ForceUpdateCanvases();"));
+            NUnit.Framework.Assert.That(
+                batchingMethod,
+                NUnit.Framework.Does.Contain("return true;"));
+        });
+    }
+
+    [NUnit.Framework.Test]
+    public void HeavyRefresh_TriesMeshBeforeCanvasForceAndRetriesOnlyAfterZeroCharacters()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "UI",
+            "InventoryLineFontFixer.cs");
+        var source = File.ReadAllText(sourcePath);
+        var method = ExtractMethodBody(source, "internal static bool TryRefreshTextSkinWithFallbackFont(object? textSkin, string? finalText)");
+
+        var firstMeshIndex = method.IndexOf(
+            "tmp.ForceMeshUpdate(ignoreActiveState: true, forceTextReparsing: true);",
+            System.StringComparison.Ordinal);
+        var canvasRetryIndex = method.IndexOf(
+            "TryForceUpdateCanvasesOncePerFrame()",
+            System.StringComparison.Ordinal);
+        var zeroCharacterBranchIndex = method.IndexOf(
+            "if (!refreshed)",
+            System.StringComparison.Ordinal);
+        var secondMeshIndex = method.IndexOf(
+            "tmp.ForceMeshUpdate(ignoreActiveState: true, forceTextReparsing: true);",
+            firstMeshIndex + 1,
+            System.StringComparison.Ordinal);
+
+        NUnit.Framework.Assert.Multiple(() =>
+        {
+            NUnit.Framework.Assert.That(firstMeshIndex, NUnit.Framework.Is.GreaterThanOrEqualTo(0));
+            NUnit.Framework.Assert.That(canvasRetryIndex, NUnit.Framework.Is.GreaterThan(firstMeshIndex));
+            NUnit.Framework.Assert.That(zeroCharacterBranchIndex, NUnit.Framework.Is.GreaterThan(firstMeshIndex));
+            NUnit.Framework.Assert.That(canvasRetryIndex, NUnit.Framework.Is.GreaterThan(zeroCharacterBranchIndex));
+            NUnit.Framework.Assert.That(secondMeshIndex, NUnit.Framework.Is.GreaterThan(canvasRetryIndex));
+            NUnit.Framework.Assert.That(
+                method,
+                NUnit.Framework.Does.Contain("canvasUpdateMode = \"not_needed\";"));
         });
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineRenderProbePatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineRenderProbePatchTests.cs
@@ -93,7 +93,10 @@ public sealed class InventoryLineRenderProbePatchTests
 
         NUnit.Framework.Assert.That(
             source,
-            NUnit.Framework.Does.Contain("InventoryLineFontFixer.TryRefreshTextSkinWithFallbackFont(itemTextSkin, translatedDisplayName)"));
+            NUnit.Framework.Does.Contain("InventoryLineFontFixer.TryRefreshTextSkinWithFallbackFontForSetData("));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("instance"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("itemTextSkin"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("translatedDisplayName"));
     }
 
     [NUnit.Framework.Test]
@@ -127,7 +130,7 @@ public sealed class InventoryLineRenderProbePatchTests
             afterOwnerIndex,
             System.StringComparison.Ordinal);
         var fontRefreshIndex = source.IndexOf(
-            "InventoryLineFontFixer.TryRefreshTextSkinWithFallbackFont(itemTextSkin, translatedDisplayName)",
+            "InventoryLineFontFixer.TryRefreshTextSkinWithFallbackFontForSetData(",
             System.StringComparison.Ordinal);
         var afterRefreshIndex = source.IndexOf(
             "\"translation-after-font-refresh\"",
@@ -136,6 +139,40 @@ public sealed class InventoryLineRenderProbePatchTests
         NUnit.Framework.Assert.That(afterOwnerIndex, NUnit.Framework.Is.GreaterThan(ownerSetIndex));
         NUnit.Framework.Assert.That(fontRefreshIndex, NUnit.Framework.Is.GreaterThan(afterOwnerIndex));
         NUnit.Framework.Assert.That(afterRefreshIndex, NUnit.Framework.Is.GreaterThan(fontRefreshIndex));
+    }
+
+    [NUnit.Framework.Test]
+    public void InventoryLineRenderProbePatch_UsesGatedSetDataFontRefresh()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "Patches",
+            "InventoryLineRenderProbePatch.cs");
+        var source = File.ReadAllText(sourcePath);
+
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Contain("InventoryLineFontFixer.TryApplyPrimaryFontToItemRowForSetData(__instance, data)"));
+    }
+
+    [NUnit.Framework.Test]
+    public void InventoryLineRenderProbePatch_RunsAfterTranslationPostfix()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "Patches",
+            "InventoryLineRenderProbePatch.cs");
+        var source = File.ReadAllText(sourcePath);
+
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("[HarmonyPriority(Priority.Last)]"));
     }
 
     [NUnit.Framework.Test]
@@ -309,7 +346,10 @@ public sealed class InventoryLineRenderProbePatchTests
 
         NUnit.Framework.Assert.That(
             source,
-            NUnit.Framework.Does.Contain("return tmp.textInfo.characterCount > 0;"));
+            NUnit.Framework.Does.Contain("var refreshed = tmp.textInfo.characterCount > 0;"));
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Contain("return refreshed;"));
     }
 
     [NUnit.Framework.Test]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/QudTestRuntimeHarnessTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/QudTestRuntimeHarnessTests.cs
@@ -21,6 +21,8 @@ public sealed class QudTestRuntimeHarnessTests
         SinkObservation.ResetForTests();
         MessageFrameTranslator.ResetForTests();
         StartReplaceTranslationPatch.ResetForTests();
+        InventoryLineTranslationPatch.ClearTranslationCachesForTests();
+        SelectableTextMenuItemTranslationPatch.ClearDisplayTranslationCacheForTests();
         StartReplaceTranslationPatch.SetDictionaryPathForTests(RepositoryDictionary("templates-variable.ja.json"));
         Translator.SetDictionaryDirectoryForTests(
             Path.GetFullPath(Path.Combine(RepositoryDictionary("templates-variable.ja.json"), "..")));
@@ -34,6 +36,8 @@ public sealed class QudTestRuntimeHarnessTests
         SinkObservation.ResetForTests();
         DynamicTextObservability.ResetForTests();
         ScopedDictionaryLookup.ResetForTests();
+        SelectableTextMenuItemTranslationPatch.ClearDisplayTranslationCacheForTests();
+        InventoryLineTranslationPatch.ClearTranslationCachesForTests();
         Translator.ResetForTests();
         if (Directory.Exists(fixturesDirectory))
         {

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/ReflectionUtilsTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/ReflectionUtilsTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+
 namespace QudJP.Tests.L1;
 
 #pragma warning disable CA1823, CS0414, S1144, S2094, S2325
@@ -62,6 +65,83 @@ public sealed class ReflectionUtilsTests
             Is.Null);
     }
 
+    [Test]
+    public void GetPropertyOrFieldValue_CachesResolvedMemberAccessor()
+    {
+        ReflectionUtils.ClearAccessorCacheForTests();
+        var target = new ReflectionTarget { Name = "alpha" };
+
+        Assert.That(ReflectionUtils.GetPropertyOrFieldValue(target, "Name"), Is.EqualTo("alpha"));
+        Assert.That(ReflectionUtils.GetPropertyOrFieldValue(target, "Name"), Is.EqualTo("alpha"));
+
+        Assert.That(ReflectionUtils.GetAccessorCacheCountForTests(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void InventoryLineTranslationPatch_UsesSharedReflectionUtilsForHotMembers()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "Patches",
+            "InventoryLineTranslationPatch.cs");
+        var source = File.ReadAllText(sourcePath);
+        var method = ExtractMethodBody(source, "private static object? GetMemberValue");
+
+        Assert.That(method, Does.Contain("ReflectionUtils.GetPropertyOrFieldValue(instance, memberName)"));
+        Assert.That(method, Does.Not.Contain("AccessTools.Property(type, memberName)"));
+        Assert.That(method, Does.Not.Contain("AccessTools.Field(type, memberName)"));
+    }
+
+    [Test]
+    public void UITextSkinReflectionAccessor_CachesTextWriteStrategiesByType()
+    {
+        var sourcePath = Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "Patches",
+            "UITextSkinReflectionAccessor.cs");
+        var source = File.ReadAllText(sourcePath);
+
+        Assert.That(source, Does.Contain("ConcurrentDictionary<Type,"));
+        Assert.That(source, Does.Contain("GetOrAdd"));
+        Assert.That(source, Does.Contain("SetText"));
+    }
+
+    private static string ExtractMethodBody(string source, string signature)
+    {
+        var start = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.That(start, Is.GreaterThanOrEqualTo(0), "method signature not found: " + signature);
+        var braceStart = source.IndexOf('{', start);
+        Assert.That(braceStart, Is.GreaterThanOrEqualTo(0), "method body not found: " + signature);
+
+        var depth = 0;
+        for (var index = braceStart; index < source.Length; index++)
+        {
+            if (source[index] == '{')
+            {
+                depth++;
+            }
+            else if (source[index] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return source.Substring(braceStart, index - braceStart + 1);
+                }
+            }
+        }
+
+        Assert.Fail("method body did not terminate: " + signature);
+        return string.Empty;
+    }
+
     private sealed class PrivatePropertyTarget
     {
         private string Secret => "private-property";
@@ -70,6 +150,11 @@ public sealed class ReflectionUtilsTests
     private sealed class InternalFieldTarget
     {
         internal readonly string State = "internal-field";
+    }
+
+    private sealed class ReflectionTarget
+    {
+        public string Name { get; set; } = string.Empty;
     }
 
     private class BaseTarget

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/UnityApiCompatibilityTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/UnityApiCompatibilityTests.cs
@@ -234,6 +234,62 @@ public sealed class UnityApiCompatibilityTests
     }
 
     [NUnit.Framework.Test]
+    public void SelectableTextMenuItemHotPath_UsesCachedAccessors()
+    {
+        var source = ReadPatchSource("SelectableTextMenuItemTranslationPatch.cs");
+
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Contain("ReflectionUtils.GetPropertyOrFieldValue(instance, \"itemText\")"));
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Contain("ReflectionUtils.GetPropertyOrFieldValue(instance, \"item\")"));
+        NUnit.Framework.Assert.That(source, NUnit.Framework.Does.Contain("GetSetTextMethod(item.GetType())"));
+
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Not.Contain("AccessTools.Property(__instance.GetType(), \"itemText\")"),
+            "SelectChanged can fire repeatedly while the context menu is open; itemText lookup should use the shared accessor cache.");
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Not.Contain("AccessTools.Field(__instance.GetType(), \"item\")"),
+            "SelectChanged can fire repeatedly while the context menu is open; item lookup should use the shared accessor cache.");
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Not.Contain("AccessTools.Method(item.GetType(), \"SetText\""),
+            "SelectChanged should cache item skin SetText lookup by runtime type.");
+    }
+
+    [NUnit.Framework.Test]
+    public void SelectableTextMenuItemProbePatch_GatesStateBuildBeforeVerboseLogging()
+    {
+        var source = ReadPatchSource("SelectableTextMenuItemProbePatch.cs");
+        var gateIndex = source.IndexOf("if (!RuntimeDiagnostics.VerboseProbesEnabled)", System.StringComparison.Ordinal);
+        var buildIndex = source.IndexOf("SelectableTextMenuItemObservability.TryBuildState", System.StringComparison.Ordinal);
+
+        NUnit.Framework.Assert.That(gateIndex, NUnit.Framework.Is.GreaterThanOrEqualTo(0));
+        NUnit.Framework.Assert.That(
+            gateIndex,
+            NUnit.Framework.Is.LessThan(buildIndex),
+            "Dev probe state collection does reflection and TMP probing; disabling verbose probes should skip it before any state build.");
+    }
+
+    [NUnit.Framework.Test]
+    public void SelectableTextMenuItemObservability_DoesNotForceTmpMeshOnHotPath()
+    {
+        var source = ReadObservabilitySource("SelectableTextMenuItemObservability.cs");
+
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Not.Contain(".ForceMeshUpdate("),
+            "Dev-only menu item probes should not force TMP mesh regeneration while context-menu selection changes are being measured.");
+        NUnit.Framework.Assert.That(
+            source,
+            NUnit.Framework.Does.Contain("ReflectionUtils.GetPropertyOrFieldValue(instance, memberName) as string"),
+            "Menu item probe data field reads should use the shared reflection accessor cache.");
+    }
+
+    [NUnit.Framework.Test]
     public void TextShellReplacementRenderer_LazilyCollectsVerboseDiagnostics()
     {
         var source = ReadUiSource("TextShellReplacementRenderer.cs");
@@ -282,6 +338,18 @@ public sealed class UnityApiCompatibilityTests
             "Assemblies",
             "src",
             "Patches",
+            fileName));
+    }
+
+    private static string ReadObservabilitySource(string fileName)
+    {
+        return File.ReadAllText(Path.Combine(
+            TestProjectPaths.GetRepositoryRoot(),
+            "Mods",
+            "QudJP",
+            "Assemblies",
+            "src",
+            "Observability",
             fileName));
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryLineTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryLineTranslationPatchTests.cs
@@ -47,14 +47,17 @@ public sealed partial class Issue201StatusScreensBatch2Tests
     {
         WriteDictionaryFile("ui-displayname-atomic.ja.json", ("water flask", "水袋"));
 
+        var initialCacheCount = InventoryLineTranslationPatch.GetTranslationCacheCountForTests();
         var first = InventoryLineTranslationPatch.TranslateItemDisplayNameForQudTest("water flask");
+        var afterFirstCacheCount = InventoryLineTranslationPatch.GetTranslationCacheCountForTests();
         var second = InventoryLineTranslationPatch.TranslateItemDisplayNameForQudTest("water flask");
 
         Assert.Multiple(() =>
         {
             Assert.That(first, Is.EqualTo("水袋"));
             Assert.That(second, Is.EqualTo(first));
-            Assert.That(InventoryLineTranslationPatch.GetTranslationCacheCountForTests(), Is.GreaterThanOrEqualTo(1));
+            Assert.That(afterFirstCacheCount, Is.EqualTo(initialCacheCount + 1));
+            Assert.That(InventoryLineTranslationPatch.GetTranslationCacheCountForTests(), Is.EqualTo(afterFirstCacheCount));
         });
     }
 
@@ -64,13 +67,17 @@ public sealed partial class Issue201StatusScreensBatch2Tests
         WriteDictionaryFile("ui-displayname-atomic.ja.json", ("water flask", "水袋"));
         WriteDictionaryFile("ui-displayname-adjectives.ja.json", ("[empty]", "[空]"));
 
+        var initialCacheCount = InventoryLineTranslationPatch.GetTranslationCacheCountForTests();
         var first = InventoryLineTranslationPatch.TranslateItemDisplayNameForQudTest("water flask [empty]");
+        var afterFirstCacheCount = InventoryLineTranslationPatch.GetTranslationCacheCountForTests();
         var second = InventoryLineTranslationPatch.TranslateItemDisplayNameForQudTest("water flask [empty]");
 
         Assert.Multiple(() =>
         {
             Assert.That(first, Is.EqualTo("水袋 [空]"));
             Assert.That(second, Is.EqualTo("水袋 [空]"));
+            Assert.That(afterFirstCacheCount, Is.EqualTo(initialCacheCount + 1));
+            Assert.That(InventoryLineTranslationPatch.GetTranslationCacheCountForTests(), Is.EqualTo(afterFirstCacheCount));
         });
     }
 

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryLineTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryLineTranslationPatchTests.cs
@@ -24,6 +24,7 @@ public sealed partial class Issue201StatusScreensBatch2Tests
         ColorShapeCaptureObservability.ResetForTests();
         DynamicTextObservability.ResetForTests();
         SinkObservation.ResetForTests();
+        InventoryLineTranslationPatch.ClearTranslationCachesForTests();
     }
 
     [TearDown]
@@ -33,11 +34,44 @@ public sealed partial class Issue201StatusScreensBatch2Tests
         ColorShapeCaptureObservability.ResetForTests();
         DynamicTextObservability.ResetForTests();
         SinkObservation.ResetForTests();
+        InventoryLineTranslationPatch.ClearTranslationCachesForTests();
 
         if (Directory.Exists(tempDirectory))
         {
             Directory.Delete(tempDirectory, recursive: true);
         }
+    }
+
+    [Test]
+    public void TranslateItemDisplayNameForQudTest_CachesRepeatedDisplayName()
+    {
+        WriteDictionaryFile("ui-displayname-atomic.ja.json", ("water flask", "水袋"));
+
+        var first = InventoryLineTranslationPatch.TranslateItemDisplayNameForQudTest("water flask");
+        var second = InventoryLineTranslationPatch.TranslateItemDisplayNameForQudTest("water flask");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.EqualTo("水袋"));
+            Assert.That(second, Is.EqualTo(first));
+            Assert.That(InventoryLineTranslationPatch.GetTranslationCacheCountForTests(), Is.GreaterThanOrEqualTo(1));
+        });
+    }
+
+    [Test]
+    public void TranslateItemDisplayNameForQudTest_CachesFallbackDisplayNameAfterVisibleMiss()
+    {
+        WriteDictionaryFile("ui-displayname-atomic.ja.json", ("water flask", "水袋"));
+        WriteDictionaryFile("ui-displayname-adjectives.ja.json", ("[empty]", "[空]"));
+
+        var first = InventoryLineTranslationPatch.TranslateItemDisplayNameForQudTest("water flask [empty]");
+        var second = InventoryLineTranslationPatch.TranslateItemDisplayNameForQudTest("water flask [empty]");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.EqualTo("水袋 [空]"));
+            Assert.That(second, Is.EqualTo("水袋 [空]"));
+        });
     }
 
     [Test]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupPickOptionTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupPickOptionTranslationPatchTests.cs
@@ -300,14 +300,19 @@ public sealed class PopupPickOptionTranslationPatchTests
     {
         WriteCommonMenuActionDictionary(("get", "取る"));
 
-        _ = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay(
+        var first = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay(
             "{{W|[g]}} {{y|get}}",
             "InventoryActionMenu:a");
-        _ = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay(
+        var second = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay(
             "{{W|[g]}} {{y|get}}",
             "InventoryActionMenu:b");
 
-        Assert.That(SelectableTextMenuItemTranslationPatch.GetDisplayTranslationCacheCountForTests(), Is.EqualTo(2));
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.EqualTo("{{W|[g]}} {{y|取る}}"));
+            Assert.That(second, Is.EqualTo("{{W|[g]}} {{y|取る}}"));
+            Assert.That(SelectableTextMenuItemTranslationPatch.GetDisplayTranslationCacheCountForTests(), Is.EqualTo(2));
+        });
     }
 
     [Test]

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupPickOptionTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupPickOptionTranslationPatchTests.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Reflection;
 using System.Text;
 using HarmonyLib;
@@ -31,6 +32,7 @@ public sealed class PopupPickOptionTranslationPatchTests
         MessagePatternTranslator.SetPatternFileForTests(patternFilePath);
         DynamicTextObservability.ResetForTests();
         SinkObservation.ResetForTests();
+        SelectableTextMenuItemTranslationPatch.ClearDisplayTranslationCacheForTests();
         File.WriteAllText(patternFilePath, "{\"patterns\":[]}\n", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         DummyPopupGenericTarget.Reset();
     }
@@ -43,6 +45,7 @@ public sealed class PopupPickOptionTranslationPatchTests
         MessagePatternTranslator.ResetForTests();
         DynamicTextObservability.ResetForTests();
         SinkObservation.ResetForTests();
+        SelectableTextMenuItemTranslationPatch.ClearDisplayTranslationCacheForTests();
 
         if (Directory.Exists(tempDirectory))
         {
@@ -204,6 +207,107 @@ public sealed class PopupPickOptionTranslationPatchTests
         var translated = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay("{{W|[g]}} {{y|get}}");
 
         Assert.That(translated, Is.EqualTo("{{W|[g]}} {{y|拾う}}"));
+    }
+
+    [Test]
+    public void TranslateMenuItemTextForDisplay_FlattensAndTranslatesNestedBottomContextHotkeyLabel()
+    {
+        WriteCommonMenuActionDictionary(("back", "戻る"));
+
+        var translated = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay(
+            "{{y|{{W|[Esc]}} Back}}");
+
+        Assert.That(translated, Is.EqualTo("{{W|[Esc]}} {{y|戻る}}"));
+    }
+
+    [Test]
+    public void SelectableTextMenuItemPostfix_TranslatesDisplayOnlyAndPreservesControlIdData()
+    {
+        WriteCommonMenuActionDictionary(("get", "取る"));
+        var menuData = new DummySelectableMenuData(
+            text: "{{W|[g]}} {{y|get}}",
+            simpleText: "get",
+            command: "CmdGet",
+            hotkey: "g");
+        var target = new DummySelectableTextMenuItemTarget(menuData);
+
+        SelectableTextMenuItemTranslationPatch.Postfix(target, newState: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(menuData.text, Is.EqualTo("{{W|[g]}} {{y|get}}"));
+            Assert.That(menuData.simpleText, Is.EqualTo("get"));
+            Assert.That(menuData.command, Is.EqualTo("CmdGet"));
+            Assert.That(menuData.hotkey, Is.EqualTo("g"));
+            Assert.That(target.ControlId, Is.EqualTo("QudTextMenuItem:get"));
+            Assert.That(target.item.Text, Is.EqualTo("{{W|{{W|[g]}} {{y|取る}}}}"));
+        });
+    }
+
+    [Test]
+    public void BottomContextDisplayTranslation_ReappliesWhenPopupRouteChangesWithoutItemTextChange()
+    {
+        WriteQudMenuItemDictionary(("remove", "QudMenuItem", "一般の外す"));
+        WriteInventoryActionDictionary(("remove", "XRL.World.IInventoryActionsEvent", "装備から外す"));
+        var menuData = new DummySelectableMenuData(
+            text: "{{W|[r]}} {{y|remove}}",
+            simpleText: "remove",
+            command: "CmdRemove",
+            hotkey: "r");
+        var target = new DummySelectableTextMenuItemTarget(menuData)
+        {
+            selected = true,
+        };
+
+        SelectableTextMenuItemTranslationPatch.ApplyDisplayTranslationIfChanged(
+            target,
+            selected: true,
+            popupIdOverride: null);
+        QudMenuBottomContextTranslationPatch.ApplyButtonDisplayTranslations(
+            new DummyQudMenuBottomContext(target),
+            popupIdOverride: "InventoryActionMenu:ABC123");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(menuData.text, Is.EqualTo("{{W|[r]}} {{y|remove}}"));
+            Assert.That(target.item.Text, Is.EqualTo("{{W|{{W|[r]}} {{y|装備から外す}}}}"));
+            Assert.That(target.item.SetTextCallCount, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void TranslateMenuItemTextForDisplay_CachesRepeatedSourceAndPopupId()
+    {
+        WriteCommonMenuActionDictionary(("get", "取る"));
+
+        var first = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay(
+            "{{W|[g]}} {{y|get}}",
+            "InventoryActionMenu:test");
+        var second = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay(
+            "{{W|[g]}} {{y|get}}",
+            "InventoryActionMenu:test");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.EqualTo("{{W|[g]}} {{y|取る}}"));
+            Assert.That(second, Is.EqualTo(first));
+            Assert.That(SelectableTextMenuItemTranslationPatch.GetDisplayTranslationCacheCountForTests(), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void TranslateMenuItemTextForDisplay_CacheSeparatesPopupIds()
+    {
+        WriteCommonMenuActionDictionary(("get", "取る"));
+
+        _ = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay(
+            "{{W|[g]}} {{y|get}}",
+            "InventoryActionMenu:a");
+        _ = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay(
+            "{{W|[g]}} {{y|get}}",
+            "InventoryActionMenu:b");
+
+        Assert.That(SelectableTextMenuItemTranslationPatch.GetDisplayTranslationCacheCountForTests(), Is.EqualTo(2));
     }
 
     [Test]
@@ -1325,6 +1429,67 @@ public sealed class PopupPickOptionTranslationPatchTests
             .Replace("\r", "\\r", StringComparison.Ordinal)
             .Replace("\n", "\\n", StringComparison.Ordinal)
             .Replace("\t", "\\t", StringComparison.Ordinal);
+    }
+
+    private sealed class DummySelectableTextMenuItemTarget
+    {
+        public DummySelectableTextMenuItemTarget(DummySelectableMenuData data)
+        {
+            this.data = data;
+            itemText = data.text;
+            ControlId = "QudTextMenuItem:" + data.simpleText;
+        }
+
+        public DummySelectableMenuData data { get; }
+
+        public string itemText { get; }
+
+        public string ControlId { get; }
+
+        public bool selected { get; set; }
+
+        public readonly DummySelectableItemSkin item = new();
+    }
+
+#pragma warning disable S1144
+    private sealed class DummySelectableItemSkin
+    {
+        public string Text { get; private set; } = string.Empty;
+
+        public int SetTextCallCount { get; private set; }
+
+        public void SetText(string value)
+        {
+            SetTextCallCount++;
+            Text = value;
+        }
+    }
+#pragma warning restore S1144
+
+    private sealed class DummyQudMenuBottomContext
+    {
+        public DummyQudMenuBottomContext(params object[] buttons)
+        {
+            this.buttons = new ArrayList(buttons);
+        }
+
+        public ArrayList buttons { get; }
+    }
+
+    private sealed class DummySelectableMenuData
+    {
+        public DummySelectableMenuData(string text, string simpleText, string command, string hotkey)
+        {
+            this.text = text;
+            this.simpleText = simpleText;
+            this.command = command;
+            this.hotkey = hotkey;
+        }
+
+        public string text;
+        public string simpleText;
+        public string command;
+        public string hotkey;
     }
 
     private sealed class HarmonyPatchScope : IDisposable

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudMenuBottomContextTranslationPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/QudMenuBottomContextTranslationPatchTests.cs
@@ -34,7 +34,7 @@ public sealed class QudMenuBottomContextTranslationPatchTests
     }
 
     [Test]
-    public void Prefix_TranslatesMenuItemText()
+    public void Prefix_DoesNotMutateMenuItemText()
     {
         WriteDictionary(("Inspect", "調べる"));
 
@@ -43,12 +43,12 @@ public sealed class QudMenuBottomContextTranslationPatchTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(((DummyMenuItem)context.items[0]!).text, Is.EqualTo("調べる"));
+            Assert.That(((DummyMenuItem)context.items[0]!).text, Is.EqualTo("Inspect"));
             Assert.That(
                 DynamicTextObservability.GetRouteFamilyHitCountForTests(
                     nameof(QudMenuBottomContextTranslationPatch),
                     "Popup.ProducerMenuItem.Exact"),
-                Is.GreaterThan(0));
+                Is.Zero);
             Assert.That(
                 SinkObservation.GetHitCountForTests(
                     nameof(PopupTranslationPatch),
@@ -61,48 +61,50 @@ public sealed class QudMenuBottomContextTranslationPatchTests
     }
 
     [Test]
-    public void Prefix_StripsDirectTranslationMarker_FromMenuItemText()
+    public void Prefix_DoesNotStripDirectTranslationMarker_FromMenuItemText()
     {
         var context = new DummyQudMenuBottomContext("調べる");
 
         RunRefreshButtonsWithPatch(context);
 
-        Assert.That(((DummyMenuItem)context.items[0]!).text, Is.EqualTo("調べる"));
+        Assert.That(((DummyMenuItem)context.items[0]!).text, Is.EqualTo("調べる"));
     }
 
     [Test]
-    public void Prefix_TranslatesAndFlattensNestedHotkeyLabel()
+    public void Prefix_DoesNotFlattenNestedHotkeyData()
     {
         WriteScopedMenuActionDictionary(("back", "戻る"));
 
-        var context = new DummyQudMenuBottomContext("{{y|{{W|[Esc]}} Back}}");
+        var source = "{{y|{{W|[Esc]}} Back}}";
+        var context = new DummyQudMenuBottomContext(source);
 
         RunRefreshButtonsWithPatch(context);
 
         Assert.Multiple(() =>
         {
-            Assert.That(((DummyMenuItem)context.items[0]!).text, Is.EqualTo("{{W|[Esc]}} {{y|戻る}}"));
+            Assert.That(((DummyMenuItem)context.items[0]!).text, Is.EqualTo(source));
             Assert.That(
                 DynamicTextObservability.GetRouteFamilyHitCountForTests(
                     nameof(QudMenuBottomContextTranslationPatch),
                     "Popup.ProducerMenuItem.HotkeyLabel"),
-                Is.GreaterThan(0));
+                Is.Zero);
         });
     }
 
     [Test]
-    public void Prefix_FlattensNestedHotkeyLabel_WhenLabelIsUntranslated()
+    public void Prefix_DoesNotFlattenNestedHotkeyLabel_WhenLabelIsUntranslated()
     {
-        var context = new DummyQudMenuBottomContext("{{y|{{W|[Esc]}} Back}}");
+        var source = "{{y|{{W|[Esc]}} Back}}";
+        var context = new DummyQudMenuBottomContext(source);
 
         RunRefreshButtonsWithPatch(context);
 
-        Assert.That(((DummyMenuItem)context.items[0]!).text, Is.EqualTo("{{W|[Esc]}} {{y|Back}}"));
+        Assert.That(((DummyMenuItem)context.items[0]!).text, Is.EqualTo(source));
     }
 
-    [TestCase("{{y|{{W|[~Accept]}} Continue}}", "{{W|[~Accept]}} {{y|続ける}}")]
-    [TestCase("{{y|{{W|[space]}} Continue}}", "{{W|[space]}} {{y|続ける}}")]
-    public void Prefix_PreservesNestedHotkeyTokenAndBrackets(string source, string expected)
+    [TestCase("{{y|{{W|[~Accept]}} Continue}}")]
+    [TestCase("{{y|{{W|[space]}} Continue}}")]
+    public void Prefix_PreservesNestedHotkeyTokenAndBrackets(string source)
     {
         WriteScopedMenuActionDictionary(("continue", "続ける"));
 
@@ -110,7 +112,7 @@ public sealed class QudMenuBottomContextTranslationPatchTests
 
         RunRefreshButtonsWithPatch(context);
 
-        Assert.That(((DummyMenuItem)context.items[0]!).text, Is.EqualTo(expected));
+        Assert.That(((DummyMenuItem)context.items[0]!).text, Is.EqualTo(source));
     }
 
     [Test]
@@ -125,7 +127,7 @@ public sealed class QudMenuBottomContextTranslationPatchTests
     }
 
     [Test]
-    public void Prefix_PreservesPopupMessageButtonColorTags()
+    public void Prefix_DoesNotMutatePopupMessageButtonColorTags()
     {
         WriteDictionary(
             ("{{W|[y]}} {{y|Yes}}", "{{W|[y]}} {{y|はい}}"),
@@ -139,8 +141,8 @@ public sealed class QudMenuBottomContextTranslationPatchTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(((DummyMenuItem)context.items[0]!).text, Is.EqualTo("{{W|[y]}} {{y|はい}}"));
-            Assert.That(((DummyMenuItem)context.items[1]!).text, Is.EqualTo("{{W|[n]}} {{y|いいえ}}"));
+            Assert.That(((DummyMenuItem)context.items[0]!).text, Is.EqualTo("{{y|{{W|[y]}} Yes}}"));
+            Assert.That(((DummyMenuItem)context.items[1]!).text, Is.EqualTo("{{y|{{W|[n]}} No}}"));
         });
     }
 

--- a/Mods/QudJP/Assemblies/src/Observability/SelectableTextMenuItemObservability.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/SelectableTextMenuItemObservability.cs
@@ -65,7 +65,6 @@ internal static class SelectableTextMenuItemObservability
             var tmp = component.GetComponentInChildren<TMP_Text>(includeInactive: true);
             if (tmp is not null)
             {
-                tmp.ForceMeshUpdate(ignoreActiveState: true, forceTextReparsing: true);
                 builder.Append(" tmpText='");
                 builder.Append(Escape(Truncate(tmp.text)));
                 builder.Append("' charCount=");
@@ -110,31 +109,7 @@ internal static class SelectableTextMenuItemObservability
 
     private static string? TryGetStringPropertyOrField(object? instance, string memberName)
     {
-        if (instance is null)
-        {
-            return null;
-        }
-
-#pragma warning disable S3011
-        var property = instance.GetType().GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-#pragma warning restore S3011
-        if (property is not null && property.PropertyType == typeof(string) && property.GetIndexParameters().Length == 0)
-        {
-#pragma warning disable S3011
-            return property.GetValue(instance) as string;
-#pragma warning restore S3011
-        }
-
-        return Access(instance, memberName) as string;
-    }
-
-    private static object? Access(object instance, string memberName)
-    {
-        var type = instance.GetType();
-#pragma warning disable S3011
-        var field = type.GetField(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-#pragma warning restore S3011
-        return field?.GetValue(instance);
+        return ReflectionUtils.GetPropertyOrFieldValue(instance, memberName) as string;
     }
 
     private static string? TryGetStringByCandidates(object? instance, params string[] memberNames)

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryLineRenderProbePatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryLineRenderProbePatch.cs
@@ -46,6 +46,7 @@ public static class InventoryLineRenderProbePatch
         return null;
     }
 
+    [HarmonyPriority(Priority.Last)]
     public static void Postfix(object __instance, object data)
     {
         try
@@ -60,7 +61,7 @@ public static class InventoryLineRenderProbePatch
             }
 #endif
 #if HAS_TMP
-            _ = InventoryLineFontFixer.TryApplyPrimaryFontToItemRow(__instance, data);
+            _ = InventoryLineFontFixer.TryApplyPrimaryFontToItemRowForSetData(__instance, data);
 #endif
 #if HAS_TMP && QUDJP_DEV_BUILD
             if (RuntimeDiagnostics.VerboseProbesEnabled)

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
@@ -10,7 +11,10 @@ namespace QudJP.Patches;
 public static class InventoryLineTranslationPatch
 {
     private const string Context = nameof(InventoryLineTranslationPatch);
+    private const int MaxTranslationCacheEntries = 4096;
     private const string WeightUnit = "lbs.";
+    private static readonly ConcurrentDictionary<InventoryTranslationCacheKey, string> TranslationCache = new();
+    private static readonly ConcurrentQueue<InventoryTranslationCacheKey> TranslationCacheOrder = new();
 
     [HarmonyTargetMethod]
     private static MethodBase? TargetMethod()
@@ -134,7 +138,10 @@ public static class InventoryLineTranslationPatch
         }
 #endif
 #if HAS_TMP
-        _ = InventoryLineFontFixer.TryRefreshTextSkinWithFallbackFont(itemTextSkin, translatedDisplayName);
+        _ = InventoryLineFontFixer.TryRefreshTextSkinWithFallbackFontForSetData(
+            instance,
+            itemTextSkin,
+            translatedDisplayName);
 #endif
 #if HAS_TMP && QUDJP_DEV_BUILD
         if (RuntimeDiagnostics.VerboseProbesEnabled)
@@ -167,6 +174,11 @@ public static class InventoryLineTranslationPatch
             return source;
         }
 
+        return GetOrAddTranslationCache(family, source, () => TranslateVisibleTextUncached(source, route, family));
+    }
+
+    private static string TranslateVisibleTextUncached(string source, string route, string family)
+    {
         var sanitizedSource = MessageFrameTranslator.StripAllDirectTranslationMarkers(source);
         var translated = ColorAwareTranslationComposer.TranslatePreservingColors(
             sanitizedSource,
@@ -183,6 +195,12 @@ public static class InventoryLineTranslationPatch
 
     private static string TranslateItemDisplayName(string source, string route)
     {
+        return GetOrAddTranslationCache("InventoryLine.ItemName", source, () =>
+            TranslateItemDisplayNameUncached(source, route));
+    }
+
+    private static string TranslateItemDisplayNameUncached(string source, string route)
+    {
         if (MerchantAdvertisementTextTranslator.TryTranslateBookTitle(source, out var translatedBookTitle))
         {
             translatedBookTitle = MessageFrameTranslator.StripAllDirectTranslationMarkers(translatedBookTitle);
@@ -194,7 +212,7 @@ public static class InventoryLineTranslationPatch
             return translatedBookTitle;
         }
 
-        var translated = TranslateVisibleText(source, route, "InventoryLine.ItemName");
+        var translated = TranslateVisibleTextUncached(source, route, "InventoryLine.ItemName");
         if (string.Equals(translated, source, StringComparison.Ordinal))
         {
             translated = GetDisplayNameRouteTranslator.TranslatePreservingColors(
@@ -214,6 +232,45 @@ public static class InventoryLineTranslationPatch
         return TranslateItemDisplayName(
             source,
             ObservabilityHelpers.ComposeContext(Context, "field=text"));
+    }
+
+    internal static void ClearTranslationCachesForTests()
+    {
+        TranslationCache.Clear();
+        while (TranslationCacheOrder.TryDequeue(out var ignored))
+        {
+            _ = ignored;
+        }
+    }
+
+    internal static int GetTranslationCacheCountForTests()
+    {
+        return TranslationCache.Count;
+    }
+
+    private static string GetOrAddTranslationCache(
+        string family,
+        string source,
+        Func<string> translate)
+    {
+        var key = new InventoryTranslationCacheKey(family, source);
+        if (TranslationCache.TryGetValue(key, out var cached))
+        {
+            return cached;
+        }
+
+        var translated = translate();
+        if (TranslationCache.TryAdd(key, translated))
+        {
+            TranslationCacheOrder.Enqueue(key);
+            while (TranslationCache.Count > MaxTranslationCacheEntries
+                && TranslationCacheOrder.TryDequeue(out var oldest))
+            {
+                TranslationCache.TryRemove(oldest, out _);
+            }
+        }
+
+        return translated;
     }
 
     private static string TranslateCategoryWeightText(string source, int amount, int weight, bool showItemCount, string route)
@@ -267,15 +324,7 @@ public static class InventoryLineTranslationPatch
 
     private static object? GetMemberValue(object instance, string memberName)
     {
-        var type = instance.GetType();
-        var property = AccessTools.Property(type, memberName);
-        if (property is not null && property.CanRead)
-        {
-            return property.GetValue(instance);
-        }
-
-        var field = AccessTools.Field(type, memberName);
-        return field?.GetValue(instance);
+        return ReflectionUtils.GetPropertyOrFieldValue(instance, memberName);
     }
 
     private static string? GetStringMemberValue(object instance, string memberName)
@@ -287,6 +336,39 @@ public static class InventoryLineTranslationPatch
     {
         var value = GetMemberValue(instance, memberName);
         return value is null ? 0 : Convert.ToInt32(value, CultureInfo.InvariantCulture);
+    }
+
+    private readonly struct InventoryTranslationCacheKey : IEquatable<InventoryTranslationCacheKey>
+    {
+        internal InventoryTranslationCacheKey(string family, string source)
+        {
+            Family = family;
+            Source = source;
+        }
+
+        internal string Family { get; }
+
+        internal string Source { get; }
+
+        public bool Equals(InventoryTranslationCacheKey other)
+        {
+            return string.Equals(Family, other.Family, StringComparison.Ordinal)
+                && string.Equals(Source, other.Source, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is InventoryTranslationCacheKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (StringComparer.Ordinal.GetHashCode(Family) * 397)
+                    ^ StringComparer.Ordinal.GetHashCode(Source);
+            }
+        }
     }
 
 }

--- a/Mods/QudJP/Assemblies/src/Patches/QudMenuBottomContextTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/QudMenuBottomContextTranslationPatch.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Diagnostics;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using HarmonyLib;
 
 namespace QudJP.Patches;
@@ -11,10 +10,6 @@ namespace QudJP.Patches;
 public static class QudMenuBottomContextTranslationPatch
 {
     private const string TargetTypeName = "Qud.UI.QudMenuBottomContext";
-    private static readonly Regex NestedHotkeyLabelPattern =
-        new Regex(
-            @"^\{\{(?<labelColor>[A-Za-z]+)\|\{\{(?<hotkeyColor>[A-Za-z]+)\|(?<hotkey>\[[^\]]+\])\}\}\s*(?<label>.*?)\}\}$",
-            RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.Singleline);
 
     [HarmonyTargetMethod]
     private static MethodBase? TargetMethod()
@@ -40,7 +35,6 @@ public static class QudMenuBottomContextTranslationPatch
         try
         {
             LogProbe(__instance, "prefix");
-            NormalizeItemTexts(__instance);
         }
         catch (Exception ex)
         {
@@ -52,6 +46,7 @@ public static class QudMenuBottomContextTranslationPatch
     {
         try
         {
+            ApplyButtonDisplayTranslations(__instance);
             LogProbe(__instance, "postfix");
         }
         catch (Exception ex)
@@ -62,78 +57,33 @@ public static class QudMenuBottomContextTranslationPatch
 
     internal static void NormalizeItemTexts(object? contextInstance)
     {
-        if (contextInstance is null)
-        {
-            return;
-        }
-
-        var itemsMember = AccessTools.Field(contextInstance.GetType(), "items");
-        if (itemsMember?.GetValue(contextInstance) is not IList items)
-        {
-            return;
-        }
-
-        for (var index = 0; index < items.Count; index++)
-        {
-            var item = items[index];
-            if (item is null)
-            {
-                continue;
-            }
-
-            var textField = AccessTools.Field(item.GetType(), "text");
-            if (textField is null || textField.FieldType != typeof(string))
-            {
-                continue;
-            }
-
-            var current = textField.GetValue(item) as string;
-            if (string.IsNullOrEmpty(current))
-            {
-                continue;
-            }
-
-            var normalized = NormalizeNestedHotkeyLabel(current!);
-            var translated = PopupTranslationPatch.TranslatePopupMenuItemTextForProducerRoute(
-                normalized,
-                nameof(QudMenuBottomContextTranslationPatch));
-            var displayText = MessageFrameTranslator.StripAllDirectTranslationMarkers(
-                translated);
-
-            if (string.Equals(displayText, current, StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            textField.SetValue(item, displayText);
-            items[index] = item;
-        }
+        // QudMenuBottomContext.RefreshButtons runs every frame. Do not mutate
+        // QudMenuItem data here; display translation belongs to
+        // SelectableTextMenuItemTranslationPatch so tutorial/control IDs remain stable.
+        _ = contextInstance;
     }
 
-    private static string NormalizeNestedHotkeyLabel(string source)
+    internal static void ApplyButtonDisplayTranslations(object? contextInstance, string? popupIdOverride = null)
     {
-        var match = NestedHotkeyLabelPattern.Match(source);
-        if (!match.Success)
+        var buttons = ReflectionUtils.GetPropertyOrFieldValue(contextInstance, "buttons") as IEnumerable;
+        if (buttons is null)
         {
-            return source;
+            return;
         }
 
-        var hotkey = match.Groups["hotkey"].Value;
-        var label = match.Groups["label"].Value;
-        if (label.Length == 0)
+        foreach (var button in buttons)
         {
-            return source;
-        }
+            if (button is null)
+            {
+                continue;
+            }
 
-        return "{{"
-            + match.Groups["hotkeyColor"].Value
-            + "|"
-            + hotkey
-            + "}} {{"
-            + match.Groups["labelColor"].Value
-            + "|"
-            + label
-            + "}}";
+            var selected = ReflectionUtils.GetPropertyOrFieldValue(button, "selected") is true;
+            SelectableTextMenuItemTranslationPatch.ApplyDisplayTranslationIfChanged(
+                button,
+                selected,
+                popupIdOverride);
+        }
     }
 
     private static void LogProbe(object? contextInstance, string phase)

--- a/Mods/QudJP/Assemblies/src/Patches/SelectableTextMenuItemProbePatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/SelectableTextMenuItemProbePatch.cs
@@ -34,6 +34,11 @@ public static class SelectableTextMenuItemProbePatch
     {
         try
         {
+            if (!RuntimeDiagnostics.VerboseProbesEnabled)
+            {
+                return;
+            }
+
             if (SelectableTextMenuItemObservability.TryBuildState(__instance, "update-postfix", out var logLine)
                 && !string.IsNullOrEmpty(logLine))
             {

--- a/Mods/QudJP/Assemblies/src/Patches/SelectableTextMenuItemTranslationPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/SelectableTextMenuItemTranslationPatch.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using HarmonyLib;
 
 namespace QudJP.Patches;
@@ -9,7 +12,16 @@ namespace QudJP.Patches;
 public static class SelectableTextMenuItemTranslationPatch
 {
     private const string Context = nameof(SelectableTextMenuItemTranslationPatch);
+    private const int MaxDisplayTranslationCacheEntries = 2048;
     private const string TargetTypeName = "Qud.UI.SelectableTextMenuItem";
+    private static readonly ConcurrentDictionary<DisplayTranslationCacheKey, string> DisplayTranslationCache = new();
+    private static readonly ConcurrentQueue<DisplayTranslationCacheKey> DisplayTranslationCacheOrder = new();
+    private static readonly ConcurrentDictionary<Type, MethodInfo> SetTextMethods = new();
+    private static ConditionalWeakTable<object, AppliedDisplayTranslationState> AppliedDisplayTranslationStates = new();
+    private static readonly Regex NestedHotkeyLabelPattern =
+        new Regex(
+            @"^\{\{(?<labelColor>[A-Za-z]+)\|\{\{(?<hotkeyColor>[A-Za-z]+)\|(?<hotkey>\[[^\]]+\])\}\}\s*(?<label>.*?)\}\}$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.Singleline);
 
     [HarmonyTargetMethod]
     private static MethodBase? TargetMethod()
@@ -39,26 +51,55 @@ public static class SelectableTextMenuItemTranslationPatch
                 return;
             }
 
-            var itemText = AccessTools.Property(__instance.GetType(), "itemText")?.GetValue(__instance) as string;
-            if (itemText is null || itemText.Length == 0)
-            {
-                return;
-            }
-
-            var translated = TranslateMenuItemTextForDisplay(itemText, TryGetPopupIdFromParentPopup(__instance));
-            if (string.Equals(translated, itemText, StringComparison.Ordinal))
-            {
-                return;
-            }
-
-            var item = AccessTools.Field(__instance.GetType(), "item")?.GetValue(__instance);
-            var setText = item is null ? null : AccessTools.Method(item.GetType(), "SetText", new[] { typeof(string) });
-            setText?.Invoke(item, new object[] { WrapForSelection(translated, newState) });
+            ApplyDisplayTranslationIfChanged(__instance, newState, popupIdOverride: null, vanillaTextAlreadyApplied: true);
         }
         catch (Exception ex)
         {
             Trace.TraceError("QudJP: {0}.Postfix failed: {1}", Context, ex);
         }
+    }
+
+    internal static void ApplyDisplayTranslationIfChanged(
+        object? instance,
+        bool selected,
+        string? popupIdOverride = null,
+        bool vanillaTextAlreadyApplied = false)
+    {
+        if (instance is null)
+        {
+            return;
+        }
+
+        var itemText = ReflectionUtils.GetPropertyOrFieldValue(instance, "itemText") as string;
+        if (itemText is null || itemText.Length == 0)
+        {
+            return;
+        }
+
+        var popupId = popupIdOverride ?? TryGetPopupIdFromParentPopup(instance);
+        var key = new AppliedDisplayTranslationKey(itemText, popupId, selected);
+        var state = AppliedDisplayTranslationStates.GetOrCreateValue(instance);
+        if (state.HasLastKey && state.LastKey.Equals(key))
+        {
+            return;
+        }
+
+        var translated = TranslateMenuItemTextForDisplay(itemText, popupId);
+        if (vanillaTextAlreadyApplied && string.Equals(translated, itemText, StringComparison.Ordinal))
+        {
+            state.SetLastKey(key);
+            return;
+        }
+
+        var item = ReflectionUtils.GetPropertyOrFieldValue(instance, "item");
+        var setText = item is null ? null : GetSetTextMethod(item.GetType());
+        if (setText is null)
+        {
+            return;
+        }
+
+        setText.Invoke(item, new object[] { WrapForSelection(translated, selected) });
+        state.SetLastKey(key);
     }
 
     internal static string TranslateMenuItemTextForDisplay(string source)
@@ -68,8 +109,94 @@ public static class SelectableTextMenuItemTranslationPatch
 
     internal static string TranslateMenuItemTextForDisplay(string source, string? popupId)
     {
+        var key = new DisplayTranslationCacheKey(source, popupId);
+        if (DisplayTranslationCache.TryGetValue(key, out var cached))
+        {
+            return cached;
+        }
+
+        var translated = TranslateMenuItemTextForDisplayUncached(key);
+        if (DisplayTranslationCache.TryAdd(key, translated))
+        {
+            RememberDisplayTranslationKey(key);
+        }
+
+        return translated;
+    }
+
+    private static MethodInfo? GetSetTextMethod(Type itemType)
+    {
+        if (SetTextMethods.TryGetValue(itemType, out var cached))
+        {
+            return cached;
+        }
+
+        var method = AccessTools.Method(itemType, "SetText", new[] { typeof(string) });
+        if (method is not null)
+        {
+            SetTextMethods.TryAdd(itemType, method);
+        }
+
+        return method;
+    }
+
+    internal static void ClearDisplayTranslationCacheForTests()
+    {
+        DisplayTranslationCache.Clear();
+        while (DisplayTranslationCacheOrder.TryDequeue(out var ignored))
+        {
+            _ = ignored;
+        }
+
+        AppliedDisplayTranslationStates = new ConditionalWeakTable<object, AppliedDisplayTranslationState>();
+    }
+
+    internal static int GetDisplayTranslationCacheCountForTests()
+    {
+        return DisplayTranslationCache.Count;
+    }
+
+    private static string TranslateMenuItemTextForDisplayUncached(DisplayTranslationCacheKey key)
+    {
+        var normalized = NormalizeNestedHotkeyLabelForDisplay(key.Source);
         return MessageFrameTranslator.StripAllDirectTranslationMarkers(
-            PopupTranslationPatch.TranslatePopupMenuItemTextForProducerRoute(source, Context, popupId));
+            PopupTranslationPatch.TranslatePopupMenuItemTextForProducerRoute(normalized, Context, key.PopupId));
+    }
+
+    private static void RememberDisplayTranslationKey(DisplayTranslationCacheKey key)
+    {
+        DisplayTranslationCacheOrder.Enqueue(key);
+        while (DisplayTranslationCache.Count > MaxDisplayTranslationCacheEntries
+            && DisplayTranslationCacheOrder.TryDequeue(out var oldest))
+        {
+            DisplayTranslationCache.TryRemove(oldest, out _);
+        }
+    }
+
+    internal static string NormalizeNestedHotkeyLabelForDisplay(string source)
+    {
+        var match = NestedHotkeyLabelPattern.Match(source);
+        if (!match.Success)
+        {
+            return source;
+        }
+
+        var hotkey = match.Groups["hotkey"].Value;
+        var label = match.Groups["label"].Value;
+        if (label.Length == 0)
+        {
+            return source;
+        }
+
+        return "{{"
+            + match.Groups["hotkeyColor"].Value
+            + "|"
+            + hotkey
+            + "}} {{"
+            + match.Groups["labelColor"].Value
+            + "|"
+            + label
+            + "}}";
     }
 
     internal static string WrapForSelection(string source, bool selected)
@@ -124,6 +251,91 @@ public static class SelectableTextMenuItemTranslationPatch
     private static string? TryGetLastPopupId(Type popupMessageType)
     {
         return AccessTools.Field(popupMessageType, "lastPopupID")?.GetValue(null) as string;
+    }
+
+    private sealed class AppliedDisplayTranslationState
+    {
+        internal bool HasLastKey { get; private set; }
+
+        internal AppliedDisplayTranslationKey LastKey { get; private set; }
+
+        internal void SetLastKey(AppliedDisplayTranslationKey key)
+        {
+            LastKey = key;
+            HasLastKey = true;
+        }
+    }
+
+    private readonly struct AppliedDisplayTranslationKey : IEquatable<AppliedDisplayTranslationKey>
+    {
+        internal AppliedDisplayTranslationKey(string source, string? popupId, bool selected)
+        {
+            Source = source;
+            PopupId = popupId;
+            Selected = selected;
+        }
+
+        internal string Source { get; }
+
+        internal string? PopupId { get; }
+
+        internal bool Selected { get; }
+
+        public bool Equals(AppliedDisplayTranslationKey other)
+        {
+            return string.Equals(Source, other.Source, StringComparison.Ordinal)
+                && string.Equals(PopupId, other.PopupId, StringComparison.Ordinal)
+                && Selected == other.Selected;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is AppliedDisplayTranslationKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hash = StringComparer.Ordinal.GetHashCode(Source);
+                hash = (hash * 397) ^ (PopupId is null ? 0 : StringComparer.Ordinal.GetHashCode(PopupId));
+                hash = (hash * 397) ^ Selected.GetHashCode();
+                return hash;
+            }
+        }
+    }
+
+    private readonly struct DisplayTranslationCacheKey : IEquatable<DisplayTranslationCacheKey>
+    {
+        internal DisplayTranslationCacheKey(string source, string? popupId)
+        {
+            Source = source;
+            PopupId = popupId ?? string.Empty;
+        }
+
+        internal string Source { get; }
+
+        internal string PopupId { get; }
+
+        public bool Equals(DisplayTranslationCacheKey other)
+        {
+            return string.Equals(Source, other.Source, StringComparison.Ordinal)
+                && string.Equals(PopupId, other.PopupId, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is DisplayTranslationCacheKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (StringComparer.Ordinal.GetHashCode(Source) * 397)
+                    ^ StringComparer.Ordinal.GetHashCode(PopupId);
+            }
+        }
     }
 
 }

--- a/Mods/QudJP/Assemblies/src/Patches/UITextSkinReflectionAccessor.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/UITextSkinReflectionAccessor.cs
@@ -7,28 +7,31 @@ namespace QudJP.Patches;
 
 internal static class UITextSkinReflectionAccessor
 {
+    private const string CacheContext = nameof(UITextSkinReflectionAccessor);
     private static readonly ConcurrentDictionary<Type, TextReadStrategy> ReadStrategies = new();
     private static readonly ConcurrentDictionary<Type, TextWriteStrategy> WriteStrategies = new();
 
     internal static string? GetCurrentText(object? uiTextSkin, string context)
     {
+        _ = context;
         if (uiTextSkin is null)
         {
             return null;
         }
 
-        var strategy = ReadStrategies.GetOrAdd(uiTextSkin.GetType(), type => BuildReadStrategy(type, context));
+        var strategy = ReadStrategies.GetOrAdd(uiTextSkin.GetType(), static type => BuildReadStrategy(type));
         return strategy.Get(uiTextSkin);
     }
 
     internal static bool SetCurrentText(object? uiTextSkin, string translated, string context)
     {
+        _ = context;
         if (uiTextSkin is null)
         {
             return false;
         }
 
-        var strategy = WriteStrategies.GetOrAdd(uiTextSkin.GetType(), type => BuildWriteStrategy(type, context));
+        var strategy = WriteStrategies.GetOrAdd(uiTextSkin.GetType(), static type => BuildWriteStrategy(type));
         return strategy.Set(uiTextSkin, translated);
     }
 
@@ -49,7 +52,7 @@ internal static class UITextSkinReflectionAccessor
         return true;
     }
 
-    private static TextReadStrategy BuildReadStrategy(Type type, string context)
+    private static TextReadStrategy BuildReadStrategy(Type type)
     {
         var textField = AccessTools.Field(type, "text");
         if (textField?.FieldType == typeof(string))
@@ -62,7 +65,7 @@ internal static class UITextSkinReflectionAccessor
         {
             Trace.TraceWarning(
                 "QudJP: {0}.GetCurrentText falling back to property 'text' for {1}.",
-                context,
+                CacheContext,
                 type.FullName);
             textProperty = AccessTools.Property(type, "text");
         }
@@ -75,7 +78,7 @@ internal static class UITextSkinReflectionAccessor
         return new TextReadStrategy(static _ => null);
     }
 
-    private static TextWriteStrategy BuildWriteStrategy(Type type, string context)
+    private static TextWriteStrategy BuildWriteStrategy(Type type)
     {
         var setText = AccessTools.Method(type, "SetText", new[] { typeof(string) });
         if (setText is not null)
@@ -102,7 +105,7 @@ internal static class UITextSkinReflectionAccessor
         {
             Trace.TraceWarning(
                 "QudJP: {0}.SetCurrentText falling back to property 'text' for {1}.",
-                context,
+                CacheContext,
                 type.FullName);
             textProperty = AccessTools.Property(type, "text");
         }

--- a/Mods/QudJP/Assemblies/src/Patches/UITextSkinReflectionAccessor.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/UITextSkinReflectionAccessor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using HarmonyLib;
 
@@ -6,6 +7,9 @@ namespace QudJP.Patches;
 
 internal static class UITextSkinReflectionAccessor
 {
+    private static readonly ConcurrentDictionary<Type, TextReadStrategy> ReadStrategies = new();
+    private static readonly ConcurrentDictionary<Type, TextWriteStrategy> WriteStrategies = new();
+
     internal static string? GetCurrentText(object? uiTextSkin, string context)
     {
         if (uiTextSkin is null)
@@ -13,25 +17,8 @@ internal static class UITextSkinReflectionAccessor
             return null;
         }
 
-        var textField = AccessTools.Field(uiTextSkin.GetType(), "text");
-        if (textField?.FieldType == typeof(string))
-        {
-            return textField.GetValue(uiTextSkin) as string;
-        }
-
-        var textProperty = AccessTools.Property(uiTextSkin.GetType(), "Text");
-        if (textProperty is null)
-        {
-            Trace.TraceWarning(
-                "QudJP: {0}.GetCurrentText falling back to property 'text' for {1}.",
-                context,
-                uiTextSkin.GetType().FullName);
-            textProperty = AccessTools.Property(uiTextSkin.GetType(), "text");
-        }
-
-        return textProperty is not null && textProperty.CanRead && textProperty.PropertyType == typeof(string)
-            ? textProperty.GetValue(uiTextSkin) as string
-            : null;
+        var strategy = ReadStrategies.GetOrAdd(uiTextSkin.GetType(), type => BuildReadStrategy(type, context));
+        return strategy.Get(uiTextSkin);
     }
 
     internal static bool SetCurrentText(object? uiTextSkin, string translated, string context)
@@ -41,37 +28,8 @@ internal static class UITextSkinReflectionAccessor
             return false;
         }
 
-        var setText = AccessTools.Method(uiTextSkin.GetType(), "SetText", new[] { typeof(string) });
-        if (setText is not null)
-        {
-            _ = setText.Invoke(uiTextSkin, new object[] { translated });
-            return true;
-        }
-
-        var textField = AccessTools.Field(uiTextSkin.GetType(), "text");
-        if (textField?.FieldType == typeof(string))
-        {
-            textField.SetValue(uiTextSkin, translated);
-            return true;
-        }
-
-        var textProperty = AccessTools.Property(uiTextSkin.GetType(), "Text");
-        if (textProperty is null)
-        {
-            Trace.TraceWarning(
-                "QudJP: {0}.SetCurrentText falling back to property 'text' for {1}.",
-                context,
-                uiTextSkin.GetType().FullName);
-            textProperty = AccessTools.Property(uiTextSkin.GetType(), "text");
-        }
-
-        if (textProperty is not null && textProperty.CanWrite && textProperty.PropertyType == typeof(string))
-        {
-            textProperty.SetValue(uiTextSkin, translated);
-            return true;
-        }
-
-        return false;
+        var strategy = WriteStrategies.GetOrAdd(uiTextSkin.GetType(), type => BuildWriteStrategy(type, context));
+        return strategy.Set(uiTextSkin, translated);
     }
 
     internal static bool SetCurrentTextField(object? uiTextSkin, string translated)
@@ -89,5 +47,95 @@ internal static class UITextSkinReflectionAccessor
 
         textField.SetValue(uiTextSkin, translated);
         return true;
+    }
+
+    private static TextReadStrategy BuildReadStrategy(Type type, string context)
+    {
+        var textField = AccessTools.Field(type, "text");
+        if (textField?.FieldType == typeof(string))
+        {
+            return new TextReadStrategy(target => textField.GetValue(target) as string);
+        }
+
+        var textProperty = AccessTools.Property(type, "Text");
+        if (textProperty is null)
+        {
+            Trace.TraceWarning(
+                "QudJP: {0}.GetCurrentText falling back to property 'text' for {1}.",
+                context,
+                type.FullName);
+            textProperty = AccessTools.Property(type, "text");
+        }
+
+        if (textProperty is not null && textProperty.CanRead && textProperty.PropertyType == typeof(string))
+        {
+            return new TextReadStrategy(target => textProperty.GetValue(target) as string);
+        }
+
+        return new TextReadStrategy(static _ => null);
+    }
+
+    private static TextWriteStrategy BuildWriteStrategy(Type type, string context)
+    {
+        var setText = AccessTools.Method(type, "SetText", new[] { typeof(string) });
+        if (setText is not null)
+        {
+            return new TextWriteStrategy((target, translated) =>
+            {
+                _ = setText.Invoke(target, new object[] { translated });
+                return true;
+            });
+        }
+
+        var textField = AccessTools.Field(type, "text");
+        if (textField?.FieldType == typeof(string))
+        {
+            return new TextWriteStrategy((target, translated) =>
+            {
+                textField.SetValue(target, translated);
+                return true;
+            });
+        }
+
+        var textProperty = AccessTools.Property(type, "Text");
+        if (textProperty is null)
+        {
+            Trace.TraceWarning(
+                "QudJP: {0}.SetCurrentText falling back to property 'text' for {1}.",
+                context,
+                type.FullName);
+            textProperty = AccessTools.Property(type, "text");
+        }
+
+        if (textProperty is not null && textProperty.CanWrite && textProperty.PropertyType == typeof(string))
+        {
+            return new TextWriteStrategy((target, translated) =>
+            {
+                textProperty.SetValue(target, translated);
+                return true;
+            });
+        }
+
+        return new TextWriteStrategy(static (_, _) => false);
+    }
+
+    private readonly struct TextReadStrategy
+    {
+        internal TextReadStrategy(Func<object, string?> get)
+        {
+            Get = get;
+        }
+
+        internal Func<object, string?> Get { get; }
+    }
+
+    private readonly struct TextWriteStrategy
+    {
+        internal TextWriteStrategy(Func<object, string, bool> set)
+        {
+            Set = set;
+        }
+
+        internal Func<object, string, bool> Set { get; }
     }
 }

--- a/Mods/QudJP/Assemblies/src/QudTest/QudTestRouteExecutor.cs
+++ b/Mods/QudJP/Assemblies/src/QudTest/QudTestRouteExecutor.cs
@@ -339,29 +339,7 @@ public static class QudTestRouteExecutor
 
     private static string ExecuteBottomContextItem(string source)
     {
-        var context = new QudTestBottomContext(source);
-        QudMenuBottomContextTranslationPatch.NormalizeItemTexts(context);
-        return context.items[0].text;
-    }
-
-    private sealed class QudTestBottomContext
-    {
-        internal readonly List<QudTestBottomContextItem> items;
-
-        internal QudTestBottomContext(string text)
-        {
-            items = [new QudTestBottomContextItem(text)];
-        }
-    }
-
-    private sealed class QudTestBottomContextItem
-    {
-        internal string text;
-
-        internal QudTestBottomContextItem(string text)
-        {
-            this.text = text;
-        }
+        return SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay(source);
     }
 }
 

--- a/Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs
+++ b/Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs
@@ -12,11 +12,18 @@ internal static class InventoryLineFontFixer
 {
 #if HAS_TMP
     private const int MaxDiagnostics = 128;
+#if QUDJP_DEV_BUILD
+    private const int MaxRefreshTimingDiagnostics = 256;
+#endif
     private const int MaxSuccessfulRefreshCacheEntries = 1024;
     private const int CleanupInterval = 128;
     private const long SuccessfulRefreshCacheTtlTicks = 5L * 60L * 10_000_000L;
     private static int diagnosticsCount;
+#if QUDJP_DEV_BUILD
+    private static int refreshTimingDiagnosticsCount;
+#endif
     private static int cleanupCount;
+    private static int lastForceUpdateCanvasesFrame = int.MinValue;
     private static readonly ConcurrentDictionary<int, SuccessfulRefreshEntry> SuccessfulRefreshKeysByLine = new();
 
     internal static bool TryApplyPrimaryFontToItemRow(object? inventoryLineInstance, object? data)
@@ -36,16 +43,65 @@ internal static class InventoryLineFontFixer
         return TryRefreshTextSkinWithFallbackFont(textSkin, displayName);
     }
 
+    internal static bool TryApplyPrimaryFontToItemRowForSetData(object? inventoryLineInstance, object? data)
+    {
+        if (inventoryLineInstance is null || data is null)
+        {
+            return false;
+        }
+
+        if (!TryGetBooleanPropertyOrField(data, "category", out var isCategory) || isCategory)
+        {
+            return false;
+        }
+
+        var displayName = TryGetStringPropertyOrField(data, "displayName");
+        var textSkin = ReflectionUtils.GetPropertyOrFieldValue(inventoryLineInstance, "text");
+        return TryRefreshTextSkinWithFallbackFontForSetData(inventoryLineInstance, textSkin, displayName);
+    }
+
     internal static bool TryRefreshTextSkinWithFallbackFont(object? textSkin, string? finalText)
     {
+#if QUDJP_DEV_BUILD
+        var timingStopwatch = RuntimeDiagnostics.VerboseProbesEnabled
+            ? System.Diagnostics.Stopwatch.StartNew()
+            : null;
+        var forceCanvasMs = 0d;
+        var forceMeshMs = 0d;
+        var canvasUpdateMode = "not_attempted";
+#endif
         if (!TryGetTextMeshPro(textSkin, out var tmp) || tmp is null)
         {
             LogDiagnostics(textSkin, null, finalText, applied: false);
+#if QUDJP_DEV_BUILD
+            LogRefreshTimingProbe(
+                "no_tmp",
+                textSkin,
+                null,
+                finalText,
+                refreshed: false,
+                timingStopwatch,
+                forceCanvasMs,
+                forceMeshMs,
+                canvasUpdateMode);
+#endif
             return false;
         }
 
         if (tmp.gameObject is null || !tmp.gameObject.activeInHierarchy || !tmp.isActiveAndEnabled)
         {
+#if QUDJP_DEV_BUILD
+            LogRefreshTimingProbe(
+                "inactive",
+                textSkin,
+                tmp,
+                finalText,
+                refreshed: false,
+                timingStopwatch,
+                forceCanvasMs,
+                forceMeshMs,
+                canvasUpdateMode);
+#endif
             return false;
         }
 
@@ -87,10 +143,97 @@ internal static class InventoryLineFontFixer
         InvokeIfPresent(tmp, "RecalculateMasking");
         tmp.havePropertiesChanged = true;
         tmp.text = currentText;
-        ForceUpdateCanvases();
+#if QUDJP_DEV_BUILD
+        var forceMeshStopwatch = timingStopwatch is null ? null : System.Diagnostics.Stopwatch.StartNew();
+#endif
         tmp.ForceMeshUpdate(ignoreActiveState: true, forceTextReparsing: true);
+#if QUDJP_DEV_BUILD
+        if (forceMeshStopwatch is not null)
+        {
+            forceMeshStopwatch.Stop();
+            forceMeshMs = forceMeshStopwatch.Elapsed.TotalMilliseconds;
+        }
+#endif
+        var refreshed = tmp.textInfo.characterCount > 0;
+        if (refreshed)
+        {
+#if QUDJP_DEV_BUILD
+            canvasUpdateMode = "not_needed";
+#endif
+        }
+
+        if (!refreshed)
+        {
+#if QUDJP_DEV_BUILD
+            var forceCanvasStopwatch = timingStopwatch is null ? null : System.Diagnostics.Stopwatch.StartNew();
+            var forcedCanvasUpdate = TryForceUpdateCanvasesOncePerFrame();
+            if (forceCanvasStopwatch is not null)
+            {
+                forceCanvasStopwatch.Stop();
+                if (forcedCanvasUpdate)
+                {
+                    forceCanvasMs = forceCanvasStopwatch.Elapsed.TotalMilliseconds;
+                }
+            }
+            canvasUpdateMode = forcedCanvasUpdate ? "performed" : "skipped_same_frame";
+
+            forceMeshStopwatch = timingStopwatch is null ? null : System.Diagnostics.Stopwatch.StartNew();
+#else
+            _ = TryForceUpdateCanvasesOncePerFrame();
+#endif
+            tmp.ForceMeshUpdate(ignoreActiveState: true, forceTextReparsing: true);
+#if QUDJP_DEV_BUILD
+            if (forceMeshStopwatch is not null)
+            {
+                forceMeshStopwatch.Stop();
+                forceMeshMs += forceMeshStopwatch.Elapsed.TotalMilliseconds;
+            }
+#endif
+            refreshed = tmp.textInfo.characterCount > 0;
+        }
         LogDiagnostics(textSkin, tmp, finalText, applied: true);
-        return tmp.textInfo.characterCount > 0;
+#if QUDJP_DEV_BUILD
+        LogRefreshTimingProbe(
+            "applied",
+            textSkin,
+            tmp,
+            finalText,
+            refreshed,
+            timingStopwatch,
+            forceCanvasMs,
+            forceMeshMs,
+            canvasUpdateMode);
+#endif
+        return refreshed;
+    }
+
+    internal static bool TryRefreshTextSkinWithFallbackFontForSetData(
+        object? inventoryLineInstance,
+        object? textSkin,
+        string? finalText)
+    {
+        var preRefreshKey = GetActiveItemLineRefreshKey(inventoryLineInstance);
+        if (HasHealthySuccessfulRefreshForCurrentKey(inventoryLineInstance, preRefreshKey))
+        {
+#if QUDJP_DEV_BUILD
+            LogRefreshTimingSkip(inventoryLineInstance, preRefreshKey, "healthy_success_cache");
+#endif
+            return true;
+        }
+
+        var refreshed = TryRefreshTextSkinWithFallbackFont(textSkin, finalText);
+        if (refreshed)
+        {
+            RecordSuccessfulRefreshForCurrentKey(
+                inventoryLineInstance,
+                GetActiveItemLineRefreshKey(inventoryLineInstance));
+        }
+        else
+        {
+            ForgetSuccessfulRefreshForLine(inventoryLineInstance);
+        }
+
+        return refreshed;
     }
 
     internal static bool IsActiveItemLine(object? inventoryLineInstance)
@@ -485,6 +628,94 @@ internal static class InventoryLineFontFixer
         }
     }
 
+#if QUDJP_DEV_BUILD
+    private static void LogRefreshTimingProbe(
+        string outcome,
+        object? textSkin,
+        TextMeshProUGUI? tmp,
+        string? finalText,
+        bool refreshed,
+        System.Diagnostics.Stopwatch? timingStopwatch,
+        double forceCanvasMs,
+        double forceMeshMs,
+        string canvasUpdateMode)
+    {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled || timingStopwatch is null)
+        {
+            return;
+        }
+
+        var count = Interlocked.Increment(ref refreshTimingDiagnosticsCount);
+        if (count > MaxRefreshTimingDiagnostics)
+        {
+            return;
+        }
+
+        timingStopwatch.Stop();
+        RuntimeDiagnostics.LogVerboseProbe(() => CreateRefreshTimingProbe(
+            outcome,
+            textSkin,
+            tmp,
+            finalText,
+            refreshed,
+            timingStopwatch.Elapsed.TotalMilliseconds,
+            forceCanvasMs,
+            forceMeshMs,
+            canvasUpdateMode));
+    }
+
+    private static void LogRefreshTimingSkip(object? inventoryLineInstance, string? refreshKey, string reason)
+    {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            return;
+        }
+
+        var count = Interlocked.Increment(ref refreshTimingDiagnosticsCount);
+        if (count > MaxRefreshTimingDiagnostics)
+        {
+            return;
+        }
+
+        var lineId = inventoryLineInstance is Component component
+            ? component.GetInstanceID().ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : "<non_component>";
+        RuntimeDiagnostics.LogVerboseProbe(() =>
+            "[QudJP] InventoryLineFontRefreshSkip/v1: "
+            + $"reason='{reason}' "
+            + $"line_id='{lineId}' "
+            + $"refresh_key_present={(!string.IsNullOrEmpty(refreshKey)).ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+    }
+
+    private static string CreateRefreshTimingProbe(
+        string outcome,
+        object? textSkin,
+        TextMeshProUGUI? tmp,
+        string? finalText,
+        bool refreshed,
+        double elapsedMs,
+        double forceCanvasMs,
+        double forceMeshMs,
+        string canvasUpdateMode)
+    {
+        var textLength = finalText?.Length ?? 0;
+        var tmpTextLength = tmp?.text?.Length ?? 0;
+        var characterCount = tmp?.textInfo.characterCount;
+        return "[QudJP] InventoryLineFontRefreshTiming/v1: "
+            + $"outcome='{outcome}' "
+            + $"refreshed={refreshed.ToString(System.Globalization.CultureInfo.InvariantCulture)} "
+            + $"elapsed_ms={elapsedMs.ToString("F3", System.Globalization.CultureInfo.InvariantCulture)} "
+            + $"force_canvas_ms={forceCanvasMs.ToString("F3", System.Globalization.CultureInfo.InvariantCulture)} "
+            + $"force_mesh_ms={forceMeshMs.ToString("F3", System.Globalization.CultureInfo.InvariantCulture)} "
+            + $"canvas_update_mode='{canvasUpdateMode}' "
+            + $"text_len={textLength.ToString(System.Globalization.CultureInfo.InvariantCulture)} "
+            + $"tmp_text_len={tmpTextLength.ToString(System.Globalization.CultureInfo.InvariantCulture)} "
+            + $"char_count={(characterCount.HasValue ? characterCount.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : "<null>")} "
+            + $"textSkin='{textSkin?.GetType().FullName ?? "<null>"}' "
+            + $"tmp='{tmp?.GetType().FullName ?? "<null>"}'";
+    }
+#endif
+
     private static string ReadCanvasCull(TextMeshProUGUI? tmp)
     {
         if (tmp is null)
@@ -502,6 +733,19 @@ internal static class InventoryLineFontFixer
         var cullProperty = canvasRenderer.GetType().GetProperty("cull");
         var cull = cullProperty?.GetValue(canvasRenderer);
         return cull?.ToString() ?? "<null>";
+    }
+
+    private static bool TryForceUpdateCanvasesOncePerFrame()
+    {
+        var currentFrame = Time.frameCount;
+        if (lastForceUpdateCanvasesFrame == currentFrame)
+        {
+            return false;
+        }
+
+        lastForceUpdateCanvasesFrame = currentFrame;
+        ForceUpdateCanvases();
+        return true;
     }
 
     private static void InvokeIfPresent(object target, string methodName)

--- a/Mods/QudJP/Assemblies/src/UI/ReflectionUtils.cs
+++ b/Mods/QudJP/Assemblies/src/UI/ReflectionUtils.cs
@@ -1,9 +1,13 @@
+using System;
+using System.Collections.Concurrent;
 using System.Reflection;
 
 namespace QudJP;
 
 internal static class ReflectionUtils
 {
+    private static readonly ConcurrentDictionary<MemberAccessorKey, Func<object, object?>> Accessors = new();
+
 #pragma warning disable S3011
     private const BindingFlags InstanceMemberFlags =
         BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
@@ -16,16 +20,35 @@ internal static class ReflectionUtils
             return null;
         }
 
-        for (var type = instance.GetType(); type is not null; type = type.BaseType)
+        var key = new MemberAccessorKey(instance.GetType(), memberName);
+        return Accessors.GetOrAdd(key, static candidate => BuildAccessor(candidate.Type, candidate.MemberName))(instance);
+    }
+
+    internal static void ClearAccessorCacheForTests()
+    {
+        Accessors.Clear();
+    }
+
+    internal static int GetAccessorCacheCountForTests()
+    {
+        return Accessors.Count;
+    }
+
+    private static Func<object, object?> BuildAccessor(Type instanceType, string memberName)
+    {
+        for (var type = instanceType; type is not null; type = type.BaseType)
         {
 #pragma warning disable S3011
             var property = type.GetProperty(memberName, InstanceMemberFlags);
 #pragma warning restore S3011
             if (property is not null && property.GetIndexParameters().Length == 0)
             {
+                return target =>
+                {
 #pragma warning disable S3011
-                return property.GetValue(instance, null);
+                    return property.GetValue(target, null);
 #pragma warning restore S3011
+                };
             }
 
 #pragma warning disable S3011
@@ -33,10 +56,43 @@ internal static class ReflectionUtils
 #pragma warning restore S3011
             if (field is not null)
             {
-                return field.GetValue(instance);
+                return target => field.GetValue(target);
             }
         }
 
-        return null;
+        return static _ => null;
+    }
+
+    private readonly struct MemberAccessorKey : IEquatable<MemberAccessorKey>
+    {
+        internal MemberAccessorKey(Type type, string memberName)
+        {
+            Type = type;
+            MemberName = memberName;
+        }
+
+        internal Type Type { get; }
+
+        internal string MemberName { get; }
+
+        public bool Equals(MemberAccessorKey other)
+        {
+            return Type == other.Type
+                && string.Equals(MemberName, other.MemberName, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is MemberAccessorKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Type.GetHashCode() * 397)
+                    ^ StringComparer.Ordinal.GetHashCode(MemberName);
+            }
+        }
     }
 }

--- a/docs/superpowers/plans/2026-05-31-inventory-menu-performance.md
+++ b/docs/superpowers/plans/2026-05-31-inventory-menu-performance.md
@@ -1,0 +1,981 @@
+# Inventory Menu Performance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce inventory context-menu open/close sluggishness without depending on dev probe removal, including bottom context menu translation, inventory row translation, reflection access, and TMP font refresh repeat work.
+
+**Architecture:** Keep producer data stable and move menu-row localization to display-only rendering. Cache pure translation/reflection decisions at type and source-text boundaries, while preserving vanilla data contracts such as `QudMenuItem.text`, `QudMenuItem.simpleText`, and tutorial `ControlId` values. Gate expensive TMP refreshes with existing healthy-refresh keys so `InventoryLine.setData` and active-row refresh paths do not both force mesh/font work for an unchanged row.
+
+**Tech Stack:** C# net48/net10-compatible QudJP Harmony patches, NUnit L1/L2/L2G tests, decompiled Caves of Qud 1.0.4 reference source under `~/dev/coq-decompiled_stable/`, `just` validation recipes.
+
+---
+
+## Current Findings
+
+- `EquipmentAPI.ShowInventoryActionMenu` opens action choices with `Popup.PickOption(... AllowEscape: true ...)`; cancel returns `null`, then `InventoryAndEquipmentStatusScreen.HandleSelectItem` calls `UpdateViewFromData()` when `bDone` is false. That rebuilds inventory rows after both menu open and menu close.
+- `Popup.PickOption` builds `QudMenuItem` values. Inventory action menu option translation is intentionally skipped in `PopupPickOptionTranslationPatch`, `PopupGetPopupOptionTranslationPatch`, and `PopupMessageTranslationPatch` to preserve tutorial/control IDs.
+- `QudMenuBottomContext.Update()` calls `RefreshButtons()` every frame. QudJP currently prefixes `RefreshButtons()` and mutates `items[index].text` through `QudMenuBottomContextTranslationPatch.NormalizeItemTexts(...)`, so the bottom context path can redo translation work at frame rate.
+- `SelectableTextMenuItemTranslationPatch` already performs display-only translation by calling `item.SetText(...)` after vanilla `SelectChanged(bool)`, without mutating `QudMenuItem` data. This is the safer boundary for menu labels.
+- `InventoryLineTranslationPatch.Postfix` runs after visible inventory rows are rebound. It repeats reflection lookup, translation route work, `OwnerTextSetter`, and `InventoryLineFontFixer.TryRefreshTextSkinWithFallbackFont(...)`.
+- `InventoryLineRenderProbePatch.Postfix` also calls `InventoryLineFontFixer.TryApplyPrimaryFontToItemRow(...)` on the same `InventoryLine.setData` target under `HAS_TMP`, which can duplicate font refresh work after `InventoryLineTranslationPatch` has already refreshed the final translated text.
+- `Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryLineTranslationPatchTests.cs` declares `Issue201StatusScreensBatch2Tests`, so focused filters must use `FullyQualifiedName~Issue201StatusScreensBatch2Tests`.
+
+## File Structure
+
+- Modify `Mods/QudJP/Assemblies/src/Patches/QudMenuBottomContextTranslationPatch.cs`: keep probe logging only; stop mutating `QudMenuItem` data during `RefreshButtons`.
+- Modify `Mods/QudJP/Assemblies/src/Patches/SelectableTextMenuItemTranslationPatch.cs`: own display-only menu text normalization, translation, and bounded display cache.
+- Modify `Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs`: add bounded caches for inventory visible text/display-name translation and use cached reflection accessors for hot fields.
+- Modify `Mods/QudJP/Assemblies/src/Patches/UITextSkinReflectionAccessor.cs`: cache `SetText`/field/property access strategies per UI text skin type.
+- Modify `Mods/QudJP/Assemblies/src/UI/ReflectionUtils.cs`: cache property/field getters used by inventory font and observability paths.
+- Modify `Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs`: add a setData refresh wrapper that checks/records healthy refresh keys and avoids repeated mesh/font work for the same final row text.
+- Modify `Mods/QudJP/Assemblies/src/Patches/InventoryLineRenderProbePatch.cs`: call the new gated setData refresh wrapper, or skip if the translation patch has already recorded a healthy refresh for the current key.
+- Test updates:
+  - `Mods/QudJP/Assemblies/QudJP.Tests/L2/QudMenuBottomContextTranslationPatchTests.cs`
+  - `Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupPickOptionTranslationPatchTests.cs`
+  - `Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupTranslationPatchTests.cs`
+  - `Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupRouteHandoffTranslationTests.cs`
+  - `Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryLineTranslationPatchTests.cs`
+  - `Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs`
+  - `Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineRenderProbePatchTests.cs`
+  - `Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineFontFixerPolicyTests.cs`
+  - `Mods/QudJP/Assemblies/QudJP.Tests/L1/ReflectionUtilsTests.cs` if no suitable existing reflection-cache policy test exists.
+
+## Task 1: Move Bottom Context Translation To Display-Only
+
+**Files:**
+- Modify: `Mods/QudJP/Assemblies/src/Patches/QudMenuBottomContextTranslationPatch.cs`
+- Modify: `Mods/QudJP/Assemblies/src/Patches/SelectableTextMenuItemTranslationPatch.cs`
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/L2/QudMenuBottomContextTranslationPatchTests.cs`
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupPickOptionTranslationPatchTests.cs`
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupTranslationPatchTests.cs`
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupRouteHandoffTranslationTests.cs`
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/L1/ColorRouteCatalogTests.cs`
+
+- [ ] **Step 1: Write failing tests for non-mutating bottom context data**
+
+Replace the mutation expectations in `QudMenuBottomContextTranslationPatchTests` with tests that prove `RefreshButtons` no longer changes `context.items[*].text`:
+
+```csharp
+[Test]
+public void Prefix_DoesNotMutateMenuItemText()
+{
+    WriteDictionary(("Inspect", "調べる"));
+
+    var context = new DummyQudMenuBottomContext("Inspect");
+    RunRefreshButtonsWithPatch(context);
+
+    Assert.Multiple(() =>
+    {
+        Assert.That(((DummyMenuItem)context.items[0]!).text, Is.EqualTo("Inspect"));
+        Assert.That(
+            DynamicTextObservability.GetRouteFamilyHitCountForTests(
+                nameof(QudMenuBottomContextTranslationPatch),
+                "Popup.ProducerMenuItem.Exact"),
+            Is.Zero);
+    });
+}
+
+[Test]
+public void Prefix_DoesNotFlattenNestedHotkeyData()
+{
+    var source = "{{y|{{W|[Esc]}} Back}}";
+    var context = new DummyQudMenuBottomContext(source);
+
+    RunRefreshButtonsWithPatch(context);
+
+    Assert.That(((DummyMenuItem)context.items[0]!).text, Is.EqualTo(source));
+}
+```
+
+Add display-path coverage in `PopupPickOptionTranslationPatchTests`:
+
+```csharp
+[Test]
+public void TranslateMenuItemTextForDisplay_FlattensAndTranslatesNestedBottomContextHotkeyLabel()
+{
+    WriteCommonMenuActionDictionary(("back", "戻る"));
+
+    var translated = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay(
+        "{{y|{{W|[Esc]}} Back}}");
+
+    Assert.That(translated, Is.EqualTo("{{W|[Esc]}} {{y|戻る}}"));
+}
+
+[Test]
+public void SelectableTextMenuItemPostfix_TranslatesDisplayOnlyAndPreservesControlIdData()
+{
+    WriteCommonMenuActionDictionary(("get", "取る"));
+    var menuData = new DummySelectableMenuData(
+        text: "{{W|[g]}} {{y|get}}",
+        simpleText: "get",
+        command: "CmdGet",
+        hotkey: "g");
+    var target = new DummySelectableTextMenuItemTarget(menuData);
+
+    SelectableTextMenuItemTranslationPatch.Postfix(target, newState: true);
+
+    Assert.Multiple(() =>
+    {
+        Assert.That(menuData.text, Is.EqualTo("{{W|[g]}} {{y|get}}"));
+        Assert.That(menuData.simpleText, Is.EqualTo("get"));
+        Assert.That(menuData.command, Is.EqualTo("CmdGet"));
+        Assert.That(menuData.hotkey, Is.EqualTo("g"));
+        Assert.That(target.ControlId, Is.EqualTo("QudTextMenuItem:get"));
+        Assert.That(target.item.Text, Is.EqualTo("{{W|{{W|[g]}} {{y|取る}}}}"));
+    });
+}
+```
+
+Add these dummy types to the same test file:
+
+```csharp
+private sealed class DummySelectableTextMenuItemTarget
+{
+    public DummySelectableTextMenuItemTarget(DummySelectableMenuData data)
+    {
+        this.data = data;
+        itemText = data.text;
+        ControlId = "QudTextMenuItem:" + data.simpleText;
+    }
+
+    public DummySelectableMenuData data { get; }
+
+    public string itemText { get; }
+
+    public string ControlId { get; }
+
+    public readonly DummySelectableItemSkin item = new();
+}
+
+private sealed class DummySelectableItemSkin
+{
+    public string Text { get; private set; } = string.Empty;
+
+    public void SetText(string value)
+    {
+        Text = value;
+    }
+}
+
+private sealed class DummySelectableMenuData
+{
+    public DummySelectableMenuData(string text, string simpleText, string command, string hotkey)
+    {
+        this.text = text;
+        this.simpleText = simpleText;
+        this.command = command;
+        this.hotkey = hotkey;
+    }
+
+    public string text;
+    public string simpleText;
+    public string command;
+    public string hotkey;
+}
+```
+
+Update `PopupTranslationPatchTests.NormalizeItemTexts_*` and `PopupRouteHandoffTranslationTests` so they assert preserved bottom-context data and display-path translation through `SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay(...)`.
+
+- [ ] **Step 2: Run the focused failing tests**
+
+Run:
+
+```bash
+dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj \
+  --filter "FullyQualifiedName~QudMenuBottomContextTranslationPatchTests|FullyQualifiedName~PopupPickOptionTranslationPatchTests|FullyQualifiedName~PopupTranslationPatchTests|FullyQualifiedName~PopupRouteHandoffTranslationTests|FullyQualifiedName~ColorRouteCatalogTests" \
+  --nologo
+```
+
+Expected: failures still reflect old behavior: bottom context data is translated/mutated by `QudMenuBottomContextTranslationPatch.NormalizeItemTexts(...)`, and nested bottom context labels are not yet normalized by the display path.
+
+- [ ] **Step 3: Stop bottom context data mutation**
+
+Change `QudMenuBottomContextTranslationPatch.Prefix` so it only probes:
+
+```csharp
+public static void Prefix(object __instance)
+{
+    try
+    {
+        LogProbe(__instance, "prefix");
+    }
+    catch (Exception ex)
+    {
+        Trace.TraceError("QudJP: QudMenuBottomContextTranslationPatch.Prefix failed: {0}", ex);
+    }
+}
+```
+
+Keep `NormalizeItemTexts(object? contextInstance)` as an internal compatibility shim for tests and older call sites, but make it a no-op with an explanatory comment:
+
+```csharp
+internal static void NormalizeItemTexts(object? contextInstance)
+{
+    // QudMenuBottomContext.RefreshButtons runs every frame. Do not mutate
+    // QudMenuItem data here; display translation belongs to
+    // SelectableTextMenuItemTranslationPatch so tutorial/control IDs remain stable.
+    _ = contextInstance;
+}
+```
+
+Remove the `Regex NestedHotkeyLabelPattern` and translation loop from this file after moving the helper to `SelectableTextMenuItemTranslationPatch`.
+
+- [ ] **Step 4: Move nested hotkey normalization into the display path**
+
+Add the regex and helper to `SelectableTextMenuItemTranslationPatch`:
+
+```csharp
+private static readonly Regex NestedHotkeyLabelPattern =
+    new Regex(
+        @"^\{\{(?<labelColor>[A-Za-z]+)\|\{\{(?<hotkeyColor>[A-Za-z]+)\|(?<hotkey>\[[^\]]+\])\}\}\s*(?<label>.*?)\}\}$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.Singleline);
+
+internal static string NormalizeNestedHotkeyLabelForDisplay(string source)
+{
+    var match = NestedHotkeyLabelPattern.Match(source);
+    if (!match.Success)
+    {
+        return source;
+    }
+
+    var hotkey = match.Groups["hotkey"].Value;
+    var label = match.Groups["label"].Value;
+    if (label.Length == 0)
+    {
+        return source;
+    }
+
+    return "{{"
+        + match.Groups["hotkeyColor"].Value
+        + "|"
+        + hotkey
+        + "}} {{"
+        + match.Groups["labelColor"].Value
+        + "|"
+        + label
+        + "}}";
+}
+```
+
+Update `TranslateMenuItemTextForDisplay` to normalize before translating:
+
+```csharp
+internal static string TranslateMenuItemTextForDisplay(string source, string? popupId)
+{
+    var normalized = NormalizeNestedHotkeyLabelForDisplay(source);
+    return MessageFrameTranslator.StripAllDirectTranslationMarkers(
+        PopupTranslationPatch.TranslatePopupMenuItemTextForProducerRoute(normalized, Context, popupId));
+}
+```
+
+Add `using System.Text.RegularExpressions;` to the file.
+
+- [ ] **Step 5: Update route catalog policy**
+
+In `ColorRouteCatalogTests`, remove the expected `PopupTranslationPatch.TranslatePopupMenuItemTextForProducerRoute(...)` producer route from `QudMenuBottomContextTranslationPatch.cs` and keep the existing `SelectableTextMenuItemTranslationPatch.cs` route expectation.
+
+- [ ] **Step 6: Re-run focused tests**
+
+Run the same focused command from Step 2.
+
+Expected: all selected tests pass.
+
+## Task 2: Add Bounded Display Translation Cache
+
+**Files:**
+- Modify: `Mods/QudJP/Assemblies/src/Patches/SelectableTextMenuItemTranslationPatch.cs`
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/L2/PopupPickOptionTranslationPatchTests.cs`
+
+- [ ] **Step 1: Write failing cache tests**
+
+Add setup/teardown calls in `PopupPickOptionTranslationPatchTests`:
+
+```csharp
+SelectableTextMenuItemTranslationPatch.ClearDisplayTranslationCacheForTests();
+```
+
+Add tests:
+
+```csharp
+[Test]
+public void TranslateMenuItemTextForDisplay_CachesRepeatedSourceAndPopupId()
+{
+    WriteCommonMenuActionDictionary(("get", "取る"));
+
+    var first = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay(
+        "{{W|[g]}} {{y|get}}",
+        "InventoryActionMenu:test");
+    var second = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay(
+        "{{W|[g]}} {{y|get}}",
+        "InventoryActionMenu:test");
+
+    Assert.Multiple(() =>
+    {
+        Assert.That(first, Is.EqualTo("{{W|[g]}} {{y|取る}}"));
+        Assert.That(second, Is.EqualTo(first));
+        Assert.That(SelectableTextMenuItemTranslationPatch.GetDisplayTranslationCacheCountForTests(), Is.EqualTo(1));
+    });
+}
+
+[Test]
+public void TranslateMenuItemTextForDisplay_CacheSeparatesPopupIds()
+{
+    WriteCommonMenuActionDictionary(("get", "取る"));
+
+    _ = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay("{{W|[g]}} {{y|get}}", "InventoryActionMenu:a");
+    _ = SelectableTextMenuItemTranslationPatch.TranslateMenuItemTextForDisplay("{{W|[g]}} {{y|get}}", "InventoryActionMenu:b");
+
+    Assert.That(SelectableTextMenuItemTranslationPatch.GetDisplayTranslationCacheCountForTests(), Is.EqualTo(2));
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj \
+  --filter "FullyQualifiedName~PopupPickOptionTranslationPatchTests" \
+  --nologo
+```
+
+Expected: compile failure because `ClearDisplayTranslationCacheForTests` and `GetDisplayTranslationCacheCountForTests` do not exist.
+
+- [ ] **Step 3: Implement bounded cache**
+
+Add to `SelectableTextMenuItemTranslationPatch`:
+
+```csharp
+private const int MaxDisplayTranslationCacheEntries = 2048;
+private static readonly ConcurrentDictionary<DisplayTranslationCacheKey, string> DisplayTranslationCache = new();
+private static readonly ConcurrentQueue<DisplayTranslationCacheKey> DisplayTranslationCacheOrder = new();
+
+internal static void ClearDisplayTranslationCacheForTests()
+{
+    DisplayTranslationCache.Clear();
+    while (DisplayTranslationCacheOrder.TryDequeue(out _))
+    {
+    }
+}
+
+internal static int GetDisplayTranslationCacheCountForTests()
+{
+    return DisplayTranslationCache.Count;
+}
+
+private static string TranslateMenuItemTextForDisplayUncached(DisplayTranslationCacheKey key)
+{
+    var normalized = NormalizeNestedHotkeyLabelForDisplay(key.Source);
+    return MessageFrameTranslator.StripAllDirectTranslationMarkers(
+        PopupTranslationPatch.TranslatePopupMenuItemTextForProducerRoute(normalized, Context, key.PopupId));
+}
+
+private static void RememberDisplayTranslationKey(DisplayTranslationCacheKey key)
+{
+    DisplayTranslationCacheOrder.Enqueue(key);
+    while (DisplayTranslationCache.Count > MaxDisplayTranslationCacheEntries
+        && DisplayTranslationCacheOrder.TryDequeue(out var oldest))
+    {
+        DisplayTranslationCache.TryRemove(oldest, out _);
+    }
+}
+
+private readonly struct DisplayTranslationCacheKey : IEquatable<DisplayTranslationCacheKey>
+{
+    internal DisplayTranslationCacheKey(string source, string? popupId)
+    {
+        Source = source;
+        PopupId = popupId ?? string.Empty;
+    }
+
+    internal string Source { get; }
+
+    internal string PopupId { get; }
+
+    public bool Equals(DisplayTranslationCacheKey other)
+    {
+        return string.Equals(Source, other.Source, StringComparison.Ordinal)
+            && string.Equals(PopupId, other.PopupId, StringComparison.Ordinal);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is DisplayTranslationCacheKey other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return StringComparer.Ordinal.GetHashCode(Source) * 397
+            ^ StringComparer.Ordinal.GetHashCode(PopupId);
+    }
+}
+```
+
+Update `TranslateMenuItemTextForDisplay`:
+
+```csharp
+internal static string TranslateMenuItemTextForDisplay(string source, string? popupId)
+{
+    var key = new DisplayTranslationCacheKey(source, popupId);
+    if (DisplayTranslationCache.TryGetValue(key, out var cached))
+    {
+        return cached;
+    }
+
+    var translated = TranslateMenuItemTextForDisplayUncached(key);
+    if (DisplayTranslationCache.TryAdd(key, translated))
+    {
+        RememberDisplayTranslationKey(key);
+    }
+
+    return translated;
+}
+```
+
+Add `using System.Collections.Concurrent;`.
+
+- [ ] **Step 4: Run tests**
+
+Run the same command from Step 2.
+
+Expected: `PopupPickOptionTranslationPatchTests` pass.
+
+## Task 3: Cache Inventory Line Translation And Reflection Access
+
+**Files:**
+- Modify: `Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs`
+- Modify: `Mods/QudJP/Assemblies/src/Patches/UITextSkinReflectionAccessor.cs`
+- Modify: `Mods/QudJP/Assemblies/src/UI/ReflectionUtils.cs`
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryLineTranslationPatchTests.cs` (`Issue201StatusScreensBatch2Tests`)
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/L1/ReflectionUtilsTests.cs`
+
+- [ ] **Step 1: Write failing inventory cache tests**
+
+Add to `Issue201StatusScreensBatch2Tests` setup/teardown in `InventoryLineTranslationPatchTests.cs`:
+
+```csharp
+InventoryLineTranslationPatch.ClearTranslationCachesForTests();
+```
+
+Add:
+
+```csharp
+[Test]
+public void TranslateItemDisplayNameForQudTest_CachesRepeatedDisplayName()
+{
+    WriteDictionaryFile("ui-displayname-atomic.ja.json", ("water flask", "水袋"));
+
+    var first = InventoryLineTranslationPatch.TranslateItemDisplayNameForQudTest("water flask");
+    var second = InventoryLineTranslationPatch.TranslateItemDisplayNameForQudTest("water flask");
+
+    Assert.Multiple(() =>
+    {
+        Assert.That(first, Is.EqualTo("水袋"));
+        Assert.That(second, Is.EqualTo(first));
+        Assert.That(InventoryLineTranslationPatch.GetTranslationCacheCountForTests(), Is.GreaterThanOrEqualTo(1));
+    });
+}
+```
+
+Modify the existing `ReflectionUtilsTests` file and add this cache test:
+
+```csharp
+namespace QudJP.Tests.L1;
+
+[TestFixture]
+[Category("L1")]
+public sealed class ReflectionUtilsTests
+{
+    [Test]
+    public void GetPropertyOrFieldValue_CachesResolvedMemberAccessor()
+    {
+        ReflectionUtils.ClearAccessorCacheForTests();
+        var target = new ReflectionTarget { Name = "alpha" };
+
+        Assert.That(ReflectionUtils.GetPropertyOrFieldValue(target, "Name"), Is.EqualTo("alpha"));
+        Assert.That(ReflectionUtils.GetPropertyOrFieldValue(target, "Name"), Is.EqualTo("alpha"));
+
+        Assert.That(ReflectionUtils.GetAccessorCacheCountForTests(), Is.EqualTo(1));
+    }
+
+    private sealed class ReflectionTarget
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}
+```
+
+Also add this helper to the same existing `ReflectionUtilsTests` file before adding source-policy tests that call `ExtractMethodBody`:
+
+```csharp
+private static string ExtractMethodBody(string source, string signature)
+{
+    var start = source.IndexOf(signature, StringComparison.Ordinal);
+    Assert.That(start, Is.GreaterThanOrEqualTo(0), "method signature not found: " + signature);
+    var braceStart = source.IndexOf('{', start);
+    Assert.That(braceStart, Is.GreaterThanOrEqualTo(0), "method body not found: " + signature);
+
+    var depth = 0;
+    for (var index = braceStart; index < source.Length; index++)
+    {
+        if (source[index] == '{')
+        {
+            depth++;
+        }
+        else if (source[index] == '}')
+        {
+            depth--;
+            if (depth == 0)
+            {
+                return source.Substring(braceStart, index - braceStart + 1);
+            }
+        }
+    }
+
+    Assert.Fail("method body did not terminate: " + signature);
+    return string.Empty;
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj \
+  --filter "FullyQualifiedName~Issue201StatusScreensBatch2Tests|FullyQualifiedName~ReflectionUtilsTests" \
+  --nologo
+```
+
+Expected: compile failure for missing cache helper methods.
+
+- [ ] **Step 3: Add inventory translation cache**
+
+In `InventoryLineTranslationPatch`, add a bounded cache similar to Task 2:
+
+```csharp
+private const int MaxTranslationCacheEntries = 4096;
+private static readonly ConcurrentDictionary<InventoryTranslationCacheKey, string> TranslationCache = new();
+private static readonly ConcurrentQueue<InventoryTranslationCacheKey> TranslationCacheOrder = new();
+
+internal static void ClearTranslationCachesForTests()
+{
+    TranslationCache.Clear();
+    while (TranslationCacheOrder.TryDequeue(out _))
+    {
+    }
+}
+
+internal static int GetTranslationCacheCountForTests()
+{
+    return TranslationCache.Count;
+}
+```
+
+Use it from `TranslateVisibleText` and `TranslateItemDisplayName`. The cache key must include the source text and translation family/route category, not object identity:
+
+```csharp
+private static string GetOrAddTranslationCache(
+    string family,
+    string source,
+    Func<string> translate)
+{
+    var key = new InventoryTranslationCacheKey(family, source);
+    if (TranslationCache.TryGetValue(key, out var cached))
+    {
+        return cached;
+    }
+
+    var translated = translate();
+    if (TranslationCache.TryAdd(key, translated))
+    {
+        TranslationCacheOrder.Enqueue(key);
+        while (TranslationCache.Count > MaxTranslationCacheEntries
+            && TranslationCacheOrder.TryDequeue(out var oldest))
+        {
+            TranslationCache.TryRemove(oldest, out _);
+        }
+    }
+
+    return translated;
+}
+```
+
+Wrap the expensive branch in `TranslateItemDisplayName`:
+
+```csharp
+private static string TranslateItemDisplayName(string source, string route)
+{
+    return GetOrAddTranslationCache("InventoryLine.ItemName", source, () =>
+        TranslateItemDisplayNameUncached(source, route));
+}
+```
+
+Move the current body of `TranslateItemDisplayName` into `TranslateItemDisplayNameUncached`.
+
+- [ ] **Step 4: Cache reflection accessors**
+
+In `InventoryLineTranslationPatch`, replace the private `GetMemberValue` implementation so the inventory hot path uses the shared cached accessor:
+
+```csharp
+private static object? GetMemberValue(object instance, string memberName)
+{
+    return ReflectionUtils.GetPropertyOrFieldValue(instance, memberName);
+}
+```
+
+Keep `GetStaticMemberValue` local because it reads static members from `XRL.UI.Options`.
+
+Add a source-policy test in `ReflectionUtilsTests`:
+
+```csharp
+[Test]
+public void InventoryLineTranslationPatch_UsesSharedReflectionUtilsForHotMembers()
+{
+    var sourcePath = Path.Combine(
+        TestProjectPaths.GetRepositoryRoot(),
+        "Mods",
+        "QudJP",
+        "Assemblies",
+        "src",
+        "Patches",
+        "InventoryLineTranslationPatch.cs");
+    var source = File.ReadAllText(sourcePath);
+    var method = ExtractMethodBody(source, "private static object? GetMemberValue");
+
+    Assert.That(method, Does.Contain("ReflectionUtils.GetPropertyOrFieldValue(instance, memberName)"));
+    Assert.That(method, Does.Not.Contain("AccessTools.Property(type, memberName)"));
+    Assert.That(method, Does.Not.Contain("AccessTools.Field(type, memberName)"));
+}
+```
+
+In `ReflectionUtils`, replace per-call member search with a per-type/member accessor cache:
+
+```csharp
+private static readonly ConcurrentDictionary<MemberAccessorKey, Func<object, object?>> Accessors = new();
+
+internal static void ClearAccessorCacheForTests()
+{
+    Accessors.Clear();
+}
+
+internal static int GetAccessorCacheCountForTests()
+{
+    return Accessors.Count;
+}
+```
+
+Build the accessor once with the same base-type walk as the current implementation. If no property/field exists, cache a lambda returning `null` so misses do not repeat reflection.
+
+In `UITextSkinReflectionAccessor`, cache the `SetText` method/field/property strategy per UI text skin type. Keep existing fallback warning behavior, but log a fallback warning only when the strategy is created, not on every row update.
+
+Add a source-policy test to `ReflectionUtilsTests`:
+
+```csharp
+[Test]
+public void UITextSkinReflectionAccessor_CachesTextWriteStrategiesByType()
+{
+    var sourcePath = Path.Combine(
+        TestProjectPaths.GetRepositoryRoot(),
+        "Mods",
+        "QudJP",
+        "Assemblies",
+        "src",
+        "Patches",
+        "UITextSkinReflectionAccessor.cs");
+    var source = File.ReadAllText(sourcePath);
+
+    Assert.That(source, Does.Contain("ConcurrentDictionary<Type,"));
+    Assert.That(source, Does.Contain("GetOrAdd"));
+    Assert.That(source, Does.Contain("SetText"));
+}
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run the command from Step 2.
+
+Expected: all selected tests pass.
+
+## Task 4: Gate Duplicate TMP Font Refresh On Inventory setData
+
+**Files:**
+- Modify: `Mods/QudJP/Assemblies/src/UI/InventoryLineFontFixer.cs`
+- Modify: `Mods/QudJP/Assemblies/src/Patches/InventoryLineTranslationPatch.cs`
+- Modify: `Mods/QudJP/Assemblies/src/Patches/InventoryLineRenderProbePatch.cs`
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineRenderProbePatchTests.cs`
+- Test: `Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryLineFontFixerPolicyTests.cs`
+
+- [ ] **Step 1: Write policy tests for gated refresh**
+
+Update `InventoryLineRenderProbePatchTests.InventoryLineTranslationPatch_RefreshesFallbackFontAfterFinalItemText` to expect the gated method name without relying on one-line formatting:
+
+```csharp
+Assert.That(
+    source,
+    Does.Contain("InventoryLineFontFixer.TryRefreshTextSkinWithFallbackFontForSetData("));
+Assert.That(source, Does.Contain("instance"));
+Assert.That(source, Does.Contain("itemTextSkin"));
+Assert.That(source, Does.Contain("translatedDisplayName"));
+```
+
+Update `InventoryLineRenderProbePatchTests.InventoryLineTranslationPatch_LogsOriginalTmpLifecycleAroundOwnerTextAndFontRefresh` so the order check uses the gated method name:
+
+```csharp
+var fontRefreshIndex = source.IndexOf(
+    "InventoryLineFontFixer.TryRefreshTextSkinWithFallbackFontForSetData(",
+    StringComparison.Ordinal);
+```
+
+Add a test proving `InventoryLineRenderProbePatch` uses the same gated path:
+
+```csharp
+[Test]
+public void InventoryLineRenderProbePatch_UsesGatedSetDataFontRefresh()
+{
+    var sourcePath = Path.Combine(
+        TestProjectPaths.GetRepositoryRoot(),
+        "Mods",
+        "QudJP",
+        "Assemblies",
+        "src",
+        "Patches",
+        "InventoryLineRenderProbePatch.cs");
+    var source = File.ReadAllText(sourcePath);
+
+    Assert.That(
+        source,
+        Does.Contain("InventoryLineFontFixer.TryApplyPrimaryFontToItemRowForSetData(__instance, data)"));
+}
+```
+
+Add a test proving `InventoryLineRenderProbePatch` runs after translation postfixes:
+
+```csharp
+[Test]
+public void InventoryLineRenderProbePatch_RunsAfterTranslationPostfix()
+{
+    var sourcePath = Path.Combine(
+        TestProjectPaths.GetRepositoryRoot(),
+        "Mods",
+        "QudJP",
+        "Assemblies",
+        "src",
+        "Patches",
+        "InventoryLineRenderProbePatch.cs");
+    var source = File.ReadAllText(sourcePath);
+
+    Assert.That(source, Does.Contain("[HarmonyPriority(Priority.Last)]"));
+}
+```
+
+In `InventoryLineFontFixerPolicyTests`, add:
+
+```csharp
+[Test]
+public void SetDataRefresh_SkipsHealthySuccessfulRefreshKeys()
+{
+    var sourcePath = Path.Combine(
+        TestProjectPaths.GetRepositoryRoot(),
+        "Mods",
+        "QudJP",
+        "Assemblies",
+        "src",
+        "UI",
+        "InventoryLineFontFixer.cs");
+    var source = File.ReadAllText(sourcePath);
+    var method = ExtractMethodBody(source, "TryRefreshTextSkinWithFallbackFontForSetData");
+
+    Assert.That(method, Does.Contain("GetActiveItemLineRefreshKey(inventoryLineInstance)"));
+    Assert.That(method, Does.Contain("HasHealthySuccessfulRefreshForCurrentKey(inventoryLineInstance, preRefreshKey)"));
+    Assert.That(method, Does.Contain("RecordSuccessfulRefreshForCurrentKey(inventoryLineInstance, GetActiveItemLineRefreshKey(inventoryLineInstance))"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj \
+  --filter "FullyQualifiedName~InventoryLineRenderProbePatchTests|FullyQualifiedName~InventoryLineFontFixerPolicyTests" \
+  --nologo
+```
+
+Expected: failures because the gated setData refresh methods do not exist.
+
+- [ ] **Step 3: Implement gated setData refresh**
+
+Add to `InventoryLineFontFixer` under `#if HAS_TMP`:
+
+```csharp
+internal static bool TryApplyPrimaryFontToItemRowForSetData(object? inventoryLineInstance, object? data)
+{
+    if (inventoryLineInstance is null || data is null)
+    {
+        return false;
+    }
+
+    if (!TryGetBooleanPropertyOrField(data, "category", out var isCategory) || isCategory)
+    {
+        return false;
+    }
+
+    var displayName = TryGetStringPropertyOrField(data, "displayName");
+    var textSkin = ReflectionUtils.GetPropertyOrFieldValue(inventoryLineInstance, "text");
+    return TryRefreshTextSkinWithFallbackFontForSetData(inventoryLineInstance, textSkin, displayName);
+}
+
+internal static bool TryRefreshTextSkinWithFallbackFontForSetData(
+    object? inventoryLineInstance,
+    object? textSkin,
+    string? finalText)
+{
+    var preRefreshKey = GetActiveItemLineRefreshKey(inventoryLineInstance);
+    if (HasHealthySuccessfulRefreshForCurrentKey(inventoryLineInstance, preRefreshKey))
+    {
+        return true;
+    }
+
+    var refreshed = TryRefreshTextSkinWithFallbackFont(textSkin, finalText);
+    if (refreshed)
+    {
+        RecordSuccessfulRefreshForCurrentKey(
+            inventoryLineInstance,
+            GetActiveItemLineRefreshKey(inventoryLineInstance));
+    }
+    else
+    {
+        ForgetSuccessfulRefreshForLine(inventoryLineInstance);
+    }
+
+    return refreshed;
+}
+```
+
+- [ ] **Step 4: Route setData callers through the gated method**
+
+Add `[HarmonyPriority(Priority.Last)]` to `InventoryLineRenderProbePatch.Postfix` so the probe/font-safety postfix runs after the translation postfix has written final Japanese text and recorded the healthy refresh key:
+
+```csharp
+[HarmonyPriority(Priority.Last)]
+public static void Postfix(object __instance, object data)
+```
+
+In `InventoryLineTranslationPatch.ApplyItemTranslations`, replace:
+
+```csharp
+_ = InventoryLineFontFixer.TryRefreshTextSkinWithFallbackFont(itemTextSkin, translatedDisplayName);
+```
+
+with:
+
+```csharp
+_ = InventoryLineFontFixer.TryRefreshTextSkinWithFallbackFontForSetData(
+    __instance,
+    itemTextSkin,
+    translatedDisplayName);
+```
+
+Use the actual parameter name in this method. If needed, rename `ApplyItemTranslations(object instance, object data)` local references so the call is:
+
+```csharp
+_ = InventoryLineFontFixer.TryRefreshTextSkinWithFallbackFontForSetData(
+    instance,
+    itemTextSkin,
+    translatedDisplayName);
+```
+
+In `InventoryLineRenderProbePatch.Postfix`, replace:
+
+```csharp
+_ = InventoryLineFontFixer.TryApplyPrimaryFontToItemRow(__instance, data);
+```
+
+with:
+
+```csharp
+_ = InventoryLineFontFixer.TryApplyPrimaryFontToItemRowForSetData(__instance, data);
+```
+
+Keep the older methods if other active-refresh paths still use them.
+
+- [ ] **Step 5: Run focused tests**
+
+Run the command from Step 2.
+
+Expected: all selected tests pass.
+
+## Task 5: Integration Validation And Runtime Evidence
+
+**Files:**
+- No new files expected unless runtime evidence is captured under an existing docs workflow.
+
+- [ ] **Step 1: Run static/build gates**
+
+Run:
+
+```bash
+just build
+just test-l1
+just test-l2
+just test-l2g
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run targeted filtered tests for the touched surface**
+
+Run:
+
+```bash
+dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj \
+  --filter "FullyQualifiedName~QudMenuBottomContextTranslationPatchTests|FullyQualifiedName~PopupPickOptionTranslationPatchTests|FullyQualifiedName~PopupTranslationPatchTests|FullyQualifiedName~PopupRouteHandoffTranslationTests|FullyQualifiedName~Issue201StatusScreensBatch2Tests|FullyQualifiedName~InventoryLineRenderProbePatchTests|FullyQualifiedName~InventoryLineFontFixerPolicyTests|FullyQualifiedName~ReflectionUtilsTests|FullyQualifiedName~TargetMethodResolutionTests" \
+  --nologo
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Runtime check**
+
+Run:
+
+```bash
+just deploy-mod
+```
+
+Manual verification in Caves of Qud 1.0.4:
+
+1. Open inventory.
+2. Select an item that has many actions.
+3. Open and close the action menu repeatedly.
+4. Move selection across several inventory rows.
+5. Confirm action labels are displayed in Japanese where dictionaries cover them.
+6. Confirm tutorial/control IDs are not broken by verifying no menu action disappears and no tutorial step requiring English `simpleText` stalls.
+7. Inspect fresh logs under `~/Library/Logs/Freehold Games/CavesOfQud/` for new QudJP errors.
+
+Expected: no new QudJP exceptions; visible row text remains translated; repeated context-menu open/close feels smoother than the pre-change baseline.
+
+## Review Gate
+
+Before implementation starts, this plan must pass an independent review cycle:
+
+1. Dispatch a fresh independent reviewer with no hidden session assumptions.
+2. Reviewer must classify findings as Critical, Important, or Minor.
+3. Fix every Critical and Important issue in this plan.
+4. Repeat the review until the reviewer returns `APPROVED`.
+5. Only then start implementation.
+
+## Self-Review
+
+- Spec coverage: includes non-probe mitigations, bottom context menu open/close work, inventory row translation re-execution, reflection access, and TMP font refresh repeat work.
+- Placeholder scan: no banned placeholder markers or unspecified test steps remain.
+- Type consistency: planned method names are stable across tests and implementation sections:
+  - `SelectableTextMenuItemTranslationPatch.ClearDisplayTranslationCacheForTests`
+  - `SelectableTextMenuItemTranslationPatch.GetDisplayTranslationCacheCountForTests`
+  - `InventoryLineTranslationPatch.ClearTranslationCachesForTests`
+  - `InventoryLineTranslationPatch.GetTranslationCacheCountForTests`
+  - `ReflectionUtils.ClearAccessorCacheForTests`
+  - `ReflectionUtils.GetAccessorCacheCountForTests`
+  - `InventoryLineFontFixer.TryRefreshTextSkinWithFallbackFontForSetData`
+  - `InventoryLineFontFixer.TryApplyPrimaryFontToItemRowForSetData`

--- a/docs/superpowers/plans/2026-05-31-inventory-menu-performance.md
+++ b/docs/superpowers/plans/2026-05-31-inventory-menu-performance.md
@@ -477,6 +477,30 @@ public void TranslateItemDisplayNameForQudTest_CachesRepeatedDisplayName()
 }
 ```
 
+Add an L2 companion assertion near the inventory display-name cache tests so the
+cache policy is tied to real localization output, not only to accessor counts:
+
+```csharp
+[Test]
+public void TranslateItemDisplayNameForQudTest_CachesRepeatedDisplayName()
+{
+    WriteDictionaryFile("ui-displayname-atomic.ja.json", ("water flask", "水袋"));
+
+    var initialCacheCount = InventoryLineTranslationPatch.GetTranslationCacheCountForTests();
+    var first = InventoryLineTranslationPatch.TranslateItemDisplayNameForQudTest("water flask");
+    var afterFirstCacheCount = InventoryLineTranslationPatch.GetTranslationCacheCountForTests();
+    var second = InventoryLineTranslationPatch.TranslateItemDisplayNameForQudTest("water flask");
+
+    Assert.Multiple(() =>
+    {
+        Assert.That(first, Is.EqualTo("水袋"));
+        Assert.That(second, Is.EqualTo(first));
+        Assert.That(afterFirstCacheCount, Is.EqualTo(initialCacheCount + 1));
+        Assert.That(InventoryLineTranslationPatch.GetTranslationCacheCountForTests(), Is.EqualTo(afterFirstCacheCount));
+    });
+}
+```
+
 Modify the existing `ReflectionUtilsTests` file and add this cache test:
 
 ```csharp
@@ -941,7 +965,7 @@ Expected: all pass.
 Run:
 
 ```bash
-just deploy-mod
+just deploy-dev
 ```
 
 Manual verification in Caves of Qud 1.0.4:


### PR DESCRIPTION
## Summary
- Move bottom context menu localization to display-only updates so `QudMenuItem` data, tutorial control IDs, command IDs, and hotkeys stay stable.
- Cache hot-path reflection, inventory row translations, selectable menu display translations, and successful TMP font refreshes.
- Reduce expensive TMP/canvas refresh work by using a cheap-first refresh path and forcing canvases only as a same-frame fallback when mesh output is still empty.
- Gate dev-only selectable menu probes before reflection/TMP state collection and add runtime timing/skip observability for inventory font refresh behavior.

## Review / Cleanup
- Fresh independent reviewer: `Banach` (`019e7c65-c5e1-7901-8e66-fc5e59546219`) returned `APPROVE`.
- ai-slop-cleaner: scoped to the changed files; no code changes made. No changed-scope debug leftovers, dead code, duplicate abstraction, or weak regression lock requiring cleanup were found. `NormalizeItemTexts` remains intentionally as a compatibility shim documented in the plan and exercised by existing tests.

## Verification
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~PopupPickOptionTranslationPatchTests.BottomContextDisplayTranslation_ReappliesWhenPopupRouteChangesWithoutItemTextChange` - PASS, 1 passed
- `dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --filter FullyQualifiedName~PopupPickOptionTranslationPatchTests|FullyQualifiedName~QudMenuBottomContextTranslationPatchTests` - PASS, 46 passed
- `just build` - PASS, 0 warnings/errors
- `git diff --check` - PASS
- `just test-l1` - PASS, 4659 passed
- `just test-l2` - PASS, 4475 passed
- `just test-l2g` - PASS, 517 passed
- `just deploy-dev` - PASS

## Runtime Evidence
- Prior Player.log after the performance deployment showed no QudJP exceptions, no canvas-force cost, healthy refresh-cache skips, and zero repair candidates. The latest code was redeployed with `just deploy-dev` after the stale-display regression fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  - 在庫行翻訳、フォント更新、メニュー表示に関する多数の新規・改訂テストを追加し、キャッシュ／反映順序／表示振る舞いを検証

* **改善**
  - 在庫行およびメニュー表示の翻訳に有界キャッシュを導入して重複処理を削減
  - 反射アクセスのキャッシュ化で取得コストを低減
  - フォント／メッシュ／Canvas強制更新の二重実行を抑止しログ計測を強化
  - ボトムコンテキスト翻訳を表示専用経路へ移行

* **ドキュメント**
  - インベントリメニュー性能改善計画を追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->