### PR TITLE
Fix Trium hologram progression block

### DIFF
--- a/Mods/QudJP/Localization/ObjectBlueprints/HiddenObjects.jp.xml
+++ b/Mods/QudJP/Localization/ObjectBlueprints/HiddenObjects.jp.xml
@@ -1299,16 +1299,16 @@
     <tag Name="BaseObject" Value="*noinherit" />
     <tag Name="ExcludeFromDynamicEncounters" />
   </object>
-  <object Name="Barathrum Hologram" Inherits="BaseTriumHologram" Replace="true">
+  <object Name="Barathrum Hologram" Inherits="BaseTriumHologram" Load="Merge">
     <part Name="Render" DisplayName="ホログラムのバラサラム（老）" />
   </object>
-  <object Name="Archon Hologram" Inherits="BaseTriumHologram" Replace="true">
+  <object Name="Archon Hologram" Inherits="BaseTriumHologram" Load="Merge">
     <part Name="Render" DisplayName="ホログラムのアーコン" />
   </object>
-  <object Name="Rebekah Hologram" Inherits="BaseTriumHologram" Replace="true">
+  <object Name="Rebekah Hologram" Inherits="BaseTriumHologram" Load="Merge">
     <part Name="Render" DisplayName="ホログラムのリベカ" />
   </object>
-  <object Name="Resheph Hologram" Inherits="BaseTriumHologram" Replace="true">
+  <object Name="Resheph Hologram" Inherits="BaseTriumHologram" Load="Merge">
     <part Name="Render" DisplayName="ホログラムのレシェフ" />
   </object>
   <object Name="BaseArkCore" Inherits="MountedFurniture" Replace="true">

--- a/docs/release-notes/unreleased/2026-08-14-trium-hologram-conversations.md
+++ b/docs/release-notes/unreleased/2026-08-14-trium-hologram-conversations.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Preserve the conversations, appearances, and descriptions of the Barathrum, archon, Rebekah, and Resheph holograms, preventing a late-game progression block.

--- a/scripts/tests/test_object_blueprint_merge_semantics.py
+++ b/scripts/tests/test_object_blueprint_merge_semantics.py
@@ -37,17 +37,24 @@ def test_trium_hologram_overlays_merge_conversation_blueprints() -> None:
         "Rebekah Hologram",
         "Resheph Hologram",
     }
-    holograms = {
-        obj.get("Name"): obj
+    holograms = [
+        obj
         for obj in root.findall("object")
         if obj.get("Name") in expected_names
-    }
-    missing_merge = sorted(
-        name for name, obj in holograms.items() if obj.get("Load") != "Merge"
-    )
+    ]
 
-    assert set(holograms) == expected_names
-    assert missing_merge == []
+    assert len(holograms) == len(expected_names)
+    assert {obj.get("Name") for obj in holograms} == expected_names
+    for hologram in holograms:
+        assert hologram.get("Inherits") == "BaseTriumHologram"
+        assert hologram.get("Load") == "Merge"
+        assert hologram.get("Replace") is None
+
+        children = list(hologram)
+        assert len(children) == 1
+        assert children[0].tag == "part"
+        assert children[0].get("Name") == "Render"
+        assert children[0].get("DisplayName")
 
 
 def test_refract_light_verb_attributes_remain_message_frame_tokens() -> None:

--- a/scripts/tests/test_object_blueprint_merge_semantics.py
+++ b/scripts/tests/test_object_blueprint_merge_semantics.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DATA_BLUEPRINTS = REPO_ROOT / "Mods/QudJP/Localization/ObjectBlueprints/Data.jp.xml"
+HIDDEN_BLUEPRINTS = (
+    REPO_ROOT / "Mods/QudJP/Localization/ObjectBlueprints/HiddenObjects.jp.xml"
+)
 ITEM_BLUEPRINTS = REPO_ROOT / "Mods/QudJP/Localization/ObjectBlueprints/Items.jp.xml"
 
 
@@ -22,6 +25,28 @@ def test_procedural_cooking_ingredient_overlays_merge_base_blueprints() -> None:
     missing_merge = [obj.get("Name") for obj in cooking_ingredients if obj.get("Load") != "Merge"]
 
     assert cooking_ingredients
+    assert missing_merge == []
+
+
+def test_trium_hologram_overlays_merge_conversation_blueprints() -> None:
+    """Translated hologram names must preserve base conversations and presentation."""
+    root = ET.parse(HIDDEN_BLUEPRINTS).getroot()  # noqa: S314 -- local repository XML
+    expected_names = {
+        "Barathrum Hologram",
+        "Archon Hologram",
+        "Rebekah Hologram",
+        "Resheph Hologram",
+    }
+    holograms = {
+        obj.get("Name"): obj
+        for obj in root.findall("object")
+        if obj.get("Name") in expected_names
+    }
+    missing_merge = sorted(
+        name for name, obj in holograms.items() if obj.get("Load") != "Merge"
+    )
+
+    assert set(holograms) == expected_names
     assert missing_merge == []
 
 


### PR DESCRIPTION
## Summary

- merge the Barathrum, archon, Rebekah, and Resheph hologram localization overlays into the Caves of Qud 1.0.5 base blueprints
- preserve each hologram's conversation script, tile, description, animation, and gameplay tags while continuing to localize its display name
- add a regression test for the four Blueprint merge contracts and a Workshop-facing release-note fragment

## Root cause

The four localized hologram objects only contained `Render.DisplayName`, but lacked per-object `Load="Merge"`. The game loader therefore replaced the complete base blueprints, removing their conversation and presentation parts. The reported Resheph hologram consequently used inherited generic presentation and could not be spoken to, blocking late-game progression.

## Player impact

The projected holograms retain their intended appearance and conversations. In particular, the Resheph projection can be spoken to so the affected late-game sequence can continue.

## Verification

- TDD regression: failed with all four missing merge contracts, then passed after the XML fix
- `just release-note-check origin/main HEAD`
- `just pr-check origin/main HEAD`
- C# tests with game references: 10,791 passed
- C# game-DLL-free tests: 10,187 passed
- Python tests: 1,560 passed, 1 skipped
- XML, localization, token, Ruff, basedpyright, and markdown-report checks passed

## Source report

- https://steamcommunity.com/workshop/filedetails/discussion/3718988020/837250028234869281/?tscn=1784144839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * Barathrum、Archon、Rebekah、Reshephのホログラムで、会話・登場・説明が正しく保持されるようになりました。
  * 終盤の進行が停止する問題を修正しました。

* **テスト**
  * ホログラム情報が正しく統合されることを検証する回帰テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->