### PR TITLE
docs: record workshop release v0.5.01

### DIFF
--- a/docs/reports/2026-06-11-workshop-v0.5.01.md
+++ b/docs/reports/2026-06-11-workshop-v0.5.01.md
@@ -1,0 +1,101 @@
+# Workshop Release v0.5.01
+
+## Identity
+
+- Version: `0.5.01`
+- Git commit: `32e6e7fa831e28af115cd8795b6bff5592b339e6`
+- Git tag: `v0.5.01`
+- Previous release tag/range: `v0.5.00..32e6e7fa831e`
+- Version source: `Mods/QudJP/manifest.json`, `CHANGELOG.md`, annotated tag `v0.5.01`
+- GitHub Release URL: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.5.01
+- GitHub Actions release run: https://github.com/ToaruPen/coq-japanese_stable/actions/runs/27309192478
+- Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
+- Steam app ID: `333640`
+- Published file ID: `3718988020`
+
+## Changenote
+
+```text
+v0.5.01 / 32e6e7fa831e
+
+更新内容:
+- inventory / equipment 画面で、日本語化後の表示名更新によって並び順や選択状態が崩れる場合を修正しました。
+- inventory action menu の更新時に、表示名・行テキスト・cursor sound の状態が安定して保たれるようにしました。
+
+既知の問題:
+- 一部の自動生成テキスト、チュートリアル、キャラクター生成画面には未翻訳または不自然な訳が残る場合があります。
+- ゲーム本体のアップデートにより、一部表示やパッチが壊れる可能性があります。
+```
+
+## Artifacts
+
+- Release ZIP: `dist/QudJP-v0.5.01.zip`
+- Release ZIP SHA256: `f747732ac68992caef9390334a13a86c0b582abb90876194781d3f773f3925c9`
+- GitHub Release asset: `QudJP-v0.5.01.zip`
+- GitHub Release asset SHA256: `f747732ac68992caef9390334a13a86c0b582abb90876194781d3f773f3925c9`
+- Workshop content folder: `dist/workshop/QudJP/`
+- Workshop VDF: `dist/workshop/workshop_item.vdf`
+
+## Preflight
+
+- [x] `git status --short --branch`
+- [x] Release range established from previous tag: `v0.5.00..32e6e7fa831e`
+- [x] `Mods/QudJP/manifest.json` version, `v0.5.01` tag, release ZIP name, changenote first line, and report version match
+- [x] `git rev-list -n1 v0.5.01` matches `git rev-parse HEAD`
+- [x] `git merge-base --is-ancestor "$(git rev-list -n1 v0.5.01)" origin/main`
+- [x] Draft GitHub Release created by tag workflow
+- [x] Workshop changenote compared with the previous release to remove already-shipped bullets
+- [x] Workshop changenote rewritten in player-facing terms and checked by `workshop-upload-preflight`
+- [x] Downloaded GitHub Release assets with `gh release download v0.5.01 --pattern 'QudJP-v0.5.01.zip*' --dir dist --clobber`
+- [x] Local pre-release validation before tag: `just build`
+- [x] Local pre-release validation before tag: `just python-check`
+- [x] Local pre-release validation before tag: `just python-test` (`1507 passed, 1 skipped`)
+- [x] Local pre-release validation before tag: `just localization-check`
+- [x] Local pre-release validation before tag: `just translation-token-check`
+- [x] Local pre-release validation before tag: `just test-l1` (`5114 passed`)
+- [x] Local pre-release validation before tag: `just test-l2` (`5056 passed`)
+- [x] Local pre-release validation before tag: `just test-l2g` (`588 passed`)
+- [x] Tag-triggered GitHub Release workflow passed
+- [x] `just release-zip-check dist/QudJP-v0.5.01.zip`
+- [x] `just build-workshop-upload dist/QudJP-v0.5.01.zip /tmp/qudjp-workshop-changenote.txt`
+- [x] VDF checked for target app/item IDs, literal multiline changenote, and no `\n` escape sequence
+- [x] `just workshop-upload-preflight dist/QudJP-v0.5.01.zip 0.5.01`
+
+## Upload
+
+- steamcmd command: `steamcmd +login "$STEAM_USER" +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_stable/dist/workshop/workshop_item.vdf +quit`
+- Upload completed at: around `2026-06-11 07:11 +0900`
+- Steam output summary: cached login for `pen4216` succeeded; content, preview image, and update commit completed with `Committing update...Success.`
+- GitHub Release published at: around `2026-06-11 07:13 +0900`
+- Notes: A first manual upload attempt using relative VDF path `dist/workshop/workshop_item.vdf` failed before publication with `Failed to load build config file`. The `build-workshop-upload` recipe printed an absolute VDF path, and the upload was rerun with that absolute path successfully.
+
+## Post-Publish Smoke
+
+- [x] Workshop page title, description, preview image, visibility, file size, and updated timestamp checked
+- [x] Subscribe/download availability checked from the Workshop page
+- [x] `steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit`
+- [x] `just workshop-download-check 0.5.01 dist/QudJP-v0.5.01.zip`
+- [ ] Mod Manager lists QudJP with expected version and preview
+- [ ] Options screen renders Japanese text and CJK glyphs
+- [ ] One short conversation renders Japanese text and CJK glyphs
+- [ ] Fresh Player.log checked for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`
+- [ ] Non-QudJP platform SDK noise, if present, recorded in notes and not conflated with QudJP blockers
+
+### Post-Publish Smoke Exceptions
+
+- Mod Manager check: not run in this session; future evidence should include a screenshot artifact showing QudJP `0.5.01` and the preview image.
+- Options/conversation rendering: not run in this session; future evidence should use screenshot diff or OCR plus a log indicator for the opened screen or conversation route.
+- Player.log audit: not run after an in-game launch in this session; future evidence should parse for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`.
+- Non-QudJP SDK noise: not assessed in this session; future evidence should record platform SDK messages separately from QudJP errors before marking smoke complete.
+
+## Decision
+
+- Result: GO
+- Notes:
+  - Upload: Steam upload to item `3718988020` succeeded.
+  - Download verification: the first forced fresh download failed with `Download item 3718988020 failed (Failure)`; a retry succeeded and downloaded `21934236 bytes`.
+  - Manifest check: the downloaded `manifest.json` reports version `0.5.01`.
+  - DLL verification: `just workshop-download-check` matched `dist/QudJP-v0.5.01.zip` and reported DLL SHA256 `53ac68748a7228afcc98a31bf49f62eced4625d8cbbb436cfdb7e618034c54ae`.
+  - Steam page metadata: observed title `Caves of Qud Japanese Mod`, file size `21.934 MB`, updated timestamp `6月10日 15時12分`, and `22` change-note entries.
+  - Changenote propagation: the public changelog page showed Steam locale/cache inconsistency during verification, so the changenote body remains pending Steam-side propagation in the web UI.
+- Rollback tag, if needed: `v0.5.00`

--- a/scripts/tests/test_build_workshop_upload.py
+++ b/scripts/tests/test_build_workshop_upload.py
@@ -408,7 +408,7 @@ def test_find_latest_release_zip_uses_name_tiebreaker_for_equal_mtime(tmp_path: 
     assert find_latest_release_zip(tmp_path) == second
 
 
-def test_main_writes_vdf_and_staging(tmp_path: Path) -> None:
+def test_main_writes_vdf_and_staging(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """CLI creates staging and workshop_item.vdf for steamcmd."""
     release_zip = tmp_path / "dist" / "QudJP-v0.2.0.zip"
     _write_release_zip(release_zip)
@@ -451,6 +451,10 @@ def test_main_writes_vdf_and_staging(tmp_path: Path) -> None:
     vdf = vdf_output.read_text(encoding="utf-8")
     assert '"publishedfileid" "3718988020"' in vdf
     assert '"changenote" "v0.2.0: initial steamcmd setup"' in vdf
+    assert (
+        f"Upload command: steamcmd +login <user> +workshop_build_item {vdf_output.resolve()} +quit"
+        in capsys.readouterr().out
+    )
 
 
 def test_main_reads_changenote_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Record Steam Workshop release evidence for QudJP v0.5.01.
- Include upload result, GitHub Release publication, fresh Workshop download check, and known remaining manual smoke items.

## Verification
- just markdown-report-check
- git diff --check

## Notes
- Steam Workshop upload already succeeded for item 3718988020.
- GitHub Release v0.5.01 has been published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * v0.5.01ワークショップリリース報告書を追加しました。バージョン情報、リリース/アップロード手順、成果物検証ログ、実行結果、既知の問題、決定事項（GO/ロールバック推奨）などを記録しています。

* **テスト**
  * CLI実行時の出力とワークショップ用生成物（ステージング情報、VDF、changenote等）を検証するテストを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->