### PR TITLE
[codex] Release QudJP v0.4.01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.4.01] - 2026-05-31
+
+### Fixed
+
+- Player.log で確認された ability label、mutation rank-up popup、liquid pour prompt/option、skill status label、generated item description、advanced toolkit の loaded-cell color tag などの未翻訳 UI・説明文を修正しました。
+- mutation popup、active effect、item mod name、popup/log 内の generated display name など、追加で見つかった runtime 生成テキストの未翻訳表示を日本語化しました。
+- color markup 付きの item name や generated display name で、日本語化後も色タグが保たれるようにしました。
+- tutorial Mehmet の POI highlight が正しく日本語化経路に乗るようにしました。
+- inventory line、menu option、bottom context 表示の処理を見直し、inventory/menu の表示更新を軽くしました。
+
+---
+
 ## [0.4.00] - 2026-05-29
 
 ### Fixed
@@ -388,7 +400,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.4.00...HEAD
+[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.4.01...HEAD
+[0.4.01]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.4.01
 [0.4.00]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.4.00
 [0.3.21]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.21
 [0.3.20]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.20

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.4.00",
+  "Version": "0.4.01",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/release-notes/unreleased/runtime-log-playerlog-20260529.md
+++ b/docs/release-notes/unreleased/runtime-log-playerlog-20260529.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Fixed Player.log-observed untranslated UI and description text, including ability labels, mutation rank-up popups with runtime numeric rank text, liquid pour prompts/options, skill status labels, generated item descriptions, and loaded-cell color tags on advanced toolkits.

--- a/docs/release-notes/unreleased/runtime-owner-routes-20260531.md
+++ b/docs/release-notes/unreleased/runtime-owner-routes-20260531.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Fixed additional Player.log-observed untranslated runtime text, including mutation popups, active effects, item mod names, generated display names in popups/logs, and color preservation for tagged item names.


### PR DESCRIPTION
## Summary
- Bump QudJP manifest version to 0.4.01
- Add the 0.4.01 changelog entry for Player.log runtime localization fixes, tutorial highlight fix, and inventory/menu performance improvements
- Consume the two unreleased release-note fragments

## Verification
- git diff --check
- just changelog-link-check
- just release-note-check origin/main HEAD
- just python-check
- just build
- just python-test
- just localization-check
- just translation-token-check
- just test-l1
- just test-l2
- just test-l2g

## Workshop
- Draft changenote prepared at /tmp/qudjp-workshop-changenote.txt
- This PR only prepares the release; tag creation and Steam upload remain gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 未翻訳のUI要素と説明文を日本語化
  * 生成テキストの追補と改善
  * 色タグの保持機能を修正
  * チュートリアルとインベントリ表示を更新

* **ドキュメント**
  * バージョン0.4.01のリリース情報を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->