### PR TITLE
fix(release): align test analyzer settings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,10 @@ jobs:
         run: dotnet build Mods/QudJP/Assemblies/QudJP.csproj --configuration Release
 
       - name: Build QudJP.Tests
-        run: dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release
+        run: |
+          dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release \
+          -p:RunAnalyzers=false \
+          -p:RunAnalyzersDuringBuild=false
 
       - name: Test QudJP
         run: dotnet test Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj --configuration Release --no-build

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -11,6 +11,12 @@ def _workflow_text() -> str:
     return (_REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 
 
+def _step_block(workflow: str, step_name: str, next_step_name: str) -> str:
+    start = workflow.index(f"      - name: {step_name}\n")
+    end = workflow.index(f"      - name: {next_step_name}\n", start)
+    return workflow[start:end]
+
+
 def test_release_workflow_runs_only_for_release_tags() -> None:
     """Release publishing is triggered by vX.Y.Z tags, not branch pushes or PRs."""
     workflow = _workflow_text()
@@ -47,6 +53,19 @@ def test_release_workflow_installs_python_test_tooling() -> None:
     assert workflow.index("npm ci") < workflow.index(node_bin_path_step)
     assert workflow.index(node_bin_path_step) < workflow.index("pytest scripts/tests/")
     assert workflow.index("npm ci") < workflow.index("pytest scripts/tests/")
+
+
+def test_release_workflow_disables_external_analyzers_only_for_test_artifact_build() -> None:
+    """Release test artifacts match CI without weakening the production build."""
+    workflow = _workflow_text()
+    production_build = _step_block(workflow, "Build QudJP", "Build QudJP.Tests")
+    test_artifact_build = _step_block(workflow, "Build QudJP.Tests", "Test QudJP")
+
+    assert "-p:RunAnalyzers" not in production_build
+    assert "-p:RunAnalyzersDuringBuild" not in production_build
+    assert "dotnet build Mods/QudJP/Assemblies/QudJP.Tests/QudJP.Tests.csproj" in test_artifact_build
+    assert "-p:RunAnalyzers=false" in test_artifact_build
+    assert "-p:RunAnalyzersDuringBuild=false" in test_artifact_build
 
 
 def test_release_workflow_creates_draft_github_release_without_steam_upload() -> None:


### PR DESCRIPTION
## Summary

- align the Release workflow test-artifact build with the analyzer settings already used by PR CI and `just` recipes
- keep analyzers enabled for the production QudJP build
- add a static workflow contract that prevents the two build steps from drifting again

## Root cause

Tag run 29443133509 failed before artifact creation because the Release workflow ran external analyzers against the no-game test stubs. That deterministically raised Sonar S2094, and the hosted SDK also reported analyzer AD0001. The production QudJP build had already passed with analyzers enabled.

## Verification

- reproduced the pre-fix no-game build failure on S2094
- no-game test build with the two established flags: 0 warnings, 0 errors
- QudJP.Tests no-game suite: 10,187 passed
- `uv run pytest scripts/tests/test_release_workflow_contract.py -q`: 6 passed
- `just python-test`: 1,545 passed, 1 skipped
- `just python-check`
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- independent subagent review: APPROVE, 0 findings

## Release recovery

This fixes future tag runs. It intentionally does not move or recreate the existing v0.5.02 tag; that release will be recovered separately from the clean tagged tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * テスト成果物のビルド時に不要なアナライザー処理を無効化し、リリース処理の安定性と効率を向上しました。
  * 本番ビルドではアナライザー設定を変更せず、従来どおり実行されます。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->