### PR TITLE
[codex] Release QudJP v0.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [0.4.01] - 2026-05-31
+## [0.4.10] - 2026-05-31
 
 ### Fixed
 
@@ -400,8 +400,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.4.01...HEAD
-[0.4.01]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.4.01
+[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.4.10...HEAD
+[0.4.10]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.4.10
 [0.4.00]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.4.00
 [0.3.21]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.21
 [0.3.20]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.3.20

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.4.01",
+  "Version": "0.4.10",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}


### PR DESCRIPTION
## Summary
- Change the prepared release identity from v0.4.01 to v0.4.10.
- Keep the same accumulated user-facing release notes and manifest content.

## Verification
- git diff --check
- just changelog-link-check
- just python-check
- just build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア**
  * バージョンを 0.4.10 にリリース

<!-- end of auto-generated comment: release notes by coderabbit.ai -->