### PR TITLE
[codex] Release QudJP v0.5.01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.5.01] - 2026-06-11
+
+### Fixed
+
+- inventory / equipment 画面で、日本語化後の表示名更新によって並び順や選択状態が崩れる場合を修正しました。
+- inventory action menu の更新時に、表示名・行テキスト・cursor sound の状態が安定して保たれるようにしました。
+
+---
+
 ## [0.5.00] - 2026-06-06
 
 ### Added
@@ -425,7 +434,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.5.00...HEAD
+[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.5.01...HEAD
+[0.5.01]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.5.01
 [0.5.00]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.5.00
 [0.4.10]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.4.10
 [0.4.00]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.4.00

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.5.00",
+  "Version": "0.5.01",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}


### PR DESCRIPTION
## Summary
- Prepare QudJP v0.5.01 release from latest HEAD 3e75775e8980.
- Bump Mods/QudJP/manifest.json to 0.5.01.
- Add CHANGELOG.md release notes for inventory/equipment refresh sorting regression fixes.

## Release range
- v0.5.00..3e75775e8980

## Verification
- git diff --check
- just changelog-link-check
- just release-note-check origin/main HEAD
- just build
- just python-check
- just python-test: 1507 passed, 1 skipped
- just localization-check
- just translation-token-check
- just test-l1: 5114 passed
- just test-l2: 5056 passed
- just test-l2g: 588 passed

## Workshop
- Target Workshop item remains appid 333640 / publishedfileid 3718988020.
- Workshop changenote draft prepared at /tmp/qudjp-workshop-changenote.txt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート v0.5.01

* **バグ修正**
  * インベントリ・装備画面での日本語化に関連する並び順および選択状態の問題を修正
  * インベントリアクションメニュー更新時の表示安定性を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->