### PR TITLE
Codify direct-marker strip-only test contract

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -276,6 +276,7 @@ Producer or queue-gated patches that translate traffic before a generic sink mus
 - direct-translation markers passing through without retranslation
 - owner-absent or queue-only traffic staying unchanged
 - observability hit counts proving transformed owner traffic is recorded and pass-through traffic is not recorded as an owner hit
+- strip-only direct-marker cases proving the visible marker is removed and no transform hit is recorded unless a real translation occurred
 
 If a route can emit articles, generated names, quantities, or placeholder-like fragments, include those emitted shapes in tests instead of replacing them with dictionary leaves.
 


### PR DESCRIPTION
## Summary
- codifies that strip-only direct-marker cases must assert marker removal and no transform hit unless real translation occurred

## Verification
- `just markdown-report-check origin/main HEAD`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * マーカー動作に関するテスト期待値を追記しました。実際の翻訳が発生する場合のみ transform hit が記録され、翻訳がない strip-only ケースでは可視マーカーが除去されることを明示しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->