### PR TITLE
docs: record Workshop v0.5.03 release evidence

### DIFF
--- a/docs/reports/2026-08-14-workshop-v0.5.03.md
+++ b/docs/reports/2026-08-14-workshop-v0.5.03.md
@@ -55,7 +55,7 @@ v0.5.03 / f9a14572da39
 
 ## Upload
 
-- steamcmd command: `/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_stable/.worktrees/release-0.5.03-tag/dist/workshop/workshop_item.vdf +quit`
+- steamcmd command: `steamcmd +login "$STEAM_USER" +workshop_build_item dist/workshop/workshop_item.vdf +quit`
 - Upload completed at: `2026-08-14 20:23:25 +0900`
 - Steam output summary: cached login succeeded; content and preview image uploaded; update commit completed with `Committing update...Success.`
 - Steam content manifest ID: `5359671526341215460`
@@ -70,7 +70,7 @@ v0.5.03 / f9a14572da39
 - [x] English Workshop page showed the expected title, `Compatible with Caves of Qud 1.0.5` description, file size, and update time
 - [x] Japanese and English changelog pages showed `v0.5.03 / f9a14572da39` and the complete multiline changenote
 - [ ] Subscribe/resubscribe checked
-- [x] `/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit`
+- [x] `steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit`
 - [x] `just workshop-download-check 0.5.03 dist/release-assets/v0.5.03/QudJP-v0.5.03.zip`
 - [x] Downloaded manifest reported version `0.5.03`
 - [x] Downloaded QudJP DLL SHA256 was `8ca623263dd475c43a97b41a913b8a23df2f8b5e79e6a94dd570ba93e8bcc1b4`

--- a/docs/reports/2026-08-14-workshop-v0.5.03.md
+++ b/docs/reports/2026-08-14-workshop-v0.5.03.md
@@ -1,0 +1,96 @@
+# Workshop Release v0.5.03
+
+## Identity
+
+- Version: `0.5.03`
+- Git commit: `f9a14572da394ec7c8b8cba02e3ef96e77fbffb9`
+- Git tag: `v0.5.03`
+- Previous release tag/range: `v0.5.02..v0.5.03`
+- Version source: `Mods/QudJP/manifest.json`, `CHANGELOG.md`, annotated tag `v0.5.03`
+- GitHub Release URL: https://github.com/ToaruPen/coq-japanese_stable/releases/tag/v0.5.03
+- Tag-triggered Release run: https://github.com/ToaruPen/coq-japanese_stable/actions/runs/31787683611
+- Workshop item: https://steamcommunity.com/sharedfiles/filedetails/?id=3718988020
+- Steam app ID: `333640`
+- Published file ID: `3718988020`
+
+## Changenote
+
+```text
+v0.5.03 / f9a14572da39
+
+修正:
+- ホログラム投影機で生成されるバラサラム、アーコン、リベカ、レシェフの会話・外見・説明が失われ、進行不能になる問題を修正しました。
+
+既知の問題:
+- 一部の自動生成テキスト、チュートリアル、キャラクター生成画面には未翻訳または不自然な訳が残る場合があります。
+- ゲーム本体のアップデートにより、一部表示やパッチが壊れる可能性があります。
+```
+
+## Artifacts
+
+- Release ZIP: `dist/release-assets/v0.5.03/QudJP-v0.5.03.zip`
+- Release ZIP SHA256: `bd9c16e153d26a6c8e8126b734b8e9424691c6d3a67b8957c8815f538efbc60c`
+- GitHub Release asset: `QudJP-v0.5.03.zip`
+- GitHub Release asset SHA256: `bd9c16e153d26a6c8e8126b734b8e9424691c6d3a67b8957c8815f538efbc60c`
+- Optional Harmony asset: `QudJP-Harmony-2.4.2-Windows.zip`
+- Optional Harmony asset SHA256: `a0e9397887b31e8cd0eb7edc99ebf87f9b86466004f2a81a7681dd759aebca6e`
+- Workshop content folder: `dist/workshop/QudJP/`
+- Workshop VDF: `dist/workshop/workshop_item.vdf`
+
+## Preflight
+
+- [x] Release tag worktree was detached and clean at `f9a14572da394ec7c8b8cba02e3ef96e77fbffb9`
+- [x] Release range established from previous tag: `v0.5.02..v0.5.03`
+- [x] `Mods/QudJP/manifest.json` version, `v0.5.03` tag, release ZIP name, changenote first line, and report version match
+- [x] `git rev-list -n1 v0.5.03` matched `git rev-parse HEAD`
+- [x] `git merge-base --is-ancestor "$(git rev-list -n1 v0.5.03)" origin/main`
+- [x] Tag-triggered Release workflow completed successfully and created the draft GitHub Release
+- [x] Release workflow passed the C# build and tests, Python lint and tests, localization checks, artifact build, identity check, and release-note rendering
+- [x] Local `just workshop-preflight 0.5.03` passed, including 112 selected tests and release artifact checks
+- [x] Workshop changenote was compared with `v0.5.02`, rewritten in player-facing terms, and checked by `workshop-upload-preflight`
+- [x] `just download-release-zip 0.5.03`
+- [x] `just release-zip-check dist/release-assets/v0.5.03/QudJP-v0.5.03.zip`
+- [x] `just build-workshop-upload dist/release-assets/v0.5.03/QudJP-v0.5.03.zip /tmp/qudjp-workshop-changenote.txt`
+- [x] `just workshop-upload-preflight dist/release-assets/v0.5.03/QudJP-v0.5.03.zip 0.5.03`
+
+## Upload
+
+- steamcmd command: `/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +workshop_build_item /Users/sankenbisha/Dev/coq-japanese_stable/.worktrees/release-0.5.03-tag/dist/workshop/workshop_item.vdf +quit`
+- Upload completed at: `2026-08-14 20:23:25 +0900`
+- Steam output summary: cached login succeeded; content and preview image uploaded; update commit completed with `Committing update...Success.`
+- Steam content manifest ID: `5359671526341215460`
+- GitHub Release published at: `2026-08-14 20:25:05 +0900`
+
+## Post-Publish Smoke
+
+- [x] Public Workshop API returned title `Caves of Qud Japanese Mod`, visibility `0`, file size `21939268`, manifest `5359671526341215460`, and updated timestamp `2026-08-14 20:23:25 +0900`
+- [x] Public API `hcontent_file` and local `appworkshop_333640.acf` both reported manifest `5359671526341215460`
+- [x] Preview image URL returned HTTP 200 with `image/png`
+- [x] Japanese Workshop page showed the expected title, `Caves of Qud 1.0.5 対応` description, file size, and update time
+- [x] English Workshop page showed the expected title, `Compatible with Caves of Qud 1.0.5` description, file size, and update time
+- [x] Japanese and English changelog pages showed `v0.5.03 / f9a14572da39` and the complete multiline changenote
+- [ ] Subscribe/resubscribe checked
+- [x] `/opt/homebrew/bin/steamcmd +login "$STEAM_USER" +workshop_download_item 333640 3718988020 validate +quit`
+- [x] `just workshop-download-check 0.5.03 dist/release-assets/v0.5.03/QudJP-v0.5.03.zip`
+- [x] Downloaded manifest reported version `0.5.03`
+- [x] Downloaded QudJP DLL SHA256 was `8ca623263dd475c43a97b41a913b8a23df2f8b5e79e6a94dd570ba93e8bcc1b4`
+- [x] `diff -qr` found no difference between staged and freshly downloaded Workshop content
+- [x] Downloaded Rosetta and Harmony helper `.command` files retained executable permissions
+- [ ] Mod Manager lists QudJP with expected version and preview
+- [ ] Options screen renders Japanese text and CJK glyphs
+- [ ] One short conversation renders Japanese text and CJK glyphs
+- [ ] Fresh Player.log checked for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`
+
+### Post-Publish Smoke Exceptions
+
+- This release did not include a fresh game launch, so Mod Manager, UI, conversation, and Player.log checks remain manual confidence boundaries.
+- Workshop artifact identity, public metadata, localized descriptions, changenote rendering, download identity, and helper permissions were verified independently of the game launch.
+
+## Decision
+
+- Result: GO
+- Notes:
+  - Steam Workshop item `3718988020` contains the verified `v0.5.03` artifact.
+  - The Workshop update and public GitHub Release identify commit `f9a14572da394ec7c8b8cba02e3ef96e77fbffb9`.
+  - Remaining confidence boundary is an in-game UI and fresh runtime-log smoke check.
+- Rollback tag, if needed: `v0.5.02`


### PR DESCRIPTION
## 概要

- Steam Workshop v0.5.03 の公開証跡を追加
- Gitタグ、GitHub Release、Workshop manifest、配布ZIPのSHA-256を記録
- 公開後の再ダウンロード検証と日本語・英語ページの表示確認を記録
- 未実施のゲーム内スモーク範囲を明記

## 影響

ドキュメントのみの変更です。配布物や実装には変更ありません。

## 検証

- `git diff --cached --check`
- `just workshop-upload-preflight dist/release-assets/v0.5.03/QudJP-v0.5.03.zip 0.5.03`
- `just workshop-download-check 0.5.03 dist/release-assets/v0.5.03/QudJP-v0.5.03.zip`
- 公開Workshop APIとローカルACFのmanifest一致
- 日本語・英語のWorkshop説明および変更履歴を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * v0.5.03のワークショップリリース報告書を追加しました。
  * リリース情報、修正内容、既知の問題、成果物の検証情報、公開結果、未確認事項、例外事項、判定結果を記録しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->