### PR TITLE
docs: record Workshop v0.5.03 runtime smoke

### DIFF
--- a/docs/reports/2026-08-14-workshop-v0.5.03.md
+++ b/docs/reports/2026-08-14-workshop-v0.5.03.md
@@ -77,14 +77,23 @@ v0.5.03 / f9a14572da39
 - [x] `diff -qr` found no difference between staged and freshly downloaded Workshop content
 - [x] Downloaded Rosetta and Harmony helper `.command` files retained executable permissions
 - [ ] Mod Manager lists QudJP with expected version and preview
-- [ ] Options screen renders Japanese text and CJK glyphs
-- [ ] One short conversation renders Japanese text and CJK glyphs
-- [ ] Fresh Player.log checked for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`
+- [x] Options screen renders Japanese text and CJK glyphs
+- [x] One short conversation renders Japanese text and CJK glyphs
+- [x] Fresh runtime log checked for QudJP build markers, missing glyph warnings, compile errors, and `MODWARN`
+
+### In-Game Runtime Evidence
+
+- The freshly downloaded Workshop Rosetta launcher loaded `QudJP.dll` from Workshop item `3718988020`.
+- QudJP completed initialization, registered the CJK font, applied 1,693 Harmony patches, and loaded 8,554 translations from 67 files.
+- The enabled-mod inventory contained only `Caves of Qud Japanese Mod`.
+- The Japanese main menu and character-creation UI rendered CJK glyphs; the operator then completed the Options and short-conversation checks without reporting a rendering issue.
+- The successful QudJP session was preserved in the rotated runtime log after the Mod Manager started a Steam-detached reload session.
+- No `MODWARN`, mod compilation error, fatal QudJP exception, or missing-glyph warning was present. The log retained the known non-fatal startup-warmup fallback notice and the skipped `HistoricStringExpanderPatch` target notice.
 
 ### Post-Publish Smoke Exceptions
 
-- This release did not include a fresh game launch, so Mod Manager, UI, conversation, and Player.log checks remain manual confidence boundaries.
-- Workshop artifact identity, public metadata, localized descriptions, changenote rendering, download identity, and helper permissions were verified independently of the game launch.
+- Subscribe/resubscribe was not repeated during this release pass.
+- The downloaded manifest and preview image were verified directly, but the Mod Manager version-and-preview rendering check remains open because its reload path started a Steam-detached child session without Workshop enumeration.
 
 ## Decision
 
@@ -92,5 +101,6 @@ v0.5.03 / f9a14572da39
 - Notes:
   - Steam Workshop item `3718988020` contains the verified `v0.5.03` artifact.
   - The Workshop update and public GitHub Release identify commit `f9a14572da394ec7c8b8cba02e3ef96e77fbffb9`.
-  - Remaining confidence boundary is an in-game UI and fresh runtime-log smoke check.
+  - Japanese UI, conversation, CJK rendering, and fresh runtime-log smoke checks passed.
+  - Remaining confidence boundaries are subscribe/resubscribe and the Mod Manager's version-and-preview rendering only.
 - Rollback tag, if needed: `v0.5.02`


### PR DESCRIPTION
## Summary
- record the downloaded Workshop build runtime smoke
- close the Japanese Options, short-conversation, CJK, and fresh-log checks
- preserve subscribe/resubscribe and Mod Manager rendering as explicit remaining boundaries

## Verification
- `git diff --check origin/main...HEAD`
- `just release-note-check origin/main HEAD`