### PR TITLE
Fix inventory action menu close responsiveness

### DIFF
--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryActionMenuCloseTimingProbeTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryActionMenuCloseTimingProbeTests.cs
@@ -1,0 +1,127 @@
+namespace QudJP.Tests.L1;
+
+[TestFixture]
+[Category("L1")]
+[NonParallelizable]
+public sealed class InventoryActionMenuCloseTimingProbeTests
+{
+    [TearDown]
+    public void TearDown()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(null);
+        InventoryActionMenuCloseTimingObservability.ResetForTests();
+    }
+
+    [Test]
+    public void BuildLogLineForTests_WritesStructuredInventoryActionMenuTimingMarker()
+    {
+        var line = InventoryActionMenuCloseTimingObservability.BuildLogLineForTests(
+            sequence: 7,
+            phase: "inventory-refresh-end",
+            elapsed: TimeSpan.FromMilliseconds(12.3456),
+            detail: "popup_id=InventoryActionMenu:abc;result=cancel");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(line, Does.Contain("[QudJP] InventoryActionMenuCloseTiming/v1:"));
+            Assert.That(line, Does.Contain("seq=7"));
+            Assert.That(line, Does.Contain("phase=inventory-refresh-end"));
+            Assert.That(line, Does.Contain("elapsed_ms=12.346"));
+            Assert.That(line, Does.Contain("detail=popup_id\\=InventoryActionMenu:abc\\;result\\=cancel"));
+        });
+    }
+
+    [Test]
+    public void LogForTests_DoesNotInvokeDetailFactory_WhenVerboseProbesAreDisabled()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(false);
+        var factoryCalls = 0;
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+            InventoryActionMenuCloseTimingObservability.LogForTests(
+                "popup-hide-request",
+                () =>
+                {
+                    factoryCalls++;
+                    return "popup_id=InventoryActionMenu:abc";
+                }));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(factoryCalls, Is.Zero);
+            Assert.That(output, Does.Not.Contain("InventoryActionMenuCloseTiming/v1"));
+        });
+    }
+
+    [Test]
+    public void ShouldSuppressInventoryRefreshAfterCancelForTests_SuppressesOnlyWhilePopupHideIsPending()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        var scope = InventoryActionMenuCloseTimingObservability.BeginMenu(actionCount: 7);
+
+        InventoryActionMenuCloseTimingObservability.EndMenu(scope, canceled: true);
+
+        Assert.That(
+            InventoryActionMenuCloseTimingObservability.ShouldSuppressInventoryRefreshAfterCancelForTests(),
+            Is.True);
+
+        InventoryActionMenuCloseTimingObservability.LogPopupHiddenAfterFrameDelay(
+            "InventoryActionMenu:(noid)",
+            previousHideNextFrame: 1,
+            currentHideNextFrame: 0);
+
+        Assert.That(
+            InventoryActionMenuCloseTimingObservability.ShouldSuppressInventoryRefreshAfterCancelForTests(),
+            Is.False);
+    }
+
+    [Test]
+    public void LogPopupHiddenAfterFrameDelay_UsesActiveSequenceElapsed_WhenNoRecentCancelExists()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        _ = InventoryActionMenuCloseTimingObservability.BeginMenu(actionCount: 7);
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (stopwatch.ElapsedMilliseconds < 15)
+        {
+            Thread.SpinWait(1000);
+        }
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+            InventoryActionMenuCloseTimingObservability.LogPopupHiddenAfterFrameDelay(
+                "InventoryActionMenu:(noid)",
+                previousHideNextFrame: 1,
+                currentHideNextFrame: 0));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(output, Does.Contain("phase=popup-hidden-after-frame-delay"));
+            Assert.That(output, Does.Not.Contain("elapsed_ms=0.000"));
+        });
+    }
+
+    [Test]
+    public void EndMenu_ClearsRecentCancelContext_WhenMenuReturnsAction()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        var canceledScope = InventoryActionMenuCloseTimingObservability.BeginMenu(actionCount: 7);
+        InventoryActionMenuCloseTimingObservability.EndMenu(canceledScope, canceled: true);
+
+        var actionScope = InventoryActionMenuCloseTimingObservability.BeginMenu(actionCount: 7);
+        InventoryActionMenuCloseTimingObservability.EndMenu(actionScope, canceled: false);
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+        {
+            var refreshScope = InventoryActionMenuCloseTimingObservability.BeginInventoryRefresh();
+            InventoryActionMenuCloseTimingObservability.EndInventoryRefresh(refreshScope);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                InventoryActionMenuCloseTimingObservability.ShouldSuppressInventoryRefreshAfterCancelForTests(),
+                Is.False);
+            Assert.That(output, Does.Not.Contain("inventory-refresh-begin"));
+            Assert.That(output, Does.Not.Contain("inventory-refresh-end"));
+        });
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryActionMenuCursorSoundPatchTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L1/InventoryActionMenuCursorSoundPatchTests.cs
@@ -4,41 +4,102 @@ namespace QudJP.Tests.L1;
 
 [TestFixture]
 [Category("L1")]
+[NonParallelizable]
 public sealed class InventoryActionMenuCursorSoundPatchTests
 {
-    [Test]
-    public void ShouldPlayCursorSound_OnlyWhenInventoryActionMenuSelectionChanges()
+    [TearDown]
+    public void TearDown()
     {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(null);
+    }
+
+    [Test]
+    public void RememberPopupController_StoresPopupIdForControllerInstance()
+    {
+        var controller = new object();
+        var popup = new FakePopupMessage
+        {
+            controller = controller,
+            PopupID = "InventoryActionMenu:abc",
+        };
+
+        InventoryActionMenuCursorSoundPatch.RememberPopupController(popup);
+
+        var found = InventoryActionMenuCursorSoundPatch.TryGetRememberedPopupId(controller, out var popupId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(found, Is.True);
+            Assert.That(popupId, Is.EqualTo("InventoryActionMenu:abc"));
+            Assert.That(
+                InventoryActionMenuCursorSoundPatch.TryGetRememberedPopupId(new object(), out _),
+                Is.False);
+        });
+    }
+
+    [Test]
+    public void ForgetPopupController_RestoresOuterPopupIdForNestedControllerContext()
+    {
+        var controller = new object();
+        var outer = new FakePopupMessage
+        {
+            controller = controller,
+            PopupID = "InventoryActionMenu:outer",
+        };
+        var inner = new FakePopupMessage
+        {
+            controller = controller,
+            PopupID = "Popup:inner",
+        };
+
+        InventoryActionMenuCursorSoundPatch.RememberPopupController(outer);
+        InventoryActionMenuCursorSoundPatch.RememberPopupController(inner);
+
         Assert.Multiple(() =>
         {
             Assert.That(
-                InventoryActionMenuCursorSoundPatch.ShouldPlayCursorSoundForTests(
-                    "InventoryActionMenu:abc",
-                    previousSelectedOption: 1,
-                    currentSelectedOption: 2,
-                    isActiveAndEnabled: true),
+                InventoryActionMenuCursorSoundPatch.TryGetRememberedPopupId(controller, out var innerPopupId),
                 Is.True);
-            Assert.That(
-                InventoryActionMenuCursorSoundPatch.ShouldPlayCursorSoundForTests(
-                    "Popup:Other",
-                    previousSelectedOption: 1,
-                    currentSelectedOption: 2,
-                    isActiveAndEnabled: true),
-                Is.False);
-            Assert.That(
-                InventoryActionMenuCursorSoundPatch.ShouldPlayCursorSoundForTests(
-                    "InventoryActionMenu:abc",
-                    previousSelectedOption: 1,
-                    currentSelectedOption: 1,
-                    isActiveAndEnabled: true),
-                Is.False);
-            Assert.That(
-                InventoryActionMenuCursorSoundPatch.ShouldPlayCursorSoundForTests(
-                    "InventoryActionMenu:abc",
-                    previousSelectedOption: 1,
-                    currentSelectedOption: 2,
-                    isActiveAndEnabled: false),
-                Is.False);
+            Assert.That(innerPopupId, Is.EqualTo("Popup:inner"));
         });
+
+        InventoryActionMenuCursorSoundPatch.ForgetPopupController(inner);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                InventoryActionMenuCursorSoundPatch.TryGetRememberedPopupId(controller, out var restoredPopupId),
+                Is.True);
+            Assert.That(restoredPopupId, Is.EqualTo("InventoryActionMenu:outer"));
+        });
+
+        InventoryActionMenuCursorSoundPatch.ForgetPopupController(outer);
+
+        Assert.That(
+            InventoryActionMenuCursorSoundPatch.TryGetRememberedPopupId(controller, out _),
+            Is.False);
+    }
+
+    [Test]
+    public void PlayCursorSoundForInventoryActionMenuController_DoesNotLogPlayed_WhenSoundMethodIsUnavailable()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        var controller = new object();
+        InventoryActionMenuCursorSoundPatch.RememberPopupController(new FakePopupMessage
+        {
+            controller = controller,
+            PopupID = "InventoryActionMenu:abc",
+        });
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+            InventoryActionMenuCursorSoundPatch.PlayCursorSoundForInventoryActionMenuController(controller));
+
+        Assert.That(output, Does.Not.Contain("InventoryActionMenuCursorSound/v1"));
+    }
+
+    private sealed class FakePopupMessage
+    {
+        public object? controller;
+        public string? PopupID;
     }
 }

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryActionMenuPatchIntegrationTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2/InventoryActionMenuPatchIntegrationTests.cs
@@ -1,0 +1,345 @@
+using System.Collections;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using QudJP.Patches;
+
+namespace QudJP.Tests.L2;
+
+[TestFixture]
+[Category("L2")]
+[NonParallelizable]
+public sealed class InventoryActionMenuPatchIntegrationTests
+{
+    [TearDown]
+    public void TearDown()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(null);
+        InventoryActionMenuCloseTimingObservability.ResetForTests();
+        InventoryActionMenuCursorSoundPatch.SetPlayCursorSoundRequestObserverForTests(null);
+        InventoryActionMenuPopupUpdateTimingPatch.ResetForTests();
+    }
+
+    [Test]
+    public void CloseTimingHarmonyPatches_SuppressCancelRefreshUntilPopupHideDelayCompletes()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        using var patches = PatchCloseTiming();
+        var menu = new DummyInventoryActionMenuTarget();
+        var popup = new DummyPopupMessageTarget
+        {
+            PopupID = "InventoryActionMenu:(noid)",
+        };
+        menu.PopupToHide = popup;
+        var inventory = new DummyInventoryStatusScreenTarget();
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+        {
+            _ = menu.Show(new ArrayList { "drop" }, cancel: true);
+            inventory.UpdateViewFromData();
+            popup.Update();
+            popup.Update();
+            inventory.UpdateViewFromData();
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(inventory.RefreshCount, Is.EqualTo(1));
+            Assert.That(output, Does.Contain("phase=popup-hide-request"));
+            Assert.That(output, Does.Contain("phase=inventory-refresh-suppressed"));
+            Assert.That(output, Does.Contain("phase=popup-hidden-after-frame-delay"));
+        });
+    }
+
+    [Test]
+    public void CloseTimingHarmonyPatches_RestoreOuterActiveMenuAfterNestedActionMenu()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        using var patches = PatchCloseTiming();
+        var outerMenu = new DummyInventoryActionMenuTarget();
+        var innerMenu = new DummyInventoryActionMenuTarget();
+        var popup = new DummyPopupMessageTarget
+        {
+            PopupID = "InventoryActionMenu:outer",
+        };
+        outerMenu.NestedMenu = innerMenu;
+        outerMenu.PopupToHide = popup;
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+            _ = outerMenu.Show(new ArrayList { "outer" }, cancel: true));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(output, Does.Contain("seq=2;phase=menu-return"));
+            Assert.That(output, Does.Contain("result\\=action"));
+            Assert.That(output, Does.Contain("seq=1;phase=popup-hide-request"));
+            Assert.That(output, Does.Contain("seq=1;phase=menu-return"));
+            Assert.That(output, Does.Contain("result\\=cancel"));
+        });
+    }
+
+    [Test]
+    public void PopupUpdateTimingPatch_SkipsReflection_WhenNoSuppressionAndVerboseProbesAreDisabled()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(false);
+        using var patches = PatchPopupUpdateOnly(typeof(DummyPopupMessageWithoutHideNextFrameTarget));
+        var popup = new DummyPopupMessageWithoutHideNextFrameTarget();
+
+        var output = TestTraceHelper.CaptureTrace(popup.Update);
+
+        Assert.That(output, Does.Not.Contain("could not read HideNextFrame"));
+    }
+
+    [Test]
+    public void PopupUpdateTimingPatch_WarnsOnce_WhenHideNextFrameCannotBeRead()
+    {
+        RuntimeDiagnostics.SetVerboseProbesEnabledForTests(true);
+        using var patches = PatchPopupUpdateOnly(typeof(DummyPopupMessageWithoutHideNextFrameTarget));
+        var popup = new DummyPopupMessageWithoutHideNextFrameTarget();
+
+        var output = TestTraceHelper.CaptureTrace(() =>
+        {
+            popup.Update();
+            popup.Update();
+        });
+
+        Assert.That(CountOccurrences(output, "could not read HideNextFrame"), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void CursorSoundHarmonyPatches_RestoreOuterPopupContextAfterNestedPopupHide()
+    {
+        using var patches = PatchCursorSound();
+        var observedPopupIds = new List<string?>();
+        InventoryActionMenuCursorSoundPatch.SetPlayCursorSoundRequestObserverForTests(
+            (_, popupId) => observedPopupIds.Add(popupId));
+        var controller = new DummyMenuControllerTarget();
+        var popup = new DummyPopupMessageTarget
+        {
+            controller = controller,
+            PopupID = "InventoryActionMenu:outer",
+        };
+
+        popup.ShowPopup();
+        popup.PopupID = "Popup:inner";
+        popup.ShowPopup();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(popup.ShowCount, Is.EqualTo(2));
+            Assert.That(
+                InventoryActionMenuCursorSoundPatch.TryGetRememberedPopupId(controller, out var innerPopupId),
+                Is.True);
+            Assert.That(innerPopupId, Is.EqualTo("Popup:inner"));
+        });
+
+        controller.PlayClick();
+
+        Assert.That(observedPopupIds, Is.EqualTo(new[] { "Popup:inner" }));
+
+        popup.Hide();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                InventoryActionMenuCursorSoundPatch.TryGetRememberedPopupId(controller, out var restoredPopupId),
+                Is.True);
+            Assert.That(restoredPopupId, Is.EqualTo("InventoryActionMenu:outer"));
+        });
+
+        popup.Hide();
+
+        Assert.That(
+            InventoryActionMenuCursorSoundPatch.TryGetRememberedPopupId(controller, out _),
+            Is.False);
+    }
+
+    private static IDisposable PatchCloseTiming()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyInventoryActionMenuTarget), nameof(DummyInventoryActionMenuTarget.Show)),
+            prefix: new HarmonyMethod(RequireMethod(
+                typeof(InventoryActionMenuShowTimingPatch),
+                nameof(InventoryActionMenuShowTimingPatch.Prefix),
+                typeof(object),
+                typeof(InventoryActionMenuCloseTimingObservability.TimingScope).MakeByRefType())),
+            postfix: new HarmonyMethod(RequireMethod(
+                typeof(InventoryActionMenuShowTimingPatch),
+                nameof(InventoryActionMenuShowTimingPatch.Postfix),
+                typeof(object),
+                typeof(InventoryActionMenuCloseTimingObservability.TimingScope))));
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupMessageTarget), nameof(DummyPopupMessageTarget.Hide)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(InventoryActionMenuPopupHideTimingPatch), nameof(InventoryActionMenuPopupHideTimingPatch.Prefix), typeof(object))));
+        PatchPopupUpdate(harmony, typeof(DummyPopupMessageTarget));
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyInventoryStatusScreenTarget), nameof(DummyInventoryStatusScreenTarget.UpdateViewFromData)),
+            prefix: new HarmonyMethod(RequireMethod(
+                typeof(InventoryActionMenuUpdateViewTimingPatch),
+                nameof(InventoryActionMenuUpdateViewTimingPatch.Prefix),
+                typeof(InventoryActionMenuCloseTimingObservability.TimingScope).MakeByRefType())),
+            postfix: new HarmonyMethod(RequireMethod(
+                typeof(InventoryActionMenuUpdateViewTimingPatch),
+                nameof(InventoryActionMenuUpdateViewTimingPatch.Postfix),
+                typeof(InventoryActionMenuCloseTimingObservability.TimingScope))));
+        return new HarmonyScope(harmony, harmonyId);
+    }
+
+    private static IDisposable PatchPopupUpdateOnly(Type popupType)
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        PatchPopupUpdate(harmony, popupType);
+        return new HarmonyScope(harmony, harmonyId);
+    }
+
+    private static void PatchPopupUpdate(Harmony harmony, Type popupType)
+    {
+        harmony.Patch(
+            original: RequireMethod(popupType, "Update"),
+            prefix: new HarmonyMethod(RequireMethod(typeof(InventoryActionMenuPopupUpdateTimingPatch), nameof(InventoryActionMenuPopupUpdateTimingPatch.Prefix), typeof(object), typeof(int).MakeByRefType())),
+            postfix: new HarmonyMethod(RequireMethod(typeof(InventoryActionMenuPopupUpdateTimingPatch), nameof(InventoryActionMenuPopupUpdateTimingPatch.Postfix), typeof(object), typeof(int))));
+    }
+
+    private static IDisposable PatchCursorSound()
+    {
+        var harmonyId = CreateHarmonyId();
+        var harmony = new Harmony(harmonyId);
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupMessageTarget), nameof(DummyPopupMessageTarget.ShowPopup)),
+            postfix: new HarmonyMethod(RequireMethod(typeof(InventoryActionMenuCursorSoundPopupContextPatch), nameof(InventoryActionMenuCursorSoundPopupContextPatch.Postfix), typeof(object))));
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyPopupMessageTarget), nameof(DummyPopupMessageTarget.Hide)),
+            prefix: new HarmonyMethod(RequireMethod(typeof(InventoryActionMenuCursorSoundPopupHideContextPatch), nameof(InventoryActionMenuCursorSoundPopupHideContextPatch.Prefix), typeof(object))));
+        harmony.Patch(
+            original: RequireMethod(typeof(DummyMenuControllerTarget), nameof(DummyMenuControllerTarget.PlayClick)),
+            postfix: new HarmonyMethod(RequireMethod(typeof(InventoryActionMenuCursorSoundPlayClickPatch), nameof(InventoryActionMenuCursorSoundPlayClickPatch.Postfix), typeof(object))));
+        return new HarmonyScope(harmony, harmonyId);
+    }
+
+    private static MethodInfo RequireMethod(Type type, string methodName, params Type[] parameterTypes)
+    {
+        return parameterTypes.Length == 0
+            ? AccessTools.Method(type, methodName) ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}")
+            : AccessTools.Method(type, methodName, parameterTypes) ?? throw new InvalidOperationException($"Method not found: {type.FullName}.{methodName}");
+    }
+
+    private static string CreateHarmonyId()
+    {
+        return $"qudjp.tests.{Guid.NewGuid():N}";
+    }
+
+    private static int CountOccurrences(string source, string value)
+    {
+        var count = 0;
+        var startIndex = 0;
+        while (true)
+        {
+            var matchIndex = source.IndexOf(value, startIndex, StringComparison.Ordinal);
+            if (matchIndex < 0)
+            {
+                return count;
+            }
+
+            count++;
+            startIndex = matchIndex + value.Length;
+        }
+    }
+
+    private sealed class DummyInventoryActionMenuTarget
+    {
+        public DummyPopupMessageTarget? PopupToHide { get; set; }
+
+        public DummyInventoryActionMenuTarget? NestedMenu { get; set; }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public object? Show(object actionTable, bool cancel)
+        {
+            _ = NestedMenu?.Show(new ArrayList { "nested" }, cancel: false);
+            if (cancel)
+            {
+                PopupToHide?.Hide();
+            }
+
+            return cancel ? null : new object();
+        }
+    }
+
+    private sealed class DummyPopupMessageTarget
+    {
+        public object? controller;
+        public string? PopupID;
+        public int HideNextFrame;
+        public int ShowCount;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void ShowPopup()
+        {
+            ShowCount++;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Hide()
+        {
+            HideNextFrame = 2;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Update()
+        {
+            if (HideNextFrame > 0)
+            {
+                HideNextFrame--;
+            }
+        }
+    }
+
+    private sealed class DummyPopupMessageWithoutHideNextFrameTarget
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Update()
+        {
+        }
+    }
+
+    private sealed class DummyInventoryStatusScreenTarget
+    {
+        public int RefreshCount { get; private set; }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void UpdateViewFromData()
+        {
+            RefreshCount++;
+        }
+    }
+
+    private sealed class DummyMenuControllerTarget
+    {
+        public int ClickCount { get; private set; }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void PlayClick()
+        {
+            ClickCount++;
+        }
+    }
+
+    private sealed class HarmonyScope : IDisposable
+    {
+        private readonly Harmony harmony;
+        private readonly string harmonyId;
+
+        internal HarmonyScope(Harmony harmony, string harmonyId)
+        {
+            this.harmony = harmony;
+            this.harmonyId = harmonyId;
+        }
+
+        public void Dispose()
+        {
+            harmony.UnpatchAll(harmonyId);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
+++ b/Mods/QudJP/Assemblies/QudJP.Tests/L2G/TargetMethodResolutionTests.cs
@@ -517,7 +517,46 @@ public sealed class TargetMethodResolutionTests
     [TestCase(typeof(StairsUpTranslationPatch), "HandleEvent", "XRL.World.Parts.StairsUp", "System.Boolean", new[] { "XRL.World.InventoryActionEvent" })]
     [TestCase(typeof(GameSummaryScreenMenuBarsTranslationPatch), "UpdateMenuBars", "Qud.UI.GameSummaryScreen", "System.Void", new string[0])]
     [TestCase(typeof(GameSummaryScreenShowTranslationPatch), "_ShowGameSummary", "Qud.UI.GameSummaryScreen", "System.Threading.Tasks.Task`1[[System.Boolean]]", new[] { "System.String", "System.String", "System.String", "System.Boolean" })]
-    [TestCase(typeof(InventoryActionMenuCursorSoundPatch), "Update", "Qud.UI.PopupMessage", "System.Void", new string[0])]
+    [TestCase(typeof(InventoryActionMenuShowTimingPatch), "ShowInventoryActionMenu", "Qud.API.EquipmentAPI", "XRL.World.InventoryAction", new[]
+    {
+        "System.Collections.Generic.Dictionary`2[[System.String],[XRL.World.InventoryAction]]",
+        "XRL.World.GameObject",
+        "XRL.World.GameObject",
+        "System.Boolean",
+        "System.Boolean",
+        "System.String",
+        "System.Collections.Generic.IComparer`1[[XRL.World.InventoryAction]]",
+        "System.Boolean",
+    })]
+    [TestCase(typeof(InventoryActionMenuPopupHideTimingPatch), "Hide", "Qud.UI.PopupMessage", "System.Void", new string[0])]
+    [TestCase(typeof(InventoryActionMenuPopupUpdateTimingPatch), "Update", "Qud.UI.PopupMessage", "System.Void", new string[0])]
+    [TestCase(typeof(InventoryActionMenuUpdateViewTimingPatch), "UpdateViewFromData", "Qud.UI.InventoryAndEquipmentStatusScreen", "System.Void", new string[0])]
+    [TestCase(typeof(InventoryActionMenuCursorSoundPlayClickPatch), "PlayClick", "Qud.UI.QudBaseMenuController`2[[Qud.UI.QudMenuItem],[Qud.UI.SelectableTextMenuItem]]", "System.Void", new string[0])]
+    [TestCase(typeof(InventoryActionMenuCursorSoundPopupContextPatch), "ShowPopup", "Qud.UI.PopupMessage", "System.Void", new[]
+    {
+        "System.String",
+        "System.Collections.Generic.List`1[[Qud.UI.QudMenuItem]]",
+        "System.Action`1[[Qud.UI.QudMenuItem]]",
+        "System.Collections.Generic.List`1[[Qud.UI.QudMenuItem]]",
+        "System.Action`1[[Qud.UI.QudMenuItem]]",
+        "System.String",
+        "System.Boolean",
+        "System.String",
+        "System.Int32",
+        "System.Action",
+        "ConsoleLib.Console.IRenderable",
+        "System.String",
+        "ConsoleLib.Console.IRenderable",
+        "System.Boolean",
+        "System.Boolean",
+        "System.Threading.CancellationToken",
+        "System.Boolean",
+        "System.String",
+        "System.String",
+        "Genkit.Location2D",
+        "System.String",
+    })]
+    [TestCase(typeof(InventoryActionMenuCursorSoundPopupHideContextPatch), "Hide", "Qud.UI.PopupMessage", "System.Void", new string[0])]
     [TestCase(typeof(MainMenuRowTranslationPatch), "setData", "MainMenuRow", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]
     [TestCase(typeof(LeftSideCategoryTranslationPatch), "setData", "Qud.UI.LeftSideCategory", "System.Void", new[] { "XRL.UI.Framework.FrameworkDataElement" })]
     [TestCase(typeof(PickTargetWindowUpdateTranslationPatch), "Update", "Qud.UI.PickTargetWindow", "System.Void", new string[0])]
@@ -557,7 +596,7 @@ public sealed class TargetMethodResolutionTests
         {
             Assert.That(targetMethod, Is.Not.Null, $"TargetMethod returned null for {patchType.FullName}");
             Assert.That(targetMethod!.Name, Is.EqualTo(expectedMethodName));
-            Assert.That(targetMethod.DeclaringType?.FullName, Is.EqualTo(expectedDeclaringType));
+            Assert.That(NormalizeTypeName(targetMethod.DeclaringType?.FullName), Is.EqualTo(expectedDeclaringType));
 
             var methodInfo = targetMethod as MethodInfo;
             Assert.That(methodInfo, Is.Not.Null, $"Expected MethodInfo for {patchType.FullName}");
@@ -569,6 +608,37 @@ public sealed class TargetMethodResolutionTests
     }
 
 #if HAS_GAME_DLL
+    [Test]
+    public void InventoryActionMenuCursorSoundPatch_ResolvesPlayableUiSoundMethod()
+    {
+        var accessor = typeof(InventoryActionMenuCursorSoundPatch).GetMethod(
+            "GetPlayUiSoundMethod",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.That(accessor, Is.Not.Null, "GetPlayUiSoundMethod helper is missing.");
+
+        var resolved = accessor!.Invoke(null, null) as MethodInfo;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resolved, Is.Not.Null, "SoundManager.PlayUISound was not resolved.");
+            Assert.That(resolved!.Name, Is.EqualTo("PlayUISound"));
+            Assert.That(resolved.DeclaringType?.FullName, Is.EqualTo("SoundManager"));
+
+            var parameterTypes = Array.ConvertAll(
+                resolved.GetParameters(),
+                static parameter => NormalizeTypeName(parameter.ParameterType.FullName));
+            Assert.That(parameterTypes, Is.EqualTo(new[]
+            {
+                "System.String",
+                "System.Single",
+                "System.Boolean",
+                "System.Boolean",
+                "SoundRequest+SoundEffectType",
+            }));
+        });
+    }
+
     [TestCase(typeof(VillageDynamicQuestRewardGameObjectTranslationPatch), "XRL.World.DynamicQuestRewardElement_GameObject", new[] { "XRL.World.GameObject" })]
     public void TargetConstructor_ResolvesExpectedSignature(
         Type patchType,

--- a/Mods/QudJP/Assemblies/src/Observability/InventoryActionMenuCloseTimingObservability.cs
+++ b/Mods/QudJP/Assemblies/src/Observability/InventoryActionMenuCloseTimingObservability.cs
@@ -1,0 +1,415 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+
+namespace QudJP;
+
+internal static class InventoryActionMenuCloseTimingObservability
+{
+    private const string ProbeMarker = "InventoryActionMenuCloseTiming/v1";
+    private const int MaxActiveMenuDepth = 16;
+    private const double RecentCancelWindowMilliseconds = 2000d;
+
+    private static readonly object SyncRoot = new();
+    private static readonly Stack<ActiveMenuContext> activeMenuStack = new();
+
+    private static int nextSequence;
+    private static int activeSequence;
+    private static long activeStartTimestamp;
+    private static int lastCancelSequence;
+    private static long lastCancelTimestamp;
+    private static bool suppressInventoryRefreshUntilPopupHidden;
+
+    internal static TimingScope BeginMenu(int actionCount)
+    {
+        var timestamp = Stopwatch.GetTimestamp();
+        int sequence;
+        var excessiveNestingDetected = false;
+        lock (SyncRoot)
+        {
+            sequence = ++nextSequence;
+            if (activeMenuStack.Count >= MaxActiveMenuDepth)
+            {
+                excessiveNestingDetected = true;
+                activeMenuStack.Clear();
+                activeSequence = 0;
+                activeStartTimestamp = 0;
+            }
+
+            activeMenuStack.Push(new ActiveMenuContext(activeSequence, activeStartTimestamp));
+            activeSequence = sequence;
+            activeStartTimestamp = timestamp;
+        }
+
+        if (excessiveNestingDetected)
+        {
+            Trace.TraceWarning("QudJP: {0} exceeded active menu nesting limit; previous context was dropped.", nameof(InventoryActionMenuCloseTimingObservability));
+        }
+
+        Log(sequence, "menu-open-begin", TimeSpan.Zero, () => "action_count=" + actionCount.ToString(CultureInfo.InvariantCulture));
+        return TimingScope.Start(sequence);
+    }
+
+    internal static void EndMenu(TimingScope scope, bool canceled)
+    {
+        if (!scope.HasValue)
+        {
+            return;
+        }
+
+        scope.Stop();
+        var timestamp = Stopwatch.GetTimestamp();
+        lock (SyncRoot)
+        {
+            if (canceled)
+            {
+                lastCancelSequence = scope.Sequence;
+                lastCancelTimestamp = timestamp;
+                suppressInventoryRefreshUntilPopupHidden = true;
+            }
+            else
+            {
+                lastCancelSequence = 0;
+                lastCancelTimestamp = 0;
+                suppressInventoryRefreshUntilPopupHidden = false;
+            }
+
+            if (activeSequence == scope.Sequence)
+            {
+                RestorePreviousActiveMenuContext();
+            }
+        }
+
+        Log(
+            scope.Sequence,
+            "menu-return",
+            scope.Elapsed,
+            () => "result=" + (canceled ? "cancel" : "action"));
+    }
+
+    internal static void LogPopupHideRequest(string? popupId)
+    {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled || !IsInventoryActionMenuPopupId(popupId))
+        {
+            return;
+        }
+
+        var sequence = GetActiveSequence();
+        if (sequence <= 0)
+        {
+            return;
+        }
+
+        Log(sequence, "popup-hide-request", ElapsedSinceActiveStart(), () => "popup_id=" + popupId);
+    }
+
+    internal static void LogPopupHiddenAfterFrameDelay(
+        string? popupId,
+        int previousHideNextFrame,
+        int currentHideNextFrame)
+    {
+        if (!IsInventoryActionMenuPopupId(popupId))
+        {
+            return;
+        }
+
+        if (!TryGetRecentSequenceElapsed(out var sequence, out var elapsed))
+        {
+            return;
+        }
+
+        if (RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            Log(
+                sequence,
+                "popup-hidden-after-frame-delay",
+                elapsed,
+                () => "popup_id=" + popupId
+                    + ";previous_hide_next_frame=" + previousHideNextFrame.ToString(CultureInfo.InvariantCulture)
+                    + ";current_hide_next_frame=" + currentHideNextFrame.ToString(CultureInfo.InvariantCulture));
+        }
+
+        ClearInventoryRefreshSuppression(sequence);
+    }
+
+    internal static bool ShouldSuppressInventoryRefreshAfterCancel()
+    {
+        lock (SyncRoot)
+        {
+            if (!suppressInventoryRefreshUntilPopupHidden || lastCancelSequence <= 0)
+            {
+                return false;
+            }
+
+            return ElapsedBetween(lastCancelTimestamp, Stopwatch.GetTimestamp()).TotalMilliseconds
+                <= RecentCancelWindowMilliseconds;
+        }
+    }
+
+    internal static bool ShouldObservePopupUpdate()
+    {
+        return RuntimeDiagnostics.VerboseProbesEnabled || ShouldSuppressInventoryRefreshAfterCancel();
+    }
+
+    internal static void LogInventoryRefreshSuppressed()
+    {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled || !TryGetRecentCancel(out var sequence, out var elapsed))
+        {
+            return;
+        }
+
+        Log(sequence, "inventory-refresh-suppressed", elapsed, () => null);
+    }
+
+    internal static TimingScope BeginInventoryRefresh()
+    {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled || !TryGetRecentCancel(out var sequence, out var elapsed))
+        {
+            return TimingScope.Empty;
+        }
+
+        Log(sequence, "inventory-refresh-begin", elapsed, () => null);
+        return TimingScope.Start(sequence);
+    }
+
+    internal static void EndInventoryRefresh(TimingScope scope)
+    {
+        if (!scope.HasValue)
+        {
+            return;
+        }
+
+        scope.Stop();
+        Log(scope.Sequence, "inventory-refresh-end", scope.Elapsed, () => null);
+    }
+
+    internal static string BuildLogLineForTests(int sequence, string phase, TimeSpan elapsed, string? detail)
+    {
+        return BuildLogLine(sequence, phase, elapsed, detail);
+    }
+
+    internal static void LogForTests(string phase, Func<string?> detailFactory)
+    {
+        if (!RuntimeDiagnostics.VerboseProbesEnabled)
+        {
+            return;
+        }
+
+        Log(1, phase, TimeSpan.Zero, detailFactory);
+    }
+
+    internal static bool ShouldSuppressInventoryRefreshAfterCancelForTests()
+    {
+        return ShouldSuppressInventoryRefreshAfterCancel();
+    }
+
+    internal static void ResetForTests()
+    {
+        lock (SyncRoot)
+        {
+            nextSequence = 0;
+            activeSequence = 0;
+            activeStartTimestamp = 0;
+            activeMenuStack.Clear();
+            lastCancelSequence = 0;
+            lastCancelTimestamp = 0;
+            suppressInventoryRefreshUntilPopupHidden = false;
+        }
+    }
+
+    private static bool TryGetRecentCancel(out int sequence, out TimeSpan elapsed)
+    {
+        var timestamp = Stopwatch.GetTimestamp();
+        lock (SyncRoot)
+        {
+            sequence = lastCancelSequence;
+            elapsed = ElapsedBetween(lastCancelTimestamp, timestamp);
+        }
+
+        return sequence > 0 && elapsed.TotalMilliseconds <= RecentCancelWindowMilliseconds;
+    }
+
+    private static int GetActiveSequence()
+    {
+        lock (SyncRoot)
+        {
+            return activeSequence;
+        }
+    }
+
+    private static void ClearInventoryRefreshSuppression(int sequence)
+    {
+        lock (SyncRoot)
+        {
+            if (lastCancelSequence == sequence)
+            {
+                suppressInventoryRefreshUntilPopupHidden = false;
+            }
+        }
+    }
+
+    private static TimeSpan ElapsedSinceActiveStart()
+    {
+        var timestamp = Stopwatch.GetTimestamp();
+        lock (SyncRoot)
+        {
+            return ElapsedBetween(activeStartTimestamp, timestamp);
+        }
+    }
+
+    private static bool TryGetRecentSequenceElapsed(out int sequence, out TimeSpan elapsed)
+    {
+        var timestamp = Stopwatch.GetTimestamp();
+        lock (SyncRoot)
+        {
+            if (lastCancelSequence > 0)
+            {
+                var cancelElapsed = ElapsedBetween(lastCancelTimestamp, timestamp);
+                if (cancelElapsed.TotalMilliseconds <= RecentCancelWindowMilliseconds)
+                {
+                    sequence = lastCancelSequence;
+                    elapsed = cancelElapsed;
+                    return true;
+                }
+            }
+
+            sequence = activeSequence;
+            elapsed = ElapsedBetween(activeStartTimestamp, timestamp);
+            return sequence > 0;
+        }
+    }
+
+    private static TimeSpan ElapsedBetween(long startTimestamp, long endTimestamp)
+    {
+        if (startTimestamp <= 0 || endTimestamp < startTimestamp)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var ticks = endTimestamp - startTimestamp;
+        return TimeSpan.FromSeconds((double)ticks / Stopwatch.Frequency);
+    }
+
+    private static void RestorePreviousActiveMenuContext()
+    {
+        if (activeMenuStack.Count <= 0)
+        {
+            activeSequence = 0;
+            activeStartTimestamp = 0;
+            return;
+        }
+
+        var previousContext = activeMenuStack.Pop();
+        activeSequence = previousContext.Sequence;
+        activeStartTimestamp = previousContext.StartTimestamp;
+    }
+
+    private static bool IsInventoryActionMenuPopupId(string? popupId)
+    {
+        return !string.IsNullOrEmpty(popupId)
+            && CultureInfo.InvariantCulture.CompareInfo.IndexOf(
+                popupId!,
+                "InventoryActionMenu",
+                CompareOptions.IgnoreCase) >= 0;
+    }
+
+    private static void Log(int sequence, string phase, TimeSpan elapsed, Func<string?> detailFactory)
+    {
+        RuntimeDiagnostics.LogVerboseProbe(() => BuildLogLine(sequence, phase, elapsed, detailFactory()));
+    }
+
+    private static string BuildLogLine(int sequence, string phase, TimeSpan elapsed, string? detail)
+    {
+        var builder = new StringBuilder();
+        builder.Append("[QudJP] ");
+        builder.Append(ProbeMarker);
+        builder.Append(": seq=");
+        builder.Append(sequence.ToString(CultureInfo.InvariantCulture));
+        builder.Append(";phase=");
+        builder.Append(EscapeFieldValue(phase));
+        builder.Append(";elapsed_ms=");
+        builder.Append(elapsed.TotalMilliseconds.ToString("0.000", CultureInfo.InvariantCulture));
+        if (detail is { Length: > 0 })
+        {
+            builder.Append(";detail=");
+            builder.Append(EscapeFieldValue(detail));
+        }
+
+        return builder.ToString();
+    }
+
+    private static string EscapeFieldValue(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        foreach (var character in value)
+        {
+            switch (character)
+            {
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+                case ';':
+                    builder.Append("\\;");
+                    break;
+                case '=':
+                    builder.Append("\\=");
+                    break;
+                case '\r':
+                    builder.Append("\\r");
+                    break;
+                case '\n':
+                    builder.Append("\\n");
+                    break;
+                default:
+                    builder.Append(character);
+                    break;
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private readonly struct ActiveMenuContext
+    {
+        internal ActiveMenuContext(int sequence, long startTimestamp)
+        {
+            Sequence = sequence;
+            StartTimestamp = startTimestamp;
+        }
+
+        internal int Sequence { get; }
+
+        internal long StartTimestamp { get; }
+    }
+
+    internal readonly struct TimingScope
+    {
+        private readonly Stopwatch? stopwatch;
+
+        private TimingScope(int sequence)
+        {
+            Sequence = sequence;
+            stopwatch = Stopwatch.StartNew();
+        }
+
+        internal static TimingScope Empty => default;
+
+        internal int Sequence { get; }
+
+        internal TimeSpan Elapsed => stopwatch?.Elapsed ?? TimeSpan.Zero;
+
+        internal bool HasValue => Sequence > 0 && stopwatch is not null;
+
+        internal static TimingScope Start(int sequence)
+        {
+            return new TimingScope(sequence);
+        }
+
+        internal void Stop()
+        {
+            stopwatch?.Stop();
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuCursorSoundPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuCursorSoundPatch.cs
@@ -1,116 +1,121 @@
 using System;
-using System.Diagnostics;
+using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using HarmonyLib;
 
 namespace QudJP.Patches;
 
-[HarmonyPatch]
 public static class InventoryActionMenuCursorSoundPatch
 {
-    private const string Context = nameof(InventoryActionMenuCursorSoundPatch);
-    private const string TargetTypeName = "Qud.UI.PopupMessage";
     private const string InventoryActionMenuPopupIdPrefix = "InventoryActionMenu:";
     private const string CursorSound = "Sounds/UI/ui_cursor_scroll";
-    private const int UnknownSelectedOption = int.MinValue;
 
     private static readonly object SyncRoot = new();
-    private static FieldInfo? controllerField;
-    private static FieldInfo? popupIdField;
+    private static readonly ConditionalWeakTable<object, PopupContext> PopupContexts = new();
     private static MethodInfo? playUiSoundMethod;
+    private static Type? soundEffectType;
+    private static Action<object?, string?>? playCursorSoundRequestObserverForTests;
 
-    [HarmonyTargetMethod]
-    private static MethodBase? TargetMethod()
+    internal static void RememberPopupController(object? popupMessage)
     {
-        var targetType = AccessTools.TypeByName(TargetTypeName);
-        if (targetType is null)
+        var controller = GetControllerFromPopupMessage(popupMessage);
+        if (controller is null)
         {
-            Trace.TraceError("QudJP: {0} target type '{1}' not found.", Context, TargetTypeName);
-            return null;
+            return;
         }
 
-        var method = AccessTools.Method(targetType, "Update", Type.EmptyTypes);
-        if (method is null)
+        var popupId = GetPopupIdFromPopupMessage(popupMessage);
+        lock (SyncRoot)
         {
-            Trace.TraceError("QudJP: {0} method 'Update()' not found on '{1}'.", Context, TargetTypeName);
-        }
+            if (!PopupContexts.TryGetValue(controller, out var context))
+            {
+                context = new PopupContext();
+                PopupContexts.Add(controller, context);
+            }
 
-        return method;
-    }
-
-    public static void Prefix(object? __instance, ref int __state)
-    {
-        try
-        {
-            __state = GetSelectedOption(__instance);
-        }
-        catch (Exception ex)
-        {
-            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
-            __state = UnknownSelectedOption;
+            context.PopupIds.Push(popupId);
         }
     }
 
-    public static void Postfix(object? __instance, int __state)
+    internal static void ForgetPopupController(object? popupMessage)
     {
-        try
+        var controller = GetControllerFromPopupMessage(popupMessage);
+        if (controller is null)
         {
-            if (__state == UnknownSelectedOption)
+            return;
+        }
+
+        lock (SyncRoot)
+        {
+            if (!PopupContexts.TryGetValue(controller, out var context))
             {
                 return;
             }
 
-            var currentSelectedOption = GetSelectedOption(__instance);
-            var popupId = GetPopupId(__instance);
-            var isActiveAndEnabled = GetBooleanMember(__instance, "isActiveAndEnabled");
-            if (ShouldPlayCursorSound(popupId, __state, currentSelectedOption, isActiveAndEnabled))
+            if (context.PopupIds.Count > 0)
             {
-                PlayCursorSound();
+                _ = context.PopupIds.Pop();
+            }
+
+            if (context.PopupIds.Count == 0)
+            {
+                PopupContexts.Remove(controller);
             }
         }
-        catch (Exception ex)
-        {
-            Trace.TraceError("QudJP: {0}.Postfix failed: {1}", Context, ex);
-        }
     }
 
-    internal static bool ShouldPlayCursorSoundForTests(
-        string? popupId,
-        int previousSelectedOption,
-        int currentSelectedOption,
-        bool isActiveAndEnabled)
+    internal static bool TryGetRememberedPopupId(object? controller, out string? popupId)
     {
-        return ShouldPlayCursorSound(popupId, previousSelectedOption, currentSelectedOption, isActiveAndEnabled);
-    }
-
-    private static bool ShouldPlayCursorSound(
-        string? popupId,
-        int previousSelectedOption,
-        int currentSelectedOption,
-        bool isActiveAndEnabled)
-    {
-        return isActiveAndEnabled
-            && popupId is not null
-            && popupId.StartsWith(InventoryActionMenuPopupIdPrefix, StringComparison.Ordinal)
-            && currentSelectedOption != UnknownSelectedOption
-            && previousSelectedOption != currentSelectedOption;
-    }
-
-    private static int GetSelectedOption(object? popupMessage)
-    {
-        var controller = GetController(popupMessage);
+        popupId = null;
         if (controller is null)
         {
-            return UnknownSelectedOption;
+            return false;
         }
 
-        var controllerType = controller.GetType();
-        var selectedOptionProperty = AccessTools.Property(controllerType, "selectedOption");
-        var value = selectedOptionProperty?.GetValue(controller);
-        return value is int selectedOption ? selectedOption : UnknownSelectedOption;
+        lock (SyncRoot)
+        {
+            if (!PopupContexts.TryGetValue(controller, out var context))
+            {
+                return false;
+            }
+
+            if (context.PopupIds.Count == 0)
+            {
+                return false;
+            }
+
+            popupId = context.PopupIds.Peek();
+            return true;
+        }
     }
 
-    private static object? GetController(object? popupMessage)
+    internal static void PlayCursorSoundForInventoryActionMenuController(object? controller)
+    {
+        var hasPopupId = TryGetRememberedPopupId(controller, out var popupId);
+        ObservePlayCursorSoundRequestForTests(controller, popupId);
+        if (!hasPopupId
+            || popupId is null
+            || !popupId.StartsWith(InventoryActionMenuPopupIdPrefix, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (PlayCursorSound())
+        {
+            LogCursorSoundPlayed(popupId);
+        }
+    }
+
+    internal static void SetPlayCursorSoundRequestObserverForTests(Action<object?, string?>? observer)
+    {
+        lock (SyncRoot)
+        {
+            playCursorSoundRequestObserverForTests = observer;
+        }
+    }
+
+    private static object? GetControllerFromPopupMessage(object? popupMessage)
     {
         if (popupMessage is null)
         {
@@ -121,7 +126,7 @@ public static class InventoryActionMenuCursorSoundPatch
         return field?.GetValue(popupMessage);
     }
 
-    private static string? GetPopupId(object? popupMessage)
+    private static string? GetPopupIdFromPopupMessage(object? popupMessage)
     {
         if (popupMessage is null)
         {
@@ -134,44 +139,51 @@ public static class InventoryActionMenuCursorSoundPatch
 
     private static FieldInfo? GetControllerField(Type popupMessageType)
     {
-        lock (SyncRoot)
-        {
-            controllerField ??= AccessTools.Field(popupMessageType, "controller");
-            return controllerField;
-        }
+        return AccessTools.Field(popupMessageType, "controller");
     }
 
     private static FieldInfo? GetPopupIdField(Type popupMessageType)
     {
-        lock (SyncRoot)
-        {
-            popupIdField ??= AccessTools.Field(popupMessageType, "PopupID");
-            return popupIdField;
-        }
+        return AccessTools.Field(popupMessageType, "PopupID");
     }
 
-    private static bool GetBooleanMember(object? instance, string memberName)
+    private static void ObservePlayCursorSoundRequestForTests(object? controller, string? popupId)
     {
-        if (instance is null)
+        Action<object?, string?>? observer;
+        lock (SyncRoot)
+        {
+            observer = playCursorSoundRequestObserverForTests;
+        }
+
+        observer?.Invoke(controller, popupId);
+    }
+
+    private static bool PlayCursorSound()
+    {
+        var method = GetPlayUiSoundMethod();
+        var effectType = GetSoundEffectType();
+        if (method is null || effectType is null)
         {
             return false;
         }
 
-        var type = instance.GetType();
-        var property = AccessTools.Property(type, memberName);
-        if (property is not null && property.PropertyType == typeof(bool))
-        {
-            return property.GetValue(instance) is true;
-        }
-
-        var field = AccessTools.Field(type, memberName);
-        return field is not null && field.FieldType == typeof(bool) && field.GetValue(instance) is true;
+        method.Invoke(null, new[] { CursorSound, 1f, false, true, Enum.ToObject(effectType, 0) });
+        return true;
     }
 
-    private static void PlayCursorSound()
+    private static void LogCursorSoundPlayed(string? popupId)
     {
-        var method = GetPlayUiSoundMethod();
-        method?.Invoke(null, new object[] { CursorSound, 1f, false, true });
+        RuntimeDiagnostics.LogVerboseProbe(() =>
+            "[QudJP] InventoryActionMenuCursorSound/v1: popup_id="
+            + EscapeDetailValue(popupId ?? string.Empty)
+            + ";source=play_click");
+    }
+
+    private static string EscapeDetailValue(string value)
+    {
+        return value.Replace("\\", "\\\\")
+            .Replace(";", "\\;")
+            .Replace("=", "\\=");
     }
 
     private static MethodInfo? GetPlayUiSoundMethod()
@@ -184,11 +196,31 @@ public static class InventoryActionMenuCursorSoundPatch
             }
 
             var soundManagerType = AccessTools.TypeByName("SoundManager");
+            var effectType = GetSoundEffectType();
+            if (effectType is null)
+            {
+                return null;
+            }
+
             playUiSoundMethod = AccessTools.Method(
                 soundManagerType,
                 "PlayUISound",
-                new[] { typeof(string), typeof(float), typeof(bool), typeof(bool) });
+                new[] { typeof(string), typeof(float), typeof(bool), typeof(bool), effectType });
             return playUiSoundMethod;
         }
+    }
+
+    private static Type? GetSoundEffectType()
+    {
+        lock (SyncRoot)
+        {
+            soundEffectType ??= AccessTools.TypeByName("SoundRequest+SoundEffectType");
+            return soundEffectType;
+        }
+    }
+
+    private sealed class PopupContext
+    {
+        internal Stack<string?> PopupIds { get; } = new();
     }
 }

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuCursorSoundPlayClickPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuCursorSoundPlayClickPatch.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class InventoryActionMenuCursorSoundPlayClickPatch
+{
+    private const string Context = nameof(InventoryActionMenuCursorSoundPlayClickPatch);
+    private const string GenericControllerTargetTypeName = "Qud.UI.QudBaseMenuController`2";
+    private const string MenuItemDataTypeName = "Qud.UI.QudMenuItem";
+    private const string MenuItemControlTypeName = "Qud.UI.SelectableTextMenuItem";
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var genericControllerType = AccessTools.TypeByName(GenericControllerTargetTypeName);
+        var menuItemDataType = AccessTools.TypeByName(MenuItemDataTypeName);
+        var menuItemControlType = AccessTools.TypeByName(MenuItemControlTypeName);
+        if (genericControllerType is null || menuItemDataType is null || menuItemControlType is null)
+        {
+            Trace.TraceError(
+                "QudJP: {0} target types not found. controller='{1}', data='{2}', control='{3}'.",
+                Context,
+                GenericControllerTargetTypeName,
+                MenuItemDataTypeName,
+                MenuItemControlTypeName);
+            return null;
+        }
+
+        var targetType = genericControllerType.MakeGenericType(menuItemDataType, menuItemControlType);
+        var method = AccessTools.Method(targetType, "PlayClick", Type.EmptyTypes);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0} method 'PlayClick()' not found on '{1}'.", Context, targetType.FullName);
+        }
+
+        return method;
+    }
+
+    public static void Postfix(object? __instance)
+    {
+        try
+        {
+            InventoryActionMenuCursorSoundPatch.PlayCursorSoundForInventoryActionMenuController(__instance);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Postfix failed: {1}", Context, ex);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuCursorSoundPopupContextPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuCursorSoundPopupContextPatch.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class InventoryActionMenuCursorSoundPopupContextPatch
+{
+    private const string Context = nameof(InventoryActionMenuCursorSoundPopupContextPatch);
+    private const string TargetTypeName = "Qud.UI.PopupMessage";
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = AccessTools.TypeByName(TargetTypeName);
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type '{1}' not found.", Context, TargetTypeName);
+            return null;
+        }
+
+        var parameterTypes = ResolveShowPopupParameterTypes();
+        if (parameterTypes is null)
+        {
+            Trace.TraceError("QudJP: {0} failed to resolve ShowPopup argument types.", Context);
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "ShowPopup", parameterTypes);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0} method 'ShowPopup' not found on '{1}'.", Context, TargetTypeName);
+        }
+
+        return method;
+    }
+
+    public static void Postfix(object? __instance)
+    {
+        try
+        {
+            InventoryActionMenuCursorSoundPatch.RememberPopupController(__instance);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Postfix failed: {1}", Context, ex);
+        }
+    }
+
+    private static Type[]? ResolveShowPopupParameterTypes()
+    {
+        var qudMenuItemType = AccessTools.TypeByName("Qud.UI.QudMenuItem");
+        var renderableType = AccessTools.TypeByName("ConsoleLib.Console.IRenderable");
+        var locationType = AccessTools.TypeByName("Genkit.Location2D");
+        if (qudMenuItemType is null || renderableType is null || locationType is null)
+        {
+            return null;
+        }
+
+        var menuItemListType = typeof(List<>).MakeGenericType(qudMenuItemType);
+        var menuItemActionType = typeof(Action<>).MakeGenericType(qudMenuItemType);
+        return
+        [
+            typeof(string),
+            menuItemListType,
+            menuItemActionType,
+            menuItemListType,
+            menuItemActionType,
+            typeof(string),
+            typeof(bool),
+            typeof(string),
+            typeof(int),
+            typeof(Action),
+            renderableType,
+            typeof(string),
+            renderableType,
+            typeof(bool),
+            typeof(bool),
+            typeof(CancellationToken),
+            typeof(bool),
+            typeof(string),
+            typeof(string),
+            locationType,
+            typeof(string),
+        ];
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuCursorSoundPopupHideContextPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuCursorSoundPopupHideContextPatch.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+public static class InventoryActionMenuCursorSoundPopupHideContextPatch
+{
+    private const string Context = nameof(InventoryActionMenuCursorSoundPopupHideContextPatch);
+    private const string TargetTypeName = "Qud.UI.PopupMessage";
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = AccessTools.TypeByName(TargetTypeName);
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type '{1}' not found.", Context, TargetTypeName);
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "Hide", Type.EmptyTypes);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0} method 'Hide()' not found on '{1}'.", Context, TargetTypeName);
+        }
+
+        return method;
+    }
+
+    public static void Prefix(object? __instance)
+    {
+        try
+        {
+            InventoryActionMenuCursorSoundPatch.ForgetPopupController(__instance);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuPopupHideTimingPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuPopupHideTimingPatch.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+using QudJP;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+internal static class InventoryActionMenuPopupHideTimingPatch
+{
+    private const string Context = nameof(InventoryActionMenuPopupHideTimingPatch);
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        return InventoryActionMenuPopupTimingHelpers.ResolvePopupMessageMethod(Context, "Hide");
+    }
+
+    public static void Prefix(object? __instance)
+    {
+        try
+        {
+            InventoryActionMenuCloseTimingObservability.LogPopupHideRequest(
+                InventoryActionMenuPopupTimingHelpers.GetPopupId(__instance));
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuPopupTimingHelpers.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuPopupTimingHelpers.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+
+namespace QudJP.Patches;
+
+internal static class InventoryActionMenuPopupTimingHelpers
+{
+    private const string TargetTypeName = "Qud.UI.PopupMessage";
+
+    internal static MethodBase? ResolvePopupMessageMethod(string context, string methodName)
+    {
+        var targetType = AccessTools.TypeByName(TargetTypeName);
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type '{1}' not found.", context, TargetTypeName);
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, methodName, Type.EmptyTypes);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.{1} target not found.", context, methodName);
+        }
+
+        return method;
+    }
+
+    internal static string? GetPopupId(object? instance)
+    {
+        if (instance is null)
+        {
+            return null;
+        }
+
+        return AccessTools.Field(instance.GetType(), "PopupID")?.GetValue(instance) as string;
+    }
+
+    internal static int? GetHideNextFrame(object? instance)
+    {
+        if (instance is null)
+        {
+            return null;
+        }
+
+        return AccessTools.Field(instance.GetType(), "HideNextFrame")?.GetValue(instance) as int?;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuPopupUpdateTimingPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuPopupUpdateTimingPatch.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
+using HarmonyLib;
+using QudJP;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+internal static class InventoryActionMenuPopupUpdateTimingPatch
+{
+    private const string Context = nameof(InventoryActionMenuPopupUpdateTimingPatch);
+
+    private static int hideNextFrameReadWarningLogged;
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        return InventoryActionMenuPopupTimingHelpers.ResolvePopupMessageMethod(Context, "Update");
+    }
+
+    public static void Prefix(object? __instance, ref int __state)
+    {
+        try
+        {
+            __state = 0;
+            if (!InventoryActionMenuCloseTimingObservability.ShouldObservePopupUpdate())
+            {
+                return;
+            }
+
+            var hideNextFrame = InventoryActionMenuPopupTimingHelpers.GetHideNextFrame(__instance);
+            if (hideNextFrame is null)
+            {
+                WarnHideNextFrameReadOnce("Prefix");
+                return;
+            }
+
+            __state = hideNextFrame.Value;
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+            __state = 0;
+        }
+    }
+
+    public static void Postfix(object? __instance, int __state)
+    {
+        try
+        {
+            if (__state <= 0 && !InventoryActionMenuCloseTimingObservability.ShouldObservePopupUpdate())
+            {
+                return;
+            }
+
+            var currentHideNextFrameValue = InventoryActionMenuPopupTimingHelpers.GetHideNextFrame(__instance);
+            if (currentHideNextFrameValue is null)
+            {
+                WarnHideNextFrameReadOnce("Postfix");
+                return;
+            }
+
+            var currentHideNextFrame = currentHideNextFrameValue.Value;
+            if (__state > 0 && currentHideNextFrame <= 0)
+            {
+                InventoryActionMenuCloseTimingObservability.LogPopupHiddenAfterFrameDelay(
+                    InventoryActionMenuPopupTimingHelpers.GetPopupId(__instance),
+                    __state,
+                    currentHideNextFrame);
+            }
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Postfix failed: {1}", Context, ex);
+        }
+    }
+
+    internal static void ResetForTests()
+    {
+        hideNextFrameReadWarningLogged = 0;
+    }
+
+    private static void WarnHideNextFrameReadOnce(string phase)
+    {
+        if (Interlocked.Exchange(ref hideNextFrameReadWarningLogged, 1) == 0)
+        {
+            Trace.TraceWarning("QudJP: {0}.{1} could not read HideNextFrame.", Context, phase);
+        }
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuShowTimingPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuShowTimingPatch.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+using QudJP;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+internal static class InventoryActionMenuShowTimingPatch
+{
+    private const string Context = nameof(InventoryActionMenuShowTimingPatch);
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var equipmentApiType = AccessTools.TypeByName("Qud.API.EquipmentAPI");
+        var gameObjectType = AccessTools.TypeByName("XRL.World.GameObject");
+        var inventoryActionType = AccessTools.TypeByName("XRL.World.InventoryAction");
+        if (equipmentApiType is null || gameObjectType is null || inventoryActionType is null)
+        {
+            Trace.TraceError("QudJP: {0} target types not found.", Context);
+            return null;
+        }
+
+        var actionTableType = typeof(Dictionary<,>).MakeGenericType(typeof(string), inventoryActionType);
+        var comparerType = typeof(IComparer<>).MakeGenericType(inventoryActionType);
+        var method = AccessTools.Method(
+            equipmentApiType,
+            "ShowInventoryActionMenu",
+            new[]
+            {
+                actionTableType,
+                gameObjectType,
+                gameObjectType,
+                typeof(bool),
+                typeof(bool),
+                typeof(string),
+                comparerType,
+                typeof(bool),
+            });
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.ShowInventoryActionMenu target not found.", Context);
+        }
+
+        return method;
+    }
+
+    public static void Prefix(object? __0, ref InventoryActionMenuCloseTimingObservability.TimingScope __state)
+    {
+        try
+        {
+            __state = InventoryActionMenuCloseTimingObservability.BeginMenu(GetCount(__0));
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+            __state = InventoryActionMenuCloseTimingObservability.TimingScope.Empty;
+        }
+    }
+
+    public static void Postfix(object? __result, InventoryActionMenuCloseTimingObservability.TimingScope __state)
+    {
+        try
+        {
+            InventoryActionMenuCloseTimingObservability.EndMenu(__state, __result is null);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Postfix failed: {1}", Context, ex);
+        }
+    }
+
+    private static int GetCount(object? actionTable)
+    {
+        return actionTable is ICollection collection ? collection.Count : -1;
+    }
+}

--- a/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuUpdateViewTimingPatch.cs
+++ b/Mods/QudJP/Assemblies/src/Patches/InventoryActionMenuUpdateViewTimingPatch.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using HarmonyLib;
+using QudJP;
+
+namespace QudJP.Patches;
+
+[HarmonyPatch]
+internal static class InventoryActionMenuUpdateViewTimingPatch
+{
+    private const string Context = nameof(InventoryActionMenuUpdateViewTimingPatch);
+    private const string TargetTypeName = "Qud.UI.InventoryAndEquipmentStatusScreen";
+
+    [HarmonyTargetMethod]
+    private static MethodBase? TargetMethod()
+    {
+        var targetType = AccessTools.TypeByName(TargetTypeName);
+        if (targetType is null)
+        {
+            Trace.TraceError("QudJP: {0} target type '{1}' not found.", Context, TargetTypeName);
+            return null;
+        }
+
+        var method = AccessTools.Method(targetType, "UpdateViewFromData", Type.EmptyTypes);
+        if (method is null)
+        {
+            Trace.TraceError("QudJP: {0}.UpdateViewFromData target not found.", Context);
+        }
+
+        return method;
+    }
+
+    public static bool Prefix(ref InventoryActionMenuCloseTimingObservability.TimingScope __state)
+    {
+        try
+        {
+            if (InventoryActionMenuCloseTimingObservability.ShouldSuppressInventoryRefreshAfterCancel())
+            {
+                InventoryActionMenuCloseTimingObservability.LogInventoryRefreshSuppressed();
+                __state = InventoryActionMenuCloseTimingObservability.TimingScope.Empty;
+                return false;
+            }
+
+            __state = InventoryActionMenuCloseTimingObservability.BeginInventoryRefresh();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Prefix failed: {1}", Context, ex);
+            __state = InventoryActionMenuCloseTimingObservability.TimingScope.Empty;
+            return true;
+        }
+    }
+
+    public static void Postfix(InventoryActionMenuCloseTimingObservability.TimingScope __state)
+    {
+        try
+        {
+            InventoryActionMenuCloseTimingObservability.EndInventoryRefresh(__state);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("QudJP: {0}.Postfix failed: {1}", Context, ex);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- suppress the inventory/equipment refresh that races immediately after canceling an inventory action menu until the popup hide delay finishes
- restore inventory action menu cursor movement audio by replaying the UI cursor sound from the menu controller `PlayClick` route scoped to `InventoryActionMenu` popups
- add close timing probes and target-resolution/unit coverage for the close timing and cursor sound routes

## Runtime evidence
- `Player.log` confirmed `InventoryActionMenuCloseTiming/v1` cancel suppression and popup-hidden markers
- `Player.log` confirmed repeated `InventoryActionMenuCursorSound/v1` markers with `source=play_click`
- unrelated existing log noise remained: duplicate QudJP mod warning, Endless EXP Scaling type conflict, and sound request pool warnings

## Verification
- focused `dotnet test` for cursor sound and target resolution: 187 passed
- `just build`
- `just test-l1`: 4936 passed
- `just test-l2g`: 572 passed
- Gemini independent review after polishment and ai-slop-cleaner cleanup: `APPROVE`

Closes #811


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * インベントリ操作の開閉・ポップアップ・非表示遅延・更新抑制を時系列で計測・ログ化する観測機能を追加しました。
  * カーソルサウンドの表示コンテキストを記憶／復元する仕組みを導入しました。

* **バグ修正**
  * キャンセル直後の不要なインベントリ更新抑制の解除タイミングを正しく扱うようにしました。

* **改善**
  * ネストされたポップアップで外側コンテキストの復元と非表示処理を強化しました。

* **テスト**
  * 開閉／キャンセル／非表示遅延／カーソル音に関する単体・統合テスト群を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->