### PR TITLE
fix(steam): preserve localized Workshop descriptions

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -8,7 +8,9 @@ upload.
 
 When asked to update the Steam Workshop item, do this first:
 
-1. Read this file, `steam/workshop_metadata.json`, and
+1. Read this file, `steam/workshop_metadata.json`,
+   `steam/workshop_description.en.txt`,
+   `steam/workshop_description.ja.txt`, and
    `steam/changenote_template.txt`.
 2. Confirm the target Workshop item is `3718988020`.
 3. Establish what "current changes" means before choosing the release version.
@@ -91,7 +93,8 @@ Public Workshop metadata:
 | Steam app ID | `333640` |
 | Workshop item ID | `3718988020` |
 | Metadata source | `steam/workshop_metadata.json` |
-| Description source | `steam/workshop_description.ja.txt` |
+| Default English description | `steam/workshop_description.en.txt` |
+| Localized Japanese description | `steam/workshop_description.ja.txt` |
 | Changenote template | `steam/changenote_template.txt` |
 | GitHub Release ZIP | `QudJP-vX.Y.Z.zip` |
 | GitHub Release checksum | `QudJP-vX.Y.Z.zip.sha256` |
@@ -311,6 +314,15 @@ sequence `\n`; Steam will show that text verbatim in Change Notes. After
 publishing, verify the rendered Workshop page and changelog in the target
 locale, for example `?l=japanese`, because Steam stores localized Change Notes
 separately.
+
+The generated VDF updates Steam's default English description from
+`steam/workshop_description.en.txt`. Steam stores the localized Japanese
+description separately, so update it from
+`steam/workshop_description.ja.txt` in the Workshop item editor whenever the
+description changes. Verify both `?l=english` and `?l=japanese` after
+publishing. Do not point `steam/workshop_metadata.json` at the Japanese file;
+doing so overwrites the default English description during the next steamcmd
+upload.
 
 Steam's KeyValues parser can reject escaped double quotes inside long
 description or changenote fields. Keep Workshop text free of literal `"`

--- a/docs/reports/2026-07-16-workshop-v0.5.02.md
+++ b/docs/reports/2026-07-16-workshop-v0.5.02.md
@@ -1,0 +1,114 @@
+# Workshop Release v0.5.02
+
+## Identity
+
+- Version: `0.5.02`
+- Git commit: `a1b4724ca912db03acf6ac815d69d671c4772b32`
+- Git tag: `v0.5.02`
+- Previous release tag/range: `v0.5.01..v0.5.02`
+- Version source: `Mods/QudJP/manifest.json`, `CHANGELOG.md`, annotated tag `v0.5.02`
+- GitHub Release URL: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.5.02
+- Tag-triggered Release run: https://github.com/ToaruPen/coq-japanese_stable/actions/runs/29443133509
+- Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
+- Harmony discussion: https://steamcommunity.com/workshop/filedetails/discussion/3718988020/572669660098532087/
+- Steam app ID: `333640`
+- Published file ID: `3718988020`
+
+## Changenote
+
+```text
+v0.5.02 / a1b4724ca912
+
+翻訳追加・改善:
+- セーブデータの情報と、古いセーブデータを開く際に後から表示される確認画面が、Caves of Qud 1.0.5 でも日本語で表示されるよう修正しました。
+- 選択後に処理が続く確認画面や取引画面で、日本語表示と操作が正しく機能するよう修正しました。
+- 派閥名と、自動生成される会話・履歴・メッセージなどに英語が残る箇所を修正しました。
+
+更新内容:
+- Caves of Qud 1.0.5 に対応しました。
+- Windows 向けに、ゲーム起動時の Mod 適用待ち時間を短縮し、元に戻せる任意導入パッケージを GitHub Release へ追加しました。通常の QudJP 導入ではゲーム本体の DLL を自動変更しません。
+
+既知の問題:
+- 一部の自動生成テキスト、チュートリアル、キャラクター生成画面には未翻訳または不自然な訳が残る場合があります。
+- ゲーム本体のアップデートにより、一部表示やパッチが壊れる可能性があります。
+```
+
+## Artifacts
+
+- Release ZIP: `dist/release-assets/v0.5.02/QudJP-v0.5.02.zip`
+- Release ZIP SHA256: `2aa47e79c4a1cc4e419f8149d7b304bb68c495267dfa10d3601b79e1adf7a0d4`
+- GitHub Release asset: `QudJP-v0.5.02.zip`
+- GitHub Release asset SHA256: `2aa47e79c4a1cc4e419f8149d7b304bb68c495267dfa10d3601b79e1adf7a0d4`
+- Optional Harmony asset: `QudJP-Harmony-2.4.2-Windows.zip`
+- Optional Harmony asset SHA256: `a0e9397887b31e8cd0eb7edc99ebf87f9b86466004f2a81a7681dd759aebca6e`
+- Workshop content folder: `dist/workshop/QudJP/`
+- Workshop VDF: `dist/workshop/workshop_item.vdf`
+
+## Preflight
+
+- [x] Release range established from previous tag: `v0.5.01..v0.5.02`
+- [x] `Mods/QudJP/manifest.json` version, `v0.5.02` tag, release ZIP name, changenote first line, and report version match
+- [x] `git rev-list -n1 v0.5.02` is `a1b4724ca912db03acf6ac815d69d671c4772b32`
+- [x] `git merge-base --is-ancestor "$(git rev-list -n1 v0.5.02)" origin/main`
+- [ ] Draft GitHub Release created by the tag workflow
+- [x] Immutable tag tree checked out in detached worktree for manual recovery
+- [x] Production no-game build completed with analyzers enabled and no warnings or errors
+- [x] No-game QudJP test artifact built with release analyzer flags and no warnings or errors
+- [x] QudJP test suite passed: `10187 passed`
+- [x] Python suite passed: `1544 passed, 1 skipped`
+- [x] Localization, encoding, glossary, XML, and translation-token checks passed
+- [x] Manual release artifacts received independent review with no findings
+- [x] Draft GitHub Release created manually from the verified immutable tag tree
+- [x] GitHub Release assets downloaded again and checked against sidecars, tag identity, manifest version, and release DLL markers
+- [x] Workshop changenote compared with the previous release and rewritten in player-facing terms
+- [x] Workshop staging generated from the downloaded GitHub Release ZIP
+- [x] Workshop upload preflight passed
+
+### Release Workflow Exception
+
+The tag-triggered Release run failed before artifact publication while building `QudJP.Tests`. Release analyzers exposed deterministic `S2094` findings and a hosted-SDK analyzer `AD0001`. PR #828 disabled analyzers only for the test-artifact build in the release workflow and added a contract test. The release tag was not moved. The published assets were built and verified manually from the detached immutable `v0.5.02` tree; the production build still ran with analyzers enabled.
+
+## Upload
+
+- steamcmd command: `/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_stable/.worktrees/release-v0.5.02-recovery/dist/workshop/workshop_item.vdf +quit`
+- Upload completed at: `2026-07-16 04:40:59 +0900`
+- Steam output summary: cached login succeeded; content, preview image, and update commit completed with `Committing update...Success.`
+- Steam content manifest ID: `4986513281384934182`
+- GitHub Release published at: `2026-07-16 04:51:00 +0900`
+- Japanese and English descriptions saved at: around `2026-07-16 04:58 +0900`
+- Harmony discussion posted at: around `2026-07-16 04:58 +0900`
+
+## Post-Publish Smoke
+
+- [x] Public Workshop API returned title `Caves of Qud Japanese Mod`, visibility `0`, file size `21939276`, and updated timestamp `2026-07-16 04:40:59 +0900`
+- [x] Public API `hcontent_file` and local `appworkshop_333640.acf` both reported manifest `4986513281384934182`
+- [x] Public changelog showed `v0.5.02 / a1b4724ca912` and the complete multiline changenote
+- [x] English description showed `Compatible with Caves of Qud 1.0.5`, `Supported Version`, and `Notes for Apple Silicon Macs`
+- [x] Japanese description showed `Caves of Qud 1.0.5 対応`, `対応バージョン`, and `macOS Apple Silicon での注意`
+- [x] Public Harmony discussion showed the expected title, GitHub Release link, supported game version, and SHA256
+- [x] Forced fresh Workshop download completed with `workshop_download_item 333640 3718988020 validate`
+- [x] `just workshop-download-check 0.5.02 dist/release-assets/v0.5.02/QudJP-v0.5.02.zip`
+- [x] Downloaded manifest reported version `0.5.02`
+- [x] Downloaded QudJP DLL SHA256 was `90d90cc94ecd4cf41f0a886c22b5c47010cde248ebaf4d08c0e4ed78e9d9a27b`
+- [x] `diff -qr` found no difference between staged and freshly downloaded Workshop content
+- [x] Downloaded Rosetta and Harmony helper `.command` files retained executable permissions
+- [ ] Mod Manager lists QudJP with expected version and preview
+- [ ] Options screen renders Japanese text and CJK glyphs
+- [ ] One short conversation renders Japanese text and CJK glyphs
+- [ ] Fresh Player.log checked for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`
+
+### Post-Publish Smoke Exceptions
+
+- Actual game launch checks were explicitly waived by the user for this release; the user will perform the in-game confirmation.
+- Because the game was not launched after publication, no fresh Player.log was generated for this smoke pass.
+- The Workshop artifact, public metadata, localized descriptions, changenote, download identity, and helper permissions were verified independently of the game launch.
+
+## Decision
+
+- Result: GO
+- Notes:
+  - Steam Workshop item `3718988020` contains the verified `v0.5.02` artifact.
+  - Both localized description surfaces identify Caves of Qud `1.0.5`.
+  - The optional Harmony 2.4.2 package is available from the public GitHub Release and documented in a dedicated Steam discussion.
+  - Remaining confidence boundary is the user-owned in-game UI and fresh runtime-log check.
+- Rollback tag, if needed: `v0.5.01`

--- a/docs/reports/2026-07-16-workshop-v0.5.02.md
+++ b/docs/reports/2026-07-16-workshop-v0.5.02.md
@@ -70,7 +70,7 @@ The tag-triggered Release run failed before artifact publication while building 
 
 ## Upload
 
-- steamcmd command: `/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_stable/.worktrees/release-v0.5.02-recovery/dist/workshop/workshop_item.vdf +quit`
+- steamcmd command: `steamcmd +login "$STEAM_USER" +workshop_build_item <worktree>/dist/workshop/workshop_item.vdf +quit`
 - Upload completed at: `2026-07-16 04:40:59 +0900`
 - Steam output summary: cached login succeeded; content, preview image, and update commit completed with `Committing update...Success.`
 - Steam content manifest ID: `4986513281384934182`

--- a/docs/reports/2026-07-16-workshop-v0.5.02.md
+++ b/docs/reports/2026-07-16-workshop-v0.5.02.md
@@ -53,7 +53,7 @@ v0.5.02 / a1b4724ca912
 - [ ] Draft GitHub Release created by the tag workflow
 - [x] Immutable tag tree checked out in detached worktree for manual recovery
 - [x] Production no-game build completed with analyzers enabled and no warnings or errors
-- [x] No-game QudJP test artifact built with release analyzer flags and no warnings or errors
+- [x] No-game QudJP test artifact built with analyzers disabled (`RunAnalyzers=false` and `RunAnalyzersDuringBuild=false`) and no warnings or errors
 - [x] QudJP test suite passed: `10187 passed`
 - [x] Python suite passed: `1544 passed, 1 skipped`
 - [x] Localization, encoding, glossary, XML, and translation-token checks passed
@@ -70,7 +70,7 @@ The tag-triggered Release run failed before artifact publication while building 
 
 ## Upload
 
-- steamcmd command: `steamcmd +login "$STEAM_USER" +workshop_build_item <worktree>/dist/workshop/workshop_item.vdf +quit`
+- steamcmd command (from the worktree root): `steamcmd +login "$STEAM_USER" +workshop_build_item ./dist/workshop/workshop_item.vdf +quit`
 - Upload completed at: `2026-07-16 04:40:59 +0900`
 - Steam output summary: cached login succeeded; content, preview image, and update commit completed with `Committing update...Success.`
 - Steam content manifest ID: `4986513281384934182`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -351,7 +351,9 @@ python scripts/sync_mod.py --dry-run
 `dist/release-assets/vX.Y.Z/QudJP-vX.Y.Z.zip` から Steam Workshop 用の staging directory と
 `steamcmd` 用 VDF を生成します。Workshop item ID や title などの公開
 metadata は `steam/workshop_metadata.json`、Workshop description は
-`steam/workshop_description.ja.txt` を source of truth にします。Workshop
+`steam/workshop_description.en.txt` を既定の英語版、
+`steam/workshop_description.ja.txt` を日本語ローカライズ版の
+source of truth にします。Workshop
 changenote は `scripts/release_notes.py render` で
 `docs/release-notes/unreleased/*.md` から下書きを生成し、必要に応じて
 `git log --oneline <previous-tag>..HEAD` と

--- a/scripts/tests/test_target_game_version_contract.py
+++ b/scripts/tests/test_target_game_version_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -28,6 +29,9 @@ CURRENT_VERSION_SURFACES = {
     ),
     "steam/workshop_description.ja.txt": re.compile(
         r"Caves of Qud (?P<version>\d+\.\d+\.\d+) 対応"
+    ),
+    "steam/workshop_description.en.txt": re.compile(
+        r"Compatible with Caves of Qud (?P<version>\d+\.\d+\.\d+)"
     ),
     "docs/RULES.md": re.compile(
         r"IDs must match game version `(?P<version>\d+\.\d+\.\d+)`"
@@ -65,6 +69,16 @@ def test_current_version_surfaces_match_readme_target() -> None:
             )
 
     assert not mismatches, "Current target-game version drift:\n" + "\n".join(mismatches)
+
+
+def test_workshop_default_description_is_english() -> None:
+    """The default steamcmd upload must not overwrite English with Japanese text."""
+    metadata = json.loads(_read("steam/workshop_metadata.json"))
+
+    assert metadata["description_file"] == "workshop_description.en.txt"
+    description = _read("steam/workshop_description.en.txt")
+    assert "Overview" in description
+    assert "概要" not in description
 
 
 def test_reference_stub_version_matches_l2g_game_assembly_contract() -> None:

--- a/steam/workshop_description.en.txt
+++ b/steam/workshop_description.en.txt
@@ -43,7 +43,7 @@ Notes for Apple Silicon Macs
 
 Reports and Contributions
 
-This project is available on GitHub. If you encounter a problem, please post it in this mod's comment section or report it as a GitHub Issue. When opening an Issue, including your Player.log would be very helpful.
+This project is available on GitHub. If you encounter a problem, please post it in this mod's comment section or report it as a GitHub Issue. When opening an Issue, including your Player.log would be very helpful. Before attaching Player.log to a public Issue, remove sensitive information such as usernames and local paths.
 
   * GitHub: https://github.com/ToaruPen/coq-japanese_stable
   * macOS Player.log: ~/Library/Logs/Freehold Games/CavesOfQud/Player.log

--- a/steam/workshop_description.en.txt
+++ b/steam/workshop_description.en.txt
@@ -1,0 +1,64 @@
+Caves of Qud Japanese Mod
+
+Note: Nearly all of the Japanese translations from the original English text were generated using generative AI. They have been reviewed, but contextual misunderstandings, mistranslations, and unusual wording are still likely. If you find any issues, please let us know. Official localization work has also begun, so this project may be discontinued in the near future.
+
+Overview
+This is an unofficial, fan-made mod for playing Caves of Qud in Japanese. It translates the UI, conversations, ability and mutation descriptions, pop-ups, message logs, and some procedurally generated text into Japanese. It also includes a CJK font for displaying Japanese text.
+
+Supported Version
+
+  * Compatible with Caves of Qud 1.0.5
+
+Main Features
+
+  * Japanese translations for dialogue
+  * Japanese translations for UI elements, including menus, options, character creation, and ability screens
+  * Japanese translations for pop-ups, message logs, the journal, death screens, and more
+  * Japanese translations for some procedurally generated text, historical text, and descriptions
+  * A bundled CJK font for displaying Japanese text
+
+Existing Saves
+
+The mod should generally work with existing saves. However, we recommend backing up any important save data before enabling it. Previously generated text already stored in a save, as well as some dynamic text, may remain in English.
+
+Installation
+
+  * Subscribe to this Workshop item.
+  * Enable Caves of Qud Japanese Mod in the in-game Mod Manager.
+  * Restart the game. That is all!
+
+Notes for Apple Silicon Macs
+
+  * When Caves of Qud is launched natively on an Apple Silicon Mac, such as an M1, M2, M3, or M4 model, the game's `0Harmony.dll` may cause Harmony patches to fail with `mprotect returned EACCES`. If this happens, this mod's UI translations may not take effect.
+  * QudJP recommends launching the game through Rosetta 2. QudJP does not automatically bundle or replace `0Harmony.dll`.
+  * This mod includes a launcher wrapper named `Launch CavesOfQud (Rosetta).command`. You can launch it by double-clicking the file in the Steam Workshop download folder.
+  * With the default Steam library location on macOS, the file is normally located at `~/Library/Application Support/Steam/steamapps/workshop/content/333640/3718988020/Launch CavesOfQud (Rosetta).command`. If you use another Steam library, look for `steamapps/workshop/content/333640/3718988020/` within that library.
+  * The wrapper first looks for the game in the default Steam library and in the Steam library containing the wrapper's Workshop folder. If it still cannot find the game, it displays a dialog asking you to select `CoQ.app`. Select `CoQ.app` from the Caves of Qud folder in your Steam library.
+  * Launching the game normally through Steam does not apply the wrapper's settings. If the translations do not work on Apple Silicon, launch the game through the wrapper each time.
+  * If Rosetta 2 is not installed, the wrapper displays an installation confirmation. Follow the prompt; no manual Terminal commands are required.
+  * Advanced direct-launch example: `arch -x86_64 $HOME/Library/Application\ Support/Steam/steamapps/common/Caves\ of\ Qud/CoQ.app/Contents/MacOS/CoQ`
+  * As an advanced alternative, our testing confirmed that replacing the game's `0Harmony.dll` with Harmony 2.4.2 allows the game to run natively on Apple Silicon. For normal use, we recommend the Rosetta launch method described above.
+  * This mod also includes `Install Native Apple Silicon Harmony.command`, which replaces the DLL only when you explicitly run it, and `Restore Game Harmony.command`, which restores the original DLL. These helpers first look for Caves of Qud based on their own location. If they cannot find it, they display a dialog asking you to select `0Harmony.dll`.
+  * To replace the DLL manually, close CoQ, extract `net48/0Harmony.dll` from `Harmony-Fat.2.4.2.0.zip` at https://github.com/pardeike/Harmony/releases/tag/v2.4.2.0, back up `~/Library/Application Support/Steam/steamapps/common/Caves of Qud/CoQ.app/Contents/Resources/Data/Managed/0Harmony.dll`, and then replace it with the extracted file. Steam file verification, reinstallation, or a game update may restore the original DLL.
+
+Reports and Contributions
+
+This project is available on GitHub. If you encounter a problem, please post it in this mod's comment section or report it as a GitHub Issue. When opening an Issue, including your Player.log would be very helpful.
+
+  * GitHub: https://github.com/ToaruPen/coq-japanese_stable
+  * macOS Player.log: ~/Library/Logs/Freehold Games/CavesOfQud/Player.log
+  * Windows Player.log: %USERPROFILE%\AppData\LocalLow\Freehold Games\CavesOfQud\Player.log
+
+Contributions are welcome!
+
+Important Notes
+  * This is not an official Japanese localization by Freehold Games.
+  * Game updates may break some translated displays or patches.
+  * Some untranslated text, layout issues, and unnatural translations may remain.
+
+Known and Currently Observed Issues
+
+  * Procedurally generated content in general
+  * The character generation screen
+  * Misaligned color tags applied to text in the message log
+  * Other minor UI issues and gaps that have not yet been identified

--- a/steam/workshop_description.ja.txt
+++ b/steam/workshop_description.ja.txt
@@ -43,7 +43,7 @@ macOS Apple Silicon での注意
 
 報告・Contribution
 
-このプロジェクトは GitHub で公開しています。何か問題があれば、この Mod のコメント欄に投稿していただくか、GitHub Issue として報告してください。Issue の場合は Player.log も添付してもらえると助かります。
+このプロジェクトは GitHub で公開しています。何か問題があれば、この Mod のコメント欄に投稿していただくか、GitHub Issue として報告してください。Issue の場合は Player.log も添付してもらえると助かります。Player.log を公開 Issue に添付する前に、ユーザー名やローカルパスなどの機微情報を削除してください。
 
   * GitHub: https://github.com/ToaruPen/coq-japanese_stable
   * macOS Player.log: ~/Library/Logs/Freehold Games/CavesOfQud/Player.log

--- a/steam/workshop_metadata.json
+++ b/steam/workshop_metadata.json
@@ -3,5 +3,5 @@
   "publishedfileid": "3718988020",
   "title": "Caves of Qud Japanese Mod",
   "visibility": "0",
-  "description_file": "workshop_description.ja.txt"
+  "description_file": "workshop_description.en.txt"
 }


### PR DESCRIPTION
## Summary

- add a canonical English Workshop description and use it for the default steamcmd upload
- keep the Japanese description as a separate localized source and document the two-locale release procedure
- add a regression contract that keeps both descriptions on Caves of Qud 1.0.5 and prevents Japanese text from replacing the English default
- record the verified QudJP v0.5.02 Workshop publication, GitHub Release, Harmony discussion, content manifest, and the user-approved runtime-smoke exception

## Root cause

The generated VDF reads `description_file` from `steam/workshop_metadata.json`. Steam applies that description to the default English locale unless an update language is selected. Because the metadata pointed at the Japanese file, the v0.5.02 upload replaced the English description with Japanese while the separately stored Japanese localization remained stale.

## Validation

- Red: `test_workshop_default_description_is_english` failed against the old Japanese metadata target
- Green: `just target-game-version-check` — 3 passed
- `just python-check`
- `just python-test` — 1546 passed, 1 skipped
- focused Workshop tests — 29 passed
- regenerated the v0.5.02 VDF from the published release ZIP and confirmed its default description is English with no Japanese body mixed in
- public English and Japanese Workshop pages both show Caves of Qud 1.0.5
- independent Codex review: APPROVE, Critical 0, Important 0

## Release evidence

- GitHub Release: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.5.02
- Steam Workshop: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
- Harmony discussion: https://steamcommunity.com/workshop/filedetails/discussion/3718988020/572669660098532087/

The actual game-launch smoke was explicitly delegated to the user; the artifact, download identity, localized descriptions, changenote, content manifest, and helper permissions were verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Steam Workshop向けに、英語の標準説明文を追加しました（日本語ローカライズ版は引き続き別管理）。
- **ドキュメント**
  - リリース手順・運用注意を更新し、英日それぞれの説明の反映タイミングやVDF生成時の注意、steamcmd上書き回避の観点を明記しました。
  - 説明文の参照元（英日両方）を整理しました。
  - 日本語「報告・Contribution」に、Player.log添付時の機微情報削除の注意を追記しました。
  - v0.5.02の公開内容と検証結果を記録しました。
- **テスト**
  - 英語標準説明文の整合性（既定参照先・内容制約）を確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->