### PR TITLE
Release QudJP v0.5.03

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.5.03] - 2026-08-14
+
+### Fixed
+
+- ホログラム投影機で生成されるバラサラム、アーコン、リベカ、レシェフの会話・外見・説明が失われ、進行不能になる問題を修正しました。
+
+---
+
 ## [0.5.02] - 2026-07-15
 
 ### Added
@@ -452,7 +460,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.5.02...HEAD
+[Unreleased]: https://github.com/ToaruPen/coq-japanese_stable/compare/v0.5.03...HEAD
+[0.5.03]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.5.03
 [0.5.02]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.5.02
 [0.5.01]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.5.01
 [0.5.00]: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.5.00

--- a/Mods/QudJP/manifest.json
+++ b/Mods/QudJP/manifest.json
@@ -3,7 +3,7 @@
   "Title": "Caves of Qud Japanese Mod",
   "Description": "Caves of Qud \u306e\u4f1a\u8a71\u30fbUI\u30fb\u81ea\u52d5\u751f\u6210\u30c6\u30ad\u30b9\u30c8\u3092\u65e5\u672c\u8a9e\u5316\u3057\u3001CJK \u30d5\u30a9\u30f3\u30c8\u3092\u540c\u68b1\u3059\u308b Mod \u3067\u3059\u3002",
   "Author": "ToaruPen & Contributors",
-  "Version": "0.5.02",
+  "Version": "0.5.03",
   "PreviewImage": "preview.png",
   "Tags": ["Localization", "UI", "Japanese"],
   "Dependencies": {}

--- a/docs/release-notes/unreleased/2026-08-14-trium-hologram-conversations.md
+++ b/docs/release-notes/unreleased/2026-08-14-trium-hologram-conversations.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Preserve the conversations, appearances, and descriptions of the Barathrum, archon, Rebekah, and Resheph holograms, preventing a late-game progression block.


### PR DESCRIPTION
## Summary

- bump the QudJP manifest version to 0.5.03
- publish the Trium hologram progression fix in the changelog
- consume the corresponding unreleased release-note fragment

## Player impact

This release preserves the conversations, appearances, and descriptions of the Barathrum, archon, Rebekah, and Resheph holograms so the late-game hologram projector sequence can continue normally.

## Verification

- `just pr-check origin/main HEAD`
- release identity, release note, and release workflow contract tests
- changelog link validation