### PR TITLE
[codex] Add QudJP translation quality audit skill

### DIFF
--- a/.codex/skills/qudjp-translation-quality-audit/SKILL.md
+++ b/.codex/skills/qudjp-translation-quality-audit/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: qudjp-translation-quality-audit
+description: Use in QudJP when auditing Japanese translation quality for contextual correctness, obvious mistranslations, strange or overly literal phrasing, natural Japanese polish, terminology consistency, glossary alignment, style consistency, or cross-file wording variance in localization XML/JSON/corpus text. Use for translation diff reviews, single suspicious translation candidates, and broad inventory sweeps; pair with qudjp-localization-triage when route ownership or generated text implementation strategy is part of the decision.
+---
+
+# QudJP Translation Quality Audit
+
+## Overview
+
+Use this skill to audit the quality of Japanese translations after, before, or during QudJP localization work. Keep it focused on translation judgment: meaning, Japanese fluency, terminology consistency, tone, and markup preservation.
+
+Do not use this skill as a shortcut for route ownership. If the question becomes "where should this dynamic/generated string be translated?" or "is this safe as a dictionary leaf?", invoke `qudjp-localization-triage` and follow `docs/RULES.md`.
+
+## Intake Classification
+
+Classify the request before investigating:
+
+- `diff-review`: the user wants changed localization files reviewed. Start from `git diff -- Mods/QudJP/Localization docs/glossary.csv` or the explicit paths.
+- `single-candidate`: the user gives one phrase, key, visible string, or suspected mistranslation. Trace that item deeply before broad scans.
+- `inventory-sweep`: the user wants suspicious translations, term drift, or style variance found across assets. Define the corpus and sampling strategy before claiming coverage.
+
+State the classification in the work summary. If the classification changes after evidence gathering, say why.
+
+For submitted snippets or hypothetical diffs, distinguish the submitted artifact from the current working tree. Review the snippet as given, then use existing files only as corroborating or conflicting evidence. Do not imply that a submitted line exists in the repository unless you found it.
+
+For inventory sweeps, use shipped localization assets and `docs/glossary.csv` as the primary corpus by default. Use prior specs, plans, reports, and archive docs only as intent evidence, not as shipped usage. Expand search terms deliberately: include singular/plural English variants, case variants, and known Japanese variants, then state which variants were searched.
+
+Default inventory depth is an exact and near-exact term sweep over the declared corpus. Expand into semantic synonyms, every related item subtype, or full source-English reclassification only when the user asks for exhaustive coverage, the initial sweep finds a risky boundary case, or the term family is known to be generated/composed. Treat `Corpus/` files as shipped text evidence, but classify whether a corpus row is authored prose, excerpted book text, or derived/tokenized support material before recommending edits from it.
+
+## Evidence Sources
+
+Use local sources first:
+
+1. Scoped repo instructions for the touched area, especially `Mods/QudJP/Localization/AGENTS.md`.
+2. `docs/RULES.md` for route boundaries, dictionary safety, markup, and placeholder rules.
+3. `docs/glossary-policy.md` and `docs/glossary.csv` for stable terms. Treat `approved` and `confirmed` rows as authoritative unless fresh evidence proves them wrong.
+4. Existing shipped localization assets under `Mods/QudJP/Localization/`.
+5. Tests under `Mods/QudJP/Assemblies/QudJP.Tests/` when behavior or route contracts matter.
+6. Decompiled source under `~/dev/coq-decompiled_stable/` when game context, producer meaning, or UI role is unclear.
+7. Fresh runtime evidence under `~/Library/Logs/Freehold Games/CavesOfQud/` when visible output or route behavior is the claim.
+
+Use wiki or other external sources only when local evidence does not settle lore, item meaning, mechanics, or authored context. When using external sources, cite the source in the final evidence summary and separate sourced fact from translation judgment.
+
+## Parallel Dispatch
+
+Use multiple agents when at least two independent judgment axes can run without sharing mutable state, especially for large diffs or inventory sweeps.
+
+Default roles:
+
+- `Context Investigator`: establish source meaning, gameplay/lore context, implementation route, and source evidence.
+- `Japanese Quality Reviewer`: judge naturalness, tone, readability, and whether the Japanese sounds like a player-facing Caves of Qud line.
+- `Consistency Auditor`: compare glossary rows, existing asset usage, context splits, and nearby terminology.
+- `Coordinator`: synthesize the reports, resolve conflicts, and choose the recommendation.
+
+Do not dispatch when the request is a tiny single phrase that can be resolved from one local file and the glossary. Do not let multiple agents edit the same files. Dispatch agents for evidence and recommendations; keep final editing decisions in the main session.
+
+When dispatching, use the templates in `references/agent-prompts.md`. Pass raw artifacts, paths, diffs, and questions. Do not pass your preferred translation or expected answer unless the task is explicitly to validate that preference.
+
+If subagent dispatch is unavailable, run the same role separation sequentially in your own analysis and state that empirical parallel evidence was not available.
+
+## Audit Criteria
+
+Check every recommendation against these gates:
+
+- **Context correctness**: The Japanese must preserve the source meaning in the specific game, UI, lore, or implementation context. Do not flatten authored fantasy terms into generic Japanese when the source is a proper noun, faction, mutation, item, caste, title, or generated phrase.
+- **Natural Japanese**: Prefer concise, idiomatic Japanese that fits the UI surface. Remove unnecessary literal English structure, but do not over-polish into a meaning that the source did not support.
+- **Consistency**: Follow `approved` and `confirmed` glossary rows. For `draft` rows, use them as evidence but verify against shipped assets. Preserve intentional context splits such as category label vs prose when documented or justified by visible usage.
+- **Style and tone**: Keep the local register. UI labels should be compact; prose can be more literary; combat/log lines should stay readable and mechanically clear.
+- **Markup and placeholders**: Preserve Qud wrappers, color codes, TMP tags, escaped markers, placeholders, numeric formats, and direct translation markers exactly unless a route-specific test proves a transformation is correct.
+- **Route safety**: Do not recommend broad dictionary additions for dynamic, procedural, sink-observed, or generated text. Escalate to `qudjp-localization-triage` when route ownership is unresolved.
+
+Accept a context split only when the surface roles differ, existing usage is internally consistent or documented, the split does not conflict with an `approved` or `confirmed` glossary row, and player-facing ambiguity is lower than forced uniformity. If any of those points is unresolved, recommend `defer` or `needs evidence` instead of treating the split as proven.
+
+## Workflow
+
+1. Read the scoped instructions and classify the intake.
+2. Identify target files, keys, source English, current Japanese, and visible context.
+3. Gather local evidence with `rg`, JSON/XML inspection, glossary lookup, and tests or decompiled source when needed.
+4. Decide whether to dispatch parallel agents. If yes, dispatch by independent role and keep their outputs separate until synthesis.
+5. Produce a recommendation per item:
+   - keep current translation
+   - change to a specific Japanese translation
+   - defer pending route evidence
+   - split by context
+   - add or update glossary row
+   - open follow-up for deterministic tooling
+6. If editing localization assets, preserve keys and structural tokens. Add release-note fragments before PR work that changes `Mods/QudJP/Localization/`.
+7. Verify with focused checks. Use `just localization-check`, `just translation-token-check`, JSON/XML parse checks, and route tests when behavior changes.
+
+For broad sweeps, separate "found issue" from "actionable edit". Boundary cases such as unknown/identified item names, generated display names, and corpus excerpts usually need visible-surface or source-route evidence before editing.
+
+## Output
+
+For small reviews, report:
+
+- target text and file/key
+- recommendation
+- evidence used
+- glossary/consistency status
+- remaining uncertainty
+- checks run or needed
+
+For multi-item reviews, use a table:
+
+| Item | Current | Recommendation | Reason | Evidence | Action |
+| --- | --- | --- | --- | --- | --- |
+
+After a parallel review, include a short synthesis:
+
+- context findings
+- Japanese quality findings
+- consistency findings
+- coordinator decision
+- conflicts between agents and how they were resolved
+
+Never present "sounds better" as the only reason. Tie polish recommendations to source meaning, local style, glossary, or player-facing readability.

--- a/.codex/skills/qudjp-translation-quality-audit/agents/openai.yaml
+++ b/.codex/skills/qudjp-translation-quality-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "QudJP Translation Quality Audit"
+  short_description: "Audit QudJP translations for context, fluency, and consistency."
+  default_prompt: "Use $qudjp-translation-quality-audit to review this QudJP translation for context accuracy, Japanese fluency, and glossary consistency."

--- a/docs/reports/2026-06-01-qudjp-translation-quality-audit-tuning.md
+++ b/docs/reports/2026-06-01-qudjp-translation-quality-audit-tuning.md
@@ -81,7 +81,7 @@ Held-out inventory follow-up:
 Fresh commands run after tuning:
 
 ```bash
-python3 /Users/sankenbisha/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/qudjp-translation-quality-audit
+python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/qudjp-translation-quality-audit
 npx secretlint .codex/skills/qudjp-translation-quality-audit docs/superpowers/specs/2026-06-01-qudjp-translation-quality-audit-design.md docs/superpowers/plans/2026-06-01-qudjp-translation-quality-audit.md
 just markdown-report-check
 uv run pytest scripts/tests/test_agent_cycle.py -q

--- a/docs/reports/2026-06-01-qudjp-translation-quality-audit-tuning.md
+++ b/docs/reports/2026-06-01-qudjp-translation-quality-audit-tuning.md
@@ -1,0 +1,96 @@
+# 2026-06-01 QudJP Translation Quality Audit Skill Tuning
+
+## Target
+
+Skill under test:
+
+```text
+.codex/skills/qudjp-translation-quality-audit/
+```
+
+Purpose: validate whether a fresh agent can use the skill to audit QudJP translation quality across single-candidate, diff-review, and inventory-sweep scenarios.
+
+## Iteration 0
+
+Static consistency check:
+
+- Frontmatter description matched the body scope: translation quality, mistranslation review, natural Japanese polish, terminology consistency, and handoff to route triage when ownership matters.
+- `references/agent-prompts.md` was discoverable from `SKILL.md`.
+
+## Iteration 1
+
+### Scenarios
+
+| Scenario | Success | Accuracy | Notes |
+| --- | --- | ---: | --- |
+| Cudgel context split | yes | 100% | Correctly classified as `single-candidate`; found local evidence; avoided route/dictionary overreach. |
+| Mutation Points / Chrome Pyramid diff | yes | 100% | Correctly classified as `diff-review`; checked wrapper preservation and glossary evidence. |
+| Grenades inventory sweep | yes | 100% | Correctly rejected global standardization; found `UnknownGrenade` and flashbang boundary cases. |
+
+### Ambiguities Found
+
+- Context split acceptance criteria were implicit.
+- Hypothetical diff handling did not explicitly distinguish submitted artifacts from current repository evidence.
+- Inventory sweeps did not explicitly define primary corpus vs prior docs.
+- Search variant expansion was implied but not stated.
+
+### Changes Applied
+
+- Added explicit submitted-snippet handling.
+- Added default inventory corpus and search-variant guidance.
+- Added context-split acceptance criteria.
+- Replaced a fixed repository path in agent prompts with `<current repository root>`.
+
+## Iteration 2
+
+### Scenarios
+
+| Scenario | Success | Accuracy | Notes |
+| --- | --- | ---: | --- |
+| Cudgel context split | yes | 100% | Agent applied context-split criteria directly. |
+| Mutation Points / Chrome Pyramid diff | yes | 100% | Agent separated hypothetical diff from current repository evidence. |
+| Grenades inventory sweep | yes | 100% | Agent treated shipped assets as primary and prior spec as intent evidence. |
+
+### Ambiguities Found
+
+- Inventory depth was still partly implicit.
+- `Corpus/` evidence handling was still underspecified.
+- Boundary cases needed clearer separation from actionable edits.
+
+### Changes Applied
+
+- Added default exact/near-exact inventory depth.
+- Added when to expand into semantic synonyms or subtype sweeps.
+- Added `Corpus/` classification guidance.
+- Added found-issue vs actionable-edit guidance for broad sweeps.
+
+## Iteration 3
+
+Held-out inventory follow-up:
+
+| Scenario | Success | Accuracy | Notes |
+| --- | --- | ---: | --- |
+| Grenades inventory sweep after second tuning | yes | 100% | Agent stated inventory depth, avoided global standardization, separated found issues from edits, and handled corpus/unknown-item boundaries. |
+
+### Remaining Ambiguity
+
+- User-provided sweep breadth can still be broader than the default. The skill now defaults to exact/near-exact coverage and requires explicit expansion criteria, which is acceptable for initial use.
+
+## Validation Commands
+
+Fresh commands run after tuning:
+
+```bash
+python3 /Users/sankenbisha/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/qudjp-translation-quality-audit
+npx secretlint .codex/skills/qudjp-translation-quality-audit docs/superpowers/specs/2026-06-01-qudjp-translation-quality-audit-design.md docs/superpowers/plans/2026-06-01-qudjp-translation-quality-audit.md
+just markdown-report-check
+uv run pytest scripts/tests/test_agent_cycle.py -q
+just tool-check
+```
+
+All passed.
+
+Known unrelated checks:
+
+- `bash scripts/check-dotfiles.sh` is not present in this repository checkout.
+- Full `npx secretlint .` currently fails on pre-existing `docs/reports/2026-05-31-workshop-v0.4.10.md`.

--- a/docs/superpowers/plans/2026-06-01-qudjp-translation-quality-audit.md
+++ b/docs/superpowers/plans/2026-06-01-qudjp-translation-quality-audit.md
@@ -1,0 +1,154 @@
+# QudJP Translation Quality Audit Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create and tune a repo-local Codex skill that audits QudJP translations for contextual correctness, natural Japanese, and terminology/style consistency.
+
+**Architecture:** Add one orchestrator skill under `.codex/skills/qudjp-translation-quality-audit/`. Keep the main `SKILL.md` concise and move reusable parallel-agent prompt templates into `references/agent-prompts.md`.
+
+**Tech Stack:** Codex skill markdown, YAML `agents/openai.yaml`, existing QudJP docs, existing skill validation scripts, `just` recipes, and `uv`-managed Python tooling.
+
+---
+
+### Task 1: Skill Structure And Design Docs
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-06-01-qudjp-translation-quality-audit-design.md`
+- Create: `docs/superpowers/plans/2026-06-01-qudjp-translation-quality-audit.md`
+- Create: `.codex/skills/qudjp-translation-quality-audit/SKILL.md`
+- Create: `.codex/skills/qudjp-translation-quality-audit/agents/openai.yaml`
+- Create: `.codex/skills/qudjp-translation-quality-audit/references/agent-prompts.md`
+
+- [ ] **Step 1: Initialize the skill skeleton**
+
+Run:
+
+```bash
+python3 /Users/sankenbisha/.codex/skills/.system/skill-creator/scripts/init_skill.py qudjp-translation-quality-audit --path .codex/skills --resources references --interface display_name='QudJP Translation Quality Audit' --interface short_description='Audit QudJP translations for context, fluency, and consistency.' --interface default_prompt='Use $qudjp-translation-quality-audit to review this QudJP translation for context accuracy, Japanese fluency, and glossary consistency.'
+```
+
+Expected: `.codex/skills/qudjp-translation-quality-audit/` exists with `SKILL.md`, `agents/openai.yaml`, and `references/`.
+
+- [ ] **Step 2: Write the design and plan documents**
+
+Create the design document with the approved architecture, boundaries, workflow, validation, and risks. Create this plan with exact paths and commands. Do not commit unless the user explicitly asks, because repo instructions say commits require explicit request.
+
+- [ ] **Step 3: Verify generated metadata**
+
+Run:
+
+```bash
+sed -n '1,80p' .codex/skills/qudjp-translation-quality-audit/agents/openai.yaml
+```
+
+Expected: `display_name`, `short_description`, and `default_prompt` are populated, and `default_prompt` mentions `$qudjp-translation-quality-audit`.
+
+### Task 2: Skill Body
+
+**Files:**
+- Modify: `.codex/skills/qudjp-translation-quality-audit/SKILL.md`
+
+- [ ] **Step 1: Replace the template with the orchestrator workflow**
+
+Write `SKILL.md` in English because LLM-facing documents must be English. Include:
+
+- Frontmatter `name` and a trigger-rich `description`.
+- Overview that distinguishes translation quality audit from route triage.
+- Intake classification for `diff-review`, `single-candidate`, and `inventory-sweep`.
+- Evidence order and required local sources.
+- Parallel dispatch rules and when not to dispatch.
+- Quality gates for contextual correctness, Japanese fluency, consistency, and markup preservation.
+- Editing guardrails and verification expectations.
+- Output format.
+
+- [ ] **Step 2: Check for template residue**
+
+Run:
+
+```bash
+rg -n 'TODO|Replace|optional|Structuring This Skill' .codex/skills/qudjp-translation-quality-audit/SKILL.md
+```
+
+Expected: no matches.
+
+### Task 3: Parallel Agent Prompt Reference
+
+**Files:**
+- Create: `.codex/skills/qudjp-translation-quality-audit/references/agent-prompts.md`
+
+- [ ] **Step 1: Add role-specific prompt templates**
+
+Write reusable templates for:
+
+- `Context Investigator`
+- `Japanese Quality Reviewer`
+- `Consistency Auditor`
+- `Coordinator synthesis`
+
+Each template must request raw evidence, uncertainty, and a compact recommendation. The prompts must not leak expected answers or tell agents which translation to prefer.
+
+- [ ] **Step 2: Check prompt reference is discoverable**
+
+Run:
+
+```bash
+rg -n 'references/agent-prompts.md|Context Investigator|Consistency Auditor' .codex/skills/qudjp-translation-quality-audit/SKILL.md .codex/skills/qudjp-translation-quality-audit/references/agent-prompts.md
+```
+
+Expected: matches in both files.
+
+### Task 4: Validation And Tuning
+
+**Files:**
+- Modify if needed: `.codex/skills/qudjp-translation-quality-audit/SKILL.md`
+- Modify if needed: `.codex/skills/qudjp-translation-quality-audit/references/agent-prompts.md`
+
+- [ ] **Step 1: Run skill validation**
+
+Run:
+
+```bash
+python3 /Users/sankenbisha/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/qudjp-translation-quality-audit
+```
+
+Expected: validation passes.
+
+- [ ] **Step 2: Run repository static checks**
+
+Run:
+
+```bash
+python3 /Users/sankenbisha/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/qudjp-translation-quality-audit
+uv run pytest scripts/tests/test_agent_cycle.py -q
+just python-check
+just tool-check
+just markdown-report-check
+npx secretlint .codex/skills/qudjp-translation-quality-audit docs/superpowers/specs/2026-06-01-qudjp-translation-quality-audit-design.md docs/superpowers/plans/2026-06-01-qudjp-translation-quality-audit.md docs/reports/2026-06-01-qudjp-translation-quality-audit-tuning.md
+```
+
+Expected: all checks pass.
+
+- [ ] **Step 3: Run empirical prompt tuning**
+
+Evaluate three scenarios:
+
+1. A single suspicious translation where the executor must distinguish mistranslation from acceptable context split.
+2. A translation diff review where markup and glossary consistency matter.
+3. An inventory-style sweep where the executor must avoid broad claims without evidence.
+
+Record scenario results, ambiguities, discretion-filled spots, and minimal fixes. If fresh subagent dispatch is unavailable, report that empirical execution was skipped and perform only a structural review.
+
+- [ ] **Step 4: Re-run validation after tuning edits**
+
+Run:
+
+```bash
+python3 /Users/sankenbisha/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/qudjp-translation-quality-audit
+uv run pytest scripts/tests/test_agent_cycle.py -q
+just python-check
+just tool-check
+just markdown-report-check
+npx secretlint .codex/skills/qudjp-translation-quality-audit docs/superpowers/specs/2026-06-01-qudjp-translation-quality-audit-design.md docs/superpowers/plans/2026-06-01-qudjp-translation-quality-audit.md docs/reports/2026-06-01-qudjp-translation-quality-audit-tuning.md
+```
+
+Expected: all checks pass.

--- a/docs/superpowers/plans/2026-06-01-qudjp-translation-quality-audit.md
+++ b/docs/superpowers/plans/2026-06-01-qudjp-translation-quality-audit.md
@@ -10,6 +10,8 @@
 
 ---
 
+## Tasks
+
 ### Task 1: Skill Structure And Design Docs
 
 **Files:**
@@ -24,7 +26,7 @@
 Run:
 
 ```bash
-python3 /Users/sankenbisha/.codex/skills/.system/skill-creator/scripts/init_skill.py qudjp-translation-quality-audit --path .codex/skills --resources references --interface display_name='QudJP Translation Quality Audit' --interface short_description='Audit QudJP translations for context, fluency, and consistency.' --interface default_prompt='Use $qudjp-translation-quality-audit to review this QudJP translation for context accuracy, Japanese fluency, and glossary consistency.'
+python3 ~/.codex/skills/.system/skill-creator/scripts/init_skill.py qudjp-translation-quality-audit --path .codex/skills --resources references --interface display_name='QudJP Translation Quality Audit' --interface short_description='Audit QudJP translations for context, fluency, and consistency.' --interface default_prompt='Use $qudjp-translation-quality-audit to review this QudJP translation for context accuracy, Japanese fluency, and glossary consistency.'
 ```
 
 Expected: `.codex/skills/qudjp-translation-quality-audit/` exists with `SKILL.md`, `agents/openai.yaml`, and `references/`.
@@ -108,7 +110,7 @@ Expected: matches in both files.
 Run:
 
 ```bash
-python3 /Users/sankenbisha/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/qudjp-translation-quality-audit
+python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/qudjp-translation-quality-audit
 ```
 
 Expected: validation passes.
@@ -118,7 +120,7 @@ Expected: validation passes.
 Run:
 
 ```bash
-python3 /Users/sankenbisha/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/qudjp-translation-quality-audit
+python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/qudjp-translation-quality-audit
 uv run pytest scripts/tests/test_agent_cycle.py -q
 just python-check
 just tool-check
@@ -143,7 +145,7 @@ Record scenario results, ambiguities, discretion-filled spots, and minimal fixes
 Run:
 
 ```bash
-python3 /Users/sankenbisha/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/qudjp-translation-quality-audit
+python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/qudjp-translation-quality-audit
 uv run pytest scripts/tests/test_agent_cycle.py -q
 just python-check
 just tool-check

--- a/docs/superpowers/specs/2026-06-01-qudjp-translation-quality-audit-design.md
+++ b/docs/superpowers/specs/2026-06-01-qudjp-translation-quality-audit-design.md
@@ -1,0 +1,57 @@
+# QudJP Translation Quality Audit Skill Design
+
+## Why
+
+QudJP の翻訳改善には、未翻訳やルート所有権の判定だけではなく、既存訳や候補訳を「文脈に対して正しいか」「日本語として自然か」「用語・文体が一貫しているか」で監査する作業が必要になる。既存の `qudjp-localization-triage` は runtime text と owner route の判断に強いが、訳文品質そのものを複数観点でレビューする入口は分離した方がよい。
+
+## What
+
+repo-local skill として `.codex/skills/qudjp-translation-quality-audit/` を作る。
+
+このスキルは次の入力を扱う。
+
+- `diff-review`: 変更済みの翻訳差分をレビューする。
+- `single-candidate`: 1つまたは少数の英語/日本語表現について、誤訳・珍訳・改善案を判断する。
+- `inventory-sweep`: 辞書、XML、コーパス、用語表から怪しい訳や表記揺れを広く探す。
+
+必要に応じて複数エージェントを派遣する。派遣の基本役割は以下。
+
+- `Context Investigator`: 実装、decompiled source、既存 asset、必要なら wiki から意味と文脈を調べる。
+- `Japanese Quality Reviewer`: 日本語としての自然さ、文体、過剰な直訳、珍訳をレビューする。
+- `Consistency Auditor`: `docs/glossary.csv`、`docs/glossary-policy.md`、既存 XML/JSON から表記揺れと context split を確認する。
+- `Coordinator`: 各観点を統合し、採用訳、却下訳、保留、追加調査、検証コマンドを決める。
+
+## Boundaries
+
+このスキルは翻訳品質の判断手順を定義する。動的/generated text の owner route 判定や sink vs producer の実装修正判断が主目的になった場合は、既存の `qudjp-localization-triage` に接続する。
+
+初期版では deterministic な表記揺れ検出スクリプトは作らない。まず人間/エージェント監査の手順、証拠順、出力形式を固める。繰り返し発生する検査だけを将来スクリプト化する。
+
+## Workflow
+
+1. 入力を `diff-review`、`single-candidate`、`inventory-sweep` に分類する。
+2. 対象範囲と証拠源を宣言する。
+3. 小さい単発候補は単独で監査し、差分や棚卸しでは独立観点ごとに複数エージェントを派遣する。
+4. 文脈正確性、自然さ、一貫性、markup/placeholder 保持を別々に判定する。
+5. Coordinator が採用案と根拠を出す。
+6. 実装する場合は、翻訳 asset 変更の通常検証と、必要に応じて owner route の既存スキルへ引き継ぐ。
+
+## Validation
+
+スキル作成後に以下を行う。
+
+- skill folder validator を通す。
+- repo の dotfiles/static check を通す。
+- empirical prompt tuning で realistic scenario を最低3つ評価する。
+  - 単発の誤訳/珍訳候補。
+  - 翻訳差分レビュー。
+  - 用語・表記揺れ棚卸し。
+- 曖昧さが出た場合はスキル文面を最小修正し、再検証する。
+
+## Risks
+
+- ルート所有権判断と訳文品質判断が混ざると、安易な dictionary leaf 追加につながる。
+- 「自然な日本語」だけを優先すると、固有名詞・用語・Caves of Qud 固有の文体が崩れる。
+- 複数エージェントの結果をそのまま採用すると、証拠レベルの違いが混ざる。
+
+このため、最終判断は Coordinator が evidence order、glossary status、既存 asset、route safety を明示して統合する。

--- a/justfile
+++ b/justfile
@@ -86,11 +86,11 @@ test-csharp:
 
 # Run Python static checks.
 python-check:
-  ruff check scripts/
+  uv run ruff check scripts/
 
 # Format Python scripts.
 python-format:
-  ruff format scripts/
+  uv run ruff format scripts/
 
 # Run Python tests.
 python-test:
@@ -525,7 +525,7 @@ roslyn-test:
 
 # Run Ruff for Roslyn Python files and basedpyright for the typed static-producer gate.
 roslyn-python-check:
-  ruff check scripts/dotnet_tool_runner.py scripts/extract_annals_patterns.py scripts/roslyn_semantic_probe.py scripts/scan_static_producer_inventory.py scripts/scan_unused_code_inventory.py scripts/static_producer_closure.py scripts/text_construction_surface_policy.py scripts/tests/test_extract_annals_patterns.py scripts/tests/test_parallel_dotnet_contract.py scripts/tests/test_roslyn_extractor_smoke.py scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_roslyn_text_construction_inventory.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_scan_unused_code_inventory.py scripts/tests/test_static_producer_closure.py scripts/tests/test_text_construction_surface_policy.py
+  uv run ruff check scripts/dotnet_tool_runner.py scripts/extract_annals_patterns.py scripts/roslyn_semantic_probe.py scripts/scan_static_producer_inventory.py scripts/scan_unused_code_inventory.py scripts/static_producer_closure.py scripts/text_construction_surface_policy.py scripts/tests/test_extract_annals_patterns.py scripts/tests/test_parallel_dotnet_contract.py scripts/tests/test_roslyn_extractor_smoke.py scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_roslyn_text_construction_inventory.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_scan_unused_code_inventory.py scripts/tests/test_static_producer_closure.py scripts/tests/test_text_construction_surface_policy.py
   uvx basedpyright scripts/dotnet_tool_runner.py scripts/roslyn_semantic_probe.py scripts/scan_static_producer_inventory.py scripts/scan_unused_code_inventory.py scripts/static_producer_closure.py scripts/text_construction_surface_policy.py scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_scan_unused_code_inventory.py scripts/tests/test_static_producer_closure.py scripts/tests/test_text_construction_surface_policy.py scripts/tests/test_roslyn_extractor_smoke.py
 
 # Run build, focused tests, and static checks for Roslyn analysis tooling.
@@ -538,7 +538,7 @@ semantic-probe *args:
 # Run focused validation for the generic Roslyn semantic probe.
 semantic-probe-check: roslyn-build-semantic-probe
   uv run pytest scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_roslyn_extractor_smoke.py -q
-  ruff check scripts/roslyn_semantic_probe.py scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_roslyn_extractor_smoke.py
+  uv run ruff check scripts/roslyn_semantic_probe.py scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_roslyn_extractor_smoke.py
   uvx basedpyright scripts/roslyn_semantic_probe.py scripts/tests/test_roslyn_semantic_probe.py scripts/tests/test_roslyn_extractor_smoke.py
 
 # Run optional real-source smoke for the generic Roslyn semantic probe.
@@ -548,7 +548,7 @@ semantic-probe-real-smoke:
 # Validate the executable localization coverage map.
 localization-coverage-map-check:
   uv run pytest scripts/tests/test_localization_coverage_map.py -q
-  ruff check scripts/localization_coverage_map.py scripts/tests/test_localization_coverage_map.py
+  uv run ruff check scripts/localization_coverage_map.py scripts/tests/test_localization_coverage_map.py
   uvx basedpyright scripts/localization_coverage_map.py scripts/tests/test_localization_coverage_map.py
 
 # Generate static producer inventory to a disposable local output.
@@ -563,7 +563,7 @@ static-producer-regenerate-tracked source_root=decompiled_root:
 # Run the static producer scanner's focused validation gate.
 static-producer-check: roslyn-build-static-producer
   uv run pytest scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_static_producer_closure.py scripts/tests/test_roslyn_extractor_smoke.py -q
-  ruff check scripts/scan_static_producer_inventory.py scripts/static_producer_closure.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_static_producer_closure.py scripts/tests/test_roslyn_extractor_smoke.py
+  uv run ruff check scripts/scan_static_producer_inventory.py scripts/static_producer_closure.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_static_producer_closure.py scripts/tests/test_roslyn_extractor_smoke.py
   uvx basedpyright scripts/scan_static_producer_inventory.py scripts/static_producer_closure.py scripts/tests/test_scan_static_producer_inventory.py scripts/tests/test_static_producer_closure.py scripts/tests/test_roslyn_extractor_smoke.py
 
 # Print the static producer owner work queue grouped by decompiled C# source file.
@@ -623,7 +623,7 @@ unused-code-gate source_root="." config="scripts/unused_code_inventory_config.js
 # Run the unused-code scanner's focused validation gate.
 unused-code-check: roslyn-build-unused-code
   uv run pytest scripts/tests/test_scan_unused_code_inventory.py scripts/tests/test_roslyn_extractor_smoke.py -q
-  ruff check scripts/scan_unused_code_inventory.py scripts/tests/test_scan_unused_code_inventory.py scripts/tests/test_roslyn_extractor_smoke.py
+  uv run ruff check scripts/scan_unused_code_inventory.py scripts/tests/test_scan_unused_code_inventory.py scripts/tests/test_roslyn_extractor_smoke.py
   uvx basedpyright scripts/scan_unused_code_inventory.py scripts/tests/test_scan_unused_code_inventory.py scripts/tests/test_roslyn_extractor_smoke.py
 
 # Audit source routes and test expectations for English function-word residue risks.

--- a/scripts/agent_cycle.sh
+++ b/scripts/agent_cycle.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 DOTFILES_ROOT=${DOTFILES_ROOT:-}
 ARTIFACT_DIR=${AGENT_LOOP_ARTIFACT_DIR:-"$ROOT_DIR/scripts/_artifacts/agent-loop"}
-PYTHON_BIN=${PYTHON_BIN:-python3.12}
+PYTHON_BIN=${PYTHON_BIN:-"uv run python"}
+read -r -a PYTHON_CMD <<<"$PYTHON_BIN"
 
 usage() {
   cat <<'USAGE'
@@ -45,7 +46,7 @@ require_dotfiles_root() {
 
 tool_check() {
   local missing=0
-  for tool in just "$PYTHON_BIN"; do
+  for tool in just "${PYTHON_CMD[0]}"; do
     if ! command -v "$tool" >/dev/null 2>&1; then
       echo "missing tool: $tool" >&2
       missing=1
@@ -208,7 +209,7 @@ render_skill_evals() {
     args+=(--scenario "$scenario")
   fi
 
-  "$PYTHON_BIN" "$ROOT_DIR/scripts/render_skill_eval_prompts.py" "${args[@]}" \
+  "${PYTHON_CMD[@]}" "$ROOT_DIR/scripts/render_skill_eval_prompts.py" "${args[@]}" \
     | tee "$ARTIFACT_DIR/skill-eval-prompts.md"
 }
 
@@ -221,8 +222,8 @@ summarize_skill_evals() {
   fi
 
   mkdir -p "$ARTIFACT_DIR"
-  "$PYTHON_BIN" "$ROOT_DIR/scripts/validate_skill_eval_results.py" "$results"
-  "$PYTHON_BIN" "$DOTFILES_ROOT/scripts/summarize-skill-eval-results.py" "$results" \
+  "${PYTHON_CMD[@]}" "$ROOT_DIR/scripts/validate_skill_eval_results.py" "$results"
+  "${PYTHON_CMD[@]}" "$DOTFILES_ROOT/scripts/summarize-skill-eval-results.py" "$results" \
     | tee "$ARTIFACT_DIR/skill-eval-summary.md"
 }
 

--- a/scripts/agent_cycle.sh
+++ b/scripts/agent_cycle.sh
@@ -5,7 +5,11 @@ ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 DOTFILES_ROOT=${DOTFILES_ROOT:-}
 ARTIFACT_DIR=${AGENT_LOOP_ARTIFACT_DIR:-"$ROOT_DIR/scripts/_artifacts/agent-loop"}
 PYTHON_BIN=${PYTHON_BIN:-"uv run python"}
-read -r -a PYTHON_CMD <<<"$PYTHON_BIN"
+if [[ -x "$PYTHON_BIN" ]] || command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  PYTHON_CMD=("$PYTHON_BIN")
+else
+  read -r -a PYTHON_CMD <<<"$PYTHON_BIN"
+fi
 
 usage() {
   cat <<'USAGE'

--- a/scripts/tests/test_agent_cycle.py
+++ b/scripts/tests/test_agent_cycle.py
@@ -98,6 +98,25 @@ def test_tool_check_allows_repo_local_render_without_dotfiles_root() -> None:
     assert "DOTFILES_ROOT not set" in completed.stdout
 
 
+def test_tool_check_uses_uv_python_by_default(tmp_path: Path) -> None:
+    """tool-check should not require a host-level python3.12 executable by default."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for tool in ("just", "uv", "ast-grep"):
+        _write_executable_stub(bin_dir, tool)
+
+    completed = _run_agent_cycle(
+        "tool-check",
+        override_path=str(bin_dir),
+        without_dotfiles_root=True,
+    )
+
+    assert completed.returncode == 1
+    assert "missing tool: python3.12" not in completed.stderr
+    assert "missing tool: dotnet" in completed.stderr
+    assert str(bin_dir / "uv") in completed.stdout
+
+
 def _write_executable_stub(bin_dir: Path, name: str) -> None:
     stub = bin_dir / name
     stub.write_text("#!/bin/sh\nprintf '%s version\\n' \"$0\"\n", encoding="utf-8")

--- a/scripts/tests/test_agent_cycle.py
+++ b/scripts/tests/test_agent_cycle.py
@@ -117,6 +117,31 @@ def test_tool_check_uses_uv_python_by_default(tmp_path: Path) -> None:
     assert str(bin_dir / "uv") in completed.stdout
 
 
+def test_tool_check_accepts_python_bin_path_with_spaces(tmp_path: Path) -> None:
+    """PYTHON_BIN may be an executable path with spaces instead of a shell command."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for tool in ("just", "ast-grep"):
+        _write_executable_stub(bin_dir, tool)
+
+    python_dir = tmp_path / "python dir"
+    python_dir.mkdir()
+    python_path = python_dir / "python3"
+    _write_executable_stub(python_dir, "python3")
+
+    completed = _run_agent_cycle(
+        "tool-check",
+        python_bin=str(python_path),
+        override_path=str(bin_dir),
+        without_dotfiles_root=True,
+    )
+
+    assert completed.returncode == 1
+    assert "missing tool: dotnet" in completed.stderr
+    assert "missing tool: " not in completed.stderr.replace("missing tool: dotnet", "")
+    assert str(python_path) in completed.stdout
+
+
 def _write_executable_stub(bin_dir: Path, name: str) -> None:
     stub = bin_dir / name
     stub.write_text("#!/bin/sh\nprintf '%s version\\n' \"$0\"\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

- Add the repo-local `qudjp-translation-quality-audit` Codex skill for translation quality review, natural Japanese polishing, terminology consistency, and multi-agent audit roles.
- Add design, implementation plan, and empirical tuning notes for the skill.
- Align agent-cycle Python execution and Ruff just recipes with `uv`, so `just tool-check` no longer depends on a host-level `python3.12` binary.

## Review / Tuning

- Ran multi-agent tuning scenarios for:
  - single-candidate context split review (`Cudgel`)
  - diff review with markup/glossary checks (`Mutation Points`, `Chrome Pyramid`)
  - inventory sweep (`Grenades`, `グレネード`, `手榴弾`)
- Independent code review verdict: `APPROVE`; one non-blocking plan-doc issue was fixed before PR creation.

## Verification

- `python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/qudjp-translation-quality-audit`
- `uv run pytest scripts/tests/test_agent_cycle.py -q`
- `just python-check`
- `just tool-check`
- `npx secretlint .codex/skills/qudjp-translation-quality-audit docs/superpowers/specs/2026-06-01-qudjp-translation-quality-audit-design.md docs/superpowers/plans/2026-06-01-qudjp-translation-quality-audit.md docs/reports/2026-06-01-qudjp-translation-quality-audit-tuning.md`
- `just markdown-report-check`
- `git diff --check`

## Notes

- `DOTFILES_ROOT not set` during `just tool-check` is informational; repo-local skill eval rendering remains available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QudJP向け日本語翻訳品質監査スキルを追加（差分レビュー／単一候補検証／在庫スイープ対応、並列レビューと統合ワークフローを含む）。

* **Documentation**
  * 監査手順書、設計仕様、実行計画、チューニングレポートを追加。

* **Chores**
  * Python実行・静的チェック呼び出しをuv経由へ統一し、実行コマンド周りを安定化。

* **Tests**
  * ツール解決周りを検証するテストを追加（uv優先やスペース含むパスの扱いなど）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->